### PR TITLE
docs(agents): warn against `git worktree prune` in sandboxed environments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ Coverage runs on every PR via the merge of Vitest + Playwright LCOVs (see `web/s
 
 - Do not modify git configuration (e.g., `.gitconfig`, `.git/config`, `git config` commands) without explicit user approval.
 - The one exception: adding a new remote to fetch a contributor's fork during PR code review is allowed without asking.
+- **Never run `git worktree prune`**, even to clean up your own temp worktrees. To remove a temp worktree, `rm -rf <path>` is sufficient; leave the stale `.git/worktrees/<name>/` admin entry alone. Sandboxed agents see registered worktrees tagged `prunable` because the host's registered path is unreachable from inside the mount, and `git worktree prune` will destroy the admin metadata of healthy worktrees indiscriminately.
 
 ## Local Data & Configuration Tips
 


### PR DESCRIPTION
## Description

Adds a third bullet to **Git Configuration** in `AGENTS.md` warning agents not to run `git worktree prune`, even when cleaning up their own temporary worktrees.

**Why:** sandboxed agents see worktrees registered against host paths that aren't reachable from inside the sandbox mount; `git worktree list` tags those as `prunable` even though the working tree is healthy. `git worktree prune` then silently destroys the admin metadata for any such entry, including the agent's own current worktree. Hit this today while cleaning up a temp worktree after merging #1372; recovery required manually reconstructing `.git/worktrees/<name>/{HEAD,commondir,gitdir}`.

The new bullet states the rule, the safe alternative (`rm -rf <path>` for temp worktrees, leave the stale admin entry alone), and the underlying reason so future agents understand the failure mode rather than just memorizing a prohibition.

`CLAUDE.md` inherits the change via the existing symlink.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**

Claude drafted the bullet text after running into the failure mode firsthand during a PR review session; substance and decision to add the rule are mine, prose is Claude's.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**What changed:** Added a new safety guideline to the "Git Configuration" section in AGENTS.md (and automatically reflected in CLAUDE.md via existing symlink) warning against running `git worktree prune` in sandboxed environments.

**What was added:** A third bullet point under "Git Configuration" that documents:
- A prohibition on running `git worktree prune` from sandboxed agents
- The root cause: sandboxes can see git worktrees registered to unreachable host paths, which `git worktree list` marks as prunable
- The danger: running `git worktree prune` removes admin metadata for these "prunable" entries, including healthy worktrees and even the agent's own current worktree
- The safe workaround: remove temporary worktrees using `rm -rf <path>` instead, leaving stale admin entries in place
- Real-world impact: documents an actual incident where manual reconstruction of `.git/worktrees/<name>/{HEAD,commondir,gitdir}` was required to recover from this failure mode

**Lines changed:** +1 (one new bullet point)

## Benefits

Prevents agents from inadvertently destroying their own worktrees or unrelated working directories when attempting routine cleanup of temporary worktrees in sandboxed environments. Captures operational knowledge from a real incident to guide future agent behavior.

**Note:** This is documentation-only; no code changes are included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->