### PR TITLE
fix(web): cap PTY resize at wterm's 256x256 grid

### DIFF
--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -120,6 +120,16 @@ pub async fn terminal_ws(
     }
 }
 
+/// Defence-in-depth cap that mirrors the client-side cap in
+/// `web/src/hooks/useTerminal.ts`. The browser's wterm WASM grid is fixed
+/// at 256x256 (vercel-labs/wterm@0.1.x); resizing the PTY past this lets
+/// the agent draw past wterm's render cap, producing visible corruption.
+/// The client should never send a larger resize, but if a future client
+/// regression slips through, clamp here so the PTY is never larger than
+/// the in-browser grid. Remove when wterm raises or removes the cap.
+const WTERM_MAX_COLS: u16 = 256;
+const WTERM_MAX_ROWS: u16 = 256;
+
 /// Unique client ID counter for primary-client tracking.
 static CLIENT_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
@@ -321,6 +331,8 @@ async fn handle_terminal_ws(
                     if let Ok(control) = serde_json::from_str::<ControlMessage>(&text) {
                         match control {
                             ControlMessage::Resize { cols, rows } if cols > 0 && rows > 0 => {
+                                let cols = cols.min(WTERM_MAX_COLS);
+                                let rows = rows.min(WTERM_MAX_ROWS);
                                 pending_size = Some((cols, rows));
 
                                 let dominated = is_primary_or_vacant(

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -120,7 +120,7 @@ pub async fn terminal_ws(
     }
 }
 
-/// Defence-in-depth cap that mirrors the client-side cap in
+/// Defense-in-depth cap that mirrors the client-side cap in
 /// `web/src/hooks/useTerminal.ts`. The browser's wterm WASM grid is fixed
 /// at 256x256 (vercel-labs/wterm@0.1.x); resizing the PTY past this lets
 /// the agent draw past wterm's render cap, producing visible corruption.

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -39,7 +39,7 @@ const INITIAL_SETTLE_MS = 250;
 // subsequent row and producing visible corruption (overlapping menus,
 // duplicated status bars). Capping the size we send to the PTY keeps the
 // agent's mental model aligned with what wterm will actually render.
-// Filed upstream at vercel-labs/wterm#NN; remove when wterm raises or
+// Filed upstream at vercel-labs/wterm#56; remove when wterm raises or
 // removes the cap.
 const WTERM_MAX_COLS = 256;
 const WTERM_MAX_ROWS = 256;

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -32,6 +32,17 @@ const RESIZE_DEBOUNCE_MS = 50;
 // a small margin. After the first resize lands the debounce drops to
 // RESIZE_DEBOUNCE_MS so live splitter drags still feel responsive.
 const INITIAL_SETTLE_MS = 250;
+// wterm's WASM grid (@wterm/core 0.1.x) is fixed at 256x256 and silently
+// clamps any larger resize. If the host-side PTY is resized past this cap,
+// the agent draws into a viewport bigger than wterm renders: long lines
+// wrap inside wterm but not in the agent's mental model, displacing every
+// subsequent row and producing visible corruption (overlapping menus,
+// duplicated status bars). Capping the size we send to the PTY keeps the
+// agent's mental model aligned with what wterm will actually render.
+// Filed upstream at vercel-labs/wterm#NN; remove when wterm raises or
+// removes the cap.
+const WTERM_MAX_COLS = 256;
+const WTERM_MAX_ROWS = 256;
 
 export interface TerminalState {
   connected: boolean;
@@ -186,16 +197,26 @@ export function useTerminal(
     let lastSentCols = -1;
     let lastSentRows = -1;
     const sendResize = (cols: number, rows: number) => {
+      // Clamp to wterm's render-grid cap before we tell the server. See
+      // WTERM_MAX_COLS comment for the failure mode this prevents.
+      const clampedCols = Math.min(cols, WTERM_MAX_COLS);
+      const clampedRows = Math.min(rows, WTERM_MAX_ROWS);
       if (isInScrollbackRef.current) {
-        pendingResizeRef.current = { cols, rows };
+        pendingResizeRef.current = { cols: clampedCols, rows: clampedRows };
         return;
       }
-      if (cols === lastSentCols && rows === lastSentRows) return;
+      if (clampedCols === lastSentCols && clampedRows === lastSentRows) return;
       const ws = wsRef.current;
       if (ws?.readyState !== WebSocket.OPEN) return;
-      ws.send(JSON.stringify({ type: "resize", cols, rows } as ResizeMessage));
-      lastSentCols = cols;
-      lastSentRows = rows;
+      ws.send(
+        JSON.stringify({
+          type: "resize",
+          cols: clampedCols,
+          rows: clampedRows,
+        } as ResizeMessage),
+      );
+      lastSentCols = clampedCols;
+      lastSentRows = clampedRows;
     };
 
     // Pre-measure cell size and seed the WTerm constructor with the

--- a/web/tests/wterm-grid-cap.spec.ts
+++ b/web/tests/wterm-grid-cap.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
+
+// Regression for #830 / #831. wterm's WASM grid (@wterm/core 0.1.x) is
+// fixed at 256x256 and silently clamps any larger resize. If the host-side
+// PTY is resized past this cap, the agent draws into a viewport bigger
+// than wterm renders: long lines wrap inside wterm but not in the agent's
+// mental model, displacing every subsequent row and producing visible
+// corruption. useTerminal.sendResize must clamp before sending so the
+// PTY size never exceeds wterm's grid.
+
+const WTERM_MAX_COLS = 256;
+const WTERM_MAX_ROWS = 256;
+
+interface ResizeMsg {
+  type: "resize";
+  cols: number;
+  rows: number;
+}
+
+function extractResizes(handle: MockHandle): ResizeMsg[] {
+  const out: ResizeMsg[] = [];
+  for (const msg of handle.wsMessages) {
+    const s = msg.toString("utf8");
+    if (!s.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(s);
+      if (parsed?.type === "resize") out.push(parsed);
+    } catch {
+      // not json
+    }
+  }
+  return out;
+}
+
+async function openSession(page: Page, handle: MockHandle) {
+  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await page
+    .locator(".wterm")
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await expect
+    .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+    .toBeGreaterThan(0);
+}
+
+test.describe("wterm grid cap workaround", () => {
+  // 4000x2400 viewport with the dashboard's default font produces well over
+  // 256 cols (and could exceed 256 rows at small fonts). Without the clamp
+  // the client would forward the unclamped measurement to the server.
+  test.use({ viewport: { width: 4000, height: 2400 }, hasTouch: false });
+
+  test("never sends a resize larger than wterm's 256x256 cap", async ({
+    page,
+  }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page, handle);
+
+    // Match the settle window used by init-resize-storm.spec so all init,
+    // font-swap, and ResizeObserver activity has completed.
+    await page.waitForTimeout(1000);
+
+    const resizes = extractResizes(handle);
+    expect(resizes.length).toBeGreaterThan(0);
+
+    const oversized = resizes.filter(
+      (r) => r.cols > WTERM_MAX_COLS || r.rows > WTERM_MAX_ROWS,
+    );
+    expect(
+      oversized,
+      `Saw ${oversized.length} resize msgs above wterm's ${WTERM_MAX_COLS}x${WTERM_MAX_ROWS} ` +
+        `grid cap. sendResize must clamp before sending so the PTY never ` +
+        `exceeds wterm's render grid. Full sequence: ` +
+        JSON.stringify(resizes),
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
> _Authored by Claude (Anthropic) through a debug session with @njbrake. The original framing of this PR overstated its connection to #830/#831; the description below has been corrected to match what an end-to-end test actually showed (see "Empirical update" section)._

## Description

Defensive workaround for vercel-labs/wterm#56 (the WASM grid is hardcoded to 256×256 and silently clamps any larger resize). Refs #830, #831 — see "Empirical update" for why this is no longer claimed as a fix.

### What changed

- `web/src/hooks/useTerminal.ts`: clamp `cols ≤ 256` and `rows ≤ 256` inside `sendResize` (and the scrollback-pending path) before the WebSocket send. Comment block points at the upstream issue.
- `src/server/ws.rs`: matching server-side clamp on the `Resize` arm as defense-in-depth against future client regressions.
- `web/tests/wterm-grid-cap.spec.ts`: new Playwright regression at a 4000×2400 viewport asserting no resize message exceeds 256 in either dimension.

### What this prevents

When the browser viewport exceeds 256 cols/rows (very wide desktop windows, ~2150+ px wide at default font), the client used to forward the unclamped measurement to the PTY. The agent then drew into a viewport bigger than wterm renders. Lines longer than 256 chars wrapped inside wterm but not in the agent's mental model, displacing every subsequent row. Capping both sides keeps the PTY size aligned with wterm's render grid. The PR removes a class of visible corruption that would otherwise hit any user on a wide monitor.

### Empirical update

I ran an end-to-end test (real `aoe serve` + tmux + claude/codex through the web at 1920×1080 and 3000×1200) and the visible rendering corruption in #830/#831 is **most likely upstream wterm#49** (DEC alternate character set: `\x1b(0` followed by `q` should render as `─`, but wterm renders the literal `q`). That's the conspicuous "qqqqqqq" row you can see at the top of claude's workspace-trust dialog and around every tmux pane border in the e2e screenshots. **PR #832's clamp doesn't fire at typical viewports**: at 1920px the cols compute to ~228, below the cap.

So this PR is defensible as **preventive infrastructure for a real wterm gap, not a fix for the screenshots in #830/#831**. The "Fixes" markers have been removed accordingly.

### Upstream issues filed

- vercel-labs/wterm#54 — wide chars / EAW desync (latent; not exercised by claude/codex through the relay)
- vercel-labs/wterm#55 — mouse modes silently ignored (focus-event part is exercised by claude + codex; mouse-tracking part is latent)
- vercel-labs/wterm#56 — grid cap (this PR's workaround)
- vercel-labs/wterm#57 — synchronized output silently ignored (defended against in the now-closed sibling PR #836; not exercised through tmux)

The conspicuous bug — vercel-labs/wterm#49 (DEC alternate character set) — was filed by another user prior to this investigation and is not addressable on the host side.

The constants `WTERM_MAX_COLS` / `WTERM_MAX_ROWS` reference vercel-labs/wterm#56 in their doc comments and should be removed once wterm raises or removes the cap.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Manual checks run locally:
- `cargo build --features serve` ✓
- `cargo test --features serve --lib server::ws` (10/10 pass) ✓
- `cargo fmt --check` ✓
- `cargo clippy --features serve --no-deps` (no warnings) ✓
- `tsc -b` ✓
- `eslint` on changed files ✓
- End-to-end test against real `aoe serve` + tmux + claude/codex (didn't reproduce #830/#831 corruption with this branch applied; the bug visible at 1920 + 3000 px viewports was wterm#49 / DEC charset, which is upstream-only)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (Anthropic), via Claude Code, in a debug session with @njbrake.

**Any Additional AI Details you'd like to share:**
The investigation read the wterm source (Zig core + DOM TypeScript) to identify the gap, captured real PTY byte streams from claude / codex / cursor-agent with `script(1)` to validate the cause, and ran a real `aoe serve` end-to-end test (after installing tmux in the sandbox) to see what the rendering actually looks like with both candidate workarounds applied. The end-to-end test produced the empirical correction that walked back the original "fix" framing.

- [x] I am an AI Agent filling out this form (check box if true)

Refs #830, #831.