### PR TITLE
feat: add declarative branch transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ website/src/pages/docs/development/internals/*.md
 web/coverage/
 web/playwright-report/
 web/playwright-live-report/
+
+# Claude Code session context (local only)
+.claude-context/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 name = "aoe-plugin-api"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "semver",
  "serde",
  "serde_json",

--- a/aoe-plugin-api/Cargo.toml
+++ b/aoe-plugin-api/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["aoe", "agent-of-empires", "plugin"]
 categories = ["development-tools"]
 
 [dependencies]
+regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -3,13 +3,14 @@
 //! This crate is the stable surface a plugin author (and the in-tree host)
 //! compiles against: the `aoe-plugin.toml` manifest schema, the capability
 //! taxonomy, and the validation rules that gate a manifest before it loads.
-//! The contribution sections (capabilities, commands, keybinds, settings,
-//! themes, ui, runtime worker) are defined here. Settings and themes are
-//! consumed by the Tier 0 registries (#2094); keybinds/commands resolve and
-//! graft at Tier 0 but execute only with the runtime host (#2095); ui slots
-//! land with #2366; the status section's consumer is the status reference
-//! plugin (#2096). Panes are not a manifest section: they ship as a `ui` slot
-//! kind (#2432). See `docs/development/internals/plugin-system.md`.
+//! The contribution sections (capabilities, branch transforms, commands,
+//! keybinds, settings, themes, ui, runtime worker) are defined here. Settings
+//! and themes are consumed by the Tier 0 registries (#2094);
+//! keybinds/commands resolve and graft at Tier 0 but execute only with the
+//! runtime host (#2095); ui slots land with #2366; the status section's
+//! consumer is the status reference plugin (#2096). Panes are not a manifest
+//! section: they ship as a `ui` slot kind (#2432). See
+//! `docs/development/internals/plugin-system.md`.
 
 mod capability;
 mod id;
@@ -18,10 +19,11 @@ mod manifest;
 pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
-    lucide_icon_name_ok, screenshot_path_ok, BuildStep, ClientAction, CommandContribution,
-    KeybindContribution, ManifestError, PluginManifest, RuntimeSpec, Screenshot,
-    SettingContribution, SettingType, StatusContribution, ThemeContribution, UiContribution,
-    UiSlot, MAX_SCREENSHOTS,
+    lucide_icon_name_ok, screenshot_path_ok, BranchTransformContribution, BuildStep, ClientAction,
+    CommandContribution, KeybindContribution, ManifestError, PluginManifest, RuntimeSpec,
+    Screenshot, SettingContribution, SettingType, StatusContribution, ThemeContribution,
+    UiContribution, UiSlot, MAX_BRANCH_TRANSFORMS, MAX_BRANCH_TRANSFORM_PATTERN_BYTES,
+    MAX_BRANCH_TRANSFORM_REPLACEMENT_BYTES, MAX_SCREENSHOTS,
 };
 
 /// Version of the manifest schema and host API this crate describes.
@@ -35,5 +37,6 @@ pub use manifest::{
 /// presentation metadata was added; 6 when a command could declare a
 /// client-executed `action` (`ClientAction`); 7 when `icon` and `icon_asset`
 /// identity metadata were added; 8 when plugins could contribute composer
-/// actions.
-pub const API_VERSION: u32 = 8;
+/// actions; 9 when plugins could contribute transforms for core-derived
+/// worktree branches.
+pub const API_VERSION: u32 = 9;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -53,6 +54,13 @@ pub struct PluginManifest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub capabilities: Vec<CapabilityId>,
 
+    /// Ordered regex replacements for the worktree branch that core derives
+    /// during initial session creation. Rust regex capture expansion is used in
+    /// each replacement. Explicitly supplied branches bypass these rules in the
+    /// host layer. Requires `api_version >= 9`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub branch_transforms: Vec<BranchTransformContribution>,
+
     /// Commands the plugin contributes (palette / CLI). Consumed by #2366.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub commands: Vec<CommandContribution>,
@@ -105,6 +113,28 @@ pub struct PluginManifest {
     /// `api_version >= 4`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aoe_version: Option<String>,
+}
+
+/// Maximum branch transform rules a manifest may declare.
+pub const MAX_BRANCH_TRANSFORMS: usize = 32;
+
+/// Maximum UTF-8 byte length of a branch transform regex pattern.
+pub const MAX_BRANCH_TRANSFORM_PATTERN_BYTES: usize = 4096;
+
+/// Maximum UTF-8 byte length of a branch transform replacement.
+pub const MAX_BRANCH_TRANSFORM_REPLACEMENT_BYTES: usize = 4096;
+
+/// An ordered regex replacement applied to the worktree branch that core
+/// derives during initial session creation. `replacement` follows Rust regex
+/// capture expansion, including `$1` and `${name}`. Explicitly supplied
+/// branches bypass branch transforms in the host layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BranchTransformContribution {
+    /// Rust regex matched against the current core-derived branch value.
+    pub pattern: String,
+    /// Replacement template expanded from the regex captures.
+    pub replacement: String,
 }
 
 /// A command the plugin contributes. The host namespaces it as
@@ -561,6 +591,49 @@ impl PluginManifest {
         check(!self.version.is_empty(), "version must not be empty".into());
         check(!self.name.is_empty(), "name must not be empty".into());
 
+        check(
+            self.branch_transforms.len() <= MAX_BRANCH_TRANSFORMS,
+            format!(
+                "at most {MAX_BRANCH_TRANSFORMS} branch transforms are allowed (got {})",
+                self.branch_transforms.len()
+            ),
+        );
+        for (i, transform) in self.branch_transforms.iter().enumerate() {
+            check(
+                !transform.pattern.is_empty(),
+                format!("branch_transforms[{i}].pattern must not be empty"),
+            );
+            check(
+                transform.pattern.len() <= MAX_BRANCH_TRANSFORM_PATTERN_BYTES,
+                format!(
+                    "branch_transforms[{i}].pattern must be at most \
+                     {MAX_BRANCH_TRANSFORM_PATTERN_BYTES} bytes (got {})",
+                    transform.pattern.len()
+                ),
+            );
+            check(
+                transform.replacement.len() <= MAX_BRANCH_TRANSFORM_REPLACEMENT_BYTES,
+                format!(
+                    "branch_transforms[{i}].replacement must be at most \
+                     {MAX_BRANCH_TRANSFORM_REPLACEMENT_BYTES} bytes (got {})",
+                    transform.replacement.len()
+                ),
+            );
+            if !transform.pattern.is_empty()
+                && transform.pattern.len() <= MAX_BRANCH_TRANSFORM_PATTERN_BYTES
+            {
+                if let Err(error) = Regex::new(&transform.pattern) {
+                    check(
+                        false,
+                        format!(
+                            "branch_transforms[{i}].pattern {:?} is not a valid Rust regex: {error}",
+                            transform.pattern
+                        ),
+                    );
+                }
+            }
+        }
+
         if let Some(RuntimeSpec::Command {
             command,
             system,
@@ -839,6 +912,12 @@ impl PluginManifest {
             check(
                 self.ui.iter().all(|u| u.slot != UiSlot::ComposerAction),
                 "composer-action UI slots require api_version >= 8".into(),
+            );
+        }
+        if self.api_version < 9 {
+            check(
+                self.branch_transforms.is_empty(),
+                "branch_transforms require api_version >= 9".into(),
             );
         }
         for key in self.setting_defaults.keys() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -1,4 +1,8 @@
-use aoe_plugin_api::{ManifestError, PluginManifest, RuntimeSpec, SettingType, UiSlot};
+use aoe_plugin_api::{
+    BranchTransformContribution, ManifestError, PluginManifest, RuntimeSpec, SettingType, UiSlot,
+    API_VERSION, MAX_BRANCH_TRANSFORMS, MAX_BRANCH_TRANSFORM_PATTERN_BYTES,
+    MAX_BRANCH_TRANSFORM_REPLACEMENT_BYTES,
+};
 
 #[test]
 fn minimal_manifest_parses_and_round_trips() {
@@ -31,6 +35,19 @@ version = "1.0.0"
 api_version = 1
 "#;
     PluginManifest::from_toml_str(toml).expect("api_version 1 stays supported");
+}
+
+#[test]
+fn existing_api_versions_parse_without_branch_transforms() {
+    assert_eq!(API_VERSION, 9);
+    for api_version in 1..API_VERSION {
+        let toml = format!(
+            "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"0.1.0\"\napi_version = {api_version}\n"
+        );
+        let manifest = PluginManifest::from_toml_str(&toml)
+            .unwrap_or_else(|error| panic!("api_version {api_version} should parse: {error}"));
+        assert!(manifest.branch_transforms.is_empty());
+    }
 }
 
 #[test]
@@ -78,6 +95,180 @@ id = "panel"
     assert_eq!(m.settings[0].key, "endpoint");
     assert_eq!(m.settings[0].value_type, SettingType::String);
     assert_eq!(m.ui[0].slot, UiSlot::StatusBar);
+}
+
+#[test]
+fn branch_transforms_parse_and_round_trip() {
+    let toml = r#"
+id = "acme.branch-style"
+name = "Branch Style"
+version = "0.1.0"
+api_version = 9
+
+[[branch_transforms]]
+pattern = '^([^/]+)-(.+)$'
+replacement = '$1/$2'
+"#;
+    let manifest = PluginManifest::from_toml_str(toml).expect("branch transform parses");
+    assert_eq!(
+        manifest.branch_transforms,
+        vec![BranchTransformContribution {
+            pattern: "^([^/]+)-(.+)$".into(),
+            replacement: "$1/$2".into(),
+        }]
+    );
+
+    let serialized = toml::to_string(&manifest).expect("serializes");
+    assert!(serialized.contains("[[branch_transforms]]"));
+    let reparsed = PluginManifest::from_toml_str(&serialized).expect("round-trips");
+    assert_eq!(reparsed.branch_transforms, manifest.branch_transforms);
+}
+
+#[test]
+fn branch_transforms_default_to_empty() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 9
+"#;
+    let manifest = PluginManifest::from_toml_str(toml).expect("manifest parses");
+    assert!(manifest.branch_transforms.is_empty());
+    assert!(!toml::to_string(&manifest)
+        .expect("serializes")
+        .contains("branch_transforms"));
+}
+
+#[test]
+fn branch_transforms_require_api_version_9() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 8
+
+[[branch_transforms]]
+pattern = '-'
+replacement = '/'
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errors) if errors.iter().any(|error| error.contains("branch_transforms require api_version >= 9"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn branch_transform_rejects_empty_pattern() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 9
+
+[[branch_transforms]]
+pattern = ''
+replacement = ''
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errors) if errors.iter().any(|error| error.contains("branch_transforms[0].pattern must not be empty"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn branch_transform_rejects_malformed_pattern() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 9
+
+[[branch_transforms]]
+pattern = '('
+replacement = '$1'
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errors) if errors.iter().any(|error| error.contains("not a valid Rust regex"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn branch_transform_rejects_oversized_pattern() {
+    let pattern = "x".repeat(MAX_BRANCH_TRANSFORM_PATTERN_BYTES + 1);
+    let toml = format!(
+        "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"0.1.0\"\napi_version = 9\n\n\
+         [[branch_transforms]]\npattern = '{pattern}'\nreplacement = ''\n"
+    );
+    let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errors) if errors.iter().any(|error| error.contains("branch_transforms[0].pattern must be at most"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn branch_transform_rejects_oversized_replacement() {
+    let replacement = "x".repeat(MAX_BRANCH_TRANSFORM_REPLACEMENT_BYTES + 1);
+    let toml = format!(
+        "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"0.1.0\"\napi_version = 9\n\n\
+         [[branch_transforms]]\npattern = 'x'\nreplacement = '{replacement}'\n"
+    );
+    let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errors) if errors.iter().any(|error| error.contains("branch_transforms[0].replacement must be at most"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn branch_transform_rejects_too_many_rules() {
+    let rules = (0..=MAX_BRANCH_TRANSFORMS)
+        .map(|_| "[[branch_transforms]]\npattern = 'x'\nreplacement = 'y'\n")
+        .collect::<String>();
+    let toml = format!(
+        "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"0.1.0\"\napi_version = 9\n\n{rules}"
+    );
+    let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errors) if errors.iter().any(|error| error.contains("branch transforms are allowed"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn branch_transform_rejects_unknown_nested_field() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 9
+
+[[branch_transforms]]
+pattern = 'x'
+replacement = 'y'
+enabled = true
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(matches!(err, ManifestError::Parse(_)), "got {err:?}");
+}
+
+#[test]
+fn branch_transform_requires_replacement() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 9
+
+[[branch_transforms]]
+pattern = 'x'
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(matches!(err, ManifestError::Parse(_)), "got {err:?}");
 }
 
 #[test]

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,12 +30,16 @@ dialog, and external orchestrators may call it directly.
 | Field | Notes |
 | --- | --- |
 | `worktree_enabled` | Set `true` to create a managed git worktree even when no explicit branch name is supplied. |
-| `worktree_branch` | Optional explicit branch or worktree name. If omitted while `worktree_enabled` is true, AoE derives a safe branch name from the resolved session title. |
+| `worktree_branch` | Optional explicit branch override. Explicit values bypass plugin transforms. If omitted while `worktree_enabled` is true, AoE derives a safe branch name from the resolved session title and applies the active plugin's transforms. |
 | `create_new_branch` | `true` creates a new branch; `false` attaches to an existing branch. |
 
 For compatibility, callers that only send `worktree_branch` still opt into
 worktree mode. To get title-derived branch names, send `worktree_enabled` as
 `true` and omit `worktree_branch`.
+
+Derived branches are transformed before collision suffixing. The created
+session's response `branch` field is the authoritative final value; clients
+should not attempt to run plugin transforms locally.
 
 **Example**
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -168,7 +168,7 @@ Add a new session
 
 ###### **Options:**
 
-* `-t`, `--title <TITLE>` — Session title (defaults to folder name)
+* `-t`, `--title <TITLE>` — Session title (generated when omitted)
 * `-i`, `--interactive` — Prompt for the session name, mirroring the TUI `n` flow. Shows the generated default; press Enter to accept it. Ignored when --title is given. Requires an interactive terminal
 * `-g`, `--group <GROUP>` — Group path (defaults to parent folder)
 * `-c`, `--cmd <COMMAND>` — Command to run (e.g., 'claude' or any other supported agent)
@@ -176,7 +176,7 @@ Add a new session
 * `-P`, `--parent <PARENT>` — Parent session (creates sub-session, inherits group)
 * `--fork-from <FORK_FROM>` — Fork an existing session: resume its conversation context in a new, independent session that then diverges. Give the source session's id or title. Terminal fork; available for agents that support forking (claude, codex, opencode)
 * `-l`, `--launch` — Launch the session immediately after creating
-* `-w`, `--worktree <WORKTREE_BRANCH>` — Create session in a git worktree for the specified branch
+* `-w`, `--worktree <WORKTREE_BRANCH>` — Create a git worktree; optionally provide an explicit branch override
 * `-b`, `--new-branch` — Create a new branch (use with --worktree)
 * `--base-branch <BASE_BRANCH>` — Branch to base the new worktree branch on (use with --new-branch). Defaults to the repository's default branch. Useful for stacking work on top of an in-flight PR branch, hot-fixing a release branch, or branching off a teammate's branch
 * `-r`, `--repo <EXTRA_REPOS>` — Additional repositories for multi-repo workspace (use with --worktree)
@@ -758,7 +758,7 @@ Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `enable` — Enable a plugin's contributions
 * `disable` — Disable a plugin; its settings stay on disk for re-enabling
 * `install` — Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. With no `@ref`, installs the repo's latest release; an explicit `@ref` installs unverified, un-audited code. Community plugins run at your own risk
-* `update` — Update an installed external plugin from its recorded source. Prompts to re-approve capabilities if the update changes the capability set
+* `update` — Update an installed external plugin from its recorded source. Prompts for approval when capabilities or other trusted behavior changes
 * `uninstall` — Uninstall an external plugin, removing its files and capability grant
 * `hash` — Print the deterministic source tree hash for a plugin directory, the value a maintainer pins in the featured index
 * `discover` — Search GitHub's `aoe-plugin` topic for installable plugins
@@ -822,13 +822,13 @@ Install an external plugin from a `gh:owner/repo[@ref]` slug or a local director
 
 ###### **Options:**
 
-* `--yes` — Grant all requested capabilities without prompting
+* `--yes` — Approve all disclosed plugin behavior without prompting
 
 
 
 ## `aoe plugin update`
 
-Update an installed external plugin from its recorded source. Prompts to re-approve capabilities if the update changes the capability set
+Update an installed external plugin from its recorded source. Prompts for approval when capabilities or other trusted behavior changes
 
 **Usage:** `aoe plugin update <ID>`
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -177,15 +177,15 @@ dependency arrow runs consumer -> substrate):
 ## Contribution schema (#2093)
 
 `PluginManifest` extends past identity to the contribution sections a plugin
-declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a
+declares: `capabilities`, `branch_transforms`, `commands`, `keybinds`, `settings`, `ui`, and a
 `runtime` worker entrypoint. These are the sections the first external plugin
 declares; they are defined in `aoe-plugin-api` and parsed/validated by the
 host, but consumed by later issues (the settings registry in #2094, the runtime
 host in #2095, the command/keybind/UI surfaces in #2366). `api_version` is now
-8 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
+9 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
 became the dockable `pane` slot, 4 for the `status` section and the
 `aoe_version` field, 5 for screenshots, 6 for command actions, 7 for identity
-icons, and 8 for the `composer-action` slot); an older `api_version` manifest
+icons, 8 for the `composer-action` slot, and 9 for branch transforms); an older `api_version` manifest
 still loads as long as it targets no newer field. Unknown top-level keys remain
 a hard parse error
 (`deny_unknown_fields`).
@@ -261,7 +261,7 @@ backup from an interrupted update is recovered on the next install/update.
 
 Web lifecycle jobs: the dashboard (Settings -> Plugins) installs, updates, and
 uninstalls a `gh:` plugin without a terminal. The same disclosure the CLI
-prompts for (capabilities, build commands, UI slots, unverified-source warning)
+prompts for (capabilities, build commands, UI slots, branch transforms, unverified-source warning)
 is returned as structured data and approved in a modal; the host then runs the
 operation as a job whose progress and build output stream to a per-job log file
 under `<plugins_dir>/jobs/<job_id>.log`, which the dashboard tails. Every update
@@ -854,7 +854,7 @@ The opt-in `updates.auto_update_plugins` setting (off by default) runs a sweep a
 TUI and `aoe serve` startup (`plugin::auto_update::spawn_if_enabled`), spawned
 non-blocking so a slow remote never delays startup. It applies only **clean**
 updates, those that need no new consent; any version that changes the capability
-set, build steps, or UI slots is skipped and left for a manual `aoe plugin
+set, build steps, UI slots, or ordered branch transform rules is skipped and left for a manual `aoe plugin
 update` so the new grant is reviewed (`install::ConsentMode::CleanOnlyNonInteractive`).
 A background sweep therefore never grants new capabilities, runs a changed build
 step unattended, or deactivates a working plugin. Applied updates take effect on

--- a/docs/development/writing-plugins.md
+++ b/docs/development/writing-plugins.md
@@ -33,7 +33,7 @@ how to build and launch it:
 id = "dev.example.my-plugin"
 name = "My Plugin"
 version = "0.1.0"
-api_version = 8
+api_version = 9
 aoe_version = ">=1.11.0, <2.0.0"
 description = "What the plugin does."
 
@@ -56,7 +56,7 @@ id = "my_plugin_pane"
 ```
 
 Pick an `id` outside the reserved `aoe.*` and `agent-of-empires.*` namespaces.
-Set `api_version` to the schema version you target (currently `8`) and
+Set `api_version` to the schema version you target (currently `9`) and
 `aoe_version` to the host range you have tested against. Every key is documented
 in the [Plugin API Reference](../plugin-api.md).
 
@@ -68,6 +68,12 @@ needed. Static contributions (commands, keybinds, themes, ui, status) need no
 capability. The user is prompted to grant the exact declared set at install, and
 the grant is pinned to the manifest hash, so an update that widens capabilities
 must be re-approved. Keep the list honest and minimal.
+
+Static `[[branch_transforms]]` rules need no worker capability, but they can
+change every branch AoE derives from a session title. AoE discloses them during
+install and requires fresh approval whenever the ordered rule set changes.
+Explicit branch overrides are never transformed. See the
+[branch transform reference](../plugin-api.md#branch-transforms).
 
 ## The worker
 

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -10,6 +10,7 @@ For workflow guidance, see the [Workflow Guide](workflow.md).
 |---------|-----|-----|
 | Create new branch | Use `-b` flag | Always creates new branch |
 | Use existing branch | Omit `-b` flag | "Attach to existing branch" toggle (TUI: `Ctrl+P`; web: in the session step under the branch field, inside the "Advanced" disclosure) |
+| Derive branch from title | Pass `-w` without a value | Leave Branch override empty |
 | Branch validation | Checks if branch exists | None (always creates) |
 | Pick a base branch | `--base-branch <name>` | `Base` field in `Ctrl+P` overlay |
 
@@ -18,6 +19,9 @@ For workflow guidance, see the [Workflow Guide](workflow.md).
 ```bash
 # Create worktree session (new branch, branched off the repo default)
 aoe add . -w feat/my-feature -b
+
+# Derive the branch from the title, including active plugin transforms
+aoe add . -w -b -t "chore: update deps"
 
 # Create worktree session (new branch, branched off a specific base)
 aoe add . -w hotfix-1 -b --base-branch release-1.2
@@ -58,6 +62,18 @@ wizard's base-branch field. Ties break in favor of `origin` so the
 historical single-remote behavior still applies when there is no
 freshness signal.
 
+With bare `-w`, AoE slugifies the resolved title and applies the active plugin's
+ordered branch transforms before checking for collisions. An explicit value such
+as `-w feat/my-feature` bypasses transforms. This distinction is shared by the
+CLI, TUI, web wizard, and HTTP API. The final branch recorded on the session is
+authoritative; a UI preview cannot account for plugin transforms or a collision
+suffix before creation.
+
+Because `-w` accepts an optional branch value, put the project path before a
+bare `-w`, as in `aoe add /path/to/repo -w -b`. If a value after `-w` looks like
+a project path, AoE rejects the ambiguous command instead of using the current
+directory.
+
 ## TUI Keyboard Shortcuts
 
 | Key | Action |
@@ -68,9 +84,9 @@ freshness signal.
 | `Enter` | Submit and create session |
 | `Esc` | Cancel |
 
-In the TUI, enable the Worktree checkbox to create a new branch and worktree. By default, the worktree name is derived from the session title. Press `Ctrl+P` on the Worktree field to set an explicit `Name`, attach to an existing branch, pick a `Base` branch the new branch is based on (defaults to the repo default), or configure extra repos. `Ctrl+P` on the `Base` field opens a branch picker over local and remote-tracking branches.
+In the TUI, enable the Worktree checkbox to create a new branch and worktree. By default, the branch is derived from the session title. Press `Ctrl+P` on the Worktree field to set an explicit `Branch override`, attach to an existing branch, pick a `Base` branch the new branch is based on (defaults to the repo default), or configure extra repos. An explicit override bypasses plugin transforms. `Ctrl+P` on the `Base` field opens a branch picker over local and remote-tracking branches.
 
-The web dashboard's new-session wizard folds the worktree controls behind the single "More options" disclosure, leaving only the project picker, session title, and agent choice visible by default. Inside More options, a "Base branch" disclosure beneath the worktree name input shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same section also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named": when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969 and #1514.
+The web dashboard's new-session wizard folds the worktree controls behind the single "More options" disclosure, leaving only the project picker, session title, and agent choice visible by default. Inside More options, the branch field is a pre-transform preview until edited; editing it creates an explicit override. A "Base branch" disclosure beneath it shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same section also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named": when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969 and #1514.
 
 ## Tying the Title and Worktree Directory
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -19,10 +19,10 @@ A manifest carries two independent version axes.
 
 | Key | Meaning |
 |---|---|
-| `api_version` | The manifest *schema* version. The current schema is `8`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `api_version` | The manifest *schema* version. The current schema is `9`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, and `9` added branch transforms.
 
 ## Top-level fields
 
@@ -30,7 +30,7 @@ Schema additions by `api_version`: `2` added contributions (commands, keybinds, 
 id = "dev.example.my-plugin"
 name = "My Plugin"
 version = "0.1.0"
-api_version = 8
+api_version = 9
 aoe_version = ">=1.11.0, <2.0.0"
 description = "What the plugin does."
 capabilities = ["runtime.worker"]
@@ -41,12 +41,13 @@ capabilities = ["runtime.worker"]
 | `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
 | `name` | string | yes | Human-readable display name. |
 | `version` | string | yes | Semantic version of the plugin. |
-| `api_version` | integer | yes | Manifest schema version, `1` to `8`. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `9`. |
 | `description` | string | no | Shown in plugin listings. Defaults to empty. |
 | `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
 | `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |
 | `screenshots` | array | no | Up to 8. Requires `api_version >= 5`. See [Screenshots](#screenshots). |
 | `setting_defaults` | table | no | Overrides for core host settings, keyed by canonical path (e.g. `"theme.idle_decay_minutes"`). Resolution is user value, then plugin override, then core default. |
+| `branch_transforms` | array | no | Ordered replacements for title-derived worktree branches. Requires `api_version >= 9`. See [Branch transforms](#branch-transforms). |
 
 ## Plugin id
 
@@ -82,6 +83,34 @@ themes, ui, status) need no capability.
 | `composer.write` | Publishing a host-validated draft edit from a `composer-action` UI-state payload. |
 
 A capability this host version does not recognize is rejected, not granted.
+
+## Branch transforms
+
+Branch transforms are ordered Rust-regex replacements applied when AoE derives a
+worktree branch from a new session title. They are static manifest contributions;
+no worker or runtime capability is required.
+
+```toml
+[[branch_transforms]]
+pattern = "^([^-]+)-(.+)$"
+replacement = "$1/$2"
+```
+
+Each rule replaces only its first match, then passes the result to the next rule
+in manifest order. Replacements support Rust regex captures such as `$1`,
+`${1}`, `$name`, and `${name}`. A manifest may declare at most 32 rules; each
+pattern and replacement is limited to 4096 UTF-8 bytes. The final branch is
+limited to 1024 bytes and must be a valid Git branch name.
+
+Transforms run after core slugifies the title and before collision suffixing.
+For example, `chore: update deps` first becomes `chore-update-deps`, the rule
+above changes it to `chore/update-deps`, and a collision may then produce
+`chore/update-deps-2`. Explicit branch overrides always bypass transforms.
+
+Only one active plugin may contribute branch transforms. If multiple active
+plugins declare them, session creation fails with a conflict instead of choosing
+an implicit precedence. Install consent discloses branch transforms, and any
+addition, removal, edit, or reordering requires fresh approval on update.
 
 ## Commands
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -88,9 +88,10 @@ prompts you once to grant that exact set. Run non-interactively with `--yes` to
 grant without prompting. A capability this version of aoe does not recognize is
 rejected rather than granted; upgrade aoe.
 
-A grant is pinned to the installed manifest. If an update expands what the
-plugin can do (new capabilities, changed build steps or UI slots, a runtime or
-trust change), it must be approved before the new version becomes active. You
+A grant is pinned to the installed manifest. If an update changes trusted
+plugin behavior (new capabilities, changed build steps or UI slots, changed
+branch transforms, or a runtime or trust change), it must be approved before
+the new version becomes active. You
 can approve in a terminal with `aoe plugin update <id>`, or in-app: the web
 dashboard's plugin settings and the TUI plugin manager show an Update action
 that opens an approval popup describing exactly what changed. Declining keeps

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -74,8 +74,11 @@ To work on a new branch with its own directory:
 # CLI
 aoe add . -w feat/my-feature -b
 
+# Or derive the branch from the title
+aoe add . -w -b -t "chore: update deps"
+
 # TUI: press n, enter a title, enable Worktree
-# Optional: press Ctrl+P on Worktree and fill in Name
+# Optional: press Ctrl+P on Worktree and fill in Branch override
 ```
 
 This creates a new git branch, a worktree directory, and a session pointing at it. When you delete the session, AoE offers to clean up the worktree too.

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -10733,7 +10733,6 @@ mod tests {
                 tool_call_id,
                 is_error,
                 content,
-                completed_at: _,
                 ..
             } => {
                 assert_eq!(tool_call_id, "tc-1");

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -16,7 +16,7 @@ pub struct AddArgs {
     /// using `--scratch`.
     path: Option<PathBuf>,
 
-    /// Session title (defaults to folder name)
+    /// Session title (generated when omitted)
     #[arg(short = 't', long)]
     title: Option<String>,
 
@@ -53,9 +53,9 @@ pub struct AddArgs {
     #[arg(short = 'l', long)]
     launch: bool,
 
-    /// Create session in a git worktree for the specified branch
-    #[arg(short = 'w', long = "worktree")]
-    worktree_branch: Option<String>,
+    /// Create a git worktree; optionally provide an explicit branch override
+    #[arg(short = 'w', long = "worktree", num_args = 0..=1)]
+    worktree_branch: Option<Option<String>>,
 
     /// Create a new branch (use with --worktree)
     #[arg(short = 'b', long = "new-branch")]
@@ -156,6 +156,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     if args.interactive && !std::io::stdin().is_terminal() {
         bail!("--interactive requires a terminal; pass --title for non-interactive naming");
     }
+    reject_ambiguous_worktree_path(&args)?;
 
     // Scratch sessions have no project path; the scratch directory is
     // provisioned below once we know the instance id. Reject an
@@ -188,10 +189,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         bail!("Path is not a directory: {}", path.display());
     }
 
-    if (!args.extra_repos.is_empty() || !args.projects.is_empty())
-        && explicit_worktree_branch(&args).is_none()
-    {
-        bail!("--repo/--project requires --worktree to specify a branch\nTip: aoe add /path --project repoB -w branch-name");
+    if (!args.extra_repos.is_empty() || !args.projects.is_empty()) && !worktree_requested(&args) {
+        bail!("--repo/--project requires --worktree\nTip: aoe add /path --project repoB -w branch-name");
     }
 
     let resolved_project_paths: Vec<PathBuf> = if args.projects.is_empty() {
@@ -278,7 +277,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // Fork intent appends. Reject these up front (before any resource creation)
     // rather than launch a fork that can't find its parent. See PR review.
     if args.fork_from.is_some() {
-        if explicit_worktree_branch(&args).is_some() || args.create_branch {
+        if worktree_requested(&args) || args.create_branch {
             bail!(
                 "`--fork-from` cannot be combined with --worktree or --new-branch: a fork must run \
                  in the parent's working directory to resume its conversation."
@@ -399,12 +398,40 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         None
     };
 
-    if let Some(branch_raw) = explicit_worktree_branch(&args) {
+    if worktree_requested(&args) {
         use crate::git::GitWorktree;
         use crate::session::WorktreeInfo;
         use chrono::Utc;
 
-        let branch_owned = builder::git_sanitize_branch_name(branch_raw);
+        let existing_branches: Vec<&str> = instances
+            .iter()
+            .filter_map(|instance| {
+                instance
+                    .worktree_info
+                    .as_ref()
+                    .map(|worktree| worktree.branch.as_str())
+            })
+            .collect();
+        let extra_repo_paths: Vec<String> = all_extra_repos
+            .iter()
+            .map(|repo| repo.to_string_lossy().into_owned())
+            .collect();
+        let taken_branches = builder::collect_taken_branches_for_derived_dedupe(
+            &existing_branches,
+            &path.to_string_lossy(),
+            &extra_repo_paths,
+            true,
+            args.create_branch,
+            false,
+        );
+        let branch_owned = builder::resolve_effective_worktree_branch(
+            true,
+            explicit_worktree_branch(&args),
+            &final_title,
+            args.create_branch,
+            &taken_branches,
+        )?
+        .expect("worktree mode always resolves a branch");
         let branch = branch_owned.as_str();
         let init_submodules = config.worktree.init_submodules && !args.no_submodules;
 
@@ -464,7 +491,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             if !GitWorktree::is_git_repo(&path) {
                 bail!(
                     "Worktree mode requires a git repository, but this path is not one: {}\n\
-                     Tip: omit --worktree-branch to start an in-place session here, \
+                     Tip: omit --worktree to start an in-place session here, \
                      or point at a git repository.",
                     path.display()
                 );
@@ -1240,9 +1267,35 @@ fn resolve_session_title(args: &AddArgs, instances: &[Instance]) -> Result<Strin
 
 fn explicit_worktree_branch(args: &AddArgs) -> Option<&str> {
     args.worktree_branch
-        .as_deref()
+        .as_ref()
+        .and_then(Option::as_deref)
         .map(str::trim)
         .filter(|branch| !branch.is_empty())
+}
+
+fn worktree_requested(args: &AddArgs) -> bool {
+    args.worktree_branch.is_some()
+}
+
+fn reject_ambiguous_worktree_path(args: &AddArgs) -> Result<()> {
+    if args.path.is_some() {
+        return Ok(());
+    }
+    let Some(value) = explicit_worktree_branch(args) else {
+        return Ok(());
+    };
+    let candidate = std::path::Path::new(value);
+    if candidate.is_absolute()
+        || candidate.is_dir()
+        || value.starts_with("./")
+        || value.starts_with("../")
+    {
+        bail!(
+            "ambiguous --worktree value {value:?}: it looks like a project path\n\
+             Put the project path before -w, for example: aoe add <path> -w -b"
+        );
+    }
+    Ok(())
 }
 
 fn prompt_session_title(default_title: &str) -> Result<String> {
@@ -1570,10 +1623,53 @@ fn resolve_sandbox_image(
 
 #[cfg(test)]
 mod tests {
-    use super::{override_launch_binary, resolve_sandbox_image};
+    use super::{
+        explicit_worktree_branch, override_launch_binary, reject_ambiguous_worktree_path,
+        resolve_sandbox_image, worktree_requested, AddArgs,
+    };
     use crate::session::config::SessionConfig;
+    use clap::Parser;
 
     const HARDCODED: &str = "ghcr.io/agent-of-empires/aoe-sandbox:latest";
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        add: AddArgs,
+    }
+
+    #[test]
+    fn worktree_flag_distinguishes_absent_derived_and_explicit_modes() {
+        let absent = TestCli::try_parse_from(["test"]).unwrap().add;
+        assert!(!worktree_requested(&absent));
+        assert_eq!(explicit_worktree_branch(&absent), None);
+
+        let derived = TestCli::try_parse_from(["test", "-w", "-b"]).unwrap().add;
+        assert!(worktree_requested(&derived));
+        assert_eq!(explicit_worktree_branch(&derived), None);
+
+        let explicit = TestCli::try_parse_from(["test", "-w", "feat/auth"])
+            .unwrap()
+            .add;
+        assert!(worktree_requested(&explicit));
+        assert_eq!(explicit_worktree_branch(&explicit), Some("feat/auth"));
+    }
+
+    #[test]
+    fn path_after_optional_worktree_value_is_rejected_as_ambiguous() {
+        let args = TestCli::try_parse_from(["test", "-w", "/tmp/project", "-b"])
+            .unwrap()
+            .add;
+        let error = reject_ambiguous_worktree_path(&args)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("Put the project path before -w"), "{error}");
+
+        let args = TestCli::try_parse_from(["test", "/tmp/project", "-w", "-b"])
+            .unwrap()
+            .add;
+        assert!(reject_ambiguous_worktree_path(&args).is_ok());
+    }
 
     #[test]
     fn override_launch_binary_uses_command_override() {

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -31,12 +31,12 @@ pub enum PluginCommands {
         /// `gh:owner/repo` (latest release) or `gh:owner/repo@ref` (unverified)
         /// or a local directory path
         source: String,
-        /// Grant all requested capabilities without prompting
+        /// Approve all disclosed plugin behavior without prompting
         #[arg(long)]
         yes: bool,
     },
-    /// Update an installed external plugin from its recorded source. Prompts to
-    /// re-approve capabilities if the update changes the capability set.
+    /// Update an installed external plugin from its recorded source. Prompts for
+    /// approval when capabilities or other trusted behavior changes.
     Update {
         /// Plugin id
         id: String,
@@ -146,6 +146,12 @@ fn run_info(id: &str) -> Result<()> {
         for u in &m.ui {
             println!("    - {} ({})", u.slot.as_str(), u.id);
         }
+    }
+    if !m.branch_transforms.is_empty() {
+        println!(
+            "  branch transforms: {} ordered rule(s)",
+            m.branch_transforms.len()
+        );
     }
     if !m.description.is_empty() {
         println!("  about:      {}", m.description);

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -666,7 +666,7 @@ impl GitWorktree {
 
         let t = std::time::Instant::now();
         let output =
-            super::command::run_git(&self.repo_path, ["worktree", "add", path_str, branch])?;
+            super::command::run_git(&self.repo_path, ["worktree", "add", "--", path_str, branch])?;
         let add_elapsed = t.elapsed();
 
         if !output.status.success() {

--- a/src/plugin/contributions.rs
+++ b/src/plugin/contributions.rs
@@ -7,7 +7,192 @@
 
 use std::path::{Component, Path, PathBuf};
 
+use regex::{Captures, Regex};
+
 use super::registry::LoadedPlugin;
+
+pub(crate) const MAX_BRANCH_OUTPUT_BYTES: usize = 1024;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum BranchTransformError {
+    #[error(
+        "multiple active plugins contribute branch transforms: {}",
+        .plugin_ids.join(", ")
+    )]
+    Conflict { plugin_ids: Vec<String> },
+    #[error("plugin `{plugin_id}` branch transform rule {rule_index} has an invalid regex")]
+    InvalidRegex {
+        plugin_id: String,
+        rule_index: usize,
+    },
+    #[error(
+        "plugin `{plugin_id}` branch transform rule {rule_index} produced output over the 1024-byte limit"
+    )]
+    OutputTooLong {
+        plugin_id: String,
+        rule_index: usize,
+    },
+    #[error(
+        "plugin `{plugin_id}` branch transform rule {rule_index} produced an invalid branch name"
+    )]
+    InvalidOutput {
+        plugin_id: String,
+        rule_index: usize,
+    },
+    #[error("resolved worktree branch name is invalid")]
+    InvalidResolvedBranch,
+}
+
+#[derive(Debug)]
+struct CompiledBranchTransform {
+    regex: Regex,
+    replacement: String,
+}
+
+fn capture_len(captures: &Captures<'_>, reference: &str) -> usize {
+    match reference.parse::<usize>() {
+        Ok(index) => captures.get(index),
+        Err(_) => captures.name(reference),
+    }
+    .map_or(0, |matched| matched.as_str().len())
+}
+
+/// Compute regex replacement expansion length without materializing captures.
+/// This mirrors the regex crate's `$name`, `${name}`, `$1`, and `$$` syntax.
+fn expanded_replacement_len(captures: &Captures<'_>, mut replacement: &str) -> usize {
+    let mut len = 0usize;
+    while let Some(dollar) = replacement.as_bytes().iter().position(|byte| *byte == b'$') {
+        len = len.saturating_add(dollar);
+        replacement = &replacement[dollar..];
+
+        if replacement.as_bytes().get(1) == Some(&b'$') {
+            len = len.saturating_add(1);
+            replacement = &replacement[2..];
+            continue;
+        }
+
+        let capture = if replacement.as_bytes().get(1) == Some(&b'{') {
+            replacement[2..]
+                .find('}')
+                .map(|end| (&replacement[2..2 + end], 3 + end))
+        } else {
+            let end = replacement.as_bytes()[1..]
+                .iter()
+                .take_while(|byte| byte.is_ascii_alphanumeric() || **byte == b'_')
+                .count();
+            (end > 0).then(|| (&replacement[1..1 + end], 1 + end))
+        };
+
+        let Some((reference, end)) = capture else {
+            len = len.saturating_add(1);
+            replacement = &replacement[1..];
+            continue;
+        };
+        len = len.saturating_add(capture_len(captures, reference));
+        replacement = &replacement[end..];
+    }
+    len.saturating_add(replacement.len())
+}
+
+fn replace_first_bounded(rule: &CompiledBranchTransform, input: &str) -> Result<String, ()> {
+    let Some(captures) = rule.regex.captures(input) else {
+        return (input.len() <= MAX_BRANCH_OUTPUT_BYTES)
+            .then(|| input.to_string())
+            .ok_or(());
+    };
+    let matched = captures.get(0).expect("capture zero always exists");
+    let output_len = matched
+        .start()
+        .saturating_add(expanded_replacement_len(&captures, &rule.replacement))
+        .saturating_add(input.len() - matched.end());
+    if output_len > MAX_BRANCH_OUTPUT_BYTES {
+        return Err(());
+    }
+
+    let mut output = String::with_capacity(output_len);
+    output.push_str(&input[..matched.start()]);
+    captures.expand(&rule.replacement, &mut output);
+    output.push_str(&input[matched.end()..]);
+    Ok(output)
+}
+
+/// An owned, immutable snapshot of the active branch transform contribution.
+#[derive(Debug, Default)]
+pub(crate) struct BranchTransformPlan {
+    plugin_id: Option<String>,
+    rules: Vec<CompiledBranchTransform>,
+}
+
+impl BranchTransformPlan {
+    pub(crate) fn apply(&self, branch: &str) -> Result<String, BranchTransformError> {
+        let Some(plugin_id) = self.plugin_id.as_deref() else {
+            return Ok(branch.to_string());
+        };
+
+        let mut output = branch.to_string();
+        for (rule_index, rule) in self.rules.iter().enumerate() {
+            output = replace_first_bounded(rule, &output).map_err(|()| {
+                BranchTransformError::OutputTooLong {
+                    plugin_id: plugin_id.to_string(),
+                    rule_index,
+                }
+            })?;
+            if !git2::Branch::name_is_valid(&output).unwrap_or(false) {
+                return Err(BranchTransformError::InvalidOutput {
+                    plugin_id: plugin_id.to_string(),
+                    rule_index,
+                });
+            }
+        }
+        Ok(output)
+    }
+}
+
+/// Build the branch transform plan from loaded plugins. Inactive contributions
+/// are ignored, and one active contributor owns the complete ordered rule set.
+pub(crate) fn branch_transform_plan(
+    plugins: &[LoadedPlugin],
+) -> Result<BranchTransformPlan, BranchTransformError> {
+    let mut contributors: Vec<&LoadedPlugin> = plugins
+        .iter()
+        .filter(|plugin| plugin.active() && !plugin.manifest.branch_transforms.is_empty())
+        .collect();
+
+    if contributors.len() > 1 {
+        let mut plugin_ids: Vec<String> = contributors
+            .iter()
+            .map(|plugin| plugin.id().to_string())
+            .collect();
+        plugin_ids.sort();
+        return Err(BranchTransformError::Conflict { plugin_ids });
+    }
+
+    let Some(plugin) = contributors.pop() else {
+        return Ok(BranchTransformPlan::default());
+    };
+    let rules = plugin
+        .manifest
+        .branch_transforms
+        .iter()
+        .enumerate()
+        .map(|(rule_index, rule)| {
+            Regex::new(&rule.pattern)
+                .map(|regex| CompiledBranchTransform {
+                    regex,
+                    replacement: rule.replacement.clone(),
+                })
+                .map_err(|_| BranchTransformError::InvalidRegex {
+                    plugin_id: plugin.id().to_string(),
+                    rule_index,
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(BranchTransformPlan {
+        plugin_id: Some(plugin.id().to_string()),
+        rules,
+    })
+}
 
 /// Resolve a plugin-relative resource path under the plugin's install
 /// directory, rejecting anything that escapes it (absolute paths, `..`). A
@@ -53,7 +238,9 @@ pub fn active_themes(plugins: &[&LoadedPlugin]) -> Vec<(String, PathBuf)> {
 mod tests {
     use super::*;
     use crate::plugin::registry::ValidationState;
-    use aoe_plugin_api::{PluginManifest, ThemeContribution, TrustLevel};
+    use aoe_plugin_api::{
+        BranchTransformContribution, PluginManifest, ThemeContribution, TrustLevel,
+    };
 
     fn loaded(dir: Option<PathBuf>, themes: Vec<ThemeContribution>) -> LoadedPlugin {
         let mut manifest = PluginManifest::from_toml_str(
@@ -82,6 +269,262 @@ api_version = 2
         ThemeContribution {
             name: name.into(),
             path: path.into(),
+        }
+    }
+
+    fn branch_transform(pattern: &str, replacement: &str) -> BranchTransformContribution {
+        BranchTransformContribution {
+            pattern: pattern.into(),
+            replacement: replacement.into(),
+        }
+    }
+
+    fn loaded_with_branch_transforms(
+        id: &str,
+        transforms: Vec<BranchTransformContribution>,
+        enabled: bool,
+        granted: bool,
+    ) -> LoadedPlugin {
+        let mut manifest = PluginManifest::from_toml_str(&format!(
+            "id = \"{id}\"\nname = \"Branch Style\"\nversion = \"0.1.0\"\napi_version = 9\n"
+        ))
+        .unwrap();
+        manifest.branch_transforms = transforms;
+        LoadedPlugin {
+            manifest,
+            enabled,
+            trust: TrustLevel::Community,
+            validation: ValidationState::Community,
+            source: None,
+            dir: None,
+            manifest_hash: "sha256:x".into(),
+            granted,
+        }
+    }
+
+    #[test]
+    fn branch_transform_replaces_only_first_match() {
+        let plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![branch_transform("-", "/")],
+            true,
+            true,
+        );
+        let plan = branch_transform_plan(&[plugin]).unwrap();
+
+        assert_eq!(
+            plan.apply("chore-update-deps").unwrap(),
+            "chore/update-deps"
+        );
+    }
+
+    #[test]
+    fn branch_transform_nonmatch_is_identity() {
+        let plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![branch_transform("^fix-", "fix/")],
+            true,
+            true,
+        );
+        let plan = branch_transform_plan(&[plugin]).unwrap();
+
+        assert_eq!(
+            plan.apply("chore-update-deps").unwrap(),
+            "chore-update-deps"
+        );
+    }
+
+    #[test]
+    fn branch_transform_preserves_manifest_order_and_expands_captures() {
+        let plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![
+                branch_transform(r"^([^-]+)-(.+)$", "$1/$2"),
+                branch_transform(r"^([^/]+)/update-(.+)$", "${1}/${2}"),
+            ],
+            true,
+            true,
+        );
+        let plan = branch_transform_plan(&[plugin]).unwrap();
+
+        assert_eq!(plan.apply("chore-update-deps").unwrap(), "chore/deps");
+    }
+
+    #[test]
+    fn branch_transform_ignores_disabled_and_ungranted_plugins() {
+        let active = loaded_with_branch_transforms(
+            "acme.active",
+            vec![branch_transform("-", "/")],
+            true,
+            true,
+        );
+        let mut disabled = loaded_with_branch_transforms(
+            "acme.disabled",
+            vec![branch_transform("x", "y")],
+            false,
+            true,
+        );
+        disabled.manifest.branch_transforms[0].pattern = "private-invalid-(".into();
+        let mut ungranted = loaded_with_branch_transforms(
+            "acme.ungranted",
+            vec![branch_transform("x", "y")],
+            true,
+            false,
+        );
+        ungranted.manifest.branch_transforms[0].pattern = "private-invalid-[".into();
+
+        let plan = branch_transform_plan(&[disabled, active, ungranted]).unwrap();
+        assert_eq!(
+            plan.apply("chore-update-deps").unwrap(),
+            "chore/update-deps"
+        );
+    }
+
+    #[test]
+    fn branch_transform_conflict_ids_are_sorted_regardless_of_input_order() {
+        let first = loaded_with_branch_transforms(
+            "acme.alpha",
+            vec![branch_transform("a", "b")],
+            true,
+            true,
+        );
+        let second = loaded_with_branch_transforms(
+            "acme.zulu",
+            vec![branch_transform("a", "b")],
+            true,
+            true,
+        );
+        let reversed = branch_transform_plan(&[second, first]).unwrap_err();
+
+        let first = loaded_with_branch_transforms(
+            "acme.alpha",
+            vec![branch_transform("a", "b")],
+            true,
+            true,
+        );
+        let second = loaded_with_branch_transforms(
+            "acme.zulu",
+            vec![branch_transform("a", "b")],
+            true,
+            true,
+        );
+        let ordered = branch_transform_plan(&[first, second]).unwrap_err();
+
+        assert_eq!(reversed, ordered);
+        assert_eq!(
+            reversed,
+            BranchTransformError::Conflict {
+                plugin_ids: vec!["acme.alpha".into(), "acme.zulu".into()]
+            }
+        );
+    }
+
+    #[test]
+    fn branch_transform_defensively_rejects_invalid_regex_without_leaking_it() {
+        let mut plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![branch_transform("valid", "replacement")],
+            true,
+            true,
+        );
+        plugin.manifest.branch_transforms[0].pattern = "private-invalid-(".into();
+
+        let error = branch_transform_plan(&[plugin]).unwrap_err();
+        assert_eq!(
+            error,
+            BranchTransformError::InvalidRegex {
+                plugin_id: "acme.branch-style".into(),
+                rule_index: 0,
+            }
+        );
+        assert!(!error.to_string().contains("private-invalid"));
+    }
+
+    #[test]
+    fn branch_transform_rejects_invalid_output_without_leaking_it() {
+        let plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![branch_transform("^private-branch$", ".")],
+            true,
+            true,
+        );
+        let plan = branch_transform_plan(&[plugin]).unwrap();
+
+        let error = plan.apply("private-branch").unwrap_err();
+        assert_eq!(
+            error,
+            BranchTransformError::InvalidOutput {
+                plugin_id: "acme.branch-style".into(),
+                rule_index: 0,
+            }
+        );
+        let message = error.to_string();
+        assert!(!message.contains("private-branch"));
+        assert!(!message.contains("^private"));
+    }
+
+    #[test]
+    fn branch_transform_rejects_oversized_output_without_leaking_it() {
+        let plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![branch_transform(
+                "^short$",
+                &"x".repeat(MAX_BRANCH_OUTPUT_BYTES + 1),
+            )],
+            true,
+            true,
+        );
+        let plan = branch_transform_plan(&[plugin]).unwrap();
+
+        let error = plan.apply("short").unwrap_err();
+        assert_eq!(
+            error,
+            BranchTransformError::OutputTooLong {
+                plugin_id: "acme.branch-style".into(),
+                rule_index: 0,
+            }
+        );
+        assert!(!error.to_string().contains(&"x".repeat(64)));
+    }
+
+    #[test]
+    fn branch_transform_bounds_capture_expansion_before_allocation() {
+        let plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![branch_transform(
+                "^(.+)$",
+                &"$1".repeat(MAX_BRANCH_OUTPUT_BYTES),
+            )],
+            true,
+            true,
+        );
+        let plan = branch_transform_plan(&[plugin]).unwrap();
+
+        assert_eq!(
+            plan.apply(&"x".repeat(MAX_BRANCH_OUTPUT_BYTES))
+                .unwrap_err(),
+            BranchTransformError::OutputTooLong {
+                plugin_id: "acme.branch-style".into(),
+                rule_index: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn branch_transform_rejects_reserved_and_option_like_branch_names() {
+        for output in ["HEAD", "-f", "--detach"] {
+            let plugin = loaded_with_branch_transforms(
+                "acme.branch-style",
+                vec![branch_transform("^source$", output)],
+                true,
+                true,
+            );
+            let plan = branch_transform_plan(&[plugin]).unwrap();
+
+            assert!(matches!(
+                plan.apply("source"),
+                Err(BranchTransformError::InvalidOutput { .. })
+            ));
         }
     }
 

--- a/src/plugin/contributions.rs
+++ b/src/plugin/contributions.rs
@@ -511,6 +511,32 @@ api_version = 2
     }
 
     #[test]
+    fn branch_transform_counts_plus_prefixed_numeric_references() {
+        let input = "x".repeat(MAX_BRANCH_OUTPUT_BYTES);
+        let regex = Regex::new("^(.+)$").unwrap();
+        let captures = regex.captures(&input).unwrap();
+        let mut expanded = String::new();
+        captures.expand("${+1}ok", &mut expanded);
+        assert_eq!(expanded, format!("{input}ok"));
+
+        let plugin = loaded_with_branch_transforms(
+            "acme.branch-style",
+            vec![branch_transform("^(.+)$", "${+1}ok")],
+            true,
+            true,
+        );
+        let plan = branch_transform_plan(&[plugin]).unwrap();
+
+        assert_eq!(
+            plan.apply(&input).unwrap_err(),
+            BranchTransformError::OutputTooLong {
+                plugin_id: "acme.branch-style".into(),
+                rule_index: 0,
+            }
+        );
+    }
+
+    #[test]
     fn branch_transform_rejects_reserved_and_option_like_branch_names() {
         for output in ["HEAD", "-f", "--detach"] {
             let plugin = loaded_with_branch_transforms(

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -137,7 +137,7 @@ pub async fn fetch(source: &PluginSource) -> Result<FetchedPlugin> {
     })
 }
 
-fn read_manifest(tree: &Path) -> Result<(PluginManifest, Vec<u8>)> {
+pub(super) fn read_manifest(tree: &Path) -> Result<(PluginManifest, Vec<u8>)> {
     let path = tree.join("aoe-plugin.toml");
     let bytes = std::fs::read(&path)
         .with_context(|| format!("no aoe-plugin.toml at {}", path.display()))?;

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -1,6 +1,7 @@
 //! Plugin enable/disable and external install / update / uninstall.
 
 use std::collections::BTreeSet;
+use std::fmt::Write as _;
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
 use std::process::Stdio;
@@ -8,6 +9,7 @@ use std::process::Stdio;
 use anyhow::{anyhow, bail, Context, Result};
 use aoe_plugin_api::{BuildStep, PluginId, PluginManifest, RuntimeSpec, UiContribution};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::session::{update_config, CapabilityGrant, Config, PluginConfig};
 
@@ -142,8 +144,9 @@ pub enum UpdateOutcome {
     Applied(InstallReport),
     /// A `CleanOnlyNonInteractive` update was skipped because it needs consent;
     /// the prior version stays installed and active. `fingerprint` identifies the
-    /// skipped version so a caller (the auto-update sweep) can compare it to the
-    /// user's recorded dismissal and avoid re-nagging.
+    /// skipped update so a caller (the auto-update sweep) can compare it to the
+    /// user's recorded dismissal and avoid re-nagging. It binds both the
+    /// installed baseline and fetched target.
     Skipped {
         id: String,
         reason: String,
@@ -160,9 +163,9 @@ pub struct UiView {
 
 /// The structured disclosure an in-app (web / TUI) update approval renders. The
 /// same payload the terminal prompt describes, so every surface consents to the
-/// identical change. `fingerprint` pins the exact content the user is approving
-/// (the source tree plus any release-binary asset and the trust class), so
-/// `apply_update` can refuse if the remote moved since this was shown.
+/// identical change. `fingerprint` pins the installed baseline, fetched target,
+/// and consent classification so `apply_update` can refuse if any of them
+/// changed since this was shown.
 #[derive(Debug, Clone, Serialize)]
 pub struct UpdateConsent {
     pub id: String,
@@ -185,7 +188,9 @@ pub struct UpdateConsent {
     pub runtime_change: Option<String>,
     /// The plugin was a verified featured plugin and the update no longer is.
     pub trust_downgrade: bool,
-    /// Content fingerprint of the version being approved.
+    /// The ordered rules that transform title-derived branch names changed.
+    pub branch_transforms_changed: bool,
+    /// Opaque fingerprint of the baseline and update being approved.
     pub fingerprint: String,
     /// Whether declining keeps the current version active (always true for the
     /// in-app path, which never touches the tree on decline).
@@ -264,6 +269,8 @@ pub struct InstallConsent {
     pub ui: Vec<UiView>,
     /// Build commands the plugin will run, unsandboxed, at install time.
     pub build_steps: Vec<String>,
+    /// The plugin can transform branch names AoE derives from session titles.
+    pub uses_branch_transforms: bool,
     /// Content fingerprint of the version being approved.
     pub fingerprint: String,
 }
@@ -377,20 +384,27 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
         bail!("install cancelled; the unverified source was not approved");
     }
     let build = build_steps(&prepared.fetched.manifest);
+    let uses_branch_transforms = !prepared.fetched.manifest.branch_transforms.is_empty();
     let granted = if assume_yes
-        || !install_needs_consent(&prepared.capabilities, build, &prepared.fetched.manifest.ui)
-    {
+        || !install_needs_consent(
+            &prepared.capabilities,
+            build,
+            &prepared.fetched.manifest.ui,
+            uses_branch_transforms,
+        ) {
         true
     } else {
-        confirm_capabilities(
+        confirm_consent(
             &prepared.id,
             &prepared.capabilities,
             &prepared.fetched.manifest.ui,
             build,
+            uses_branch_transforms,
+            "install",
         )?
     };
     if !granted {
-        bail!("install cancelled; no capabilities were granted");
+        bail!("install cancelled; the plugin changes were not approved");
     }
     apply_prepared_install(&prepared, &OperationLog::Inherit)
 }
@@ -426,6 +440,7 @@ pub async fn preview_install(input: &str) -> Result<InstallConsent> {
             .iter()
             .map(|s| s.command.join(" "))
             .collect(),
+        uses_branch_transforms: !p.fetched.manifest.branch_transforms.is_empty(),
         fingerprint: p.fingerprint.clone(),
     })
 }
@@ -491,6 +506,9 @@ struct Prepared {
     /// Content fingerprint of the currently installed version, from the
     /// lockfile; `None` when no lock entry exists.
     prior_fingerprint: Option<String>,
+    /// Hash of the installed manifest bytes, or `None` when the manifest is
+    /// missing. Unlike the lockfile fingerprint, this detects local tampering.
+    prior_manifest_hash: Option<String>,
     /// The installed source ref and resolved commit (from the lockfile), and the
     /// fetched target ref and commit. Drive the changelog assembly in
     /// `preview_update`. `requested_ref` is the source tag/branch (a no-`@ref`
@@ -506,6 +524,7 @@ struct Prepared {
     removed_capabilities: Vec<String>,
     build_changed: bool,
     ui_changed: bool,
+    branch_transforms_changed: bool,
     runtime_change: Option<String>,
     trust_downgrade: bool,
     needs_consent: bool,
@@ -521,10 +540,70 @@ fn fingerprint(tree_hash: &str, asset_sha256: Option<&str>, trust: &str) -> Stri
     format!("{tree_hash}|{}|{trust}", asset_sha256.unwrap_or(""))
 }
 
+/// Fingerprint an update approval as a transition, not just as fetched target
+/// content. Otherwise a preview made against one installed version could be
+/// replayed after another update changed the consent baseline.
+fn update_approval_fingerprint(prepared: &Prepared) -> String {
+    fn part(hasher: &mut Sha256, value: &str) {
+        hasher.update((value.len() as u64).to_be_bytes());
+        hasher.update(value.as_bytes());
+    }
+
+    fn optional_part(hasher: &mut Sha256, value: Option<&str>) {
+        match value {
+            Some(value) => {
+                part(hasher, "present");
+                part(hasher, value);
+            }
+            None => part(hasher, "missing"),
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    part(&mut hasher, "aoe-plugin-update-approval-v1");
+    part(&mut hasher, &prepared.id);
+    part(&mut hasher, &prepared.source_str);
+    optional_part(&mut hasher, prepared.prior_fingerprint.as_deref());
+    optional_part(&mut hasher, prepared.prior_manifest_hash.as_deref());
+    match &prepared.prior_grant {
+        Some(grant) => {
+            part(&mut hasher, "grant");
+            part(&mut hasher, &grant.manifest_hash);
+            part(&mut hasher, &grant.capabilities.len().to_string());
+            for capability in &grant.capabilities {
+                part(&mut hasher, capability);
+            }
+        }
+        None => part(&mut hasher, "no-grant"),
+    }
+    part(&mut hasher, &prepared.from_version);
+    part(&mut hasher, &prepared.fingerprint);
+    part(
+        &mut hasher,
+        if prepared.needs_consent {
+            "consent-required"
+        } else {
+            "safe"
+        },
+    );
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(7 + digest.len() * 2);
+    out.push_str("sha256:");
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn branch_transforms_changed(prior: &PluginManifest, target: &PluginManifest) -> bool {
+    prior.branch_transforms != target.branch_transforms
+}
+
 /// Fetch an installed plugin's recorded source and diff it against what is on
 /// disk, classifying whether the update needs fresh consent. Network-only: it
 /// never touches the installed tree.
 async fn prepare_update(id: &str) -> Result<Prepared> {
+    PluginId::new(id.to_string()).map_err(|e| anyhow!("{e}"))?;
     let config = Config::load()?;
     let plugin_config = config
         .plugins
@@ -535,6 +614,25 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
         .clone()
         .ok_or_else(|| anyhow!("{id} is a builtin plugin; there is nothing to update"))?;
     let prior_grant = plugin_config.grant.clone();
+    let manifest_path = super::plugins_dir()?.join(id).join("aoe-plugin.toml");
+    let prior_manifest_bytes = match std::fs::read(&manifest_path) {
+        Ok(bytes) => Some(bytes),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            return Err(e).with_context(|| format!("reading installed manifest for {id}"));
+        }
+    };
+    let prior_manifest_hash = prior_manifest_bytes
+        .as_deref()
+        .map(PluginManifest::hash_bytes);
+    // Invalid, unsupported, or ID-tampered installed manifests are not trusted
+    // comparison baselines, but the recorded source can still repair them after
+    // the replacement receives fresh consent.
+    let prior_manifest = prior_manifest_bytes
+        .as_deref()
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .and_then(|text| PluginManifest::from_toml_str(text).ok())
+        .filter(|manifest| manifest.id.as_str() == id);
 
     let source = PluginSource::parse(&source_str)?;
     // A no-`@ref` install tracks the release channel: re-resolve the latest
@@ -618,6 +716,20 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
     // manifest while declaring UI slots must re-disclose them: otherwise an
     // update could add dashboard slots the user never saw.
     let ui_changed = manifest_changed && !fetched.manifest.ui.is_empty();
+    // The on-disk manifest is mutable user state, not an approval source. If it
+    // no longer matches the prior grant, conservatively re-disclose transforms
+    // even when its current rules happen to match the fetched target.
+    let prior_manifest_trusted = prior_manifest.is_some()
+        && prior_grant
+            .as_ref()
+            .zip(prior_manifest_hash.as_ref())
+            .is_some_and(|(grant, hash)| grant.manifest_hash == *hash);
+    let branch_transforms_changed = match prior_manifest.as_ref() {
+        Some(prior) if prior_manifest_trusted => {
+            branch_transforms_changed(prior, &fetched.manifest)
+        }
+        _ => true,
+    };
     // A worker that switches between an in-tree command and a downloaded release
     // binary is a meaningful change in auditability, even when capabilities are
     // unchanged; disclose and re-prompt for it.
@@ -641,12 +753,13 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
 
     // Re-prompt when there is something to consent to or disclose: capabilities
     // that changed, a build recipe that could have changed, UI slots on a
-    // changed manifest, a runtime-kind switch, or a trust downgrade. Dropping
-    // all capabilities with no other trigger has nothing to grant, so it still
-    // (re)grants silently.
+    // changed manifest, branch transform changes, a runtime-kind switch, or a
+    // trust downgrade. Dropping all capabilities with no other trigger has
+    // nothing to grant, so it still (re)grants silently.
     let needs_consent = (!capabilities.is_empty() && caps_changed)
         || build_changed
         || ui_changed
+        || branch_transforms_changed
         || runtime_change.is_some()
         || trust_downgrade;
 
@@ -660,6 +773,7 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
         manifest_hash,
         fingerprint,
         prior_fingerprint,
+        prior_manifest_hash,
         prior_requested_ref,
         prior_resolved_commit,
         target_requested_ref,
@@ -670,6 +784,7 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
         removed_capabilities,
         build_changed,
         ui_changed,
+        branch_transforms_changed,
         runtime_change,
         trust_downgrade,
         needs_consent,
@@ -736,14 +851,16 @@ async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcom
             return Ok(UpdateOutcome::Skipped {
                 id: id.to_string(),
                 reason: skip_reason(&prepared),
-                fingerprint: prepared.fingerprint.clone(),
+                fingerprint: update_approval_fingerprint(&prepared),
             });
         }
-        if confirm_capabilities(
+        if confirm_consent(
             id,
             &prepared.capabilities,
             &prepared.fetched.manifest.ui,
             build_steps(&prepared.fetched.manifest),
+            prepared.branch_transforms_changed,
+            "update",
         )? {
             Some(CapabilityGrant {
                 manifest_hash: prepared.manifest_hash.clone(),
@@ -809,7 +926,8 @@ fn consent_of(p: &Prepared, changelog: UpdateChangelog) -> UpdateConsent {
             .collect(),
         runtime_change: p.runtime_change.clone(),
         trust_downgrade: p.trust_downgrade,
-        fingerprint: p.fingerprint.clone(),
+        branch_transforms_changed: p.branch_transforms_changed,
+        fingerprint: update_approval_fingerprint(p),
         stays_active_if_declined: true,
         changelog,
     }
@@ -836,7 +954,8 @@ async fn changelog_of(p: &Prepared) -> UpdateChangelog {
 /// the in-app (web / TUI) "what would this update do" probe. Network-only.
 pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
     let prepared = prepare_update(id).await?;
-    if prepared.prior_fingerprint.as_ref() == Some(&prepared.fingerprint) {
+    if !prepared.needs_consent && prepared.prior_fingerprint.as_ref() == Some(&prepared.fingerprint)
+    {
         return Ok(UpdatePreview::NoUpdate);
     }
     // One best-effort changelog fetch, behind this explicit user-driven preview.
@@ -844,14 +963,15 @@ pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
     if !prepared.needs_consent {
         return Ok(UpdatePreview::SafeUpdate {
             to_version: prepared.fetched.manifest.version.clone(),
-            fingerprint: prepared.fingerprint.clone(),
+            fingerprint: update_approval_fingerprint(&prepared),
             changelog,
         });
     }
+    let approval_fingerprint = update_approval_fingerprint(&prepared);
     let dismissed = Config::load()
         .ok()
         .and_then(|c| c.plugins.get(id).and_then(|p| p.dismissed_update.clone()))
-        == Some(prepared.fingerprint.clone());
+        == Some(approval_fingerprint);
     Ok(UpdatePreview::ConsentRequired {
         consent: Box::new(consent_of(&prepared, changelog)),
         dismissed,
@@ -859,20 +979,20 @@ pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
 }
 
 /// Apply an update that was previewed in-app, granting whatever the fetched
-/// manifest declares. `expected_fingerprint` pins the exact content the user
-/// approved: if the remote moved since the preview, this refuses rather than
-/// silently granting something the user never saw. A capability-expanding update
-/// MUST carry a fingerprint, so approval cannot bypass the stale-preview guard;
-/// a safe update may omit it. Clears any recorded dismissal on success (via
-/// `persist_update`).
+/// manifest declares. `expected_fingerprint` pins the installed baseline,
+/// fetched target, and consent classification the user reviewed. A
+/// consent-needing update MUST carry a fingerprint, so approval cannot bypass
+/// the stale-preview guard; a safe update may omit it. Clears any recorded
+/// dismissal on success (via `persist_update`).
 pub async fn apply_update(
     id: &str,
     expected_fingerprint: Option<String>,
     log: &OperationLog,
 ) -> Result<InstallReport> {
     let prepared = prepare_update(id).await?;
+    let approval_fingerprint = update_approval_fingerprint(&prepared);
     match &expected_fingerprint {
-        Some(expected) if *expected != prepared.fingerprint => {
+        Some(expected) if *expected != approval_fingerprint => {
             bail!(
                 "the available update for {id} changed since it was shown; review it again before approving"
             );
@@ -919,6 +1039,9 @@ fn skip_reason(prepared: &Prepared) -> String {
     }
     if prepared.ui_changed {
         parts.push("UI change");
+    }
+    if prepared.branch_transforms_changed {
+        parts.push("automatic branch naming change");
     }
     if prepared.runtime_change.is_some() {
         parts.push("runtime change");
@@ -1073,7 +1196,7 @@ async fn resolve_source(
 
 /// Confirm an install that is off the audited-release default path (an explicit
 /// ref, or the no-release default-branch fallback). Mirrors
-/// [`confirm_capabilities`]: a non-interactive stdin without `--yes` is an
+/// [`confirm_consent`]: a non-interactive stdin without `--yes` is an
 /// error, not a silent yes. The caller has already printed what is being
 /// installed, so this only states the trust caveat and prompts.
 fn confirm_unverified() -> Result<bool> {
@@ -1159,27 +1282,29 @@ fn install_needs_consent(
     capabilities: &[String],
     build: &[BuildStep],
     ui: &[UiContribution],
+    uses_branch_transforms: bool,
 ) -> bool {
-    !capabilities.is_empty() || !build.is_empty() || !ui.is_empty()
+    !capabilities.is_empty() || !build.is_empty() || !ui.is_empty() || uses_branch_transforms
 }
 
-/// Prompt the user to grant a plugin's capabilities and run any build steps.
+/// Prompt the user to approve a plugin's disclosed behavior and build steps.
 /// Fails on a non-interactive stdin rather than silently granting; the caller
 /// can pass `--yes` there. Build steps are disclosed verbatim because they run
 /// as the user, outside capability enforcement, before the plugin is
 /// registered.
-fn confirm_capabilities(
+fn confirm_consent(
     id: &str,
     capabilities: &[String],
     ui: &[UiContribution],
     build: &[BuildStep],
+    branch_transforms_changed: bool,
+    action: &str,
 ) -> Result<bool> {
     if !io::stdin().is_terminal() {
-        bail!(
-            "{id} requests capabilities [{}]{} but stdin is not a terminal; re-run with --yes to grant them",
-            capabilities.join(", "),
-            if build.is_empty() { "" } else { " and declares build steps" },
-        );
+        if action == "install" {
+            bail!("{id} requires approval but stdin is not a terminal; re-run with --yes to approve the install");
+        }
+        bail!("{id} requires approval but stdin is not a terminal; run the update from a terminal to review it");
     }
     if !capabilities.is_empty() {
         println!("Plugin {id} requests these capabilities:");
@@ -1193,6 +1318,19 @@ fn confirm_capabilities(
         println!("Plugin {id} will add UI elements to these dashboard slots:");
         for u in ui {
             println!("  - {} ({})", u.slot.as_str(), u.id);
+        }
+    }
+    if branch_transforms_changed {
+        if action == "install" {
+            println!(
+                "Plugin {id} can change branch names AoE derives from session titles.\n\
+                 Explicit branch overrides are not transformed."
+            );
+        } else {
+            println!(
+                "Plugin {id}'s automatic branch naming behavior changed.\n\
+                 Title-derived branches may differ; explicit branch overrides are not transformed."
+            );
         }
     }
     if !build.is_empty() {
@@ -1215,7 +1353,7 @@ fn confirm_capabilities(
          plugin is not contained. Build steps run as your user before any capability gate. Only\n\
          install plugins you trust."
     );
-    print!("Grant them and install? [y/N] ");
+    print!("Approve and {action}? [y/N] ");
     io::stdout().flush()?;
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
@@ -1468,7 +1606,7 @@ fn write_lock(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aoe_plugin_api::UiSlot;
+    use aoe_plugin_api::{BranchTransformContribution, UiSlot};
     use serial_test::serial;
     use std::ffi::OsString;
 
@@ -1541,18 +1679,45 @@ mod tests {
     }
 
     #[test]
-    fn install_consent_required_for_caps_build_or_ui() {
+    fn install_consent_required_for_caps_build_ui_or_branch_transforms() {
         // Nothing declared: auto-grant is fine.
-        assert!(!install_needs_consent(&[], &[], &[]));
+        assert!(!install_needs_consent(&[], &[], &[], false));
         // A capability needs a grant.
-        assert!(install_needs_consent(&["net".to_string()], &[], &[]));
+        assert!(install_needs_consent(&["net".to_string()], &[], &[], false));
         // A UI-only plugin must still prompt so the slots are disclosed (#2366):
         // the regression this guards is auto-granting when only `ui` is set.
         assert!(install_needs_consent(
             &[],
             &[],
-            &[ui(UiSlot::StatusBar, "s")]
+            &[ui(UiSlot::StatusBar, "s")],
+            false
         ));
+        assert!(install_needs_consent(&[], &[], &[], true));
+    }
+
+    #[test]
+    fn branch_transform_update_comparison_is_exact_and_ordered() {
+        let rule = |pattern: &str, replacement: &str| BranchTransformContribution {
+            pattern: pattern.to_string(),
+            replacement: replacement.to_string(),
+        };
+        let mut prior = manifest_with_aoe_version(None);
+        prior.branch_transforms = vec![rule("^([^-]+)-(.+)$", "$1/$2"), rule("_", "-")];
+
+        let mut unchanged = manifest_with_aoe_version(None);
+        unchanged.branch_transforms = prior.branch_transforms.clone();
+        assert!(!branch_transforms_changed(&prior, &unchanged));
+
+        let mut changed = manifest_with_aoe_version(None);
+        changed.branch_transforms = vec![rule("^([^-]+)-(.+)$", "${1}/${2}")];
+        assert!(branch_transforms_changed(&prior, &changed));
+
+        let mut reordered = manifest_with_aoe_version(None);
+        reordered.branch_transforms = prior.branch_transforms.iter().cloned().rev().collect();
+        assert!(branch_transforms_changed(&prior, &reordered));
+
+        let removed = manifest_with_aoe_version(None);
+        assert!(branch_transforms_changed(&prior, &removed));
     }
 
     #[tokio::test]

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -190,6 +190,9 @@ pub struct UpdateConsent {
     pub trust_downgrade: bool,
     /// The ordered rules that transform title-derived branch names changed.
     pub branch_transforms_changed: bool,
+    /// The installed manifest is missing or cannot be verified against a valid
+    /// prior grant; applying the update replaces it from the recorded source.
+    pub repairs_untrusted_manifest: bool,
     /// Opaque fingerprint of the baseline and update being approved.
     pub fingerprint: String,
     /// Whether declining keeps the current version active (always true for the
@@ -400,6 +403,7 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
             &prepared.fetched.manifest.ui,
             build,
             uses_branch_transforms,
+            false,
             "install",
         )?
     };
@@ -525,6 +529,7 @@ struct Prepared {
     build_changed: bool,
     ui_changed: bool,
     branch_transforms_changed: bool,
+    repairs_untrusted_manifest: bool,
     runtime_change: Option<String>,
     trust_downgrade: bool,
     needs_consent: bool,
@@ -716,19 +721,20 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
     // manifest while declaring UI slots must re-disclose them: otherwise an
     // update could add dashboard slots the user never saw.
     let ui_changed = manifest_changed && !fetched.manifest.ui.is_empty();
-    // The on-disk manifest is mutable user state, not an approval source. If it
-    // no longer matches the prior grant, conservatively re-disclose transforms
-    // even when its current rules happen to match the fetched target.
+    // The on-disk manifest is mutable user state, not an approval source. A
+    // missing or untrusted manifest needs conservative repair approval, while
+    // branch-transform disclosure remains specific to the fetched behavior.
     let prior_manifest_trusted = prior_manifest.is_some()
         && prior_grant
             .as_ref()
             .zip(prior_manifest_hash.as_ref())
             .is_some_and(|(grant, hash)| grant.manifest_hash == *hash);
+    let repairs_untrusted_manifest = !prior_manifest_trusted;
     let branch_transforms_changed = match prior_manifest.as_ref() {
         Some(prior) if prior_manifest_trusted => {
             branch_transforms_changed(prior, &fetched.manifest)
         }
-        _ => true,
+        _ => !fetched.manifest.branch_transforms.is_empty(),
     };
     // A worker that switches between an in-tree command and a downloaded release
     // binary is a meaningful change in auditability, even when capabilities are
@@ -753,13 +759,15 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
 
     // Re-prompt when there is something to consent to or disclose: capabilities
     // that changed, a build recipe that could have changed, UI slots on a
-    // changed manifest, branch transform changes, a runtime-kind switch, or a
-    // trust downgrade. Dropping all capabilities with no other trigger has
-    // nothing to grant, so it still (re)grants silently.
+    // changed manifest, branch transform changes, an unverifiable installed
+    // manifest, a runtime-kind switch, or a trust downgrade. Dropping all
+    // capabilities with no other trigger has nothing to grant, so it still
+    // (re)grants silently.
     let needs_consent = (!capabilities.is_empty() && caps_changed)
         || build_changed
         || ui_changed
         || branch_transforms_changed
+        || repairs_untrusted_manifest
         || runtime_change.is_some()
         || trust_downgrade;
 
@@ -785,6 +793,7 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
         build_changed,
         ui_changed,
         branch_transforms_changed,
+        repairs_untrusted_manifest,
         runtime_change,
         trust_downgrade,
         needs_consent,
@@ -860,6 +869,7 @@ async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcom
             &prepared.fetched.manifest.ui,
             build_steps(&prepared.fetched.manifest),
             prepared.branch_transforms_changed,
+            prepared.repairs_untrusted_manifest,
             "update",
         )? {
             Some(CapabilityGrant {
@@ -927,6 +937,7 @@ fn consent_of(p: &Prepared, changelog: UpdateChangelog) -> UpdateConsent {
         runtime_change: p.runtime_change.clone(),
         trust_downgrade: p.trust_downgrade,
         branch_transforms_changed: p.branch_transforms_changed,
+        repairs_untrusted_manifest: p.repairs_untrusted_manifest,
         fingerprint: update_approval_fingerprint(p),
         stays_active_if_declined: true,
         changelog,
@@ -1042,6 +1053,9 @@ fn skip_reason(prepared: &Prepared) -> String {
     }
     if prepared.branch_transforms_changed {
         parts.push("automatic branch naming change");
+    }
+    if prepared.repairs_untrusted_manifest {
+        parts.push("installed manifest verification");
     }
     if prepared.runtime_change.is_some() {
         parts.push("runtime change");
@@ -1298,6 +1312,7 @@ fn confirm_consent(
     ui: &[UiContribution],
     build: &[BuildStep],
     branch_transforms_changed: bool,
+    repairs_untrusted_manifest: bool,
     action: &str,
 ) -> Result<bool> {
     if !io::stdin().is_terminal() {
@@ -1332,6 +1347,12 @@ fn confirm_consent(
                  Title-derived branches may differ; explicit branch overrides are not transformed."
             );
         }
+    }
+    if repairs_untrusted_manifest {
+        println!(
+            "Plugin {id}'s installed manifest is missing or cannot be verified against a valid prior approval.\n\
+             This update will replace it from the recorded source."
+        );
     }
     if !build.is_empty() {
         println!(

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -97,6 +97,15 @@ pub fn active_plugin_themes() -> Vec<(String, PathBuf)> {
     contributions::active_themes(&active)
 }
 
+/// Compile an owned branch transform plan from one process-wide registry
+/// snapshot. Loading and applying the plan never observes different plugin
+/// states within one branch resolution.
+pub(crate) fn active_branch_transform_plan(
+) -> Result<contributions::BranchTransformPlan, contributions::BranchTransformError> {
+    let reg = registry();
+    contributions::branch_transform_plan(reg.all())
+}
+
 /// Rebuild the registry from the current on-disk config (after an
 /// enable/disable), so the change is reflected the next time any surface reads
 /// the active set.

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -12,6 +12,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 
 use crate::git::error::GitError;
+use crate::plugin::contributions::BranchTransformError;
 use crate::session::config::SessionConfig;
 use crate::session::{ClaimOp, EnsureReadyError, EnsureReadyOutcome, Instance, Status, Storage};
 
@@ -4991,13 +4992,20 @@ pub async fn create_session(
 /// Pick the client-facing message for a failed session creation.
 ///
 /// The full error is always logged server-side; this only governs what
-/// reaches the browser. We whitelist the well-typed `GitError` variants
+/// reaches the browser. We whitelist well-typed branch-transform errors and
+/// the `GitError` variants
 /// that carry a clear, actionable, credential-free message (a branch name
 /// or a worktree path the user chose) and let everything else fall back to
 /// the generic string. This keeps raw git stderr, libgit2 internals, IO
 /// paths, and arbitrary `bail!` strings off the wire even though the
 /// duplicate-worktree case now surfaces its real message.
 fn public_create_session_error(e: &anyhow::Error) -> String {
+    if let Some(transform_err) = e
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<BranchTransformError>())
+    {
+        return transform_err.to_string();
+    }
     if let Some(git_err) = e.chain().find_map(|c| c.downcast_ref::<GitError>()) {
         match git_err {
             GitError::WorktreeAlreadyExists(_)
@@ -6837,6 +6845,29 @@ mod tests {
         assert_eq!(
             public_create_session_error(&other),
             "Failed to create session"
+        );
+    }
+
+    #[test]
+    fn public_create_session_error_forwards_safe_branch_transform_errors() {
+        let conflict = anyhow::Error::from(BranchTransformError::Conflict {
+            plugin_ids: vec!["acme.alpha".to_string(), "acme.beta".to_string()],
+        })
+        .context("private-title-derived-branch");
+        let message = public_create_session_error(&conflict);
+        assert_eq!(
+            message,
+            "multiple active plugins contribute branch transforms: acme.alpha, acme.beta"
+        );
+        assert!(!message.contains("private-title"));
+
+        let invalid = anyhow::Error::from(BranchTransformError::InvalidOutput {
+            plugin_id: "acme.alpha".to_string(),
+            rule_index: 2,
+        });
+        assert_eq!(
+            public_create_session_error(&invalid),
+            "plugin `acme.alpha` branch transform rule 2 produced an invalid branch name"
         );
     }
 

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -11,6 +11,7 @@ use chrono::Utc;
 use crate::containers;
 use crate::git::error::GitError;
 use crate::git::GitWorktree;
+use crate::plugin::contributions::{BranchTransformError, MAX_BRANCH_OUTPUT_BYTES};
 
 use super::{
     civilizations, Config, Instance, SandboxInfo, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
@@ -459,23 +460,13 @@ pub fn build_instance(
         existing_titles,
         &taken_branches,
     )?;
-    let branch_source = resolve_worktree_branch(
+    let effective_worktree_branch = resolve_effective_worktree_branch(
         params.worktree_enabled,
         params.worktree_branch.as_deref(),
         &final_title,
-    );
-
-    let effective_worktree_branch: Option<String> = match branch_source {
-        None => None,
-        Some(BranchSource::Explicit(name)) => Some(name),
-        Some(BranchSource::Derived(name)) => {
-            if params.create_new_branch {
-                Some(dedupe_branch_name(&name, &taken_branches))
-            } else {
-                Some(name)
-            }
-        }
-    };
+        params.create_new_branch,
+        &taken_branches,
+    )?;
 
     if let Some(branch) = &effective_worktree_branch {
         if !params.extra_repo_paths.is_empty() {
@@ -889,36 +880,71 @@ pub(crate) fn collect_taken_branches_for_derived_dedupe(
     taken
 }
 
-/// Origin of an effective worktree branch name. The builder uses this to decide
-/// whether collisions with existing branches should be resolved by suffixing
-/// (Derived) or surfaced as an error (Explicit).
-#[derive(Debug, Clone)]
-pub(crate) enum BranchSource {
-    /// User typed this name explicitly. Treat conflicts as a hard error.
-    Explicit(String),
-    /// Derived from the session title. Suffix on conflict.
-    Derived(String),
-}
-
-fn resolve_worktree_branch(
+pub(crate) fn resolve_effective_worktree_branch(
     worktree_enabled: bool,
     worktree_branch: Option<&str>,
     final_title: &str,
-) -> Option<BranchSource> {
-    if !worktree_enabled {
-        return None;
-    }
-    Some(
-        match worktree_branch.map(str::trim).filter(|b| !b.is_empty()) {
-            // Defense-in-depth: even if the frontend slug missed a forbidden
-            // char (or the caller is a CLI/API user typing a title-shaped
-            // string into the branch field), sanitise here so libgit2 never
-            // sees a value it'll reject with InvalidSpec. `/` is preserved
-            // since it's the legal namespace separator in git refs.
-            Some(b) => BranchSource::Explicit(git_sanitize_branch_name(b)),
-            None => BranchSource::Derived(branch_name_from_title(final_title)),
+    create_new_branch: bool,
+    taken_branches: &HashSet<String>,
+) -> Result<Option<String>> {
+    resolve_effective_worktree_branch_with_transform(
+        worktree_enabled,
+        worktree_branch,
+        final_title,
+        create_new_branch,
+        taken_branches,
+        |branch| {
+            let plan = crate::plugin::active_branch_transform_plan()?;
+            Ok(plan.apply(branch)?)
         },
     )
+}
+
+fn resolve_effective_worktree_branch_with_transform<F>(
+    worktree_enabled: bool,
+    worktree_branch: Option<&str>,
+    final_title: &str,
+    create_new_branch: bool,
+    taken_branches: &HashSet<String>,
+    transform: F,
+) -> Result<Option<String>>
+where
+    F: FnOnce(&str) -> Result<String>,
+{
+    if !worktree_enabled {
+        return Ok(None);
+    }
+
+    if let Some(branch) = worktree_branch.map(str::trim).filter(|b| !b.is_empty()) {
+        // Defense-in-depth: even if the frontend slug missed a forbidden char
+        // (or the caller is a CLI/API user typing a title-shaped string into
+        // the branch field), sanitise here so libgit2 never sees a value it'll
+        // reject with InvalidSpec. `/` is preserved since it's the legal
+        // namespace separator in git refs.
+        let branch = git_sanitize_branch_name(branch);
+        validate_resolved_worktree_branch(&branch)?;
+        return Ok(Some(branch));
+    }
+
+    let transformed = transform(&branch_name_from_title(final_title))?;
+    validate_resolved_worktree_branch(&transformed)?;
+
+    if !create_new_branch {
+        return Ok(Some(transformed));
+    }
+
+    let branch = dedupe_branch_name(&transformed, taken_branches);
+    validate_resolved_worktree_branch(&branch)?;
+    Ok(Some(branch))
+}
+
+fn validate_resolved_worktree_branch(branch: &str) -> Result<()> {
+    if branch.len() > MAX_BRANCH_OUTPUT_BYTES
+        || !git2::Branch::name_is_valid(branch).unwrap_or(false)
+    {
+        return Err(BranchTransformError::InvalidResolvedBranch.into());
+    }
+    Ok(())
 }
 
 /// Replace characters that git ref names cannot contain (per
@@ -1208,28 +1234,147 @@ mod tests {
     }
 
     #[test]
-    fn test_worktree_branch_derived_from_title_when_name_empty() {
-        let branch = resolve_worktree_branch(true, None, "Fix Login Flow").unwrap();
-        assert!(matches!(branch, BranchSource::Derived(ref s) if s == "fix-login-flow"));
+    fn test_derived_branch_transform_runs_before_collision_dedupe() {
+        let taken = HashSet::from(["chore/update-deps".to_string()]);
+        let calls = std::cell::Cell::new(0);
+
+        let branch = resolve_effective_worktree_branch_with_transform(
+            true,
+            None,
+            "chore: update deps",
+            true,
+            &taken,
+            |derived| {
+                calls.set(calls.get() + 1);
+                assert_eq!(derived, "chore-update-deps");
+                Ok(derived.replacen('-', "/", 1))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(branch.as_deref(), Some("chore/update-deps-2"));
+        assert_eq!(calls.get(), 1);
     }
 
     #[test]
-    fn test_worktree_branch_preserves_explicit_name() {
-        // The git-safe sanitiser leaves valid refs alone: '/' is a legal
-        // namespace separator, so `feat/auth` survives unchanged.
-        let branch = resolve_worktree_branch(true, Some("feat/auth"), "Fix Login Flow").unwrap();
-        assert!(matches!(branch, BranchSource::Explicit(ref s) if s == "feat/auth"));
+    fn test_explicit_branch_never_invokes_transform_or_dedupes() {
+        let taken = HashSet::from(["feat/auth".to_string()]);
+        let branch = resolve_effective_worktree_branch_with_transform(
+            true,
+            Some("feat/auth"),
+            "Fix Login Flow",
+            true,
+            &taken,
+            |_| panic!("explicit branches must not load or apply plugin transforms"),
+        )
+        .unwrap();
+
+        assert_eq!(branch.as_deref(), Some("feat/auth"));
     }
 
     #[test]
-    fn test_worktree_branch_sanitizes_explicit_with_spaces() {
+    fn test_explicit_branch_preserves_existing_sanitization() {
         // Without this, the value reaches libgit2 and surfaces as the opaque
         // 'reference name … is not valid' InvalidSpec error in the dashboard.
-        let branch =
-            resolve_worktree_branch(true, Some("Exploration and issues v2"), "Fix Login Flow")
-                .unwrap();
-        assert!(
-            matches!(branch, BranchSource::Explicit(ref s) if s == "Exploration-and-issues-v2")
+        let branch = resolve_effective_worktree_branch_with_transform(
+            true,
+            Some("Exploration and issues v2"),
+            "Fix Login Flow",
+            false,
+            &HashSet::new(),
+            |_| panic!("explicit branches must not load or apply plugin transforms"),
+        )
+        .unwrap();
+
+        assert_eq!(branch.as_deref(), Some("Exploration-and-issues-v2"));
+    }
+
+    #[test]
+    fn test_explicit_branch_is_validated_after_sanitization() {
+        let error = resolve_effective_worktree_branch_with_transform(
+            true,
+            Some("feat//auth"),
+            "Fix Login Flow",
+            true,
+            &HashSet::new(),
+            |_| panic!("explicit branches must not load or apply plugin transforms"),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.downcast_ref::<BranchTransformError>(),
+            Some(&BranchTransformError::InvalidResolvedBranch)
+        );
+    }
+
+    #[test]
+    fn test_disabled_worktree_never_invokes_transform() {
+        let branch = resolve_effective_worktree_branch_with_transform(
+            false,
+            Some("feat/auth"),
+            "Fix Login Flow",
+            true,
+            &HashSet::new(),
+            |_| panic!("disabled worktree mode must not load or apply plugin transforms"),
+        )
+        .unwrap();
+
+        assert_eq!(branch, None);
+    }
+
+    #[test]
+    fn test_no_transform_preserves_derived_branch_behavior() {
+        let branch = resolve_effective_worktree_branch_with_transform(
+            true,
+            None,
+            "Fix Login Flow",
+            false,
+            &HashSet::new(),
+            |derived| Ok(derived.to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(branch.as_deref(), Some("fix-login-flow"));
+    }
+
+    #[test]
+    fn test_invalid_transformed_branch_fails_with_typed_safe_error() {
+        let error = resolve_effective_worktree_branch_with_transform(
+            true,
+            None,
+            "Private Branch",
+            false,
+            &HashSet::new(),
+            |_| Ok("private-invalid/.".to_string()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.downcast_ref::<BranchTransformError>(),
+            Some(&BranchTransformError::InvalidResolvedBranch)
+        );
+        assert!(!error.to_string().contains("private-invalid"));
+    }
+
+    #[test]
+    fn test_invalid_final_branch_after_dedupe_fails() {
+        let transformed = "a".repeat(MAX_BRANCH_OUTPUT_BYTES);
+        assert!(validate_resolved_worktree_branch(&transformed).is_ok());
+        let taken = HashSet::from([transformed.clone()]);
+
+        let error = resolve_effective_worktree_branch_with_transform(
+            true,
+            None,
+            "Branch",
+            true,
+            &taken,
+            |_| Ok(transformed),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.downcast_ref::<BranchTransformError>(),
+            Some(&BranchTransformError::InvalidResolvedBranch)
         );
     }
 
@@ -1285,11 +1430,6 @@ mod tests {
         // back to "session" rather than producing a name libgit2 will refuse.
         assert_eq!(git_sanitize_branch_name("@"), "session");
         assert_eq!(git_sanitize_branch_name("HEAD"), "session");
-    }
-
-    #[test]
-    fn test_worktree_branch_disabled_without_worktree() {
-        assert!(resolve_worktree_branch(false, Some("feat/auth"), "Fix Login Flow").is_none());
     }
 
     #[test]

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -304,7 +304,7 @@ impl NewSessionDialog {
                 let repos_count = self.workspace_repos.len();
                 let summary = match (name.is_empty(), repos_count) {
                     (true, 0) => None,
-                    (true, n) => Some(format!("  (auto, {}, {} repos)", branch_mode, n)),
+                    (true, n) => Some(format!("  (derived, {}, {} repos)", branch_mode, n)),
                     (false, 0) => Some(format!("  ({}, {})", name, branch_mode)),
                     (false, n) => Some(format!("  ({}, {}, {} repos)", name, branch_mode, n)),
                 };
@@ -801,14 +801,14 @@ impl NewSessionDialog {
             .constraints(constraints)
             .split(inner);
 
-        // Name
+        // Optional explicit branch; blank delegates derivation to the builder.
         render_text_field(
             frame,
             chunks[0],
-            "Name:",
+            "Branch override:",
             &self.worktree_branch,
             self.worktree_config_focused_field == 0,
-            Some("(empty = title)"),
+            Some("(empty = derive from title; overrides bypass transforms)"),
             theme,
         );
         self.worktree_config_rects.push((0, chunks[0]));

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -653,11 +653,23 @@ impl PluginManagerDialog {
         ))];
         if review.consent.is_some() {
             lines.push(Line::from(Span::styled(
-                "This update expands what the plugin can do.",
+                "This update changes trusted plugin behavior.",
                 Style::default().fg(theme.dimmed),
             )));
         }
         lines.push(Line::from(""));
+
+        if review
+            .consent
+            .as_ref()
+            .is_some_and(|consent| consent.branch_transforms_changed)
+        {
+            lines.push(Line::from(Span::styled(
+                "Automatic branch naming changed; explicit overrides are unaffected.",
+                Style::default().fg(theme.waiting),
+            )));
+            lines.push(Line::from(""));
+        }
 
         // Changelog, shown for every update.
         push_changelog_lines(&mut lines, &review.changelog, theme);

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -671,6 +671,18 @@ impl PluginManagerDialog {
             lines.push(Line::from(""));
         }
 
+        if review
+            .consent
+            .as_ref()
+            .is_some_and(|consent| consent.repairs_untrusted_manifest)
+        {
+            lines.push(Line::from(Span::styled(
+                "Installed manifest is missing or cannot be verified; update restores it from the recorded source.",
+                Style::default().fg(theme.waiting),
+            )));
+            lines.push(Line::from(""));
+        }
+
         // Changelog, shown for every update.
         push_changelog_lines(&mut lines, &review.changelog, theme);
         lines.push(Line::from(""));

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4916,34 +4916,6 @@ fn permission_response_tokens(
     }
 }
 
-#[cfg(test)]
-mod permission_response_tokens_tests {
-    use super::*;
-    use crate::agents::{KeyToken, PermissionResponse};
-    use crate::tui::dialogs::PermissionResponseChoice;
-
-    #[test]
-    fn maps_each_choice_to_its_own_field() {
-        let response = PermissionResponse {
-            allow: &[KeyToken::Literal("1")],
-            allow_always: &[KeyToken::Literal("2")],
-            deny: &[KeyToken::Literal("3")],
-        };
-        assert_eq!(
-            permission_response_tokens(&response, PermissionResponseChoice::Allow),
-            response.allow
-        );
-        assert_eq!(
-            permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
-            response.allow_always
-        );
-        assert_eq!(
-            permission_response_tokens(&response, PermissionResponseChoice::Deny),
-            response.deny
-        );
-    }
-}
-
 impl HomeView {
     /// Size to boot a cold/dead agent pane at on live-send entry: the visible
     /// preview output rect when known, else the full terminal. `preview_pane_area`
@@ -6489,5 +6461,33 @@ impl HomeView {
     ) -> anyhow::Result<()> {
         self.try_mutate_instance(id, |inst| inst.start_container_terminal_with_size(size))
             .map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod permission_response_tokens_tests {
+    use super::*;
+    use crate::agents::{KeyToken, PermissionResponse};
+    use crate::tui::dialogs::PermissionResponseChoice;
+
+    #[test]
+    fn maps_each_choice_to_its_own_field() {
+        let response = PermissionResponse {
+            allow: &[KeyToken::Literal("1")],
+            allow_always: &[KeyToken::Literal("2")],
+            deny: &[KeyToken::Literal("3")],
+        };
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::Allow),
+            response.allow
+        );
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
+            response.allow_always
+        );
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::Deny),
+            response.deny
+        );
     }
 }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1426,7 +1426,7 @@ fn test_cli_add_sanitizes_explicit_worktree_branch() {
 
 #[test]
 #[serial]
-fn test_cli_add_blank_worktree_branch_falls_back_to_normal_title() {
+fn test_cli_add_blank_worktree_branch_derives_from_generated_title() {
     let h = TuiTestHarness::new("cli_blank_branch_title_fallback");
     let project = h.home_path().join("blank-branch-title-project");
     init_git_repo(&project);
@@ -1434,7 +1434,7 @@ fn test_cli_add_blank_worktree_branch_falls_back_to_normal_title() {
     let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-w", "   ", "-b"]);
     assert!(
         add_output.status.success(),
-        "blank explicit worktree branch should fall back instead of creating branch 'session':\nstdout: {}\nstderr: {}",
+        "blank worktree branch should derive from a generated title:\nstdout: {}\nstderr: {}",
         String::from_utf8_lossy(&add_output.stdout),
         String::from_utf8_lossy(&add_output.stderr)
     );
@@ -1448,19 +1448,110 @@ fn test_cli_add_blank_worktree_branch_falls_back_to_normal_title() {
         "blank worktree branch should not become an empty session title"
     );
     assert!(
-        session["worktree_info"].is_null(),
-        "blank worktree branch should not create a managed worktree"
+        session["worktree_info"]["managed_by_aoe"] == true,
+        "present but blank -w should opt into a managed worktree"
+    );
+    assert!(
+        !session["worktree_info"]["branch"]
+            .as_str()
+            .unwrap_or_default()
+            .is_empty(),
+        "the generated title should resolve to a non-empty branch"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_bare_worktree_applies_plugin_transform_but_explicit_branch_bypasses_it() {
+    let h = TuiTestHarness::new("cli_branch_transform");
+    let project = h.home_path().join("branch-transform-project");
+    init_git_repo(&project);
+
+    let plugin = h.home_path().join("branch-transform-plugin");
+    std::fs::create_dir_all(&plugin).unwrap();
+    std::fs::write(
+        plugin.join("aoe-plugin.toml"),
+        r#"
+id = "acme.branch-style"
+name = "Branch Style"
+version = "1.0.0"
+api_version = 9
+
+[[branch_transforms]]
+pattern = "-"
+replacement = "/"
+"#,
+    )
+    .unwrap();
+    let install = h.run_cli(&["plugin", "install", plugin.to_str().unwrap(), "--yes"]);
+    assert!(
+        install.status.success(),
+        "plugin install failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
     );
 
-    let branch = Command::new("git")
-        .args(["branch", "--list", "session"])
-        .current_dir(&project)
-        .output()
-        .expect("git branch --list");
+    let derived = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-w",
+        "-b",
+        "-t",
+        "chore: update deps",
+    ]);
     assert!(
-        String::from_utf8_lossy(&branch.stdout).trim().is_empty(),
-        "blank explicit branch should not create the sanitizer fallback branch"
+        derived.status.success(),
+        "derived worktree add failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&derived.stdout),
+        String::from_utf8_lossy(&derived.stderr)
     );
+
+    let explicit = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-w",
+        "manual-branch",
+        "-b",
+        "-t",
+        "explicit branch",
+    ]);
+    assert!(
+        explicit.status.success(),
+        "explicit worktree add failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&explicit.stdout),
+        String::from_utf8_lossy(&explicit.stderr)
+    );
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let derived = sessions
+        .iter()
+        .find(|session| session["title"].as_str() == Some("chore: update deps"))
+        .expect("derived session");
+    assert_eq!(
+        derived["worktree_info"]["branch"].as_str(),
+        Some("chore/update-deps")
+    );
+    let explicit = sessions
+        .iter()
+        .find(|session| session["title"].as_str() == Some("explicit branch"))
+        .expect("explicit session");
+    assert_eq!(
+        explicit["worktree_info"]["branch"].as_str(),
+        Some("manual-branch")
+    );
+
+    for branch in ["chore/update-deps", "manual-branch"] {
+        let output = Command::new("git")
+            .args(["branch", "--list", branch])
+            .current_dir(&project)
+            .output()
+            .expect("git branch --list");
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains(branch),
+            "expected branch {branch} to exist"
+        );
+    }
 }
 
 #[test]

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -3,6 +3,7 @@
 //! bare repo via `AOE_GITHUB_CLONE_BASE` and release assets come from a local
 //! axum fixture via `AOE_UPDATE_API_BASE`. Never touches the network.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -10,9 +11,32 @@ use agent_of_empires::plugin::install::{self, UpdateOutcome, UpdatePreview};
 use agent_of_empires::plugin::lockfile::Lockfile;
 use agent_of_empires::plugin::registry::PluginRegistry;
 use agent_of_empires::plugin::{auto_update, update_check};
-use agent_of_empires::session::Config;
+use agent_of_empires::session::{update_config, Config};
 use serial_test::serial;
 use tempfile::TempDir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn preserve(key: &'static str) -> Self {
+        Self {
+            key,
+            previous: std::env::var_os(key),
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
 
 /// Isolate the app dir under a fresh temp HOME for the duration of a test.
 ///
@@ -1144,6 +1168,7 @@ async fn branch_transform_only_install_requires_approval() {
 #[serial]
 async fn changed_branch_transforms_require_pinned_consent_and_block_clean_update() {
     let _home = isolate();
+    let _clone_base = EnvVarGuard::preserve("AOE_GITHUB_CLONE_BASE");
     let base = tempfile::tempdir().unwrap();
     make_bare_repo(
         base.path(),
@@ -1196,14 +1221,13 @@ async fn changed_branch_transforms_require_pinned_consent_and_block_clean_update
         .unwrap_err()
         .to_string();
     assert!(error.contains("requires the fingerprint"), "got: {error}");
-
-    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
 }
 
 #[tokio::test]
 #[serial]
 async fn unchanged_branch_transforms_remain_a_safe_update() {
     let _home = isolate();
+    let _clone_base = EnvVarGuard::preserve("AOE_GITHUB_CLONE_BASE");
     let base = tempfile::tempdir().unwrap();
     let v1 = branch_transform_manifest("1.0.0", "$1/$2");
     make_bare_repo(base.path(), "acme", "upd", &[("aoe-plugin.toml", &v1)]);
@@ -1216,8 +1240,6 @@ async fn unchanged_branch_transforms_remain_a_safe_update() {
         install::preview_update("acme.upd").await.unwrap(),
         UpdatePreview::SafeUpdate { .. }
     ));
-
-    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
 }
 
 #[tokio::test]
@@ -1281,9 +1303,23 @@ async fn update_repairs_an_untrusted_installed_manifest() {
 
     std::fs::write(&installed_manifest, "not valid TOML = [").unwrap();
     assert!(load_registry().get("acme.upd").is_none());
+    match install::update_clean("acme.upd").await.unwrap() {
+        UpdateOutcome::Skipped { reason, .. } => {
+            assert!(
+                reason.contains("installed manifest verification"),
+                "{reason}"
+            );
+            assert!(
+                !reason.contains("automatic branch naming change"),
+                "{reason}"
+            );
+        }
+        other => panic!("expected manifest repair to be skipped, got {other:?}"),
+    }
     let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
         UpdatePreview::ConsentRequired { consent, .. } => {
-            assert!(consent.branch_transforms_changed);
+            assert!(!consent.branch_transforms_changed);
+            assert!(consent.repairs_untrusted_manifest);
             consent.fingerprint
         }
         other => panic!("expected consent_required, got {other:?}"),
@@ -1299,7 +1335,11 @@ async fn update_repairs_an_untrusted_installed_manifest() {
 
     std::fs::remove_file(&installed_manifest).unwrap();
     let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
-        UpdatePreview::ConsentRequired { consent, .. } => consent.fingerprint,
+        UpdatePreview::ConsentRequired { consent, .. } => {
+            assert!(!consent.branch_transforms_changed);
+            assert!(consent.repairs_untrusted_manifest);
+            consent.fingerprint
+        }
         other => panic!("expected consent_required, got {other:?}"),
     };
     install::apply_update(
@@ -1310,6 +1350,27 @@ async fn update_repairs_an_untrusted_installed_manifest() {
     .await
     .unwrap();
     assert!(load_registry().get("acme.upd").unwrap().active());
+}
+
+#[tokio::test]
+#[serial]
+async fn update_requires_verification_when_a_matching_manifest_has_no_prior_grant() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(src.path(), PLAIN_MANIFEST);
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+    update_config(|config| {
+        config.plugins.get_mut("acme.upd").unwrap().grant = None;
+    })
+    .unwrap();
+
+    match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => {
+            assert!(!consent.branch_transforms_changed);
+            assert!(consent.repairs_untrusted_manifest);
+        }
+        other => panic!("expected consent_required, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -997,7 +997,18 @@ command = ["false"]
     )
     .unwrap();
 
-    let err = install::update("acme.upd").await.unwrap_err().to_string();
+    let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => consent.fingerprint,
+        other => panic!("expected consent_required, got {other:?}"),
+    };
+    let err = install::apply_update(
+        "acme.upd",
+        Some(fingerprint),
+        &install::OperationLog::Inherit,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
     assert!(err.contains("build step"), "got: {err}");
 
     // The prior install is intact: directory, artifact, and recorded version.
@@ -1097,6 +1108,209 @@ name = "Upd"
 version = "1.0.0"
 api_version = 2
 "#;
+
+fn branch_transform_manifest(version: &str, replacement: &str) -> String {
+    format!(
+        r#"
+id = "acme.upd"
+name = "Upd"
+version = "{version}"
+api_version = 9
+
+[[branch_transforms]]
+pattern = "^([^-]+)-(.+)$"
+replacement = "{replacement}"
+"#
+    )
+}
+
+#[tokio::test]
+#[serial]
+async fn branch_transform_only_install_requires_approval() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let manifest = branch_transform_manifest("1.0.0", "$1/$2");
+    let dir = write_plugin_dir(src.path(), &manifest);
+
+    let error = install::install(dir.to_str().unwrap(), false)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("requires approval"), "got: {error}");
+    assert!(load_registry().get("acme.upd").is_none());
+}
+
+#[tokio::test]
+#[serial]
+async fn changed_branch_transforms_require_pinned_consent_and_block_clean_update() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", PLAIN_MANIFEST)],
+    );
+    install::install("gh:acme/upd@main", true).await.unwrap();
+
+    let transformed = branch_transform_manifest("2.0.0", "$1/$2");
+    // Tamper the mutable installed manifest to match the future target. Update
+    // classification must use the prior grant hash, not trust this as the
+    // approval baseline and misclassify the new transforms as unchanged.
+    std::fs::write(
+        agent_of_empires::plugin::plugins_dir()
+            .unwrap()
+            .join("acme.upd/aoe-plugin.toml"),
+        &transformed,
+    )
+    .unwrap();
+    push_new_commit(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", &transformed)],
+    );
+
+    match install::update_clean("acme.upd").await.unwrap() {
+        UpdateOutcome::Skipped { reason, .. } => {
+            assert!(
+                reason.contains("automatic branch naming change"),
+                "{reason}"
+            );
+        }
+        other => panic!("expected branch transform update to be skipped, got {other:?}"),
+    }
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "1.0.0"
+    );
+
+    match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => {
+            assert!(consent.branch_transforms_changed);
+        }
+        other => panic!("expected consent_required, got {other:?}"),
+    }
+    let error = install::apply_update("acme.upd", None, &install::OperationLog::Inherit)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("requires the fingerprint"), "got: {error}");
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn unchanged_branch_transforms_remain_a_safe_update() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    let v1 = branch_transform_manifest("1.0.0", "$1/$2");
+    make_bare_repo(base.path(), "acme", "upd", &[("aoe-plugin.toml", &v1)]);
+    install::install("gh:acme/upd@main", true).await.unwrap();
+
+    let v2 = branch_transform_manifest("2.0.0", "$1/$2");
+    push_new_commit(base.path(), "acme", "upd", &[("aoe-plugin.toml", &v2)]);
+
+    assert!(matches!(
+        install::preview_update("acme.upd").await.unwrap(),
+        UpdatePreview::SafeUpdate { .. }
+    ));
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn update_approval_is_bound_to_the_installed_baseline() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(src.path(), PLAIN_MANIFEST);
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    let safe_v2 = PLAIN_MANIFEST.replace("1.0.0", "2.0.0");
+    std::fs::write(dir.join("aoe-plugin.toml"), &safe_v2).unwrap();
+    let stale_fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::SafeUpdate { fingerprint, .. } => fingerprint,
+        other => panic!("expected safe_update, got {other:?}"),
+    };
+
+    let transformed_v3 = branch_transform_manifest("3.0.0", "$1/$2");
+    std::fs::write(dir.join("aoe-plugin.toml"), &transformed_v3).unwrap();
+    let v3_fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => consent.fingerprint,
+        other => panic!("expected consent_required, got {other:?}"),
+    };
+    install::apply_update(
+        "acme.upd",
+        Some(v3_fingerprint),
+        &install::OperationLog::Inherit,
+    )
+    .await
+    .unwrap();
+
+    // The original A -> B preview cannot approve C -> B. The target is the same,
+    // but the installed transform baseline and consent classification changed.
+    std::fs::write(dir.join("aoe-plugin.toml"), &safe_v2).unwrap();
+    let error = install::apply_update(
+        "acme.upd",
+        Some(stale_fingerprint),
+        &install::OperationLog::Inherit,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("changed since it was shown"), "got: {error}");
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "3.0.0",
+        "a stale approval keeps the current baseline",
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn update_repairs_an_untrusted_installed_manifest() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(src.path(), PLAIN_MANIFEST);
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+    let installed_manifest = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.upd/aoe-plugin.toml");
+
+    std::fs::write(&installed_manifest, "not valid TOML = [").unwrap();
+    assert!(load_registry().get("acme.upd").is_none());
+    let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => {
+            assert!(consent.branch_transforms_changed);
+            consent.fingerprint
+        }
+        other => panic!("expected consent_required, got {other:?}"),
+    };
+    install::apply_update(
+        "acme.upd",
+        Some(fingerprint),
+        &install::OperationLog::Inherit,
+    )
+    .await
+    .unwrap();
+    assert!(load_registry().get("acme.upd").unwrap().active());
+
+    std::fs::remove_file(&installed_manifest).unwrap();
+    let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => consent.fingerprint,
+        other => panic!("expected consent_required, got {other:?}"),
+    };
+    install::apply_update(
+        "acme.upd",
+        Some(fingerprint),
+        &install::OperationLog::Inherit,
+    )
+    .await
+    .unwrap();
+    assert!(load_registry().get("acme.upd").unwrap().active());
+}
 
 #[tokio::test]
 #[serial]

--- a/web/src/components/session-wizard/__tests__/SessionStep.advanced.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionStep.advanced.test.tsx
@@ -50,7 +50,7 @@ describe("SessionStep Advanced disclosure (#1514)", () => {
     expect(getByPlaceholderText("Auto-generated if empty")).toBeTruthy();
     // Folded controls are absent before expanding.
     expect(queryByRole("switch")).toBeNull();
-    expect(queryByPlaceholderText("Uses session title if empty")).toBeNull();
+    expect(queryByPlaceholderText("Derived from session title if empty")).toBeNull();
     expect(queryByPlaceholderText("Optional, for organizing related sessions")).toBeNull();
   });
 
@@ -58,7 +58,7 @@ describe("SessionStep Advanced disclosure (#1514)", () => {
     const { expandAdvanced, getByPlaceholderText, getByRole } = renderStep();
     expandAdvanced();
     expect(getByRole("switch", { name: /Create a worktree/ })).toBeTruthy();
-    expect(getByPlaceholderText("Uses session title if empty")).toBeTruthy();
+    expect(getByPlaceholderText("Derived from session title if empty")).toBeTruthy();
     expect(getByRole("switch", { name: /Attach to existing branch/ })).toBeTruthy();
     // The base-branch picker's disclosure button (its input shares the
     // same accessible name but is not a button).
@@ -69,7 +69,7 @@ describe("SessionStep Advanced disclosure (#1514)", () => {
   it("editing the branch input emits a worktreeBranch change", () => {
     const { expandAdvanced, onChange, getByPlaceholderText } = renderStep();
     expandAdvanced();
-    fireEvent.change(getByPlaceholderText("Uses session title if empty"), {
+    fireEvent.change(getByPlaceholderText("Derived from session title if empty"), {
       target: { value: "feat/x" },
     });
     expect(onChange).toHaveBeenCalledWith("worktreeBranch", "feat/x");

--- a/web/src/components/session-wizard/sessionNames.test.ts
+++ b/web/src/components/session-wizard/sessionNames.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyBranchOverride, getReviewSummary, slugifyBranch } from "./sessionNames";
+import { applyBranchOverride, slugifyBranch } from "./sessionNames";
 
 describe("applyBranchOverride", () => {
   it("marks a non-empty branch as a manual override", () => {
@@ -33,8 +33,9 @@ describe("slugifyBranch", () => {
     expect(slugifyBranch("Fix: login @ mobile #42")).toBe("fix-login-mobile-42");
   });
 
-  it("replaces forward slashes; git allows them but the slug stays kebab", () => {
-    expect(slugifyBranch("feat/auth.refactor")).toBe("feat-auth-refactor");
+  it("preserves valid forward slashes as branch namespace separators", () => {
+    expect(slugifyBranch("feat/auth.refactor")).toBe("feat/auth-refactor");
+    expect(slugifyBranch("/feat//auth/")).toBe("feat/auth");
   });
 
   it("folds Latin diacritics and ligatures", () => {
@@ -51,21 +52,5 @@ describe("slugifyBranch", () => {
     expect(slugifyBranch("")).toBe("session");
     expect(slugifyBranch("---")).toBe("session");
     expect(slugifyBranch("🚀")).toBe("session");
-  });
-});
-
-describe("getReviewSummary", () => {
-  it("shows the branch when the title is blank because the backend reuses it", () => {
-    expect(getReviewSummary("", "feature/custom")).toEqual({
-      title: "feature/custom",
-      branch: "feature/custom",
-    });
-  });
-
-  it("shows the title-derived branch when no explicit branch is set", () => {
-    expect(getReviewSummary("session-title", "")).toEqual({
-      title: "session-title",
-      branch: "session-title",
-    });
   });
 });

--- a/web/src/components/session-wizard/sessionNames.ts
+++ b/web/src/components/session-wizard/sessionNames.ts
@@ -28,6 +28,13 @@ export function slugifyBranch(title: string): string {
   let out = "";
   let lastDash = false;
   for (const ch of stripped) {
+    if (ch === "/") {
+      while (out.endsWith("-")) out = out.slice(0, -1);
+      if (out.length === 0 || out.endsWith("/")) continue;
+      out += "/";
+      lastDash = true;
+      continue;
+    }
     const code = ch.charCodeAt(0);
     const isAlnum = (code >= 0x30 && code <= 0x39) || (code >= 0x61 && code <= 0x7a);
     if (isAlnum || ch === "-" || ch === "_") {
@@ -39,7 +46,7 @@ export function slugifyBranch(title: string): string {
       lastDash = true;
     }
   }
-  while (out.endsWith("-")) out = out.slice(0, -1);
+  while (out.endsWith("-") || out.endsWith("/")) out = out.slice(0, -1);
   return out.length === 0 ? "session" : out;
 }
 
@@ -57,18 +64,5 @@ export function applyBranchOverride(
   return {
     worktreeBranch,
     worktreeBranchDirty: true,
-  };
-}
-
-export function getReviewSummary(
-  title: string,
-  worktreeBranch: string,
-): {
-  title: string;
-  branch: string;
-} {
-  return {
-    title: title || worktreeBranch || "Auto-generated",
-    branch: worktreeBranch || title || "Auto-generated",
   };
 }

--- a/web/src/components/session-wizard/steps/SessionStep.tsx
+++ b/web/src/components/session-wizard/steps/SessionStep.tsx
@@ -6,6 +6,7 @@ interface WizardData {
   path: string;
   title: string;
   worktreeBranch: string;
+  worktreeBranchDirty: boolean;
   useWorktree: boolean;
   /** Attach to an existing branch's worktree instead of creating one.
    *  Mirrors the TUI new-session toggle. See #969. */
@@ -143,16 +144,20 @@ export function SessionStep({ data, onChange, embedded = false }: Props) {
 
       {!data.scratch && data.useWorktree && (
         <div className="mb-5">
-          <label className="block text-sm text-text-dim mb-1.5">Branch / worktree name</label>
+          <label className="block text-sm text-text-dim mb-1.5">Derived branch preview / override</label>
           <input
             type="text"
             value={data.worktreeBranch}
             onChange={(e) => onChange("worktreeBranch", e.target.value)}
-            placeholder="Uses session title if empty"
+            placeholder="Derived from session title if empty"
             className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
           />
           <p className="text-xs text-text-dim mt-1">
-            The branch name is also the worktree directory name. Leave blank to use the session title.
+            {data.worktreeBranchDirty && data.worktreeBranch.trim()
+              ? "Explicit branch override; plugin transforms do not apply. AoE may still sanitize invalid Git-ref characters."
+              : data.worktreeBranchDirty
+                ? "Blank derives from the resolved title at creation; active plugin transforms may change it."
+                : "Preview before plugin transforms and collision suffixing. Edit to set an explicit branch override."}
           </p>
 
           <label

--- a/web/src/components/settings/PluginInstallConsentModal.tsx
+++ b/web/src/components/settings/PluginInstallConsentModal.tsx
@@ -17,7 +17,7 @@ interface PluginInstallConsentModalProps {
 
 /// The in-app capability-consent popup for a web plugin install. Renders the
 /// same disclosure the terminal prompt prints (capabilities, build commands, UI
-/// slots, unverified-source warning) and gates the install behind an explicit
+/// slots, branch transforms, unverified-source warning) and gates the install behind an explicit
 /// Approve, so the web path never silently grants what the CLI prompts for.
 export function PluginInstallConsentModal({
   consent,
@@ -87,6 +87,13 @@ export function PluginInstallConsentModal({
             <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">Capabilities</p>
             <p className="text-xs text-status-warning">{consent.capabilities.join(", ")}</p>
           </div>
+        )}
+
+        {consent.uses_branch_transforms && (
+          <p className="mb-3 text-xs text-status-warning" data-testid="plugin-install-branch-transforms">
+            Automatic branch naming: this plugin can transform branch names AoE derives for new worktrees. Explicit
+            branch overrides are not transformed.
+          </p>
         )}
 
         {consent.build_steps.length > 0 && (

--- a/web/src/components/settings/PluginUpdateConsentModal.tsx
+++ b/web/src/components/settings/PluginUpdateConsentModal.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import type { PluginUpdateChangelog, PluginUpdateConsent } from "../../lib/api";
 
 interface PluginUpdateConsentModalProps {
-  /** The access disclosure when the update expands what the plugin can do, or
+  /** The disclosure when the update changes trusted plugin behavior, or
    *  null for a safe version bump (changelog only, no consent). */
   consent: PluginUpdateConsent | null;
   /** Plugin display name for the header. */
@@ -29,8 +29,8 @@ interface PluginUpdateConsentModalProps {
 
 /// The in-app update review popup, used for every in-UI plugin update. It always
 /// shows the changelog between the installed and target version. When the update
-/// also expands access (`consent` is non-null) it adds the capability diff, UI
-/// slots, build commands, and runtime / trust disclosures, and gates behind an
+/// also changes trusted behavior (`consent` is non-null) it adds the capability diff, UI
+/// slots, build commands, branch transforms, and runtime / trust disclosures, and gates behind an
 /// explicit Approve with a Decline that records the dismissal. A safe version
 /// bump (`consent` is null) shows only the changelog with Cancel / Update.
 export function PluginUpdateConsentModal({
@@ -96,7 +96,14 @@ export function PluginUpdateConsentModal({
 
         {needsConsent && (
           <p className="mb-3 text-xs text-text-dim">
-            This update expands what the plugin can do. Review the new access before approving.
+            This update changes trusted plugin behavior. Review the changes before approving.
+          </p>
+        )}
+
+        {consent?.branch_transforms_changed && (
+          <p className="mb-3 text-xs text-status-warning" data-testid="plugin-update-branch-transforms">
+            Automatic branch naming changed. This can change branch names AoE derives for new worktrees; explicit branch
+            overrides are not transformed.
           </p>
         )}
 

--- a/web/src/components/settings/PluginUpdateConsentModal.tsx
+++ b/web/src/components/settings/PluginUpdateConsentModal.tsx
@@ -107,6 +107,13 @@ export function PluginUpdateConsentModal({
           </p>
         )}
 
+        {consent?.repairs_untrusted_manifest && (
+          <p className="mb-3 text-xs text-status-warning" data-testid="plugin-update-manifest-repair">
+            The installed manifest is missing or cannot be verified against a valid prior approval. This update will
+            restore it from the recorded source.
+          </p>
+        )}
+
         {consent && consent.added_capabilities.length > 0 && (
           <div className="mb-3" data-testid="plugin-update-added-caps">
             <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -658,6 +658,7 @@ describe("PluginsSettings", () => {
         runtime_change: null,
         trust_downgrade: false,
         branch_transforms_changed: true,
+        repairs_untrusted_manifest: false,
         fingerprint: "treeB||community",
         stays_active_if_declined: true,
         changelog: releaseChangelog,
@@ -816,6 +817,7 @@ describe("PluginsSettings", () => {
           runtime_change: "the worker is now a downloaded release binary",
           trust_downgrade: true,
           branch_transforms_changed: false,
+          repairs_untrusted_manifest: true,
           fingerprint: "treeD||community",
           stays_active_if_declined: true,
           changelog: emptyChangelog,
@@ -828,6 +830,7 @@ describe("PluginsSettings", () => {
     await findByTestId("plugin-update-consent-modal");
     expect((await findByTestId("plugin-update-runtime-change")).textContent).toContain("release binary");
     await findByTestId("plugin-update-trust-downgrade");
+    await findByTestId("plugin-update-manifest-repair");
     // An empty (but available) changelog reads as "No changelog available".
     await findByTestId("plugin-update-changelog-empty");
   });

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -657,6 +657,7 @@ describe("PluginsSettings", () => {
         build_steps: ["sh build.sh"],
         runtime_change: null,
         trust_downgrade: false,
+        branch_transforms_changed: true,
         fingerprint: "treeB||community",
         stays_active_if_declined: true,
         changelog: releaseChangelog,
@@ -674,6 +675,9 @@ describe("PluginsSettings", () => {
     await findByTestId("plugin-update-consent-modal");
     expect((await findByTestId("plugin-update-added-caps")).textContent).toContain("fs.read");
     expect((await findByTestId("plugin-update-build-steps")).textContent).toContain("sh build.sh");
+    expect((await findByTestId("plugin-update-branch-transforms")).textContent).toMatch(
+      /explicit branch overrides are not transformed/i,
+    );
     // The changelog is shown alongside the access disclosure.
     expect((await findByTestId("plugin-update-changelog")).textContent).toContain("v0.2.0");
   });
@@ -811,6 +815,7 @@ describe("PluginsSettings", () => {
           build_steps: [],
           runtime_change: "the worker is now a downloaded release binary",
           trust_downgrade: true,
+          branch_transforms_changed: false,
           fingerprint: "treeD||community",
           stays_active_if_declined: true,
           changelog: emptyChangelog,
@@ -905,6 +910,7 @@ describe("PluginsSettings", () => {
       capabilities: ["net"],
       ui: [],
       build_steps: ["sh build.sh"],
+      uses_branch_transforms: true,
       fingerprint: "treeA||community",
     },
   };
@@ -921,6 +927,9 @@ describe("PluginsSettings", () => {
     await findByTestId("plugin-install-consent-modal");
     expect((await findByTestId("plugin-install-caps")).textContent).toContain("net");
     expect((await findByTestId("plugin-install-build-steps")).textContent).toContain("sh build.sh");
+    expect((await findByTestId("plugin-install-branch-transforms")).textContent).toMatch(
+      /explicit branch overrides are not transformed/i,
+    );
   });
 
   it("Approving an install starts the job pinned to the previewed fingerprint", async () => {

--- a/web/src/lib/__tests__/pluginsApi.test.ts
+++ b/web/src/lib/__tests__/pluginsApi.test.ts
@@ -9,6 +9,7 @@ import {
   applyPluginUpdate,
   dismissPluginUpdate,
   fetchPlugins,
+  previewPluginInstall,
   previewPluginUpdate,
   setPluginEnabled,
   updateSettings,
@@ -109,6 +110,7 @@ const consentPreview = {
     runtime_change: null,
     trust_downgrade: false,
     branch_transforms_changed: true,
+    repairs_untrusted_manifest: false,
     fingerprint: "treeB||community",
     stays_active_if_declined: true,
   },
@@ -142,6 +144,46 @@ describe("previewPluginUpdate", () => {
     ]) {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify(bad), { status: 200 }));
       expect((await previewPluginUpdate("acme.plugin")).kind).toBe("error");
+    }
+  });
+
+  it("rejects missing or non-boolean consent disclosure flags", async () => {
+    const { branch_transforms_changed: _branch, ...withoutBranchTransforms } = consentPreview.consent;
+    const { repairs_untrusted_manifest: _repair, ...withoutRepair } = consentPreview.consent;
+    for (const consent of [
+      withoutBranchTransforms,
+      { ...consentPreview.consent, branch_transforms_changed: "yes" },
+      withoutRepair,
+      { ...consentPreview.consent, repairs_untrusted_manifest: "yes" },
+    ]) {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ kind: "consent_required", dismissed: false, consent }), { status: 200 }),
+      );
+      expect((await previewPluginUpdate("acme.plugin")).kind).toBe("error");
+    }
+  });
+});
+
+describe("previewPluginInstall", () => {
+  const installPreview = {
+    id: "acme.plugin",
+    version: "1.0.0",
+    source: "gh:acme/plugin",
+    notice: "installing v1.0.0",
+    unverified: false,
+    validation: "community",
+    capabilities: [],
+    ui: [],
+    build_steps: [],
+    uses_branch_transforms: true,
+    fingerprint: "treeA||community",
+  };
+
+  it("rejects missing or non-boolean branch-transform disclosure", async () => {
+    const { uses_branch_transforms: _usesTransforms, ...withoutDisclosure } = installPreview;
+    for (const payload of [withoutDisclosure, { ...installPreview, uses_branch_transforms: "yes" }]) {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+      expect((await previewPluginInstall("gh:acme/plugin")).kind).toBe("error");
     }
   });
 });

--- a/web/src/lib/__tests__/pluginsApi.test.ts
+++ b/web/src/lib/__tests__/pluginsApi.test.ts
@@ -108,6 +108,7 @@ const consentPreview = {
     build_steps: [],
     runtime_change: null,
     trust_downgrade: false,
+    branch_transforms_changed: true,
     fingerprint: "treeB||community",
     stays_active_if_declined: true,
   },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -471,7 +471,7 @@ export interface PluginUpdateChangelog {
   more_url: string | null;
 }
 
-/** Structured disclosure for a capability-expanding plugin update, mirroring the
+/** Structured disclosure for a consent-requiring plugin update, mirroring the
  *  Rust `UpdateConsent`. Drives the consent modal. */
 export interface PluginUpdateConsent {
   id: string;
@@ -485,6 +485,7 @@ export interface PluginUpdateConsent {
   build_steps: string[];
   runtime_change: string | null;
   trust_downgrade: boolean;
+  branch_transforms_changed: boolean;
   fingerprint: string;
   stays_active_if_declined: boolean;
   changelog: PluginUpdateChangelog;
@@ -565,6 +566,7 @@ export interface PluginInstallConsent {
   capabilities: string[];
   ui: PluginUpdateUiView[];
   build_steps: string[];
+  uses_branch_transforms: boolean;
   fingerprint: string;
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -486,6 +486,7 @@ export interface PluginUpdateConsent {
   runtime_change: string | null;
   trust_downgrade: boolean;
   branch_transforms_changed: boolean;
+  repairs_untrusted_manifest: boolean;
   fingerprint: string;
   stays_active_if_declined: boolean;
   changelog: PluginUpdateChangelog;
@@ -513,7 +514,11 @@ function isValidPreview(payload: Record<string, unknown>): payload is PluginUpda
     case "safe_update":
       return typeof payload.fingerprint === "string";
     case "consent_required":
-      return typeof payload.consent === "object" && payload.consent !== null;
+      if (typeof payload.consent !== "object" || payload.consent === null) return false;
+      return (
+        typeof (payload.consent as Record<string, unknown>).branch_transforms_changed === "boolean" &&
+        typeof (payload.consent as Record<string, unknown>).repairs_untrusted_manifest === "boolean"
+      );
     default:
       return false;
   }
@@ -584,7 +589,12 @@ export async function previewPluginInstall(source: string): Promise<PluginInstal
       body: JSON.stringify({ source }),
     });
     const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-    if (res.ok && payload && typeof payload.fingerprint === "string") {
+    if (
+      res.ok &&
+      payload &&
+      typeof payload.fingerprint === "string" &&
+      typeof payload.uses_branch_transforms === "boolean"
+    ) {
       return { kind: "ok", consent: payload as unknown as PluginInstallConsent };
     }
     const message =

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -665,6 +665,8 @@
       "components": [
         "web/src/components/session-wizard/SessionWizard.tsx",
         "web/src/components/session-wizard/sessionNames.ts",
+        "web/src/components/session-wizard/wizardReducer.ts",
+        "web/src/components/session-wizard/steps/SessionStep.tsx",
         "web/src/lib/types.ts"
       ]
     },

--- a/web/tests/wizard-attach-existing.spec.ts
+++ b/web/tests/wizard-attach-existing.spec.ts
@@ -144,7 +144,7 @@ test.describe("Wizard attach-existing toggle (#969)", () => {
     await page.goto("/");
     await openWithProject(page);
     await expandMoreOptions(page);
-    await wizard(page).getByPlaceholder("Uses session title if empty").fill("feat/new");
+    await wizard(page).getByPlaceholder("Derived from session title if empty").fill("feat/new");
     await wizard(page)
       .getByRole("button", { name: /Launch session/ })
       .click();
@@ -189,7 +189,7 @@ test.describe("Wizard attach-existing toggle (#969)", () => {
     await page.goto("/");
     await openWithProject(page);
     await expandMoreOptions(page);
-    await wizard(page).getByPlaceholder("Uses session title if empty").fill("feat/existing");
+    await wizard(page).getByPlaceholder("Derived from session title if empty").fill("feat/existing");
     await attachToggle(page).click();
     await wizard(page)
       .getByRole("button", { name: /Launch session/ })

--- a/web/tests/wizard-form-ui.spec.ts
+++ b/web/tests/wizard-form-ui.spec.ts
@@ -101,7 +101,8 @@ test.describe("Wizard form UI stories", () => {
     // The branch input lives in the worktree controls under More options.
     await expandMoreOptions(page);
 
-    await expect(page.getByPlaceholder("Uses session title if empty")).toHaveValue("autogen-branch-here");
+    await expect(page.getByPlaceholder("Derived from session title if empty")).toHaveValue("autogen-branch-here");
+    await expect(page.getByText(/Preview before plugin transforms and collision suffixing/)).toBeVisible();
   });
 
   test("group-level New session button prefills the wizard with the repo path", async ({ page }) => {

--- a/web/tests/wizard-session-step.spec.ts
+++ b/web/tests/wizard-session-step.spec.ts
@@ -105,19 +105,19 @@ test.describe("Wizard session step (#1219)", () => {
     });
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "true");
     // Branch input visible while worktree is on.
-    await expect(w.getByPlaceholder("Uses session title if empty")).toBeVisible();
+    await expect(w.getByPlaceholder("Derived from session title if empty")).toBeVisible();
     await expect(w.getByRole("button", { name: "Base branch" })).toBeVisible();
     // Flip off: branch input + Base branch picker disappear. The "More
     // options" fold stays open.
     await worktreeToggle.click();
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "false");
-    await expect(w.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
+    await expect(w.getByPlaceholder("Derived from session title if empty")).toHaveCount(0);
     await expect(w.getByRole("button", { name: "Base branch" })).toHaveCount(0);
     // Flip back on: the branch input re-mounts (ported from the live
     // wizard-worktree-toggle story).
     await worktreeToggle.click();
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "true");
-    await expect(w.getByPlaceholder("Uses session title if empty")).toBeVisible();
+    await expect(w.getByPlaceholder("Derived from session title if empty")).toBeVisible();
   });
 
   test("worktree toggle defaults off when worktree.enabled is false (#2423)", async ({ page }) => {
@@ -133,7 +133,7 @@ test.describe("Wizard session step (#1219)", () => {
     const worktreeToggle = w.getByRole("switch", { name: /Create a worktree/ });
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "false");
     // Branch input + Base branch picker stay hidden while worktree is off.
-    await expect(w.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
+    await expect(w.getByPlaceholder("Derived from session title if empty")).toHaveCount(0);
     await expect(w.getByRole("button", { name: "Base branch" })).toHaveCount(0);
   });
 
@@ -145,9 +145,16 @@ test.describe("Wizard session step (#1219)", () => {
     await expandMoreOptions(page);
     const w = wizard(page);
     await w.getByPlaceholder("Auto-generated if empty").fill("My Cool Feature");
-    const branchInput = w.getByPlaceholder("Uses session title if empty");
+    const branchInput = w.getByPlaceholder("Derived from session title if empty");
     // SET_FIELD on title cascades into worktreeBranch via slugifyBranch().
     await expect(branchInput).toHaveValue("my-cool-feature");
+    await expect(w.getByText(/Preview before plugin transforms and collision suffixing/)).toBeVisible();
+
+    await branchInput.fill("feat/manual");
+    await expect(w.getByText(/Explicit branch override; plugin transforms do not apply/)).toBeVisible();
+
+    await branchInput.fill("");
+    await expect(w.getByText(/Blank derives from the resolved title at creation/)).toBeVisible();
   });
 
   test("submit sends worktree_enabled + create_new_branch with More options left closed", async ({ page }) => {
@@ -256,7 +263,7 @@ test.describe("Wizard session step (#1219)", () => {
     // away. The title is an essential and stays visible.
     await expect(w.getByRole("button", { name: "More options" })).toHaveAttribute("aria-expanded", "false");
     await expect(w.getByPlaceholder("Auto-generated if empty")).toBeVisible();
-    await expect(w.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
+    await expect(w.getByPlaceholder("Derived from session title if empty")).toHaveCount(0);
     await expect(w.getByPlaceholder("Optional, for organizing related sessions")).toHaveCount(0);
     await expect(w.getByRole("button", { name: "Base branch" })).toHaveCount(0);
   });
@@ -270,7 +277,7 @@ test.describe("Wizard session step (#1219)", () => {
     const w = wizard(page);
     // Worktree toggle defaults on.
     await expect(w.getByRole("switch", { name: /Create a worktree/ })).toHaveAttribute("aria-checked", "true");
-    await expect(w.getByPlaceholder("Uses session title if empty")).toBeVisible();
+    await expect(w.getByPlaceholder("Derived from session title if empty")).toBeVisible();
     await expect(w.getByRole("switch", { name: /Attach to existing branch/ })).toBeVisible();
     await expect(w.getByRole("button", { name: "Base branch" })).toBeVisible();
     // Group input is visible and editable.

--- a/web/tests/wizard-single-screen.spec.ts
+++ b/web/tests/wizard-single-screen.spec.ts
@@ -110,7 +110,7 @@ test.describe("Single-screen wizard (#2210)", () => {
     await openWizard(page);
     await selectProject(page, "/tmp/example");
     await expandMoreOptions(page);
-    await page.getByPlaceholder("Uses session title if empty").fill("my-feature-branch");
+    await page.getByPlaceholder("Derived from session title if empty").fill("my-feature-branch");
     await launch(page);
 
     await expect.poll(() => captured.body?.worktree_enabled).toBe(true);


### PR DESCRIPTION
## Description

Adds API v9 `[[branch_transforms]]` contributions so an enabled plugin can rewrite only title-derived worktree branch names while preserving the human-readable session title. Explicit branch overrides bypass transforms, transformed names are bounded and validated before Git or filesystem side effects, and collision suffixing runs afterward.

The host accepts one active transform contributor, applies rules in manifest order, and requires install or update consent whenever automatic branch naming behavior is introduced or changed. Update approvals are pinned to both the trusted installed baseline and fetched target so stale approvals and locally tampered manifests cannot bypass re-consent.

The CLI now supports bare `-w` for a derived worktree branch while retaining `-w <branch>` as an explicit override. TUI, server, web disclosures, generated CLI docs, plugin docs, and regression coverage are updated consistently.

Discussed in #268 and requested in #1641.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The dashboard changes are limited to branch-preview and plugin-consent disclosures; automated UI coverage is included instead of a recording.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features serve,e2e-tests -- -D warnings`
- `cargo test --features serve` (5,154 unit tests plus integration and doc targets)
- `cargo build --features serve`
- `npm run format:check`, `npm run lint`, `npm run build`
- `npm run test:unit` (306 files, 3,393 tests, no type errors)
- Affected mocked Playwright specs (20 tests)
- Focused full-binary CLI e2e coverage for derived transforms and explicit bypass

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR does not change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

OpenCode using `gpt-5.6-sol`.

**Any Additional AI Details you would like to share:**

AI assisted with implementation, tests, documentation, and adversarial review. All listed quality gates were run locally.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added plugin-driven branch rewriting for managed worktrees via a new API v9 `[[branch_transforms]]` manifest contribution (ordered regex rules).
- When creating a worktree branch from the session title, AoE now applies the configured branch transforms, then validates the result and handles naming collisions; explicit branch overrides bypass all transforms.
- Extended the CLI `aoe add` worktree flag to support a “bare” `-w` (derive from title and transform) while keeping `-w <branch>` as an explicit override (no transforms), plus added ambiguity checks for the optional `-w` value.
- Updated the host’s plugin lifecycle/consent behavior so installs and updates prompt users when automatic branch naming behavior is introduced or changed, with tighter “what approval applies to” fingerprinting.
- Improved safety: added bounds on transform counts and output sizes, validated transform rules, rejected invalid/unsafe results, and added clearer, non-leaking server error messaging.
- Refreshed UI and disclosures across CLI, TUI, and web (session wizard and plugin consent modals) to explain derived branch previews vs branch overrides, including updated placeholders/tooltips and review disclosures.
- Updated docs and regenerated CLI/plugin reference text to match the new semantics, removed/retired older worktree-branch resolution paths in the session builder, and removed a now-redundant web helper.
- Expanded testing: added unit/integration coverage for transform parsing, ordering, limits, conflicts, and end-to-end CLI/web/Playwright flows; hardened git worktree invocation with an added `--` separator.
- Minor housekeeping: updated `.gitignore` to ignore Claude Code session context.

## Benefits

- Lets users standardize branch names automatically using plugins, without losing control: explicit overrides always remain untouched.
- Makes branch-transform behavior more transparent and safer by validating and bounding outputs and by prompting for approval whenever automatic naming behavior changes.
- Improves consistency across CLI, TUI, and web so users see the same “derived vs override” behavior everywhere.

## Key technical details (for reviewers)

- Added `branch_transforms` to the v9 plugin manifest with strict limits and regex validation; host builds a transform plan, applies first-match-only rewriting, validates via git branch-name rules, and enforces a max output byte bound.
- Session worktree branch resolution was refactored to apply transforms only for derived branches; explicit branches are sanitized/validated but never transformed.
- Plugin install/update consent now includes branch-transform change classification and uses fingerprint-based verification to ensure approvals match the specific behavior transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->