### PR TITLE
Plan: Web Push notifications for the dashboard

### DIFF
--- a/docs/plans/web-push-notifications.md
+++ b/docs/plans/web-push-notifications.md
@@ -1,0 +1,263 @@
+# Plan: Web Push notifications for the aoe dashboard
+
+## Problem
+
+A user runs `aoe serve --remote` on their dev box and opens the resulting Cloudflare tunnel URL on their phone. They start a Claude Code session in a worktree. Five minutes later, Claude hits a permission prompt or completes a long operation and waits for input.
+
+Today, the user has no way to know this happened unless they are actively looking at the tab. The dashboard has no push notifications, no favicon badge, no tab-title alert, no sound. If the tab isn't the frontmost tab, the agent sits idle indefinitely while the user does other things.
+
+This kills the core value proposition of the web dashboard: **remote, asynchronous agent access**. Without notifications, the dashboard is just "SSH with a prettier terminal." With notifications, it becomes "set the agent running, put the phone in your pocket, come back when it pings you."
+
+Secondary motivation: on iOS, notifications delivered to an installed PWA appear on the Lock Screen. Tapping one unlocks the device and deep-links straight to the right session. That is the lock-screen access path the user asked about. There is no PWA-on-Lock-Screen widget API on iOS (Apple doesn't expose Live Activities or Control Center to web); notifications are the vehicle.
+
+## Goal
+
+Deliver Web Push notifications from `aoe serve` to an installed PWA. Minimum viable behavior:
+- On the transition Running → Waiting (agent needs user input), send a push to every subscribed device.
+- Notification body shows the session title; tapping the notification opens the PWA deep-linked to that session.
+- User opts in from a Settings toggle inside the PWA; opting in asks for browser permission and registers a Web Push subscription.
+- A "Send test notification" button so the user can confirm it works end-to-end before walking away.
+
+Stretch (not in v1):
+- Running → Error and Running → Idle-after-long-run triggers.
+- Per-session opt-in.
+- Rich notification actions (Approve/Reject from the lock screen). Pairs with the future permission-UI feature.
+- Quiet hours / throttling.
+
+## Non-goals
+
+- Local-mode (http://) support on iOS. iOS requires HTTPS for push. Tunnel mode already gives HTTPS. Non-iOS browsers that allow push over http://localhost can still work; we won't block it, but we won't test for it either.
+- Android-specific feature parity. Firefox/Chrome Android should work via standard Web Push; no custom Android plumbing.
+- Replacing the TUI's in-terminal notification mechanism. aoe already has desktop sound alerts and tmux bell; this adds a web-specific channel, doesn't replace them.
+
+## Approach
+
+Standard Web Push over VAPID. Server signs pushes with a VAPID private key; client registers a Service Worker push subscription using the VAPID public key; server POSTs payloads to the push endpoint URLs the browsers vend.
+
+### Server side (`src/server/`)
+
+**New module:** `src/server/push.rs`
+
+- **VAPID keypair:** Generated on first server start, persisted to `$app_dir/push.vapid.json` (same directory as `serve.token`). Permissions 0600, owner-only read. Loaded on every subsequent start. Key is P-256 ECDSA as required by the Web Push spec.
+- **Subscription storage:** Persisted to `$app_dir/push.subscriptions.json`. Entries are `{endpoint, p256dh_key, auth_key, created_at, user_agent}` keyed by endpoint. Loaded on start into a `RwLock<HashMap<String, Subscription>>` in `AppState`. Writes are atomic (write-to-temp + rename).
+- **Garbage collection:** When a send returns 410 Gone (subscription expired) or 404 Not Found, remove the entry and persist. No explicit heartbeat or TTL.
+
+**New endpoints:**
+- `GET  /api/push/vapid-public-key` → `{ "public_key": "<base64url>" }`
+- `POST /api/push/subscribe` → body: the browser's `PushSubscription.toJSON()` shape. Stores it. Returns 204.
+- `POST /api/push/unsubscribe` → body: `{ "endpoint": "..." }`. Removes by endpoint. Returns 204.
+- `POST /api/push/test` → fires a one-shot test notification to all of the caller's subscriptions (identified by endpoint match against the request's stored subscriptions, or all subscriptions if we can't narrow it). Returns 204.
+
+All endpoints are auth-gated like the rest of `/api/*`.
+
+**Status transition hook:** In the existing `status_poll_loop` (currently refreshes tmux state every 2s), add a per-session `previous_status` map. When a session transitions `Running → Waiting`, enqueue a push send for that session. Send happens on a spawned Tokio task so the poll loop doesn't block on slow push endpoints.
+
+**Push payload shape:**
+```json
+{
+  "title": "Claude is waiting",
+  "body": "<session title>",
+  "url": "/sessions/<session-id>",
+  "tag": "session-<session-id>",
+  "session_id": "<session-id>"
+}
+```
+The `tag` coalesces repeat notifications for the same session — if Claude waits, gets input, waits again, the second notification replaces the first on the lock screen rather than stacking.
+
+**Crate choice:** `web-push = "0.10"` for signing and sending. It handles VAPID JWT construction and AES-128-GCM payload encryption. Mature crate, low dependency weight.
+
+### Client side (`web/`)
+
+**Extend `public/sw.js`:**
+Current `sw.js` has install/activate only and no fetch handler. Add:
+- `push` event listener: parses the payload, calls `self.registration.showNotification(title, { body, tag, data: { url } })`.
+- `notificationclick` event listener: closes the notification, calls `clients.openWindow(event.notification.data.url)` after checking for an already-open PWA window that matches.
+
+**New component:** `web/src/components/NotificationSettings.tsx`, rendered as a section inside `SettingsView.tsx`.
+- Shows current state: Off / Asking / Enabled / Denied / Unsupported.
+- Primary button: "Enable notifications" (Off → Asking → Enabled flow).
+- Secondary button: "Send test notification" (visible only when Enabled).
+- Disable button: "Turn off notifications" (visible only when Enabled).
+- iOS-specific inline help: "On iPhone, you need to add this dashboard to your Home Screen first. Tap the Share icon in Safari, then 'Add to Home Screen.' Then open the installed app to enable notifications."
+- "Unsupported" state appears on browsers without Push API, or on iOS Safari that isn't running as a PWA. Detection: `'PushManager' in window && navigator.serviceWorker` plus platform heuristic for iOS-not-standalone.
+
+**New hook:** `web/src/hooks/usePushSubscription.ts`
+- Reads current state from `Notification.permission` and `ServiceWorkerRegistration.pushManager.getSubscription()`.
+- `enable()`: requests permission, fetches VAPID public key, calls `pushManager.subscribe({ userVisibleOnly: true, applicationServerKey })`, POSTs the subscription to `/api/push/subscribe`.
+- `disable()`: unsubscribes locally, POSTs to `/api/push/unsubscribe`.
+- `sendTest()`: POSTs to `/api/push/test`.
+
+**Manifest check:** Audit `web/public/manifest.json` to ensure `display: "standalone"`, `start_url: "/"`, `icons` with 192 and 512 present. Required for iOS to treat it as an installable PWA.
+
+### Test plan
+
+**Rust side (`cargo test`):**
+- VAPID keypair: generate, persist, reload, same key.
+- Subscription storage: add, persist, reload, remove, persist.
+- GC on 410/404: subscription removed from store.
+- Status transition detection: given a sequence of status updates, correct push enqueues.
+
+**Frontend (`playwright`):**
+- Settings → Enable button flow (mock permission grant, mock server endpoints, verify subscription posted).
+- Test-notification button posts to `/api/push/test`.
+- iOS-not-standalone heuristic shows "Unsupported" state.
+- Disable button unsubscribes and posts to `/api/push/unsubscribe`.
+
+**End-to-end (manual, documented in `docs/push-notifications.md`):**
+- Install PWA on iPhone (iOS 16.4+).
+- Open PWA, enable notifications, send test → appears on Lock Screen.
+- Start a Claude session that will hit a permission prompt, put phone on lock screen, observe notification.
+- Tap notification → PWA opens to that session.
+
+### Effort estimate
+
+Roughly:
+- `push.rs` module + VAPID + storage + endpoints: ~1 day CC
+- Status transition hook in `status_poll_loop`: ~2 hours CC
+- Service worker changes: ~2 hours CC
+- React Settings component + hook: ~half day CC
+- Tests (unit + Playwright): ~half day CC
+- Documentation (docs/push-notifications.md + user-facing help): ~2 hours CC
+
+Total: ~3 days CC. This is a lake, not an ocean.
+
+## Files touched
+
+New:
+- `src/server/push.rs`
+- `web/src/components/NotificationSettings.tsx`
+- `web/src/hooks/usePushSubscription.ts`
+- `web/tests/push-notifications.spec.ts`
+- `docs/push-notifications.md`
+
+Modified:
+- `src/server/mod.rs` — add `push` module, `AppState` fields for VAPID/subscriptions, hook push send into `status_poll_loop`, register new routes.
+- `src/server/api.rs` — not touched (push endpoints live in push.rs).
+- `Cargo.toml` — add `web-push = "0.10"`.
+- `web/public/sw.js` — add push + notificationclick handlers.
+- `web/public/manifest.json` — verify PWA installability fields (edit if missing any).
+- `web/src/components/SettingsView.tsx` — render new NotificationSettings section.
+- `docs/cli/reference.md` — regen if CLI changes (it shouldn't).
+
+## Open questions for review
+
+1. Is `Running → Waiting` the right sole trigger for v1? Or should we ship with Running → Error too (errors are higher-severity)?
+2. Should subscriptions be tied to a device/passphrase identity so one user's "disable" affects only their devices, or is global-per-server fine for v1?
+3. Should we log push sends to the tracing log? Useful for debugging, potential minor privacy concern if logs are shared.
+4. The `web-push` crate is at 0.10, not 1.x — is maturity risk acceptable? Alternatives: reqwest + manual VAPID JWT + aes-gcm crate.
+
+---
+
+## Phase 1: CEO Review — Findings
+
+Codex unavailable in this environment (OpenAI auth). Review proceeds `[subagent-only]`.
+
+### Premise gate: Option A chosen
+User confirmed the plan's premises: Web Push is the right vehicle, notifications-before-permission-UI is the right sequencing, PWA install friction is an acceptable user-base gate. Subagent pushed back on all three; user accepted the risk.
+
+### CEO findings adopted into the plan
+- **Subscription security (subagent finding #4 — HIGH):** bind subscriptions to the auth token; invalidate all subscriptions on token rotation. Added to Eng scope.
+- **Status-transition flake (subagent finding #5 — MEDIUM):** add a dwell requirement before firing a push (e.g., session must be `Waiting` for ≥5s). Prevents phone buzzes on transient scrape flicker. Added to Eng scope.
+- **Scope estimate (subagent finding #6 — MEDIUM):** revise estimate from 3d CC to 5d CC to absorb token-rotation UX, subscription GC, rate-limiting of push sends, and the dwell mechanism.
+
+### CEO findings deferred
+- **Sequencing (subagent finding #1 — CRITICAL):** permission-approval UI is out of scope for v1. User accepts the "half-feature" critique. Permission UI tracked as the next dashboard feature.
+- **Alternative vehicles (subagent finding #3 — HIGH):** Telegram/ntfy integrations not in scope. User accepts that PWA-install friction gates the feature. Can add as additional channels later.
+- **Unproven premise (subagent finding #2 — HIGH):** proceeding without instrumenting current dashboard usage first. User's call.
+
+---
+
+## Phase 2: Design Review — Findings (all auto-adopted into plan scope)
+
+### Critical (were: missing from plan)
+- **State machine expansion.** Replace the 5-state model with a discriminated union: `{kind: 'off'|'asking'|'subscribing'|'enabled'|'sending-test'|'disabling'|'denied'|'unsupported'|'stale'|'error', error?: string}`. Every button disabled during transient states with inline spinner suffix ("Enabling…"). Without this, double-click race-fires subscribes during the 500ms–3s handshake.
+- **iOS denied vs denied-in-settings branch.** After `requestPermission()` returns `denied`, re-run the standalone check and branch error copy: "Denied — iOS requires adding to Home Screen first" with inline steps vs "Denied — enable notifications for this site in Settings > Safari."
+
+### High
+- **Delivery feedback loop.** `/api/push/test` returns `{delivered: N, failed: N, gone: N}` (not 204). UI shows "Sent to 2 devices. Didn't see it? Check Focus/DND, then try again." Add a "last successful delivery" row mirroring SecuritySettings' `Row` pattern.
+- **Silent-revocation recovery path (stale state).** Permission granted but `getSubscription()` returns null → show warn-tone badge "Reconnection needed" + single Re-enable button. Poll `/api/push/subscriptions/mine` on SettingsView mount.
+- **Platform-gated iOS help.** `<details>` disclosure "How to enable on iPhone" shown only when `state === 'unsupported' && isIOSSafari`. Numbered `<ol>` with Share-icon glyph inline. Desktop sees nothing.
+
+### Medium
+- **Visual language match.** Reuse `Row` and `Badge` components from `SecuritySettings.tsx:1-129`. Extract both to a shared `ui/Row.tsx` + `ui/Badge.tsx` (new, DRY — P4). `NotificationSettings` leads with a status Row (`<Badge tone="ok">enabled · 2 devices</Badge>`), actions below.
+- **Enabled-but-undeliverable.** Server tracks last-delivery outcome per subscription. If last ≥3 consecutive attempts failed, show `<Badge tone="warn">enabled · delivery failing</Badge>` + "Diagnose" button that re-runs the test and surfaces the server-side error.
+- **Device list.** `ConnectedDevices.tsx` pattern already exists — small per-subscription list below buttons: `{ua_summary, created_at, [Revoke]}`. Revoke POSTs to `/api/push/unsubscribe` with that endpoint.
+
+### Scope impact
+Design findings add: shared `Row`/`Badge` extraction, expanded state machine, server-side delivery-outcome tracking, device-list UI, stale-state detection + poll endpoint. Revised effort estimate: **5d → 7d CC**.
+
+---
+
+## Phase 3: Eng Review — Findings
+
+### Consensus table `[subagent-only]`
+
+| Dimension | Subagent | Codex | Consensus |
+|---|---|---|---|
+| Architecture sound? | DISAGREE (poll-loop is wrong hook; bus better) | N/A | Flagged → taste decision |
+| Test coverage sufficient? | DISAGREE (no concurrency, no auth-boundary) | N/A | Adopt |
+| Performance risks addressed? | DISAGREE (no per-send timeout, no semaphore) | N/A | Adopt |
+| Security threats covered? | DISAGREE (token-binding underspec; proxy leak) | N/A | Adopt |
+| Error paths handled? | DISAGREE (GC race, VAPID keygen race, dwell+tag) | N/A | Adopt |
+
+### Auto-adopted into plan (completeness, P1 + security, mechanical)
+
+**Push-send robustness (F-E2):** every `WebPushClient::send` wrapped in `tokio::time::timeout(Duration::from_secs(10), ...)`, concurrency capped via a `tokio::sync::Semaphore` with 8 permits. Without these, a single dead FCM endpoint + N subscriptions accumulates leaked tasks at 2s intervals.
+
+**Token-binding spec (F-S1, from CEO finding #4):** each `Subscription` stores `owner_token_hash: [u8; 32]` = SHA-256 of the token used at subscribe time. `auth_middleware` sets a request extension `AuthenticatedTokenHash([u8; 32])` that handlers read. All `/api/push/*` handlers filter to owner-matching rows. `TokenManager::rotate()` iterates stored subscriptions and drops rows whose hash isn't the new-or-grace-period hash. Unsubscribe also requires owner match.
+
+**Proxy leak defense (F-S3):** build `WebPushClient` with `reqwest::Client::builder().no_proxy().build()` injected. Document why in `push.rs` (corporate MITM proxies would otherwise see endpoint URLs).
+
+**VAPID keygen race (F-E6):** acquire exclusive `fs2::FileExt::try_lock_exclusive` on `push.vapid.json.lock` before the generate-and-write sequence. Prevents two concurrent `aoe serve` invocations (dev rapid-restart, daemon SIGHUP recovery) from racing and producing two keypairs.
+
+**GC race with in-flight send (F-E3):** each `Subscription` gets a generation counter. GC path removes only if the current entry's generation matches the value observed at send-start. Simple optimistic lock.
+
+**Dwell + post-send cooldown (F-E1):** dwell (≥5s in Waiting before firing) is not sufficient on its own. Add a post-send cooldown of 60s per session: once a push fires, suppress further sends for that session until it leaves `Waiting`, then returns. `HashMap<InstanceId, LastNotifiedAt>`.
+
+**Test ownership fallback removed (F-T3):** `/api/push/test` requires `{endpoint}` in the body; fires only to that subscription. No "fire to all" fallback — that would let any authenticated caller spam every registered device.
+
+**Service worker `renotify: true` (F-H4):** otherwise iOS silently updates the banner with no buzz/sound when `tag` matches.
+
+**Concurrency + auth-boundary tests (F-T1, F-T2):** two concurrent 410s on the same endpoint; subscribe-during-send race; dwell-during-flicker; subscribe with T1 → rotate to T2 → assert subscription dropped; unsubscribe with wrong-owner endpoint → 403.
+
+**Document threat model + caveats (F-S2, F-H2, F-H3, F-D1):** new `docs/push-notifications.md` covers: endpoint URLs are correlatable by push providers (Apple/Google, acceptable given single-owner threat model), SW activation path (new push handler requires PWA re-open after upgrade), deep-link 401-then-rehydrate path on installed PWA, `web-push` crate caveats (0.10.x pin, feature flags to avoid openssl, consider reqwest+aes-gcm roll-your-own if scope grows).
+
+**Extract PushState from AppState (F-A2):** `AppState` already has 10 fields. New push fields (`vapid`, `subscriptions`, `delivery_outcomes`, `notified_at`) live on a `PushState` owned by a single `AppState.push` field.
+
+### Scope impact
+Eng findings revise effort: **7d → 9–10d CC**. The token-binding plumbing (request extension + middleware propagation + rotate-invalidation) is a day on its own.
+
+---
+
+## Phase 4: Final Approval — Decisions
+
+### Taste decision resolved
+**Option Y adopted: status-change event bus.**
+
+- `AppState` gains a `tokio::sync::broadcast::Sender<StatusChange>` field (channel capacity ~64). `StatusChange = { instance_id, old: Status, new: Status, at: DateTime<Utc> }`.
+- `Instance::update_status_with_metadata` gains a caller-provided `Option<&broadcast::Sender<StatusChange>>` param. When `old != new`, emit. Callers that don't care (TUI-only paths) pass `None`.
+- `status_poll_loop` passes the bus handle.
+- `push.rs` runs a dedicated consumer task that subscribes to the bus, applies dwell + cooldown state, and enqueues sends through the semaphore-bounded worker.
+- Unit tests feed the bus directly, no tmux required.
+
+**Scope impact of the bus:** +~1d CC for the refactor (touches `instance.rs`, TUI callers, storage). Revised total: **10–11d CC.**
+
+### Milestone split (implicit)
+User chose single-PR delivery (option B, not C). The final scope is one ~10-day PR. If it gets unwieldy during implementation, a reviewer can carve out the bus refactor as a prerequisite PR.
+
+### Rejected options
+- **X (poll-loop snapshot diff):** rejected in favor of bus. User prioritized cleaner multi-trigger future and testability without tmux over ~1d of scope.
+
+### Approved scope
+Everything in this plan document, with the bus architecture from Option Y. All auto-adopted findings from all three phases are in scope. Deferred items remain deferred.
+
+---
+
+## Autoplan summary
+- **Dual voices:** `[subagent-only]` throughout (codex unavailable, 401 in this environment).
+- **Phases run:** CEO, Design, Eng. DX skipped (no developer-facing API surface).
+- **User challenges surfaced at premise gate:** 2 (sequencing, alternative vehicles). Both resolved by user choosing Option A (ship as planned).
+- **Taste decisions surfaced at final gate:** 1 (bus vs. poll diff). Resolved by user choosing Option B (bus).
+- **Auto-decided findings:** 21 (completeness + mechanical + security).
+- **Effort estimate evolution:** 3d → 5d → 7d → 9–10d → 10–11d. Each phase added real gaps; each bump is justified in the phase's findings section above.
+- **Status:** APPROVED, ready for `/ship` when implementation is complete.

--- a/docs/plans/web-push-notifications.md
+++ b/docs/plans/web-push-notifications.md
@@ -4,53 +4,98 @@
 
 A user runs `aoe serve --remote` on their dev box and opens the resulting Cloudflare tunnel URL on their phone. They start a Claude Code session in a worktree. Five minutes later, Claude hits a permission prompt or completes a long operation and waits for input.
 
-Today, the user has no way to know this happened unless they are actively looking at the tab. The dashboard has no push notifications, no favicon badge, no tab-title alert, no sound. If the tab isn't the frontmost tab, the agent sits idle indefinitely while the user does other things.
+Today, the user has no way to know this happened unless they are actively looking at the tab. The dashboard has no push notifications, no favicon badge, no tab-title alert, no sound. If the tab is not the frontmost tab, the agent sits idle indefinitely while the user does other things.
 
-This kills the core value proposition of the web dashboard: **remote, asynchronous agent access**. Without notifications, the dashboard is just "SSH with a prettier terminal." With notifications, it becomes "set the agent running, put the phone in your pocket, come back when it pings you."
+This kills the core value proposition of the web dashboard: remote, asynchronous agent access. Without notifications, the dashboard is just "SSH with a prettier terminal." With notifications, it becomes "set the agent running, put the phone in your pocket, come back when it pings you."
 
-Secondary motivation: on iOS, notifications delivered to an installed PWA appear on the Lock Screen. Tapping one unlocks the device and deep-links straight to the right session. That is the lock-screen access path the user asked about. There is no PWA-on-Lock-Screen widget API on iOS (Apple doesn't expose Live Activities or Control Center to web); notifications are the vehicle.
+Secondary motivation: on iOS, notifications delivered to an installed PWA appear on the Lock Screen. Tapping one unlocks the device and deep-links straight to the right session. That is the lock-screen access path the feature delivers. There is no PWA-on-Lock-Screen widget API on iOS (Apple does not expose Live Activities or Control Center to web); notifications are the vehicle.
 
 ## Goal
 
 Deliver Web Push notifications from `aoe serve` to an installed PWA. Minimum viable behavior:
-- On the transition Running → Waiting (agent needs user input), send a push to every subscribed device.
+- On the transition Running to Waiting (agent needs user input), send a push to every subscribed device whose owner matches the current auth token.
 - Notification body shows the session title; tapping the notification opens the PWA deep-linked to that session.
-- User opts in from a Settings toggle inside the PWA; opting in asks for browser permission and registers a Web Push subscription.
+- Two levels of toggle (see Toggleability below).
 - A "Send test notification" button so the user can confirm it works end-to-end before walking away.
 
 Stretch (not in v1):
-- Running → Error and Running → Idle-after-long-run triggers.
+- Running to Error and Running to Idle-after-long-run triggers.
 - Per-session opt-in.
 - Rich notification actions (Approve/Reject from the lock screen). Pairs with the future permission-UI feature.
 - Quiet hours / throttling.
 
 ## Non-goals
 
-- Local-mode (http://) support on iOS. iOS requires HTTPS for push. Tunnel mode already gives HTTPS. Non-iOS browsers that allow push over http://localhost can still work; we won't block it, but we won't test for it either.
+- Local-mode (`http://`) support on iOS. iOS requires HTTPS for push. Tunnel mode already gives HTTPS. Non-iOS browsers that allow push over `http://localhost` can still work; we will not block it, but will not test for it either.
 - Android-specific feature parity. Firefox/Chrome Android should work via standard Web Push; no custom Android plumbing.
-- Replacing the TUI's in-terminal notification mechanism. aoe already has desktop sound alerts and tmux bell; this adds a web-specific channel, doesn't replace them.
+- Replacing the TUI's in-terminal notification mechanism. aoe already has desktop sound alerts and tmux bell; this adds a web-specific channel, it does not replace them.
+
+## Toggleability
+
+Two levels. Both must work.
+
+**Server-level toggle (`web.notifications_enabled`, default true).** A new config field on `WebConfig`, editable in the TUI settings screen per CLAUDE.md convention. When false:
+- `/api/push/*` endpoints return 404 instead of registering subscriptions.
+- The status-change event bus consumer in `push.rs` drops all events (or never starts).
+- The frontend, on fetching `GET /api/push/status`, sees `{enabled: false}` and shows a disabled state in `NotificationSettings` with help text: "Push notifications are disabled by the server. Contact the operator to enable."
+- Existing subscriptions persist but are not sent to. Flipping back to true resumes delivery without user re-opt-in.
+
+Wiring required per CLAUDE.md (`## Settings & Configuration`):
+- Add `FieldKey::WebNotificationsEnabled` in `src/tui/settings/fields.rs`.
+- Add a `SettingField` entry in the matching `build_*_fields()`.
+- Wire `apply_field_to_global()` and `apply_field_to_profile()`.
+- Add a `clear_profile_override()` case in `src/tui/settings/input.rs`.
+- Add the field to `WebConfigOverride` in `profile_config.rs` with merge logic in `merge_configs()`.
+
+**User-level toggle (Settings UI in the dashboard).** The `NotificationSettings` component with states Off, Asking, Subscribing, Enabled, Sending-test, Disabling, Denied, Unsupported, Stale, Error. Primary Enable/Disable buttons, a Send-test button when enabled, a device list with per-device Revoke. Details in "Client side" below.
 
 ## Approach
 
-Standard Web Push over VAPID. Server signs pushes with a VAPID private key; client registers a Service Worker push subscription using the VAPID public key; server POSTs payloads to the push endpoint URLs the browsers vend.
+Standard Web Push over VAPID. Server signs pushes with a VAPID private key; client registers a Service Worker push subscription using the VAPID public key; server POSTs payloads to the push endpoint URLs the browsers vend. Status changes flow through an internal event bus so the detection logic is decoupled from tmux polling and testable without a real tmux.
 
 ### Server side (`src/server/`)
 
-**New module:** `src/server/push.rs`
+**New module:** `src/server/push.rs`, exporting a `PushState` struct that owns VAPID, the subscription store, delivery-outcome tracking, the dwell/cooldown map, and the broadcast-channel consumer task.
 
-- **VAPID keypair:** Generated on first server start, persisted to `$app_dir/push.vapid.json` (same directory as `serve.token`). Permissions 0600, owner-only read. Loaded on every subsequent start. Key is P-256 ECDSA as required by the Web Push spec.
-- **Subscription storage:** Persisted to `$app_dir/push.subscriptions.json`. Entries are `{endpoint, p256dh_key, auth_key, created_at, user_agent}` keyed by endpoint. Loaded on start into a `RwLock<HashMap<String, Subscription>>` in `AppState`. Writes are atomic (write-to-temp + rename).
-- **Garbage collection:** When a send returns 410 Gone (subscription expired) or 404 Not Found, remove the entry and persist. No explicit heartbeat or TTL.
+**New field on `AppState`:** `push: PushState`. (Not individual fields; the Eng review flagged `AppState` as already god-struct-shaped.)
+
+**New event bus:** `AppState.status_tx: broadcast::Sender<StatusChange>` with capacity ~64. `StatusChange = { instance_id, old: Status, new: Status, at: DateTime<Utc> }`. `Instance::update_status_with_metadata` gains a `Option<&broadcast::Sender<StatusChange>>` parameter; when `old != new` it emits. Callers that do not care (TUI-only paths) pass `None`. `status_poll_loop` and any future caller that wants transitions emitted pass the handle.
+
+**VAPID keypair.** Generated on first server start, persisted to `$app_dir/push.vapid.json`. Permissions 0600. Key is P-256 ECDSA. To prevent concurrent `aoe serve` invocations racing (dev restart, daemon SIGHUP recovery path from commit 5494e8b), the generate-and-write sequence acquires an exclusive `fs2::FileExt::try_lock_exclusive` on `push.vapid.json.lock`. If the lock is held, wait briefly and re-read the file rather than generating a second keypair.
+
+**Subscription storage.** Persisted to `$app_dir/push.subscriptions.json`, atomic write (temp+rename). Each `Subscription`:
+
+```rust
+struct Subscription {
+    endpoint: String,           // PushSubscription.endpoint
+    p256dh: String,             // base64url from PushSubscription.toJSON().keys.p256dh
+    auth: String,               // base64url from PushSubscription.toJSON().keys.auth
+    owner_token_hash: [u8; 32], // SHA-256 of the bearer token at subscribe-time
+    user_agent: String,
+    created_at: DateTime<Utc>,
+    generation: u64,            // optimistic-lock counter for GC-during-send
+    last_delivery: Option<DeliveryOutcome>,
+}
+```
+
+Loaded on start into a `RwLock<HashMap<String /* endpoint */, Subscription>>` on `PushState`.
+
+**Token-hash ownership (security).** `auth::auth_middleware` (`src/server/auth.rs:196`) sets a request extension `AuthenticatedTokenHash([u8; 32])` after validating the bearer token. All `/api/push/*` handlers read this extension and filter the subscription store by `owner_token_hash`. `TokenManager::rotate` (`src/server/mod.rs:110`) iterates subscriptions and drops any whose hash is not the new-or-grace-period hash. Unsubscribe also requires owner match; cross-owner unsubscribe returns 403.
+
+**Garbage collection.** On send, if the response is 410 Gone or 404 Not Found, remove the entry, but only if its `generation` counter matches the value observed at send-start. A concurrent `subscribe` for the same endpoint increments the counter; the stale-GC condition prevents wiping a freshly re-subscribed entry.
+
+**Dwell + post-send cooldown.** Firing requires the session to have been in `Waiting` for at least 5 seconds (`DWELL_MS = 5_000`) to suppress flicker. After a push fires for a session, suppress further pushes until the session leaves `Waiting`, OR 60 seconds have elapsed since the last fire for that session (`COOLDOWN_MS = 60_000`), whichever comes second. Internal state: `HashMap<InstanceId, { waiting_since: Option<Instant>, last_notified: Option<Instant> }>`.
+
+**Push send robustness.** Each send wrapped in `tokio::time::timeout(Duration::from_secs(10), ...)`. Concurrent sends capped via `tokio::sync::Semaphore` with 8 permits. The `WebPushClient` is built with a `reqwest::Client` constructed via `reqwest::Client::builder().no_proxy().build()` to prevent leaking endpoint URLs and payloads through corporate MITM proxies.
 
 **New endpoints:**
-- `GET  /api/push/vapid-public-key` → `{ "public_key": "<base64url>" }`
-- `POST /api/push/subscribe` → body: the browser's `PushSubscription.toJSON()` shape. Stores it. Returns 204.
-- `POST /api/push/unsubscribe` → body: `{ "endpoint": "..." }`. Removes by endpoint. Returns 204.
-- `POST /api/push/test` → fires a one-shot test notification to all of the caller's subscriptions (identified by endpoint match against the request's stored subscriptions, or all subscriptions if we can't narrow it). Returns 204.
+- `GET  /api/push/status` returns `{ enabled: bool }`, gating UI affordances.
+- `GET  /api/push/vapid-public-key` returns `{ public_key: "<base64url>" }`. 404 when disabled.
+- `POST /api/push/subscribe` accepts the browser's `PushSubscription.toJSON()` body, stores it with owner hash. Returns 204. 404 when disabled.
+- `POST /api/push/unsubscribe` accepts `{ endpoint }`, removes only if owner matches. Returns 204 (or 403 on mismatch). 404 when disabled.
+- `POST /api/push/test` accepts `{ endpoint }` (required, no "fire to all" fallback). Fires one push. Returns `{ delivered: u32, failed: u32, gone: u32 }` so the UI can show real outcome, not just a 204.
 
 All endpoints are auth-gated like the rest of `/api/*`.
-
-**Status transition hook:** In the existing `status_poll_loop` (currently refreshes tmux state every 2s), add a per-session `previous_status` map. When a session transitions `Running → Waiting`, enqueue a push send for that session. Send happens on a spawned Tokio task so the poll loop doesn't block on slow push endpoints.
 
 **Push payload shape:**
 ```json
@@ -62,202 +107,160 @@ All endpoints are auth-gated like the rest of `/api/*`.
   "session_id": "<session-id>"
 }
 ```
-The `tag` coalesces repeat notifications for the same session — if Claude waits, gets input, waits again, the second notification replaces the first on the lock screen rather than stacking.
+The `tag` coalesces repeat notifications for the same session, so subsequent pushes replace the prior banner rather than stacking. The service worker passes `renotify: true` to `showNotification`; without it, iOS silently updates the existing banner with no buzz or sound.
 
-**Crate choice:** `web-push = "0.10"` for signing and sending. It handles VAPID JWT construction and AES-128-GCM payload encryption. Mature crate, low dependency weight.
+**Crate choice.** `web-push = "0.10"` with `default-features = false` and pure-Rust crypto features only (avoids transitive `openssl`). The crate handles VAPID JWT construction and AES-128-GCM payload encryption. Roll-your-own alternative (`reqwest` + manual JWT + `aes-gcm`) is ~200 lines; acceptable if the crate's maintenance slows.
 
 ### Client side (`web/`)
 
 **Extend `public/sw.js`:**
-Current `sw.js` has install/activate only and no fetch handler. Add:
-- `push` event listener: parses the payload, calls `self.registration.showNotification(title, { body, tag, data: { url } })`.
-- `notificationclick` event listener: closes the notification, calls `clients.openWindow(event.notification.data.url)` after checking for an already-open PWA window that matches.
+- `push` event listener: parses the JSON payload, calls `self.registration.showNotification(title, { body, tag, renotify: true, data: { url } })`.
+- `notificationclick` event listener: closes the notification, searches `clients.matchAll({ type: 'window' })` for an already-open PWA window and focuses it (navigating to `url` if different), else `clients.openWindow(url)`.
 
-**New component:** `web/src/components/NotificationSettings.tsx`, rendered as a section inside `SettingsView.tsx`.
-- Shows current state: Off / Asking / Enabled / Denied / Unsupported.
-- Primary button: "Enable notifications" (Off → Asking → Enabled flow).
-- Secondary button: "Send test notification" (visible only when Enabled).
-- Disable button: "Turn off notifications" (visible only when Enabled).
-- iOS-specific inline help: "On iPhone, you need to add this dashboard to your Home Screen first. Tap the Share icon in Safari, then 'Add to Home Screen.' Then open the installed app to enable notifications."
-- "Unsupported" state appears on browsers without Push API, or on iOS Safari that isn't running as a PWA. Detection: `'PushManager' in window && navigator.serviceWorker` plus platform heuristic for iOS-not-standalone.
+Known limitation documented in `docs/push-notifications.md`: users who upgrade aoe while the PWA is installed do not get the new handlers until the service worker activates, which happens on next PWA open. First-bug-report preempt: "enable notifications after the PWA has been re-opened once following an upgrade."
 
-**New hook:** `web/src/hooks/usePushSubscription.ts`
-- Reads current state from `Notification.permission` and `ServiceWorkerRegistration.pushManager.getSubscription()`.
-- `enable()`: requests permission, fetches VAPID public key, calls `pushManager.subscribe({ userVisibleOnly: true, applicationServerKey })`, POSTs the subscription to `/api/push/subscribe`.
-- `disable()`: unsubscribes locally, POSTs to `/api/push/unsubscribe`.
-- `sendTest()`: POSTs to `/api/push/test`.
+**New component:** `web/src/components/NotificationSettings.tsx`, rendered as a section inside `SettingsView.tsx`. State modeled as a discriminated union:
 
-**Manifest check:** Audit `web/public/manifest.json` to ensure `display: "standalone"`, `start_url: "/"`, `icons` with 192 and 512 present. Required for iOS to treat it as an installable PWA.
+```ts
+type State =
+  | { kind: 'off' }
+  | { kind: 'asking' }
+  | { kind: 'subscribing' }
+  | { kind: 'enabled'; devices: Device[] }
+  | { kind: 'sending-test' }
+  | { kind: 'disabling' }
+  | { kind: 'denied' }
+  | { kind: 'unsupported'; reason: 'no-api' | 'ios-not-standalone' }
+  | { kind: 'stale' }                    // permission granted but no subscription on server
+  | { kind: 'error'; message: string }
+  | { kind: 'disabled-by-server' };     // /api/push/status returned enabled: false
+```
+
+Transient states (`asking`, `subscribing`, `sending-test`, `disabling`) disable buttons with inline spinner suffix ("Enabling...") so double-clicks cannot race. The `enabled` variant shows a device list reusing the `ConnectedDevices.tsx` pattern; each row has `{user_agent_summary, created_at, Revoke}`. Revoke POSTs to `/api/push/unsubscribe` with that endpoint. Last-delivery-outcome timestamp shown alongside; if the last 3 attempts all failed, show `<Badge tone="warn">enabled, delivery failing</Badge>` and a Diagnose button that re-runs the test and surfaces the server-side error.
+
+**iOS denied-vs-denied-in-settings branch.** After `requestPermission()` returns `denied`, re-run the standalone check. If not standalone, render the `unsupported` variant with an `<ol>` of the Add-to-Home-Screen steps plus the inline Share-icon glyph. If standalone, render `denied` with copy pointing to Settings > Safari > Notifications. The `<ol>` is rendered only in the unsupported variant, so desktop users never see the iOS steps.
+
+**Visual language.** `NotificationSettings` leads with a status Row (tone badge, count of devices) matching `SecuritySettings.tsx:1-129` visually. Extract the shared `Row` and `Badge` primitives to `web/src/components/ui/Row.tsx` and `web/src/components/ui/Badge.tsx` so both sections use the same source.
+
+**New hook:** `web/src/hooks/usePushSubscription.ts`. Reads live state from `Notification.permission` and `ServiceWorkerRegistration.pushManager.getSubscription()`. Provides `enable()`, `disable()`, `sendTest()`, and `refresh()`. `refresh()` also polls `/api/push/status` on mount so `disabled-by-server` is reflected without a page reload.
+
+**Stale-state detection.** If `Notification.permission === 'granted'` and `getSubscription()` is null, the local subscription was revoked by the OS or the server dropped the subscription on token rotation. Render `stale` variant with a single Re-enable button.
+
+**Manifest audit.** `web/public/manifest.json` already has `display: "standalone"`, `start_url: "/"`, `icons` with 192 and 512. No edits required; the plan's earlier "audit required" wording was out of date. Confirmed.
 
 ### Test plan
 
-**Rust side (`cargo test`):**
+**Rust unit tests (`cargo test --features serve`):**
 - VAPID keypair: generate, persist, reload, same key.
+- VAPID keygen lock: two spawned tasks calling the init function concurrently produce one keypair, not two.
 - Subscription storage: add, persist, reload, remove, persist.
-- GC on 410/404: subscription removed from store.
-- Status transition detection: given a sequence of status updates, correct push enqueues.
+- GC race: generation counter prevents wiping a freshly re-subscribed entry when the previous generation returns 410.
+- Token-rotation invalidation: subscribe with T1; call `TokenManager::rotate`; subscription store no longer contains T1-hash-owned entries after grace period.
+- Unsubscribe cross-owner: subscribe as T1, attempt unsubscribe as T2 with same endpoint, expect 403.
+- Dwell + cooldown: feed a `broadcast::Receiver<StatusChange>` a sequence of transitions (Running to Waiting for 3s, back to Running, back to Waiting for 6s); assert exactly one push enqueued.
+- Server-enabled flag off: `/api/push/*` returns 404 even when subscribed; consumer task drains events without sending.
 
-**Frontend (`playwright`):**
-- Settings → Enable button flow (mock permission grant, mock server endpoints, verify subscription posted).
-- Test-notification button posts to `/api/push/test`.
-- iOS-not-standalone heuristic shows "Unsupported" state.
-- Disable button unsubscribes and posts to `/api/push/unsubscribe`.
+**Frontend Playwright (`web/tests/`):**
+- Enable-button flow: mock permission grant + mock server endpoints; verify subscription posted with correct body shape.
+- Transient-state button disable: click Enable, assert button disabled until server ack.
+- Test-notification button: posts to `/api/push/test`, surfaces `{delivered, failed, gone}` in UI.
+- iOS-not-standalone heuristic: emulate iPhone + non-standalone; assert `unsupported` variant with steps.
+- Disable flow: unsubscribes locally, POSTs to `/api/push/unsubscribe`, returns to `off` state.
+- Stale detection: mock `Notification.permission === 'granted'` + `getSubscription() === null`; assert `stale` variant.
+- Disabled-by-server: mock `/api/push/status` returning `{enabled: false}`; assert disabled copy and no Enable button.
 
-**End-to-end (manual, documented in `docs/push-notifications.md`):**
-- Install PWA on iPhone (iOS 16.4+).
-- Open PWA, enable notifications, send test → appears on Lock Screen.
-- Start a Claude session that will hit a permission prompt, put phone on lock screen, observe notification.
-- Tap notification → PWA opens to that session.
+**End-to-end (manual, documented in `docs/push-notifications.md` alongside implementation):**
+- Install the PWA on iPhone (iOS 16.4+) via Safari, Share, Add to Home Screen.
+- Open the installed PWA, enable notifications in Settings, tap Send test; notification appears on the Lock Screen.
+- Start a Claude session that will hit a permission prompt; put the phone on the Lock Screen; observe the notification when Claude waits.
+- Tap the notification; PWA opens and deep-links to the session.
+- Flip `web.notifications_enabled` to false in TUI settings; the PWA's Settings view updates within ~5s via `/api/push/status` poll.
 
-### Effort estimate
+## Effort estimate
 
-Roughly:
-- `push.rs` module + VAPID + storage + endpoints: ~1 day CC
-- Status transition hook in `status_poll_loop`: ~2 hours CC
-- Service worker changes: ~2 hours CC
-- React Settings component + hook: ~half day CC
-- Tests (unit + Playwright): ~half day CC
-- Documentation (docs/push-notifications.md + user-facing help): ~2 hours CC
+~10 to 11 days CC. Rough breakdown:
 
-Total: ~3 days CC. This is a lake, not an ocean.
+| Piece | Effort |
+|---|---|
+| Event bus refactor (`broadcast::Sender<StatusChange>`, wrap `update_status_with_metadata`, thread through all callers) | 1 day |
+| `push.rs` module: VAPID gen+lock, subscription store with generation counters, dwell+cooldown map, semaphore-bounded send, timeout, no-proxy reqwest client | 2 days |
+| Token-hash ownership: `AuthenticatedTokenHash` request extension, propagation, filter on every `/api/push/*` handler, rotate-invalidation | 1 day |
+| 4 API endpoints + `/api/push/status` + auth wiring | 0.5 day |
+| Server config toggle: `web.notifications_enabled`, TUI field wiring (FieldKey, SettingField, apply functions, `WebConfigOverride`, merge logic) | 0.5 day |
+| Service worker: push + notificationclick with `renotify: true` | 0.25 day |
+| React `NotificationSettings` component with 11-variant state machine + device list + iOS branch + stale detection + disabled-by-server | 1.5 days |
+| `usePushSubscription` hook | 0.25 day |
+| Extract shared `Row` and `Badge` primitives | 0.25 day |
+| Rust unit tests (concurrency, token rotation, dwell, keygen lock, disabled flag) | 1 day |
+| Playwright tests (all 7 listed above) | 1 day |
+| Docs (`docs/push-notifications.md`: threat model, iOS install steps, SW activation caveat, crate-choice rationale) | 0.5 day |
+| Buffer for integration surprises and codex review round | 0.5 day |
+
+This is a lake, not an ocean. Natural split if one PR is too large:
+- **Milestone 1 (~5 days):** event bus, `push.rs` core, VAPID, endpoints, token-hash binding, server-enabled flag, SW push handler, minimal Settings toggle, test button. End-to-end loop works.
+- **Milestone 2 (~5 days):** full state machine, delivery-outcome feedback, stale detection, device list, shared primitives, concurrency tests, docs.
 
 ## Files touched
 
-New:
+New files:
 - `src/server/push.rs`
 - `web/src/components/NotificationSettings.tsx`
+- `web/src/components/ui/Row.tsx` (extracted from `SecuritySettings.tsx`)
+- `web/src/components/ui/Badge.tsx` (extracted from `SecuritySettings.tsx`)
 - `web/src/hooks/usePushSubscription.ts`
 - `web/tests/push-notifications.spec.ts`
-- `docs/push-notifications.md`
+- `docs/push-notifications.md` (user-facing docs, separate from this plan)
 
 Modified:
-- `src/server/mod.rs` — add `push` module, `AppState` fields for VAPID/subscriptions, hook push send into `status_poll_loop`, register new routes.
-- `src/server/api.rs` — not touched (push endpoints live in push.rs).
-- `Cargo.toml` — add `web-push = "0.10"`.
-- `web/public/sw.js` — add push + notificationclick handlers.
-- `web/public/manifest.json` — verify PWA installability fields (edit if missing any).
-- `web/src/components/SettingsView.tsx` — render new NotificationSettings section.
-- `docs/cli/reference.md` — regen if CLI changes (it shouldn't).
+- `src/server/mod.rs`: register `push` module, add `AppState.push: PushState` and `AppState.status_tx`, add `/api/push/*` routes.
+- `src/server/auth.rs`: `auth_middleware` sets `AuthenticatedTokenHash` request extension after token validation.
+- `src/session/instance.rs`: `update_status_with_metadata` accepts an optional `&broadcast::Sender<StatusChange>` and emits on `old != new`.
+- `src/session/config.rs` (or wherever `WebConfig` lives): add `notifications_enabled: bool` field defaulting to true.
+- `src/tui/settings/fields.rs`: new `FieldKey`.
+- `src/tui/settings/input.rs`: `clear_profile_override` case.
+- `src/tui/settings/profile_config.rs`: `WebConfigOverride` entry, `merge_configs` logic.
+- (wherever `build_*_fields()` lives): new `SettingField` entry.
+- `Cargo.toml`: `web-push = { version = "0.10", default-features = false, features = ["..."] }` (pick the pure-Rust-crypto set), `fs2`.
+- `web/public/sw.js`: push and notificationclick handlers.
+- `web/src/components/SettingsView.tsx`: render `NotificationSettings` section.
+- `web/src/components/SecuritySettings.tsx`: replace local `Row`/`Badge` with imports from `ui/`.
+- `docs/cli/reference.md`: regenerated via `cargo xtask gen-docs` if any CLI changes land (they should not).
 
-## Open questions for review
+## Deferred (tracked, not dropped)
 
-1. Is `Running → Waiting` the right sole trigger for v1? Or should we ship with Running → Error too (errors are higher-severity)?
-2. Should subscriptions be tied to a device/passphrase identity so one user's "disable" affects only their devices, or is global-per-server fine for v1?
-3. Should we log push sends to the tracing log? Useful for debugging, potential minor privacy concern if logs are shared.
-4. The `web-push` crate is at 0.10, not 1.x — is maturity risk acceptable? Alternatives: reqwest + manual VAPID JWT + aes-gcm crate.
+- **Permission-approval UI from the lock screen** (CEO sequencing critique): next dashboard feature.
+- **Running to Error and Running to Idle triggers**: stretch; adding them motivated the bus architecture.
+- **Telegram/ntfy/email as additional channels**: possible after v1 usage signal.
+- **Per-session opt-in**: stretch; requires `subscription.session_filter: Option<Vec<SessionId>>` and a per-session toggle in the sidebar.
+- **Rich notification actions (Approve/Reject)**: pairs with the future permission-UI feature.
+- **Quiet hours / throttling**: stretch.
+- **Usage instrumentation**: skipped; the premise that remote async use is the dominant workflow is accepted without evidence.
 
----
+## Review history
 
-## Phase 1: CEO Review — Findings
+This plan went through a `/autoplan` pipeline (CEO, Design, Eng). Codex voice was unavailable in the review environment (OpenAI 401). All phases ran `[subagent-only]`. A second pass with working Codex auth before implementation is recommended.
 
-Codex unavailable in this environment (OpenAI auth). Review proceeds `[subagent-only]`.
+**Premise gate (Phase 1, user-decided):** chose Option A, ship Web Push as planned over alternatives Telegram/ntfy, accepting PWA install friction and the "notifications without permission UI" half-feature critique.
 
-### Premise gate: Option A chosen
-User confirmed the plan's premises: Web Push is the right vehicle, notifications-before-permission-UI is the right sequencing, PWA install friction is an acceptable user-base gate. Subagent pushed back on all three; user accepted the risk.
+**Taste gate (Phase 4, user-decided):** chose Option B, event bus over poll-loop snapshot diff. Plus ~1 day for testability and cleaner multi-trigger future.
 
-### CEO findings adopted into the plan
-- **Subscription security (subagent finding #4 — HIGH):** bind subscriptions to the auth token; invalidate all subscriptions on token rotation. Added to Eng scope.
-- **Status-transition flake (subagent finding #5 — MEDIUM):** add a dwell requirement before firing a push (e.g., session must be `Waiting` for ≥5s). Prevents phone buzzes on transient scrape flicker. Added to Eng scope.
-- **Scope estimate (subagent finding #6 — MEDIUM):** revise estimate from 3d CC to 5d CC to absorb token-rotation UX, subscription GC, rate-limiting of push sends, and the dwell mechanism.
+**Auto-adopted findings** (principles P1 completeness + P4 DRY + security/mechanical):
+- Token-hash binding with `AuthenticatedTokenHash` request extension, filter on every handler, rotate-invalidation.
+- Per-send `timeout(10s)` + `Semaphore(8)` concurrency cap + `reqwest::Client::builder().no_proxy()`.
+- `fs2` exclusive lock on VAPID keypair generation.
+- Subscription generation counter to prevent GC race with in-flight send.
+- Dwell (5s) and post-send cooldown (60s per session).
+- `/api/push/test` requires explicit `endpoint`, no "fire to all" fallback (closes spam vector).
+- Service worker `renotify: true`.
+- Delivery-outcome tracking with Diagnose button when last 3 attempts failed.
+- 11-variant state machine (up from the original 5).
+- iOS denied-branch: standalone-check after deny to render correct help.
+- Platform-gated iOS help: steps only render in the `unsupported`+`ios-not-standalone` variant.
+- Shared `Row`/`Badge` extraction to `web/src/components/ui/`.
+- Device list with per-device Revoke.
+- Stale-state detection via `/api/push/status` poll on mount.
+- `PushState` extracted from `AppState` to avoid god-struct.
+- Concurrency + auth-boundary tests added to the Rust suite.
+- Docs covering threat model, iOS install steps, SW-activation-on-upgrade, crate-choice rationale.
 
-### CEO findings deferred
-- **Sequencing (subagent finding #1 — CRITICAL):** permission-approval UI is out of scope for v1. User accepts the "half-feature" critique. Permission UI tracked as the next dashboard feature.
-- **Alternative vehicles (subagent finding #3 — HIGH):** Telegram/ntfy integrations not in scope. User accepts that PWA-install friction gates the feature. Can add as additional channels later.
-- **Unproven premise (subagent finding #2 — HIGH):** proceeding without instrumenting current dashboard usage first. User's call.
-
----
-
-## Phase 2: Design Review — Findings (all auto-adopted into plan scope)
-
-### Critical (were: missing from plan)
-- **State machine expansion.** Replace the 5-state model with a discriminated union: `{kind: 'off'|'asking'|'subscribing'|'enabled'|'sending-test'|'disabling'|'denied'|'unsupported'|'stale'|'error', error?: string}`. Every button disabled during transient states with inline spinner suffix ("Enabling…"). Without this, double-click race-fires subscribes during the 500ms–3s handshake.
-- **iOS denied vs denied-in-settings branch.** After `requestPermission()` returns `denied`, re-run the standalone check and branch error copy: "Denied — iOS requires adding to Home Screen first" with inline steps vs "Denied — enable notifications for this site in Settings > Safari."
-
-### High
-- **Delivery feedback loop.** `/api/push/test` returns `{delivered: N, failed: N, gone: N}` (not 204). UI shows "Sent to 2 devices. Didn't see it? Check Focus/DND, then try again." Add a "last successful delivery" row mirroring SecuritySettings' `Row` pattern.
-- **Silent-revocation recovery path (stale state).** Permission granted but `getSubscription()` returns null → show warn-tone badge "Reconnection needed" + single Re-enable button. Poll `/api/push/subscriptions/mine` on SettingsView mount.
-- **Platform-gated iOS help.** `<details>` disclosure "How to enable on iPhone" shown only when `state === 'unsupported' && isIOSSafari`. Numbered `<ol>` with Share-icon glyph inline. Desktop sees nothing.
-
-### Medium
-- **Visual language match.** Reuse `Row` and `Badge` components from `SecuritySettings.tsx:1-129`. Extract both to a shared `ui/Row.tsx` + `ui/Badge.tsx` (new, DRY — P4). `NotificationSettings` leads with a status Row (`<Badge tone="ok">enabled · 2 devices</Badge>`), actions below.
-- **Enabled-but-undeliverable.** Server tracks last-delivery outcome per subscription. If last ≥3 consecutive attempts failed, show `<Badge tone="warn">enabled · delivery failing</Badge>` + "Diagnose" button that re-runs the test and surfaces the server-side error.
-- **Device list.** `ConnectedDevices.tsx` pattern already exists — small per-subscription list below buttons: `{ua_summary, created_at, [Revoke]}`. Revoke POSTs to `/api/push/unsubscribe` with that endpoint.
-
-### Scope impact
-Design findings add: shared `Row`/`Badge` extraction, expanded state machine, server-side delivery-outcome tracking, device-list UI, stale-state detection + poll endpoint. Revised effort estimate: **5d → 7d CC**.
-
----
-
-## Phase 3: Eng Review — Findings
-
-### Consensus table `[subagent-only]`
-
-| Dimension | Subagent | Codex | Consensus |
-|---|---|---|---|
-| Architecture sound? | DISAGREE (poll-loop is wrong hook; bus better) | N/A | Flagged → taste decision |
-| Test coverage sufficient? | DISAGREE (no concurrency, no auth-boundary) | N/A | Adopt |
-| Performance risks addressed? | DISAGREE (no per-send timeout, no semaphore) | N/A | Adopt |
-| Security threats covered? | DISAGREE (token-binding underspec; proxy leak) | N/A | Adopt |
-| Error paths handled? | DISAGREE (GC race, VAPID keygen race, dwell+tag) | N/A | Adopt |
-
-### Auto-adopted into plan (completeness, P1 + security, mechanical)
-
-**Push-send robustness (F-E2):** every `WebPushClient::send` wrapped in `tokio::time::timeout(Duration::from_secs(10), ...)`, concurrency capped via a `tokio::sync::Semaphore` with 8 permits. Without these, a single dead FCM endpoint + N subscriptions accumulates leaked tasks at 2s intervals.
-
-**Token-binding spec (F-S1, from CEO finding #4):** each `Subscription` stores `owner_token_hash: [u8; 32]` = SHA-256 of the token used at subscribe time. `auth_middleware` sets a request extension `AuthenticatedTokenHash([u8; 32])` that handlers read. All `/api/push/*` handlers filter to owner-matching rows. `TokenManager::rotate()` iterates stored subscriptions and drops rows whose hash isn't the new-or-grace-period hash. Unsubscribe also requires owner match.
-
-**Proxy leak defense (F-S3):** build `WebPushClient` with `reqwest::Client::builder().no_proxy().build()` injected. Document why in `push.rs` (corporate MITM proxies would otherwise see endpoint URLs).
-
-**VAPID keygen race (F-E6):** acquire exclusive `fs2::FileExt::try_lock_exclusive` on `push.vapid.json.lock` before the generate-and-write sequence. Prevents two concurrent `aoe serve` invocations (dev rapid-restart, daemon SIGHUP recovery) from racing and producing two keypairs.
-
-**GC race with in-flight send (F-E3):** each `Subscription` gets a generation counter. GC path removes only if the current entry's generation matches the value observed at send-start. Simple optimistic lock.
-
-**Dwell + post-send cooldown (F-E1):** dwell (≥5s in Waiting before firing) is not sufficient on its own. Add a post-send cooldown of 60s per session: once a push fires, suppress further sends for that session until it leaves `Waiting`, then returns. `HashMap<InstanceId, LastNotifiedAt>`.
-
-**Test ownership fallback removed (F-T3):** `/api/push/test` requires `{endpoint}` in the body; fires only to that subscription. No "fire to all" fallback — that would let any authenticated caller spam every registered device.
-
-**Service worker `renotify: true` (F-H4):** otherwise iOS silently updates the banner with no buzz/sound when `tag` matches.
-
-**Concurrency + auth-boundary tests (F-T1, F-T2):** two concurrent 410s on the same endpoint; subscribe-during-send race; dwell-during-flicker; subscribe with T1 → rotate to T2 → assert subscription dropped; unsubscribe with wrong-owner endpoint → 403.
-
-**Document threat model + caveats (F-S2, F-H2, F-H3, F-D1):** new `docs/push-notifications.md` covers: endpoint URLs are correlatable by push providers (Apple/Google, acceptable given single-owner threat model), SW activation path (new push handler requires PWA re-open after upgrade), deep-link 401-then-rehydrate path on installed PWA, `web-push` crate caveats (0.10.x pin, feature flags to avoid openssl, consider reqwest+aes-gcm roll-your-own if scope grows).
-
-**Extract PushState from AppState (F-A2):** `AppState` already has 10 fields. New push fields (`vapid`, `subscriptions`, `delivery_outcomes`, `notified_at`) live on a `PushState` owned by a single `AppState.push` field.
-
-### Scope impact
-Eng findings revise effort: **7d → 9–10d CC**. The token-binding plumbing (request extension + middleware propagation + rotate-invalidation) is a day on its own.
-
----
-
-## Phase 4: Final Approval — Decisions
-
-### Taste decision resolved
-**Option Y adopted: status-change event bus.**
-
-- `AppState` gains a `tokio::sync::broadcast::Sender<StatusChange>` field (channel capacity ~64). `StatusChange = { instance_id, old: Status, new: Status, at: DateTime<Utc> }`.
-- `Instance::update_status_with_metadata` gains a caller-provided `Option<&broadcast::Sender<StatusChange>>` param. When `old != new`, emit. Callers that don't care (TUI-only paths) pass `None`.
-- `status_poll_loop` passes the bus handle.
-- `push.rs` runs a dedicated consumer task that subscribes to the bus, applies dwell + cooldown state, and enqueues sends through the semaphore-bounded worker.
-- Unit tests feed the bus directly, no tmux required.
-
-**Scope impact of the bus:** +~1d CC for the refactor (touches `instance.rs`, TUI callers, storage). Revised total: **10–11d CC.**
-
-### Milestone split (implicit)
-User chose single-PR delivery (option B, not C). The final scope is one ~10-day PR. If it gets unwieldy during implementation, a reviewer can carve out the bus refactor as a prerequisite PR.
-
-### Rejected options
-- **X (poll-loop snapshot diff):** rejected in favor of bus. User prioritized cleaner multi-trigger future and testability without tmux over ~1d of scope.
-
-### Approved scope
-Everything in this plan document, with the bus architecture from Option Y. All auto-adopted findings from all three phases are in scope. Deferred items remain deferred.
-
----
-
-## Autoplan summary
-- **Dual voices:** `[subagent-only]` throughout (codex unavailable, 401 in this environment).
-- **Phases run:** CEO, Design, Eng. DX skipped (no developer-facing API surface).
-- **User challenges surfaced at premise gate:** 2 (sequencing, alternative vehicles). Both resolved by user choosing Option A (ship as planned).
-- **Taste decisions surfaced at final gate:** 1 (bus vs. poll diff). Resolved by user choosing Option B (bus).
-- **Auto-decided findings:** 21 (completeness + mechanical + security).
-- **Effort estimate evolution:** 3d → 5d → 7d → 9–10d → 10–11d. Each phase added real gaps; each bump is justified in the phase's findings section above.
-- **Status:** APPROVED, ready for `/ship` when implementation is complete.
+**Deferred despite surfacing in review:** the four items listed under "Deferred" above, each with rationale.


### PR DESCRIPTION
## Description

A design doc, not code. Captures the plan for Web Push notifications delivered to the installed PWA so the dashboard can reach users on their iPhone Lock Screen when an agent is waiting for input.

Scope: a new `push.rs` module on the server, VAPID keypair generation and storage, 4 auth-gated endpoints (`/api/push/{vapid-public-key,subscribe,unsubscribe,test}`), a broadcast-channel event bus for session status transitions, a `NotificationSettings` component in the Settings view, and service-worker `push` + `notificationclick` handlers. All driven from the single transition `Running → Waiting` in v1. Effort: ~10–11d CC.

The plan itself was produced through a `/autoplan` review (CEO → Design → Eng). All three review phases, their findings, which were auto-adopted, which were surfaced as user decisions, and the two gate questions you answered are documented in the plan file.

**Two gates answered during review:**
1. **Premise gate:** shipped Web Push (over Telegram/ntfy/email alternatives) and accepted "notifications without permission UI" as the v1 cut.
2. **Taste gate:** chose a broadcast-channel event bus over a poll-loop snapshot diff for status-transition detection (+~1d, buys testability without tmux and a cleaner path to multi-trigger expansion).

**Review caveats noted in the plan:**
- Codex voice was unavailable in the review environment (OpenAI 401). All three phases ran `[subagent-only]`. A second /autoplan pass with working Codex auth before implementation would be a good check.
- The 21 auto-adopted findings are documented but not individually confirmed. Skim the three "Auto-adopted" sections — that's where scope tripled from the original 3d estimate to 10–11d. Each is defensible; each deserves a conscious ack before the first commit.

**Deferred (tracked in the plan):**
- Permission-approval UI from the lock screen (CEO's sequencing critique) — next dashboard feature.
- Running → Error and Running → Idle triggers — stretch list; will motivate expansion of the bus.
- Telegram/ntfy as additional channels — possible after v1 data.

## PR Type

- [x] Documentation
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting (it's a design doc, not code)
- [x] New and existing tests pass (no code changes)
- [x] Documentation was updated where necessary (this IS the documentation)
- [ ] For UI changes: included screenshot or recording — N/A

## Testing

N/A — design doc only. The plan's own "Test plan" section lists the Rust unit tests, Playwright specs, and manual E2E verification the implementation PR will need to include.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context), with an independent Claude subagent providing adversarial review voices for each phase. Codex was unavailable due to auth in this environment.

**Any Additional AI Details you'd like to share:** The plan went through a structured 3-phase review where the assistant surfaced every gate decision to the human maintainer. The final effort estimate (10–11d) is ~3.5x the initial estimate (3d) because each review phase identified real gaps (security binding, state machine completeness, concurrency/timeout hardening, event bus refactor). The expansion trail is documented in the plan itself.

- [x] I am an AI Agent filling out this form (check box if true)