### PR TITLE
feat(tui): merge remote aoe serve sessions into the local session list

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -67,6 +67,12 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe project list`↴](#aoe-project-list)
 * [`aoe project add`↴](#aoe-project-add)
 * [`aoe project remove`↴](#aoe-project-remove)
+* [`aoe remote`↴](#aoe-remote)
+* [`aoe remote list`↴](#aoe-remote-list)
+* [`aoe remote add`↴](#aoe-remote-add)
+* [`aoe remote remove`↴](#aoe-remote-remove)
+* [`aoe remote enable`↴](#aoe-remote-enable)
+* [`aoe remote disable`↴](#aoe-remote-disable)
 * [`aoe worktree`↴](#aoe-worktree)
 * [`aoe worktree list`↴](#aoe-worktree-list)
 * [`aoe worktree info`↴](#aoe-worktree-info)
@@ -148,6 +154,7 @@ Run without arguments to launch the TUI dashboard.
 * `plugin` — Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `profile` — Manage profiles (separate workspaces)
 * `project` — Manage the project registry used by multi-repo session pickers
+* `remote` — Manage remote `aoe serve` daemons whose sessions appear in the local list
 * `worktree` — Manage git worktrees for parallel development
 * `tmux` — tmux integration utilities
 * `sounds` — Manage sound effects for agent state transitions
@@ -1087,6 +1094,88 @@ Remove a project from the registry
 
   Possible values: `global`, `profile`
 
+
+
+
+## `aoe remote`
+
+Manage remote `aoe serve` daemons whose sessions appear in the local list
+
+**Usage:** `aoe remote <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List configured remotes
+* `add` — Add a remote daemon whose sessions appear in the local list
+* `remove` — Remove a remote
+* `enable` — Enable a remote without re-entering its URL
+* `disable` — Skip a remote's sessions without deleting its entry
+
+
+
+## `aoe remote list`
+
+List configured remotes
+
+**Usage:** `aoe remote list [OPTIONS]`
+
+###### **Options:**
+
+* `--json` — Output as JSON
+
+
+
+## `aoe remote add`
+
+Add a remote daemon whose sessions appear in the local list
+
+**Usage:** `aoe remote add [OPTIONS] <NAME> <URL>`
+
+###### **Arguments:**
+
+* `<NAME>` — Short label for the remote; badged onto each of its rows
+* `<URL>` — Base URL of the remote daemon, e.g. `http://linuxbox:8080`. A `?token=` copied from the remote's `aoe url` output is accepted and lifted into the stored token
+
+###### **Options:**
+
+* `--token <TOKEN>` — Bearer token for the remote daemon. Omit for a `--no-auth` daemon or when the token is already in the URL
+* `--force` — Replace an existing entry with the same name
+
+
+
+## `aoe remote remove`
+
+Remove a remote
+
+**Usage:** `aoe remote remove <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Name of the remote to remove
+
+
+
+## `aoe remote enable`
+
+Enable a remote without re-entering its URL
+
+**Usage:** `aoe remote enable <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Name of the remote
+
+
+
+## `aoe remote disable`
+
+Skip a remote's sessions without deleting its entry
+
+**Usage:** `aoe remote disable <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Name of the remote
 
 
 

--- a/docs/guides/remote-sessions.md
+++ b/docs/guides/remote-sessions.md
@@ -1,0 +1,118 @@
+# Merged Remote Sessions
+
+Show the sessions running on another machine in your local `aoe` TUI, alongside your own.
+
+If you keep sessions on a laptop and also run agents on a Linux box, this puts both lists on one screen. Each remote gets its own section at the bottom of the sidebar, below Archived and Trash, and you can open a remote session's transcript and composer without leaving the TUI.
+
+## What this is (and is not)
+
+The merged list is a **read-only mirror plus a live transcript**. A remote row lets you read the session, watch it work, and send it messages through the structured view. It does not let you run local operations against it.
+
+| | Local sessions | Remote sessions |
+|---|---|---|
+| Read transcript, send messages | yes | yes |
+| Stop, delete, restart, rename | yes | no |
+| Diff view, worktree edits | yes | no |
+| tmux attach | yes | no |
+| Create new sessions | yes | no |
+
+Two limits are worth understanding before you set this up:
+
+- **Structured-view sessions only.** A remote terminal (tmux) session is not listed, because its pane cannot be attached from another machine without SSH'ing into the host first. Showing the row would advertise something the TUI cannot do.
+- **No local filesystem.** A remote session's worktree lives on the other machine, so the diff view, file watching, and worktree editing do not apply.
+
+For anything outside that, use the remote's own web dashboard (`aoe serve`), or SSH in and run `aoe` there.
+
+## Setup
+
+### 1. Run a daemon on the remote machine
+
+On the Linux box:
+
+```bash
+aoe serve --host 0.0.0.0
+```
+
+The daemon must be reachable from your local machine. On a LAN, `--host 0.0.0.0` plus the box's IP is enough. Across networks, put both machines on a tailnet and use the Tailscale hostname; see [Tailscale Setup](tailscale.md).
+
+Print the URL and token:
+
+```bash
+aoe url
+```
+
+### 2. Add the remote locally
+
+On your laptop:
+
+```bash
+aoe remote add linuxbox http://linuxbox:8080 --token <token>
+```
+
+You can also paste the tokenized URL from `aoe url` directly; the token is lifted out of the query string and stored in its own field, so it never sits in the URL on disk:
+
+```bash
+aoe remote add linuxbox 'http://linuxbox:8080/?token=abc123'
+```
+
+The name (`linuxbox`) is the label badged onto each row and used as the section header, so keep it short. Letters, digits, `-`, and `_` only.
+
+### 3. Open the TUI
+
+Remote sections appear at the bottom of the sidebar within a few seconds:
+
+```
+  my-local-session                  ⠿ running
+  another-local                     ⠒ idle
+▼ ⊘ Trash (1)
+▼ ⇄ linuxbox (3)
+    refactor-parser                 ⠿
+    fix-flaky-test                  ⠛
+    docs-pass                       ⠒
+```
+
+Press Enter on a remote row to open its structured view in the preview pane, the same embedded view local structured sessions use. Enter on the section header collapses it.
+
+## Managing remotes
+
+```bash
+aoe remote list              # show configured remotes (never prints tokens)
+aoe remote list --json
+aoe remote add <name> <url>  # --token <t>, --force to replace
+aoe remote remove <name>
+aoe remote disable <name>    # skip it without deleting the entry
+aoe remote enable <name>
+```
+
+`disable` is the one to reach for when a box is off for a while: a disabled remote is skipped entirely, so it stops painting an error on every refresh. The entry stays, so re-enabling needs no URL or token.
+
+Entries live in your config under `[remotes.<name>]`:
+
+```toml
+[remotes.linuxbox]
+url = "http://linuxbox:8080"
+token = "abc123"
+enabled = true
+```
+
+## Reading the section header
+
+The header carries the remote's connection state, so an unreachable box is never confused with one that simply has no sessions:
+
+- `⇄ linuxbox (3)` — connected, three structured sessions.
+- `⇄ linuxbox (0) connecting…` — first fetch has not returned yet.
+- `⇄ linuxbox (2) unreachable: <error>` — the last refresh failed. The two rows are the previous snapshot, kept so a brief network blip does not empty the section.
+
+Remote rows use static status glyphs rather than the animated spinners local rows use. The list is re-fetched every few seconds, so an animation would imply a liveness this side does not actually sample. Once you open a remote session, its structured view holds its own WebSocket and updates live.
+
+## Security notes
+
+- The token in `[remotes.<name>]` grants full dashboard access to that daemon. Your config file holds it in plaintext, so treat it like any other credential in a dotfile.
+- Do not expose `aoe serve --host 0.0.0.0` to the open internet with a guessable token. Use a tailnet, a VPN, or `aoe serve --remote` with a passphrase.
+- `aoe remote list` deliberately reports only whether a token is stored, not its value, so its output is safe to paste into a bug report.
+
+## Related
+
+- [Web Dashboard](web-dashboard.md) — the full `aoe serve` reference.
+- [Tailscale Setup](tailscale.md) — reaching another machine across networks.
+- [Structured View](../structured-view.md) — the transcript and composer a remote row opens.

--- a/src/acp/client/discovery.rs
+++ b/src/acp/client/discovery.rs
@@ -105,6 +105,10 @@ pub enum Source {
     Env,
     /// Read from `<app_dir>/serve.url`.
     LocalDaemon,
+    /// A `[remotes.<name>]` entry in the user's config. Never eligible for
+    /// the loopback `serve.token` re-read in [`DaemonEndpoint::resolved_token`]:
+    /// a configured remote's credential belongs to another machine's daemon.
+    ConfiguredRemote,
 }
 
 #[derive(Debug, Error)]
@@ -142,6 +146,39 @@ pub fn discover_env() -> Option<DaemonEndpoint> {
         token,
         Source::Env,
     ))
+}
+
+/// Build an endpoint for a `[remotes.<name>]` config entry.
+///
+/// Unlike [`discover`] this never falls back to a local daemon: a remote
+/// row must talk to the box it names or show an error, because silently
+/// resolving to localhost would list the wrong machine's sessions under
+/// the remote's badge.
+pub fn endpoint_for_remote(remote: &crate::session::config::RemoteConfig) -> DaemonEndpoint {
+    // A URL pasted straight out of `serve.url` carries `?token=`. Prefer the
+    // explicit `token` field, falling back to the query so `aoe remote add
+    // <url-with-token>` works before normalization has stripped it.
+    let token = remote
+        .token
+        .clone()
+        .filter(|t| !t.is_empty())
+        .or_else(|| extract_token(&remote.url).map(str::to_string));
+    DaemonEndpoint::new(
+        trim_query(remote.url.trim())
+            .trim_end_matches('/')
+            .to_string(),
+        token,
+        Source::ConfiguredRemote,
+    )
+}
+
+/// Split a user-supplied remote URL into the bare base URL plus any
+/// `?token=` it carried, so the token is stored in its own field instead
+/// of being duplicated inside the URL. Used by `aoe remote add`.
+pub fn split_remote_url(input: &str) -> (String, Option<String>) {
+    let trimmed = input.trim();
+    let token = extract_token(trimmed).map(str::to_string);
+    (trim_query(trimmed).trim_end_matches('/').to_string(), token)
 }
 
 /// Local serve daemon discovery. Returns `Err(NoLocalDaemon)` when no

--- a/src/acp/client/mod.rs
+++ b/src/acp/client/mod.rs
@@ -28,6 +28,8 @@ pub mod http;
 pub mod ws;
 
 pub use daemon_manager::{require_daemon, ManagerError};
-pub use discovery::{discover, DaemonEndpoint, DiscoveryError, Source};
+pub use discovery::{
+    discover, endpoint_for_remote, split_remote_url, DaemonEndpoint, DiscoveryError, Source,
+};
 pub use http::{HttpClient, HttpError, PluginCommandView, REPLAY_PAGE_SIZE};
 pub use ws::{connect as ws_connect, WsError, WsHandle, WsMessage};

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -153,6 +153,13 @@ pub enum Commands {
         command: ProjectCommands,
     },
 
+    /// Manage remote `aoe serve` daemons whose sessions appear in the local list
+    #[cfg(feature = "serve")]
+    Remote {
+        #[command(subcommand)]
+        command: crate::cli::remote::RemoteCommands,
+    },
+
     /// Manage git worktrees for parallel development
     Worktree {
         #[command(subcommand)]
@@ -275,6 +282,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "plugin",
     "profile",
     "project",
+    "remote",
     "worktree",
     "tmux",
     "sounds",
@@ -323,6 +331,8 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Plugin { .. } => "plugin",
         Commands::Profile { .. } => "profile",
         Commands::Project { .. } => "project",
+        #[cfg(feature = "serve")]
+        Commands::Remote { .. } => "remote",
         Commands::Worktree { .. } => "worktree",
         Commands::Tmux { .. } => "tmux",
         Commands::Sounds { .. } => "sounds",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,10 @@ pub mod plugin;
 pub mod profile;
 pub mod project;
 pub mod ps;
+/// Serve-gated: a remote is only useful when this binary can speak to a
+/// daemon, which is the `serve` feature's client half (`acp::client`).
+#[cfg(feature = "serve")]
+pub mod remote;
 pub mod remove;
 pub mod send;
 #[cfg(feature = "serve")]

--- a/src/cli/remote.rs
+++ b/src/cli/remote.rs
@@ -1,0 +1,262 @@
+//! `aoe remote` subcommands: manage the remote `aoe serve` daemons whose
+//! sessions are merged into the local session list.
+//!
+//! Config-only. Nothing here contacts a remote: `add` validates the URL's
+//! shape and writes the entry, and the TUI's refresh loop reports
+//! reachability on the row itself. That keeps `add` fast and usable while
+//! the other box is still booting, and puts connection errors in the one
+//! place the user is going to look for them.
+
+use anyhow::{bail, Result};
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use crate::acp::client::split_remote_url;
+use crate::session::config::{load_config, update_config, RemoteConfig};
+
+#[derive(Subcommand)]
+pub enum RemoteCommands {
+    /// List configured remotes
+    #[command(alias = "ls")]
+    List(RemoteListArgs),
+
+    /// Add a remote daemon whose sessions appear in the local list
+    Add(RemoteAddArgs),
+
+    /// Remove a remote
+    #[command(alias = "rm")]
+    Remove(RemoteRemoveArgs),
+
+    /// Enable a remote without re-entering its URL
+    Enable(RemoteToggleArgs),
+
+    /// Skip a remote's sessions without deleting its entry
+    Disable(RemoteToggleArgs),
+}
+
+#[derive(Args)]
+pub struct RemoteListArgs {
+    /// Output as JSON
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args)]
+pub struct RemoteAddArgs {
+    /// Short label for the remote; badged onto each of its rows
+    name: String,
+
+    /// Base URL of the remote daemon, e.g. `http://linuxbox:8080`. A
+    /// `?token=` copied from the remote's `aoe url` output is accepted and
+    /// lifted into the stored token.
+    url: String,
+
+    /// Bearer token for the remote daemon. Omit for a `--no-auth` daemon or
+    /// when the token is already in the URL.
+    #[arg(long)]
+    token: Option<String>,
+
+    /// Replace an existing entry with the same name
+    #[arg(long)]
+    force: bool,
+}
+
+#[derive(Args)]
+pub struct RemoteRemoveArgs {
+    /// Name of the remote to remove
+    name: String,
+}
+
+#[derive(Args)]
+pub struct RemoteToggleArgs {
+    /// Name of the remote
+    name: String,
+}
+
+#[derive(Serialize)]
+struct RemoteListEntry {
+    name: String,
+    url: String,
+    enabled: bool,
+    /// Whether a token is stored, never the token itself: `aoe remote list`
+    /// output ends up in issue reports and terminal scrollback.
+    has_token: bool,
+}
+
+pub async fn run(command: RemoteCommands) -> Result<()> {
+    match command {
+        RemoteCommands::List(args) => list(args),
+        RemoteCommands::Add(args) => add(args),
+        RemoteCommands::Remove(args) => remove(args),
+        RemoteCommands::Enable(args) => set_enabled(args, true),
+        RemoteCommands::Disable(args) => set_enabled(args, false),
+    }
+}
+
+fn list(args: RemoteListArgs) -> Result<()> {
+    let config = load_config()?.unwrap_or_default();
+    let entries: Vec<RemoteListEntry> = config
+        .remotes
+        .iter()
+        .map(|(name, cfg)| RemoteListEntry {
+            name: name.clone(),
+            url: cfg.url.clone(),
+            enabled: cfg.enabled,
+            has_token: cfg.token.as_ref().is_some_and(|t| !t.is_empty()),
+        })
+        .collect();
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+
+    if entries.is_empty() {
+        println!("No remotes configured. Add one with `aoe remote add <name> <url>`.");
+        return Ok(());
+    }
+
+    for entry in entries {
+        let state = if entry.enabled { "" } else { " (disabled)" };
+        let auth = if entry.has_token { "" } else { " [no token]" };
+        println!("{}\t{}{}{}", entry.name, entry.url, auth, state);
+    }
+    Ok(())
+}
+
+fn add(args: RemoteAddArgs) -> Result<()> {
+    let name = args.name.trim().to_string();
+    validate_name(&name)?;
+
+    let (url, url_token) = split_remote_url(&args.url);
+    validate_url(&url)?;
+    // An explicit `--token` wins over one embedded in the URL, so a user
+    // correcting a stale pasted URL does not silently keep the old token.
+    let token = args
+        .token
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .or(url_token);
+
+    let existed = update_config(|config| {
+        let existed = config.remotes.contains_key(&name);
+        if existed && !args.force {
+            return existed;
+        }
+        config.remotes.insert(
+            name.clone(),
+            RemoteConfig {
+                url: url.clone(),
+                token: token.clone(),
+                enabled: true,
+            },
+        );
+        existed
+    })?;
+
+    if existed && !args.force {
+        bail!("remote '{name}' already exists; pass --force to replace it");
+    }
+
+    if existed {
+        println!("Replaced remote '{}' -> {}", name, url);
+    } else {
+        println!("Added remote '{}' -> {}", name, url);
+    }
+    if token.is_none() {
+        println!(
+            "No token stored. If that daemon requires auth, re-add with --token \
+             (find it in `aoe url` on the remote)."
+        );
+    }
+    Ok(())
+}
+
+fn remove(args: RemoteRemoveArgs) -> Result<()> {
+    let name = args.name.trim().to_string();
+    let removed = update_config(|config| config.remotes.remove(&name).is_some())?;
+    if !removed {
+        bail!("no remote named '{name}'");
+    }
+    println!("Removed remote '{}'", name);
+    Ok(())
+}
+
+fn set_enabled(args: RemoteToggleArgs, enabled: bool) -> Result<()> {
+    let name = args.name.trim().to_string();
+    let found = update_config(|config| match config.remotes.get_mut(&name) {
+        Some(entry) => {
+            entry.enabled = enabled;
+            true
+        }
+        None => false,
+    })?;
+    if !found {
+        bail!("no remote named '{name}'");
+    }
+    println!(
+        "{} remote '{}'",
+        if enabled { "Enabled" } else { "Disabled" },
+        name
+    );
+    Ok(())
+}
+
+/// Names index a TOML table and are rendered as a section header, so keep
+/// them to characters that need no quoting and cannot be confused with the
+/// `<prefix>/<name>` section-path format.
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("remote name cannot be empty");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        bail!("remote name may only contain letters, digits, '-', and '_'");
+    }
+    Ok(())
+}
+
+fn validate_url(url: &str) -> Result<()> {
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        bail!("remote URL must start with http:// or https:// (got '{url}')");
+    }
+    // `http://` alone parses as a scheme with no authority; require a host.
+    let host = url
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or_default();
+    if host.is_empty() || host.starts_with('/') {
+        bail!("remote URL is missing a host (got '{url}')");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_name_accepts_plain_labels() {
+        assert!(validate_name("linuxbox").is_ok());
+        assert!(validate_name("build-box_2").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_separators_and_empty() {
+        // A '/' would collide with the `<prefix>/<name>` section-path format.
+        assert!(validate_name("linux/box").is_err());
+        assert!(validate_name("").is_err());
+        assert!(validate_name("has space").is_err());
+    }
+
+    #[test]
+    fn validate_url_requires_scheme_and_host() {
+        assert!(validate_url("http://linuxbox:8080").is_ok());
+        assert!(validate_url("https://box.tailnet.ts.net").is_ok());
+        assert!(validate_url("linuxbox:8080").is_err());
+        assert!(validate_url("http://").is_err());
+        assert!(validate_url("http:///nohost").is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -437,6 +437,8 @@ async fn run(
         Some(Commands::Project { command }) => {
             cli::project::run(&profile, profile_explicit, command).await
         }
+        #[cfg(feature = "serve")]
+        Some(Commands::Remote { command }) => cli::remote::run(command).await,
         Some(Commands::Worktree { command }) => cli::worktree::run(&profile, command).await,
         // `apply` merges settings and writes the project registry, so it has to
         // run after migrations have brought that data to the current shape.

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -97,6 +97,14 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tools: HashMap<String, ToolSessionConfig>,
 
+    /// Remote `aoe serve` daemons whose sessions are merged into the local
+    /// session list, keyed by the short label each row is badged with
+    /// (`[remotes.linuxbox]`). Managed by `aoe remote add` / `remove`
+    /// rather than the settings schema: like [`Config::tools`] the entries
+    /// are user-named, so there is no fixed field for a widget to bind to.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub remotes: BTreeMap<String, RemoteConfig>,
+
     /// Per-plugin configuration keyed by plugin id (`[plugins."aoe.web"]`).
     /// An explicit typed map rather than a root-level flatten, so plugin
     /// enable-state survives every save without a root catch-all quietly
@@ -223,6 +231,31 @@ impl Default for PluginConfig {
             dismissed_update: None,
         }
     }
+}
+
+/// A remote `aoe serve` daemon contributing sessions to the local list.
+///
+/// Only structured-view sessions are merged: a remote tmux pane cannot be
+/// attached from this machine without SSH'ing into the host first, so
+/// surfacing those rows would promise an interaction the TUI cannot honor.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteConfig {
+    /// Base URL of the remote daemon (`http://linuxbox:8080`). Stored
+    /// without a trailing slash or query string; `aoe remote add`
+    /// normalizes both, and a `?token=` in the pasted URL is lifted into
+    /// [`Self::token`] so the secret is not duplicated on disk.
+    pub url: String,
+
+    /// Bearer token for the remote daemon, or `None` when it runs with
+    /// `--no-auth`. Kept alongside the URL rather than in the URL so it
+    /// never reaches a log line or a `ps` listing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+
+    /// Skip this remote without deleting its entry, so a box that is
+    /// simply off does not paint an error row on every refresh.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
 }
 
 /// Configuration for a user-defined tool session (lazygit, yazi, tig, etc.)

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -23,6 +23,32 @@ pub const ARCHIVED_SECTION_NAME: &str = "Archived";
 pub const TRASH_SECTION_PATH: &str = "__aoe_trash_section__";
 pub const TRASH_SECTION_NAME: &str = "Trash";
 
+/// Synthetic group path prefix for a remote daemon's shelf section. Unlike
+/// the Archived and Trash sentinels there is one section per configured
+/// remote, so the remote's name is appended: `<prefix>/<name>`. Shares the
+/// `__aoe_*__` convention so code that already skips synthetic headers
+/// keeps skipping these.
+pub const REMOTE_SECTION_PREFIX: &str = "__aoe_remote_section__";
+
+/// Synthetic group path for one remote's section header.
+pub fn remote_section_path(name: &str) -> String {
+    format!("{}/{}", REMOTE_SECTION_PREFIX, name)
+}
+
+/// True for a remote shelf header path. The bare prefix is not a header;
+/// only `<prefix>/<name>` is.
+#[inline]
+pub fn is_remote_section_path(path: &str) -> bool {
+    remote_name_from_section_path(path).is_some()
+}
+
+/// Recover the remote name from a path built by [`remote_section_path`].
+pub fn remote_name_from_section_path(path: &str) -> Option<&str> {
+    path.strip_prefix(REMOTE_SECTION_PREFIX)
+        .and_then(|rest| rest.strip_prefix('/'))
+        .filter(|n| !n.is_empty())
+}
+
 #[inline]
 pub fn is_archived_section_path(path: &str) -> bool {
     path == ARCHIVED_SECTION_PATH
@@ -368,6 +394,24 @@ pub enum Item {
         id: String,
         depth: usize,
     },
+    /// A session owned by a remote `aoe serve` daemon, mirrored into the
+    /// list read-only.
+    ///
+    /// Deliberately not an `Item::Session`: that variant's `id` is resolved
+    /// against `HomeView::instances` by every local operation, so reusing
+    /// it would make remote rows silently addressable by `stop`, `delete`,
+    /// worktree edits, and tmux attach, all of which act on this machine.
+    /// A distinct variant means an operation reaches a remote row only if
+    /// it explicitly matches this arm.
+    RemoteSession {
+        /// Config key of the owning `[remotes.<name>]` entry.
+        remote: String,
+        /// Session id as the remote daemon knows it. Not unique against
+        /// local ids in principle, so never look one up without the
+        /// `remote` half.
+        id: String,
+        depth: usize,
+    },
 }
 
 impl Item {
@@ -375,6 +419,17 @@ impl Item {
         match self {
             Item::Group { depth, .. } => *depth,
             Item::Session { depth, .. } => *depth,
+            Item::RemoteSession { depth, .. } => *depth,
+        }
+    }
+
+    /// The local session id this row addresses, if any. Remote rows return
+    /// `None`: they have no local `Instance`, and callers that treat an id
+    /// as locally resolvable must skip them.
+    pub fn local_session_id(&self) -> Option<&str> {
+        match self {
+            Item::Session { id, .. } => Some(id),
+            Item::Group { .. } | Item::RemoteSession { .. } => None,
         }
     }
 }
@@ -1060,6 +1115,55 @@ pub fn append_archived_section(items: &mut Vec<Item>, instances: &[Instance], co
             depth: 1,
         });
     }
+}
+
+/// Append one synthetic section per remote daemon, each a depth-0 header
+/// followed by that remote's mirrored session rows.
+///
+/// Unlike Archived and Trash, a remote section is pushed even when it holds
+/// no sessions: an empty section is how a configured-but-idle (or
+/// unreachable) box stays visible. Suppressing it would make a remote that
+/// failed to connect indistinguishable from one that was never configured,
+/// which is the state a user most needs to see.
+///
+/// Sits below Archived and Trash so the local workspace keeps the top of
+/// the list; see `HomeView::build_flat_items`.
+pub fn append_remote_sections<'a, I>(items: &mut Vec<Item>, sources: I)
+where
+    I: IntoIterator<Item = RemoteSectionView<'a>>,
+{
+    for source in sources {
+        items.push(Item::Group {
+            path: remote_section_path(source.name),
+            name: source.name.to_string(),
+            depth: 0,
+            collapsed: source.collapsed,
+            session_count: source.session_ids.len(),
+            profile: None,
+            archived_at: None,
+        });
+
+        if source.collapsed {
+            continue;
+        }
+
+        for id in source.session_ids {
+            items.push(Item::RemoteSession {
+                remote: source.name.to_string(),
+                id: id.to_string(),
+                depth: 1,
+            });
+        }
+    }
+}
+
+/// Borrowed view of a remote source, so `groups` can lay out the section
+/// without depending on the TUI's `RemoteSource` state (which owns network
+/// and endpoint concerns this module has no business knowing about).
+pub struct RemoteSectionView<'a> {
+    pub name: &'a str,
+    pub collapsed: bool,
+    pub session_ids: Vec<&'a str>,
 }
 
 /// Append the synthetic Trash section to `items`: a depth-0 header followed
@@ -2869,5 +2973,148 @@ mod tests {
         let inst: Instance = serde_json::from_str(legacy).unwrap();
         assert!(!inst.is_archived());
         assert!(inst.archived_at.is_none());
+    }
+
+    // --- Remote sections ---
+
+    #[test]
+    fn remote_section_path_roundtrips() {
+        let path = remote_section_path("linuxbox");
+        assert!(is_remote_section_path(&path));
+        assert_eq!(remote_name_from_section_path(&path), Some("linuxbox"));
+    }
+
+    #[test]
+    fn remote_section_path_rejects_other_shelves_and_bare_prefix() {
+        // The Archived / Trash sentinels must not be mistaken for a remote
+        // header, or `update_selected` would disarm the wrong keybindings.
+        assert!(!is_remote_section_path(TRASH_SECTION_PATH));
+        assert!(!is_remote_section_path(ARCHIVED_SECTION_PATH));
+        // The bare prefix is not a header; only `<prefix>/<name>` is.
+        assert!(!is_remote_section_path(REMOTE_SECTION_PREFIX));
+        assert_eq!(remote_name_from_section_path(REMOTE_SECTION_PREFIX), None);
+        assert_eq!(
+            remote_name_from_section_path(&format!("{}/", REMOTE_SECTION_PREFIX)),
+            None
+        );
+    }
+
+    #[test]
+    fn append_remote_sections_emits_header_then_rows() {
+        let mut items = Vec::new();
+        append_remote_sections(
+            &mut items,
+            vec![RemoteSectionView {
+                name: "linuxbox",
+                collapsed: false,
+                session_ids: vec!["a", "b"],
+            }],
+        );
+        assert_eq!(items.len(), 3);
+        match &items[0] {
+            Item::Group {
+                path,
+                name,
+                depth,
+                session_count,
+                ..
+            } => {
+                assert_eq!(path, &remote_section_path("linuxbox"));
+                assert_eq!(name, "linuxbox");
+                assert_eq!(*depth, 0);
+                assert_eq!(*session_count, 2);
+            }
+            other => panic!("expected a group header, got {other:?}"),
+        }
+        match &items[1] {
+            Item::RemoteSession { remote, id, depth } => {
+                assert_eq!(remote, "linuxbox");
+                assert_eq!(id, "a");
+                assert_eq!(*depth, 1);
+            }
+            other => panic!("expected a remote row, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_remote_sections_collapsed_emits_header_only_but_keeps_count() {
+        let mut items = Vec::new();
+        append_remote_sections(
+            &mut items,
+            vec![RemoteSectionView {
+                name: "box",
+                collapsed: true,
+                session_ids: vec!["a", "b", "c"],
+            }],
+        );
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            // The count still reflects the hidden rows, matching how the
+            // Archived / Trash headers behave when collapsed.
+            Item::Group { session_count, .. } => assert_eq!(*session_count, 3),
+            other => panic!("expected a group header, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_remote_sections_keeps_empty_section_visible() {
+        // Unlike Archived / Trash, an empty remote section is still pushed:
+        // it is how a configured-but-idle or unreachable box stays visible.
+        let mut items = Vec::new();
+        append_remote_sections(
+            &mut items,
+            vec![RemoteSectionView {
+                name: "offline",
+                collapsed: false,
+                session_ids: vec![],
+            }],
+        );
+        assert_eq!(items.len(), 1);
+    }
+
+    #[test]
+    fn append_remote_sections_preserves_source_order() {
+        let mut items = Vec::new();
+        append_remote_sections(
+            &mut items,
+            vec![
+                RemoteSectionView {
+                    name: "alpha",
+                    collapsed: false,
+                    session_ids: vec!["a"],
+                },
+                RemoteSectionView {
+                    name: "beta",
+                    collapsed: false,
+                    session_ids: vec!["b"],
+                },
+            ],
+        );
+        let headers: Vec<&str> = items
+            .iter()
+            .filter_map(|i| match i {
+                Item::Group { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(headers, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn item_local_session_id_excludes_remote_rows() {
+        // The guarantee the whole design leans on: a remote row never yields
+        // an id that a local lookup would treat as resolvable.
+        let local = Item::Session {
+            id: "local".into(),
+            depth: 0,
+        };
+        let remote = Item::RemoteSession {
+            remote: "box".into(),
+            id: "remote".into(),
+            depth: 1,
+        };
+        assert_eq!(local.local_session_id(), Some("local"));
+        assert_eq!(remote.local_session_id(), None);
+        assert_eq!(remote.depth(), 1);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -63,11 +63,13 @@ pub use fork::{ForkDenied, ForkSeed};
 /// favorite exactly when it is pinned as one.
 pub(crate) use groups::is_live_favorite;
 pub use groups::{
-    append_archived_section, append_archived_section_by_project, append_trash_section,
-    archived_project_sub_path, flatten_sessions_by_attention, flatten_tree,
-    flatten_tree_all_profiles, is_archived_section_path, is_trash_section_path,
-    is_within_archived_section, is_within_trash_section, Group, GroupTree, Item,
-    ARCHIVED_SECTION_NAME, ARCHIVED_SECTION_PATH, TRASH_SECTION_NAME, TRASH_SECTION_PATH,
+    append_archived_section, append_archived_section_by_project, append_remote_sections,
+    append_trash_section, archived_project_sub_path, flatten_sessions_by_attention, flatten_tree,
+    flatten_tree_all_profiles, is_archived_section_path, is_remote_section_path,
+    is_trash_section_path, is_within_archived_section, is_within_trash_section,
+    remote_name_from_section_path, remote_section_path, Group, GroupTree, Item, RemoteSectionView,
+    ARCHIVED_SECTION_NAME, ARCHIVED_SECTION_PATH, REMOTE_SECTION_PREFIX, TRASH_SECTION_NAME,
+    TRASH_SECTION_PATH,
 };
 #[cfg(feature = "serve")]
 pub(crate) use instance::ResumeAttemptPolicy;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -191,6 +191,11 @@ pub struct App {
     /// the sync `execute_action` can't lend out).
     #[cfg(feature = "serve")]
     pending_structured_view_open: Option<String>,
+    /// Set by `Action::OpenRemoteStructuredView`: `(remote name, session id)`
+    /// for a mirrored remote row the user activated. Same stash-for-the-async-
+    /// loop reason as `pending_structured_view_open`.
+    #[cfg(feature = "serve")]
+    pending_remote_structured_open: Option<(String, String)>,
     /// Set by `Action::SwitchSessionView` so the async main loop can run
     /// the daemon switch POST (awaited; the sync handler can't).
     #[cfg(feature = "serve")]
@@ -494,6 +499,8 @@ impl App {
             mosh_active,
             #[cfg(feature = "serve")]
             pending_structured_view_open: None,
+            #[cfg(feature = "serve")]
+            pending_remote_structured_open: None,
             #[cfg(feature = "serve")]
             pending_daemon_start_open: None,
             #[cfg(feature = "serve")]
@@ -1860,6 +1867,15 @@ impl App {
                 needs_full_refresh = true;
             }
 
+            // Remote daemon session lists. Arms its own refresh on an
+            // interval and applies whatever has returned, so a slow or
+            // unreachable remote never blocks the tick.
+            #[cfg(feature = "serve")]
+            if self.home.tick_remotes() {
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+
             // Fade the settings "Settings saved" toast once its window passes,
             // even if the user has stopped typing. Fires at most once per save,
             // so a full refresh here is free.
@@ -2967,6 +2983,11 @@ impl App {
         }
 
         #[cfg(feature = "serve")]
+        if let Some((remote, session_id)) = self.pending_remote_structured_open.take() {
+            self.open_remote_structured_view(&remote, &session_id).await;
+        }
+
+        #[cfg(feature = "serve")]
         if let Some(session_id) = self.pending_smart_rename.take() {
             self.perform_smart_rename(&session_id).await;
         }
@@ -3139,6 +3160,44 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    /// Mount and enter the embedded structured view against a remote
+    /// daemon.
+    ///
+    /// Shorter than [`Self::open_structured_view`] because the archived /
+    /// trashed and no-local-daemon branches do not apply: the merged list
+    /// only ever holds live structured sessions, and the daemon in question
+    /// is already running on the other machine (that is why we can see the
+    /// row at all). `EmbeddedView::connect` is endpoint-parameterized, so
+    /// the remote case needs no separate view implementation.
+    #[cfg(feature = "serve")]
+    async fn open_remote_structured_view(&mut self, remote: &str, session_id: &str) {
+        // Re-resolve from current config rather than trusting an endpoint
+        // captured at keypress time: the remote may have been removed or
+        // retargeted in between.
+        let config = crate::session::config::load_config()
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        let Some(entry) = config.remotes.get(remote).filter(|r| r.enabled) else {
+            self.update_status = Some(UpdateStatus::transient(format!(
+                "remote '{remote}' is no longer configured"
+            )));
+            return;
+        };
+        let endpoint = crate::acp::client::endpoint_for_remote(entry);
+        if self
+            .home
+            .structured_preview
+            .as_ref()
+            .is_some_and(|v| v.session_id() == session_id)
+        {
+            self.activate_embedded();
+            return;
+        }
+        self.connect_embedded_structured(endpoint, session_id).await;
+        self.activate_embedded();
     }
 
     /// Flip the mounted embedded view to interactive mode (exiting
@@ -3530,6 +3589,10 @@ impl App {
                 // lend; the loop picks `pending_structured_view_open` up after
                 // we return.
                 self.pending_structured_view_open = Some(id);
+            }
+            #[cfg(feature = "serve")]
+            Action::OpenRemoteStructuredView { remote, session_id } => {
+                self.pending_remote_structured_open = Some((remote, session_id));
             }
             #[cfg(feature = "serve")]
             Action::SwitchSessionView(id) => {
@@ -4180,6 +4243,17 @@ pub enum Action {
     /// against the borrowed terminal + event stream.
     #[cfg(feature = "serve")]
     OpenStructuredView(String),
+    /// Open the structured view for a session owned by a remote daemon.
+    /// Stashed in `pending_remote_structured_open` and drained beside
+    /// `pending_structured_view_open`. Carries the remote's config name
+    /// rather than a resolved endpoint so the drain re-resolves against
+    /// current config: a `remote remove` between keypress and drain must
+    /// not still connect.
+    #[cfg(feature = "serve")]
+    OpenRemoteStructuredView {
+        remote: String,
+        session_id: String,
+    },
     /// Flip a session's persisted view (structured ↔ terminal) through the
     /// daemon's switch endpoints. Stashed in `pending_view_switch` (the
     /// POST needs the async loop) and drained alongside

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2729,6 +2729,14 @@ impl HomeView {
             KeyCode::Char('<') => self.shrink_list(),
             KeyCode::Char('>') => self.grow_list(),
             KeyCode::Enter => {
+                // A remote row is activatable but deliberately leaves
+                // `selected_session` unset (see `update_selected`), so it needs
+                // its own arm here; `activate_selected_session` dispatches on
+                // `selected_remote` first.
+                #[cfg(feature = "serve")]
+                if self.selected_remote.is_some() {
+                    return self.activate_selected_session();
+                }
                 if self.selected_session.is_some() {
                     return self.activate_selected_session();
                 } else if let Some(Item::Group { path, .. }) = self.flat_items.get(self.cursor) {
@@ -3854,6 +3862,23 @@ impl HomeView {
                         payload: PaletteAction::JumpToCursor(idx),
                     });
                 }
+                // Remote rows get a jump entry too, badged with the remote's
+                // name so the palette makes clear which machine owns it.
+                // JumpToCursor only moves the cursor, so the entry commits to
+                // nothing a remote row cannot do.
+                Item::RemoteSession { remote, id, .. } => {
+                    let Some(title) = self.remote_session_title(remote, id) else {
+                        continue;
+                    };
+                    entries.push(PaletteCommand {
+                        id: "jump-remote-session",
+                        title: format!("Jump to remote session: {} ({})", title, remote),
+                        group: PaletteGroup::Sessions,
+                        keywords: vec!["session", "jump", "remote"],
+                        hotkey: String::new(),
+                        payload: PaletteAction::JumpToCursor(idx),
+                    });
+                }
                 Item::Group { name, path, .. } => {
                     // The synthetic Archived section header (and any
                     // sub-folder rendered under it in Project mode) is
@@ -3863,6 +3888,7 @@ impl HomeView {
                     // intentionally disarms.
                     if crate::session::is_within_archived_section(path)
                         || crate::session::is_within_trash_section(path)
+                        || crate::session::is_remote_section_path(path)
                     {
                         continue;
                     }
@@ -3988,7 +4014,11 @@ impl HomeView {
             .iter()
             .filter_map(|item| match item {
                 Item::Session { id, .. } => Some(id.clone()),
-                Item::Group { .. } => None,
+                // Attention cycling walks local status transitions
+                // (Waiting, freshly-idle). A remote row has no local
+                // status history to cycle through, and stopping on one
+                // would strand `w` on a row whose only action is "open".
+                Item::Group { .. } | Item::RemoteSession { .. } => None,
             })
             .collect();
         let current_session = self.selected_session.clone();
@@ -4152,6 +4182,16 @@ impl HomeView {
     /// between the `Enter` keybind and double-click activation so the two
     /// paths can't drift.
     pub(super) fn activate_selected_session(&mut self) -> Option<Action> {
+        // Remote rows are checked first and never fall through: they set
+        // `selected_remote` instead of `selected_session`, so the local
+        // paths below cannot resolve one anyway, but returning here keeps
+        // the "one row, one action" contract obvious.
+        #[cfg(feature = "serve")]
+        if let Some((remote, session_id)) = self.selected_remote.clone() {
+            // Same preview-pane handoff as the local structured path.
+            self.exit_live_send_if_active();
+            return Some(Action::OpenRemoteStructuredView { remote, session_id });
+        }
         let id = self.selected_session.clone()?;
         if let Some(inst) = self.get_instance(&id) {
             if matches!(inst.status, Status::Deleting | Status::Creating) {
@@ -4277,11 +4317,38 @@ impl HomeView {
                     self.selected_session = Some(id.clone());
                     self.selected_group = None;
                     self.selected_group_profile = None;
+                    #[cfg(feature = "serve")]
+                    {
+                        self.selected_remote = None;
+                    }
+                }
+                Item::RemoteSession { remote, id, .. } => {
+                    // Every local selection field stays clear so no local
+                    // keybinding can fire against a row this machine does not
+                    // own; `selected_remote` carries the target for the one
+                    // action that does apply (open the structured view).
+                    #[cfg(feature = "serve")]
+                    {
+                        self.selected_remote = Some((remote.clone(), id.clone()));
+                    }
+                    #[cfg(not(feature = "serve"))]
+                    let _ = (remote, id);
+                    self.selected_session = None;
+                    self.selected_group = None;
+                    self.selected_group_profile = None;
                 }
                 Item::Group { path, .. } => {
                     self.selected_session = None;
+                    #[cfg(feature = "serve")]
+                    {
+                        self.selected_remote = None;
+                    }
                     if crate::session::is_within_archived_section(path)
                         || crate::session::is_within_trash_section(path)
+                        // A remote section header is synthetic in the same way:
+                        // it cannot be renamed, deleted, or moved, so it must
+                        // not arm the group keybindings either.
+                        || crate::session::is_remote_section_path(path)
                     {
                         // The synthetic Archived section (and any
                         // project sub-folder rendered under it in
@@ -4404,6 +4471,16 @@ impl HomeView {
         }
         if crate::session::is_trash_section_path(path) {
             self.toggle_trashed_section();
+            return;
+        }
+        // Same story for a remote section header: not a member of any
+        // GroupTree, and its collapsed state lives on the `RemoteSource`.
+        #[cfg(feature = "serve")]
+        if let Some(name) = crate::session::remote_name_from_section_path(path) {
+            let name = name.to_string();
+            if self.toggle_remote_section(&name) {
+                self.rebuild_flat_items();
+            }
             return;
         }
         if self.group_by == GroupByMode::Project {
@@ -4893,6 +4970,14 @@ impl HomeView {
                     return true;
                 }
             }
+            // A remote row supports exactly one action (open the structured
+            // view), which Enter and double-click already provide. Every entry
+            // the session menu offers acts on local state, so open no menu
+            // rather than one whose rows would silently do nothing. The cursor
+            // move above still happened, so the right-click at least selects.
+            if matches!(self.flat_items[idx], super::Item::RemoteSession { .. }) {
+                return true;
+            }
             let is_group = matches!(self.flat_items[idx], super::Item::Group { .. });
             // A real project header in project view gets the pin menu; the
             // cursor was just moved onto this row, so `project_group_at_cursor`
@@ -4908,7 +4993,9 @@ impl HomeView {
                         .get_instance(id)
                         .map(|inst| (inst.is_archived(), inst.is_snoozed(), inst.is_unread()))
                         .unwrap_or((false, false, false)),
-                    super::Item::Group { .. } => (false, false, false),
+                    super::Item::Group { .. } | super::Item::RemoteSession { .. } => {
+                        (false, false, false)
+                    }
                 };
                 // Snooze is an Attention-sort triage primitive: the `'h'`
                 // keybinding only fires in Attention sort, so the menu omits
@@ -4924,7 +5011,9 @@ impl HomeView {
                 // refuse. Matches the web sidebar's `acp_can_fork` gating.
                 let can_fork = match &self.flat_items[idx] {
                     super::Item::Session { id, .. } => self.session_can_fork(id),
-                    super::Item::Group { .. } => false,
+                    // Forking creates a local session from a local worktree;
+                    // neither exists for a remote row.
+                    super::Item::Group { .. } | super::Item::RemoteSession { .. } => false,
                 };
                 // View switching mirrors the web sidebar's per-session
                 // switch action: offered when a structured session can go
@@ -4933,7 +5022,9 @@ impl HomeView {
                 // the daemon.
                 let switch_view = match &self.flat_items[idx] {
                     super::Item::Session { id, .. } => self.session_switch_view_target(id),
-                    super::Item::Group { .. } => None,
+                    // Flipping a remote session's view would need a write
+                    // against the remote daemon; the merged list is read-only.
+                    super::Item::Group { .. } | super::Item::RemoteSession { .. } => None,
                 };
                 ContextMenuDialog::for_session(
                     anchor,
@@ -5620,7 +5711,7 @@ impl HomeView {
             // which tracks `cursor`, not the click target; and we'd open
             // the wrong session.
             return match item {
-                Item::Session { .. } => {
+                Item::Session { .. } | Item::RemoteSession { .. } => {
                     if self.cursor != abs_idx {
                         self.cursor = abs_idx;
                         self.update_selected();
@@ -5634,6 +5725,17 @@ impl HomeView {
         match item {
             Item::Group { path, .. } => {
                 self.toggle_group_collapsed(&path);
+                None
+            }
+            // A single click selects a remote row and stops there. The
+            // configurable click actions (live-send, attach) all drive a
+            // local pane, so the remote row's only gesture stays the
+            // deliberate one: Enter or double-click.
+            Item::RemoteSession { .. } => {
+                if self.cursor != abs_idx {
+                    self.cursor = abs_idx;
+                    self.update_selected();
+                }
                 None
             }
             Item::Session { id, .. } => {
@@ -6622,6 +6724,16 @@ impl HomeView {
                 Item::Group { name, path, .. } => {
                     format!("{} {}", name, path)
                 }
+                // Remote rows are searchable by title, remote name, and the
+                // remote's project path, so `/linuxbox` gathers that whole
+                // section. Search only moves the cursor, so matching one
+                // commits to nothing a remote row cannot do.
+                Item::RemoteSession { remote, id, .. } => {
+                    match self.remote_search_haystack(remote, id) {
+                        Some(haystack) => haystack,
+                        None => continue,
+                    }
+                }
             };
 
             let haystack_utf32 = Utf32Str::new(&haystack, &mut buf);
@@ -6675,6 +6787,16 @@ impl HomeView {
                 }
                 Item::Group { name, path, .. } => {
                     format!("{} {}", name, path)
+                }
+                // Remote rows are searchable by title, remote name, and the
+                // remote's project path, so `/linuxbox` gathers that whole
+                // section. Search only moves the cursor, so matching one
+                // commits to nothing a remote row cannot do.
+                Item::RemoteSession { remote, id, .. } => {
+                    match self.remote_search_haystack(remote, id) {
+                        Some(haystack) => haystack,
+                        None => continue,
+                    }
                 }
             };
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4,6 +4,13 @@ pub(crate) mod bindings;
 mod input;
 mod live_send;
 mod operations;
+/// Remote-daemon session sources. Serve-gated: the whole module talks to
+/// `acp::client`, which only exists with `serve`. `Item::RemoteSession` and
+/// `append_remote_sections` are deliberately NOT gated, so every match arm
+/// in the view compiles identically in both builds; a TUI-only build simply
+/// never constructs one.
+#[cfg(feature = "serve")]
+pub(crate) mod remotes;
 pub(crate) mod render;
 
 #[cfg(test)]
@@ -409,6 +416,14 @@ pub(super) const ICON_STOPPED: &str = "⠒";
 /// monochrome terminals and for colorblind users. See #2250.
 pub(super) const ICON_DORMANT: &str = "⠶";
 pub(super) const ICON_DELETING: &str = "✕";
+/// Static Running / Waiting glyphs for mirrored remote rows. Local rows
+/// animate those two states with a spinner keyed off `created_at`; a remote
+/// row is re-listed every few seconds, so an animation would imply a
+/// frame-accurate liveness this side does not have. Same single-width
+/// braille family as `ICON_IDLE` so the remote shelf reads as one system,
+/// and distinct in shape from `ICON_DORMANT` for monochrome terminals.
+pub(super) const ICON_REMOTE_RUNNING: &str = "⠿";
+pub(super) const ICON_REMOTE_WAITING: &str = "⠛";
 pub(super) const ICON_COLLAPSED: &str = "▶";
 pub(super) const ICON_EXPANDED: &str = "▼";
 /// Marks a pinned project header in project view. Geometric per DESIGN.md
@@ -420,6 +435,10 @@ pub(super) const ICON_PINNED: &str = "◆";
 /// hit-testing on terminals that render them double-width or as tofu).
 pub(super) const ICON_TRASH_SECTION: &str = "⊘";
 pub(super) const ICON_ARCHIVED_SECTION: &str = "▤";
+/// Type glyph for a remote daemon's section header. Single-width geometric
+/// per DESIGN.md, and distinct from the Trash / Archived shelf glyphs so
+/// the three system shelves are told apart by shape.
+pub(super) const ICON_REMOTE_SECTION: &str = "⇄";
 
 /// Hook progress for a session being created in the background
 pub(super) struct CreatingHookProgress {
@@ -458,9 +477,35 @@ pub struct HomeView {
     pub(super) group_trees: HashMap<String, GroupTree>,
     pub(super) flat_items: Vec<Item>,
 
+    /// Configured remote daemons whose sessions are mirrored into the list,
+    /// one synthetic bottom-shelf section each. Rebuilt from config on
+    /// `refresh_from_config`; refreshed over the network on its own cadence
+    /// (see `tick_remotes`).
+    #[cfg(feature = "serve")]
+    pub(super) remote_sources: Vec<remotes::RemoteSource>,
+    /// Receiver for in-flight remote refreshes. `None` until the first
+    /// refresh is armed (i.e. when at least one remote is configured), so a
+    /// user with no remotes pays nothing.
+    #[cfg(feature = "serve")]
+    remote_rx: Option<std::sync::mpsc::Receiver<remotes::RemoteUpdate>>,
+    #[cfg(feature = "serve")]
+    remote_tx: Option<std::sync::mpsc::Sender<remotes::RemoteUpdate>>,
+    /// When the next remote refresh may be armed. `None` means "arm on the
+    /// next tick", which is the initial state so the sections populate
+    /// without waiting out a full interval.
+    #[cfg(feature = "serve")]
+    remote_next_refresh: Option<Instant>,
+
     // UI state
     pub(super) cursor: usize,
     pub(super) selected_session: Option<String>,
+    /// `(remote name, remote session id)` when the cursor sits on a mirrored
+    /// remote row. Deliberately separate from `selected_session`: every
+    /// local keybinding gates on `selected_session.is_some()`, so keeping
+    /// remote selection in its own field disarms all of them at once
+    /// instead of relying on each one to re-check the row's kind.
+    #[cfg(feature = "serve")]
+    pub(super) selected_remote: Option<(String, String)>,
     pub(super) selected_group: Option<String>,
     /// Which profile the selected group belongs to (for scoped group operations)
     pub(super) selected_group_profile: Option<String>,
@@ -2152,8 +2197,18 @@ impl HomeView {
             pending_added: HashMap::new(),
             group_trees,
             flat_items: Vec::new(),
+            #[cfg(feature = "serve")]
+            remote_sources: remotes::sources_from_config(&resolved.remotes),
+            #[cfg(feature = "serve")]
+            remote_rx: None,
+            #[cfg(feature = "serve")]
+            remote_tx: None,
+            #[cfg(feature = "serve")]
+            remote_next_refresh: None,
             cursor: 0,
             selected_session: None,
+            #[cfg(feature = "serve")]
+            selected_remote: None,
             selected_group: None,
             selected_group_profile: None,
             view_mode,
@@ -3595,6 +3650,264 @@ impl HomeView {
         !outcome.applied.is_empty() || !outcome.rolled_back.is_empty()
     }
 
+    /// Rebuild `remote_sources` from a freshly resolved config, preserving
+    /// the last fetched snapshot for remotes that survived the edit.
+    ///
+    /// Preserving matters because config is re-resolved on every settings
+    /// save and on every watcher-driven reload: rebuilding from scratch
+    /// would blank every remote section back to "connecting…" whenever the
+    /// user changed an unrelated setting.
+    #[cfg(feature = "serve")]
+    fn sync_remote_sources(
+        &mut self,
+        remotes: &std::collections::BTreeMap<String, crate::session::config::RemoteConfig>,
+    ) {
+        let mut rebuilt = remotes::sources_from_config(remotes);
+        for source in &mut rebuilt {
+            if let Some(prev) = self.remote_sources.iter().find(|p| p.name == source.name) {
+                // Only carry the snapshot forward when the endpoint is
+                // unchanged. A retargeted URL must re-fetch, not keep
+                // showing the old box's sessions under the same name.
+                if prev.endpoint.base_url == source.endpoint.base_url {
+                    source.sessions = prev.sessions.clone();
+                    source.last_error = prev.last_error.clone();
+                    source.loaded = prev.loaded;
+                    // Carry the in-flight marker with the endpoint it belongs
+                    // to: the outstanding task still reports under this name,
+                    // and clearing the flag here would let the next tick spawn
+                    // a duplicate. A retargeted URL deliberately resets it, so
+                    // the new endpoint is fetched immediately; the stale reply
+                    // is then absorbed harmlessly by the next drain.
+                    source.in_flight = prev.in_flight;
+                }
+                source.collapsed = prev.collapsed;
+            }
+        }
+        self.remote_sources = rebuilt;
+    }
+
+    /// Arm a refresh when the interval has elapsed, then drain whatever has
+    /// come back. Returns true if any section changed, so the caller can
+    /// rebuild `flat_items`.
+    ///
+    /// Called from the `App::run` tick. Cheap and allocation-free when no
+    /// remotes are configured: the empty-source check returns before any
+    /// channel is created.
+    #[cfg(feature = "serve")]
+    pub fn tick_remotes(&mut self) -> bool {
+        if self.remote_sources.is_empty() {
+            // Drop a channel left over from a config edit that removed the
+            // last remote, so late replies cannot resurrect a stale section.
+            self.remote_rx = None;
+            self.remote_tx = None;
+            return false;
+        }
+
+        let now = Instant::now();
+        if self.remote_next_refresh.is_none_or(|next| now >= next) {
+            if self.remote_tx.is_none() {
+                let (tx, rx) = std::sync::mpsc::channel();
+                self.remote_tx = Some(tx);
+                self.remote_rx = Some(rx);
+            }
+            // Cloned out of the option so `spawn_refresh` can take
+            // `remote_sources` mutably (it marks each source in-flight)
+            // without a second borrow of `self`.
+            if let Some(tx) = self.remote_tx.clone() {
+                remotes::spawn_refresh(&mut self.remote_sources, &tx);
+            }
+            self.remote_next_refresh = Some(now + remotes::REMOTE_REFRESH_INTERVAL);
+        }
+
+        if !self.drain_remote_updates() {
+            return false;
+        }
+        // A changed section adds or removes rows, so `flat_items` has to be
+        // rebuilt; a repaint alone would keep showing the old tree. Done here
+        // rather than in the caller so the rebuild cannot be forgotten at a
+        // future callsite.
+        self.refresh_rows_preserving_selection();
+        true
+    }
+
+    /// Apply completed refreshes. Non-blocking: a remote that has not
+    /// replied yet keeps its previous snapshot.
+    #[cfg(feature = "serve")]
+    fn drain_remote_updates(&mut self) -> bool {
+        let Some(rx) = self.remote_rx.as_ref() else {
+            return false;
+        };
+        let mut updates = Vec::new();
+        loop {
+            match rx.try_recv() {
+                Ok(update) => updates.push(update),
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    // Every sender clone is gone. Re-arm from scratch on the
+                    // next tick rather than going permanently quiet.
+                    self.remote_rx = None;
+                    self.remote_tx = None;
+                    break;
+                }
+            }
+        }
+        if updates.is_empty() {
+            return false;
+        }
+
+        let mut changed = false;
+        for update in updates {
+            let Some(source) = self
+                .remote_sources
+                .iter_mut()
+                .find(|s| s.name == update.name)
+            else {
+                // The remote was removed from config while its fetch was in
+                // flight. Drop the reply.
+                continue;
+            };
+            source.loaded = true;
+            source.in_flight = false;
+            match update.result {
+                Ok(sessions) => {
+                    // Compare before assigning so an unchanged poll does not
+                    // force a tree rebuild every interval.
+                    let same = source.sessions.len() == sessions.len()
+                        && source.sessions.iter().zip(&sessions).all(|(a, b)| {
+                            a.id == b.id && a.title == b.title && a.status == b.status
+                        });
+                    if !same || source.last_error.is_some() {
+                        source.sessions = sessions;
+                        changed = true;
+                    }
+                    source.last_error = None;
+                }
+                Err(e) => {
+                    if source.last_error.as_deref() != Some(e.as_str()) {
+                        changed = true;
+                    }
+                    tracing::debug!(
+                        target: "tui.remotes",
+                        remote = %source.name,
+                        error = %e,
+                        "remote session list refresh failed",
+                    );
+                    source.last_error = Some(e);
+                }
+            }
+        }
+        changed
+    }
+
+    /// Look up a mirrored remote session by the pair that identifies it.
+    /// Both halves are required: remote ids are only unique per daemon.
+    #[cfg(feature = "serve")]
+    pub(super) fn remote_session(
+        &self,
+        remote: &str,
+        id: &str,
+    ) -> Option<(&remotes::RemoteSource, &remotes::RemoteSession)> {
+        let source = self.remote_sources.iter().find(|s| s.name == remote)?;
+        Some((source, source.session(id)?))
+    }
+
+    /// Status and title for a mirrored remote row, or `None` when the row
+    /// has outlived its snapshot.
+    ///
+    /// Exists in both build configurations so the `Item::RemoteSession`
+    /// render and input arms need no `cfg` of their own. Without `serve`
+    /// there is no remotes module and no way to construct such a row, so
+    /// the stub always returns `None`.
+    #[cfg(feature = "serve")]
+    pub(super) fn remote_row_display(
+        &self,
+        remote: &str,
+        id: &str,
+    ) -> Option<(crate::session::Status, String)> {
+        let (_, session) = self.remote_session(remote, id)?;
+        let title = if session.title.is_empty() {
+            "(untitled)".to_string()
+        } else {
+            session.title.clone()
+        };
+        Some((session.status(), title))
+    }
+
+    #[cfg(not(feature = "serve"))]
+    pub(super) fn remote_row_display(
+        &self,
+        _remote: &str,
+        _id: &str,
+    ) -> Option<(crate::session::Status, String)> {
+        None
+    }
+
+    /// Connection-state suffix for a remote section header, or `None` for a
+    /// non-remote header or a healthy loaded remote. Defined in both build
+    /// configurations for the same reason as `remote_row_display`.
+    #[cfg(feature = "serve")]
+    pub(super) fn remote_section_subtitle(&self, path: &str) -> Option<String> {
+        let name = crate::session::remote_name_from_section_path(path)?;
+        self.remote_sources
+            .iter()
+            .find(|s| s.name == name)?
+            .subtitle()
+    }
+
+    #[cfg(not(feature = "serve"))]
+    pub(super) fn remote_section_subtitle(&self, _path: &str) -> Option<String> {
+        None
+    }
+
+    /// Title of a mirrored remote row, for the command palette.
+    pub(super) fn remote_session_title(&self, remote: &str, id: &str) -> Option<String> {
+        self.remote_row_display(remote, id).map(|(_, title)| title)
+    }
+
+    /// Search haystack for a mirrored remote row: title, remote name, and
+    /// the remote's project path. Includes the path so `/` search matches a
+    /// repo name the same way it does for local rows, and the remote name so
+    /// searching for the machine gathers its whole section.
+    #[cfg(feature = "serve")]
+    pub(super) fn remote_search_haystack(&self, remote: &str, id: &str) -> Option<String> {
+        let (_, session) = self.remote_session(remote, id)?;
+        Some(format!(
+            "{} {} {}",
+            session.title, remote, session.project_path
+        ))
+    }
+
+    #[cfg(not(feature = "serve"))]
+    pub(super) fn remote_search_haystack(&self, _remote: &str, _id: &str) -> Option<String> {
+        None
+    }
+
+    /// Toggle a remote section's collapsed state. Kept in memory rather
+    /// than persisted: unlike Archived/Trash, a remote section's contents
+    /// change with another machine's activity, so a collapse the user set
+    /// days ago is more likely to hide news than to reduce noise.
+    #[cfg(feature = "serve")]
+    pub(super) fn toggle_remote_section(&mut self, remote: &str) -> bool {
+        if let Some(source) = self.remote_sources.iter_mut().find(|s| s.name == remote) {
+            source.collapsed = !source.collapsed;
+            return true;
+        }
+        false
+    }
+
+    /// Borrowed layout views for `append_remote_sections`.
+    #[cfg(feature = "serve")]
+    fn remote_section_views(&self) -> Vec<crate::session::RemoteSectionView<'_>> {
+        self.remote_sources
+            .iter()
+            .map(|s| crate::session::RemoteSectionView {
+                name: &s.name,
+                collapsed: s.collapsed,
+                session_ids: s.sessions.iter().map(|x| x.id.as_str()).collect(),
+            })
+            .collect()
+    }
+
     /// Drain the startup-recovery channel and apply each `RecoveryUpdate`
     /// to the in-memory `Instance` snapshot. Released the recovery lock
     /// (and the receiver) when all workers have completed.
@@ -3700,11 +4013,30 @@ impl HomeView {
     fn refresh_rows_preserving_selection(&mut self) {
         let prev_selected_session = self.selected_session.clone();
         let prev_selected_group = self.selected_group.clone();
+        #[cfg(feature = "serve")]
+        let prev_selected_remote = self.selected_remote.clone();
 
         self.rebuild_flat_items();
 
         let mut restored = false;
-        if let Some(ref sid) = prev_selected_session {
+        // Remote first: a remote row sets neither `selected_session` nor
+        // `selected_group`, so without this the cursor would fall through to
+        // the length clamp and jump on every refresh that added a row above.
+        #[cfg(feature = "serve")]
+        if let Some((ref prev_remote, ref prev_id)) = prev_selected_remote {
+            for (idx, item) in self.flat_items.iter().enumerate() {
+                if let Item::RemoteSession { remote, id, .. } = item {
+                    if remote == prev_remote && id == prev_id {
+                        self.cursor = idx;
+                        restored = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if restored {
+            // Fall through to the search/selection tail below.
+        } else if let Some(ref sid) = prev_selected_session {
             for (idx, item) in self.flat_items.iter().enumerate() {
                 if let Item::Session { id, .. } = item {
                     if id == sid {
@@ -4929,6 +5261,21 @@ impl HomeView {
         !self.instances.is_empty()
     }
 
+    /// Whether any remote is configured and enabled. Distinct from "any
+    /// remote row exists": a configured remote with zero sessions (or an
+    /// unreachable one) still renders a section header, and that header is
+    /// the only place its connection error is reported, so the empty-state
+    /// placeholder must not replace it.
+    #[cfg(feature = "serve")]
+    pub(super) fn has_remote_sources(&self) -> bool {
+        !self.remote_sources.is_empty()
+    }
+
+    #[cfg(not(feature = "serve"))]
+    pub(super) fn has_remote_sources(&self) -> bool {
+        false
+    }
+
     pub fn get_instance(&self, id: &str) -> Option<&Instance> {
         self.instances.get(id)
     }
@@ -5024,8 +5371,18 @@ impl HomeView {
             Item::Group { path, .. } => {
                 crate::session::is_within_archived_section(path)
                     || crate::session::is_within_trash_section(path)
+                    // Remote sections are appended after Archived and Trash,
+                    // so they extend the same contiguous shelf suffix. Without
+                    // this arm a remote section present while both local
+                    // shelves are empty would leave `shelf_start` at `None`
+                    // and the renderer would treat remote rows as workspace
+                    // rows, breaking the sidebar split and shelf hit-testing.
+                    || crate::session::is_remote_section_path(path)
             }
-            Item::Session { .. } => false,
+            // A remote session row only ever appears under its own header,
+            // which the arm above already matches, so the scan has found the
+            // shelf start before reaching one.
+            Item::Session { .. } | Item::RemoteSession { .. } => false,
         })
     }
 
@@ -5054,6 +5411,7 @@ impl HomeView {
             let mut items = flatten_sessions_by_attention(&filtered);
             append_archived_section(&mut items, &filtered, self.archived_section_collapsed);
             append_trash_section(&mut items, &filtered, self.trashed_section_collapsed);
+            self.append_remotes(&mut items);
             return items;
         }
 
@@ -5078,7 +5436,20 @@ impl HomeView {
         append_archived_section(&mut items, &archive_pool, self.archived_section_collapsed);
         // Trash sits below Archived, also pinned to the bottom.
         append_trash_section(&mut items, &archive_pool, self.trashed_section_collapsed);
+        self.append_remotes(&mut items);
         items
+    }
+
+    /// Append the remote-daemon sections below every local shelf.
+    ///
+    /// A no-op in a TUI-only build (no `remotes` module), and a no-op with
+    /// `serve` when nothing is configured, so a user who never adds a remote
+    /// sees an unchanged list.
+    fn append_remotes(&self, items: &mut Vec<Item>) {
+        #[cfg(feature = "serve")]
+        crate::session::append_remote_sections(items, self.remote_section_views());
+        #[cfg(not(feature = "serve"))]
+        let _ = items;
     }
 
     fn build_flat_items_by_project(&self) -> Vec<Item> {
@@ -5144,6 +5515,9 @@ impl HomeView {
         // Trash is a flat shelf even in project mode (recovery list, not a
         // workspace), pinned below the Archived section.
         append_trash_section(&mut items, &grouped, self.trashed_section_collapsed);
+        // Remote sections stay flat in project mode too: a remote row has no
+        // local worktree, so it has no project to be grouped under.
+        self.append_remotes(&mut items);
         items
     }
 
@@ -6392,6 +6766,9 @@ impl HomeView {
                         .get_instance(id.as_str())
                         .map(|i| i.source_profile.clone());
                 }
+                // A remote session belongs to another machine's profile, which
+                // has no meaning for local profile-scoped operations.
+                crate::session::Item::RemoteSession { .. } => return None,
                 crate::session::Item::Group { profile, path, .. } => {
                     if let Some(p) = profile {
                         return Some(p.clone());
@@ -7389,6 +7766,8 @@ impl HomeView {
         crate::session::set_favorites_first(config.session.favorites_first);
         self.tips_unseen = tips_unseen_count(&config);
         self.tool_configs = config.tools;
+        #[cfg(feature = "serve")]
+        self.sync_remote_sources(&config.remotes);
         self.tool_hotkey_cache = input::build_tool_hotkey_cache(&self.tool_configs);
         let hotkey_warnings = input::validate_tool_hotkeys(&self.tool_configs);
         if matches!(origin, ConfigRefreshOrigin::Interactive)

--- a/src/tui/home/remotes.rs
+++ b/src/tui/home/remotes.rs
@@ -1,0 +1,307 @@
+//! Remote `aoe serve` daemons merged into the local session list.
+//!
+//! Each `[remotes.<name>]` config entry becomes a [`RemoteSource`]: a
+//! synthetic bottom-shelf section, sibling of Archived and Trash, holding
+//! the structured-view sessions that machine owns. Rows are read-only
+//! mirrors of the remote daemon's `/api/sessions`; the only interaction
+//! they support is opening the embedded structured view against the
+//! remote endpoint, which is already endpoint-parameterized
+//! (`EmbeddedView::connect`).
+//!
+//! Why remote rows are NOT `Instance`s in `HomeView::instances`: every
+//! local operation (stop, delete, worktree edit, diff, tmux attach)
+//! resolves its target through `instances`, against this machine's
+//! filesystem and tmux server. A synthesized `Instance` would make all of
+//! those silently addressable and wrong. Keeping remote rows in their own
+//! collection behind a distinct [`crate::session::Item`] variant means an
+//! operation that has not opted in cannot reach them at all.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::acp::client::{endpoint_for_remote, DaemonEndpoint, HttpClient};
+use crate::session::config::RemoteConfig;
+use crate::session::{Status, View};
+
+/// How often each enabled remote is re-listed. Slower than the local
+/// status poller's hot tier: this is a cross-network request per remote,
+/// and a merged row's value is "what is running over there", which does
+/// not need sub-second fidelity. The embedded structured view drives its
+/// own WebSocket once opened, so an open session stays live regardless.
+pub(crate) const REMOTE_REFRESH_INTERVAL: Duration = Duration::from_secs(6);
+
+/// Subset of the daemon's `/api/sessions` row the merged list needs.
+///
+/// `serde` skips unknown fields, so a newer daemon adding columns does not
+/// break an older client. Every field carries a `default` for the same
+/// reason in reverse: an older daemon omitting one must not fail the whole
+/// list and blank the section.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoteSession {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub project_path: String,
+    /// The daemon serializes this with `format!("{:?}")`, so it arrives
+    /// capitalized ("Running") rather than in `Status`'s lowercase serde
+    /// repr. Parsed by [`parse_api_status`] instead of deserialized
+    /// directly, so an unrecognized value degrades to `Unknown` rather
+    /// than failing the row.
+    #[serde(default)]
+    pub status: String,
+    /// How the remote session renders. Defaults to `terminal` so an older
+    /// daemon's response (which omits the field) still deserializes.
+    #[serde(default)]
+    pub view: View,
+}
+
+impl RemoteSession {
+    pub fn status(&self) -> Status {
+        parse_api_status(&self.status)
+    }
+}
+
+/// Map the daemon's `Debug`-formatted status onto [`Status`], tolerating
+/// case differences and unknown variants. A remote running a newer `aoe`
+/// may report a status this binary has never heard of; that must render as
+/// Unknown, not drop the row.
+pub fn parse_api_status(raw: &str) -> Status {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "running" => Status::Running,
+        "waiting" => Status::Waiting,
+        "idle" => Status::Idle,
+        "stopped" => Status::Stopped,
+        "error" => Status::Error,
+        "starting" => Status::Starting,
+        "deleting" => Status::Deleting,
+        "creating" => Status::Creating,
+        _ => Status::Unknown,
+    }
+}
+
+/// One configured remote plus the last snapshot fetched from it.
+pub(crate) struct RemoteSource {
+    /// Config key; the label badged onto each row and used as the section
+    /// header name.
+    pub name: String,
+    pub endpoint: DaemonEndpoint,
+    /// Structured-view sessions from the last successful refresh. Retained
+    /// across a failed refresh so a transient network blip dims the
+    /// section rather than emptying it.
+    pub sessions: Vec<RemoteSession>,
+    /// Error text from the most recent refresh, cleared on success.
+    pub last_error: Option<String>,
+    /// True once a refresh has completed (either way), so the section can
+    /// distinguish "connecting…" from "no sessions".
+    pub loaded: bool,
+    pub collapsed: bool,
+    /// A fetch for this remote is outstanding. The client timeout (15s) is
+    /// longer than the refresh interval (6s), so without this a remote that
+    /// black-holes packets would accumulate two or three overlapping
+    /// requests. Skipping it keeps at most one in flight per remote and
+    /// makes the effective cadence honest rather than compounding.
+    pub in_flight: bool,
+}
+
+impl RemoteSource {
+    fn new(name: String, config: &RemoteConfig) -> Self {
+        Self {
+            name,
+            endpoint: endpoint_for_remote(config),
+            sessions: Vec::new(),
+            last_error: None,
+            loaded: false,
+            collapsed: false,
+            in_flight: false,
+        }
+    }
+
+    /// Status line shown on the section header, right of the count.
+    pub fn subtitle(&self) -> Option<String> {
+        if let Some(err) = &self.last_error {
+            return Some(format!("unreachable: {}", first_line(err)));
+        }
+        if !self.loaded {
+            return Some("connecting…".to_string());
+        }
+        None
+    }
+
+    pub fn session(&self, id: &str) -> Option<&RemoteSession> {
+        self.sessions.iter().find(|s| s.id == id)
+    }
+}
+
+/// Keep only the first line of a client error. `HttpError`'s Display can
+/// carry a multi-line reqwest chain, which would break the single-row
+/// section header.
+fn first_line(text: &str) -> String {
+    text.lines().next().unwrap_or(text).trim().to_string()
+}
+
+/// A completed refresh for one remote, delivered back to the UI tick.
+pub(crate) struct RemoteUpdate {
+    pub name: String,
+    pub result: Result<Vec<RemoteSession>, String>,
+}
+
+/// Build the source list from config, dropping disabled entries.
+///
+/// Sorted by name so the shelf order is stable across refreshes (config is
+/// a `BTreeMap`, but being explicit keeps the guarantee local).
+pub(crate) fn sources_from_config(
+    remotes: &std::collections::BTreeMap<String, RemoteConfig>,
+) -> Vec<RemoteSource> {
+    let mut sources: Vec<RemoteSource> = remotes
+        .iter()
+        .filter(|(_, cfg)| cfg.enabled && !cfg.url.trim().is_empty())
+        .map(|(name, cfg)| RemoteSource::new(name.clone(), cfg))
+        .collect();
+    sources.sort_by(|a, b| a.name.cmp(&b.name));
+    sources
+}
+
+/// Spawn one fetch per remote that does not already have one outstanding,
+/// reporting each back over `tx`.
+///
+/// Fire-and-forget: a task whose send fails (UI torn down) just ends. The
+/// caller re-arms on its own cadence rather than looping in here, so a hung
+/// request cannot pile up behind an interval timer.
+pub(crate) fn spawn_refresh(sources: &mut [RemoteSource], tx: &mpsc::Sender<RemoteUpdate>) {
+    for source in sources {
+        if source.in_flight {
+            continue;
+        }
+        source.in_flight = true;
+        let name = source.name.clone();
+        let endpoint = source.endpoint.clone();
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let result = fetch_sessions(endpoint).await;
+            let _ = tx.send(RemoteUpdate { name, result });
+        });
+    }
+}
+
+/// List a remote's structured-view sessions.
+///
+/// Terminal-view sessions are filtered out here rather than at render
+/// time: a remote tmux pane cannot be attached from this machine, so a row
+/// for one would advertise an action the TUI has no way to perform.
+async fn fetch_sessions(endpoint: DaemonEndpoint) -> Result<Vec<RemoteSession>, String> {
+    let client = HttpClient::new(endpoint).map_err(|e| e.to_string())?;
+    let sessions = client
+        .list_sessions::<RemoteSession>()
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut structured: Vec<RemoteSession> = sessions
+        .into_iter()
+        .filter(|s| s.view == View::Structured)
+        .collect();
+    structured.sort_by(|a, b| a.title.cmp(&b.title));
+    Ok(structured)
+}
+
+/// Test-only source pre-loaded with a session list, so view tests can
+/// exercise remote rows without standing up a daemon.
+#[cfg(test)]
+pub(crate) fn test_source(name: &str, sessions: Vec<RemoteSession>) -> RemoteSource {
+    let mut source = RemoteSource::new(
+        name.to_string(),
+        &RemoteConfig {
+            url: "http://remote.test:8080".to_string(),
+            token: None,
+            enabled: true,
+        },
+    );
+    source.sessions = sessions;
+    source.loaded = true;
+    source
+}
+
+/// Test-only structured remote session row.
+#[cfg(test)]
+pub(crate) fn test_session(id: &str, title: &str, status: &str) -> RemoteSession {
+    RemoteSession {
+        id: id.to_string(),
+        title: title.to_string(),
+        project_path: "/remote/repo".to_string(),
+        status: status.to_string(),
+        view: View::Structured,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_api_status_accepts_debug_casing() {
+        // The daemon emits `format!("{:?}", status)`, not the lowercase
+        // serde repr, so the capitalized forms are the real wire values.
+        assert_eq!(parse_api_status("Running"), Status::Running);
+        assert_eq!(parse_api_status("Waiting"), Status::Waiting);
+        assert_eq!(parse_api_status("idle"), Status::Idle);
+    }
+
+    #[test]
+    fn parse_api_status_unknown_variant_degrades() {
+        // A newer daemon reporting a status this binary lacks must not
+        // drop the row.
+        assert_eq!(parse_api_status("Hibernating"), Status::Unknown);
+        assert_eq!(parse_api_status(""), Status::Unknown);
+    }
+
+    #[test]
+    fn sources_from_config_skips_disabled_and_blank() {
+        let mut remotes = std::collections::BTreeMap::new();
+        remotes.insert(
+            "on".to_string(),
+            RemoteConfig {
+                url: "http://a:8080".into(),
+                token: None,
+                enabled: true,
+            },
+        );
+        remotes.insert(
+            "off".to_string(),
+            RemoteConfig {
+                url: "http://b:8080".into(),
+                token: None,
+                enabled: false,
+            },
+        );
+        remotes.insert(
+            "blank".to_string(),
+            RemoteConfig {
+                url: "   ".into(),
+                token: None,
+                enabled: true,
+            },
+        );
+        let sources = sources_from_config(&remotes);
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].name, "on");
+    }
+
+    #[test]
+    fn subtitle_reports_connecting_then_error() {
+        let cfg = RemoteConfig {
+            url: "http://a:8080".into(),
+            token: None,
+            enabled: true,
+        };
+        let mut source = RemoteSource::new("a".into(), &cfg);
+        assert_eq!(source.subtitle().as_deref(), Some("connecting…"));
+        source.loaded = true;
+        assert_eq!(source.subtitle(), None);
+        source.last_error = Some("connection refused\nsecond line".into());
+        assert_eq!(
+            source.subtitle().as_deref(),
+            Some("unreachable: connection refused")
+        );
+    }
+}

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -10,7 +10,8 @@ use rattles::presets::prelude as spinners;
 
 use super::{
     get_indent, live_send, HomeView, TerminalMode, ViewMode, ICON_ARCHIVED_SECTION, ICON_COLLAPSED,
-    ICON_DELETING, ICON_DORMANT, ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_PINNED, ICON_STOPPED,
+    ICON_DELETING, ICON_DORMANT, ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_PINNED,
+    ICON_REMOTE_RUNNING, ICON_REMOTE_SECTION, ICON_REMOTE_WAITING, ICON_STOPPED,
     ICON_TRASH_SECTION, ICON_UNKNOWN, ICON_UNREAD,
 };
 use crate::containers::image_update::ImageUpdate;
@@ -1077,7 +1078,10 @@ impl HomeView {
             );
         }
 
-        if !self.has_instances() && !self.has_any_groups() {
+        // `has_remote_sources` is part of the emptiness test: a user whose only
+        // rows are mirrored from a remote still has a list to show, and the
+        // "Press 'n' to create one" placeholder would hide it entirely.
+        if !self.has_instances() && !self.has_any_groups() && !self.has_remote_sources() {
             let empty_text = vec![
                 Line::from(""),
                 Line::from("No sessions yet").style(Style::default().fg(theme.dimmed)),
@@ -1420,7 +1424,21 @@ impl HomeView {
                 } else {
                     None
                 };
-                let text = if let Some(glyph) = section_glyph {
+                // A remote's header carries its connection state, so an
+                // unreachable box reads as "unreachable" rather than as a
+                // remote that genuinely has no sessions.
+                let remote_subtitle = self.remote_section_subtitle(path);
+                let text = if let Some(subtitle) = remote_subtitle {
+                    Cow::Owned(format!(
+                        "{} {} ({}) {}",
+                        ICON_REMOTE_SECTION, name, session_count, subtitle
+                    ))
+                } else if crate::session::is_remote_section_path(path) {
+                    Cow::Owned(format!(
+                        "{} {} ({})",
+                        ICON_REMOTE_SECTION, name, session_count
+                    ))
+                } else if let Some(glyph) = section_glyph {
                     Cow::Owned(format!("{} {} ({})", glyph, name, session_count))
                 } else if pinned {
                     Cow::Owned(format!("{} ({}) {}", name, session_count, ICON_PINNED))
@@ -1444,6 +1462,48 @@ impl HomeView {
                         .add_modifier(ratatui::style::Modifier::DIM);
                 }
                 (icon, text, style)
+            }
+            // A mirrored remote row. Deliberately quieter than a local row:
+            // static status glyph (no spinner), no activity column, no row
+            // tag. Those all read as "this machine is doing work"; the
+            // animation in particular would claim a liveness this side only
+            // samples every few seconds. The status color still carries over
+            // so Waiting/Error remain scannable.
+            Item::RemoteSession { remote, id, .. } => {
+                match self.remote_row_display(remote, id) {
+                    Some((status, title)) => {
+                        let icon = match status {
+                            Status::Running => ICON_REMOTE_RUNNING,
+                            Status::Waiting => ICON_REMOTE_WAITING,
+                            Status::Idle => ICON_IDLE,
+                            Status::Stopped => ICON_STOPPED,
+                            Status::Error => ICON_ERROR,
+                            Status::Deleting => ICON_DELETING,
+                            Status::Unknown | Status::Starting | Status::Creating => ICON_UNKNOWN,
+                        };
+                        let color = match status {
+                            Status::Running => theme.running,
+                            Status::Waiting => theme.waiting,
+                            Status::Error => theme.error,
+                            Status::Deleting => theme.waiting,
+                            Status::Idle
+                            | Status::Unknown
+                            | Status::Starting
+                            | Status::Creating => theme.idle,
+                            Status::Stopped => theme.dimmed,
+                        };
+                        (icon, Cow::Owned(title), Style::default().fg(color))
+                    }
+                    // The row outlived its snapshot: a refresh landed between
+                    // the tree rebuild and this paint. Render an inert
+                    // placeholder rather than skipping the line, so row count
+                    // and cursor indices stay consistent with `flat_items`.
+                    None => (
+                        ICON_UNKNOWN,
+                        Cow::Borrowed("…"),
+                        Style::default().fg(theme.dimmed),
+                    ),
+                }
             }
             Item::Session { id, .. } => {
                 if let Some(inst) = self.get_instance(id) {
@@ -3729,6 +3789,9 @@ impl HomeView {
                     (Some("Attach"), Some("Live"))
                 }
             }
+            // A remote row has exactly one gesture, and no Tab complement:
+            // live-send drives a local pane.
+            Some(Item::RemoteSession { .. }) => (Some("Open"), None),
             None => (None, None),
         };
         if let Some(enter_action_text) = enter_action_text {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5086,6 +5086,9 @@ fn test_o_key_flat_items_sorted_az() {
                     }
                 }
             }
+            // No remotes are configured in these fixtures, so no remote row
+            // can appear; the arm exists to keep the match exhaustive.
+            Item::RemoteSession { .. } => {}
         }
     }
 
@@ -5121,6 +5124,9 @@ fn test_o_key_flat_items_sorted_za() {
                     }
                 }
             }
+            // No remotes are configured in these fixtures, so no remote row
+            // can appear; the arm exists to keep the match exhaustive.
+            Item::RemoteSession { .. } => {}
         }
     }
 
@@ -5158,6 +5164,9 @@ fn test_o_key_flat_items_newest_preserves_insertion_order() {
                     }
                 }
             }
+            // No remotes are configured in these fixtures, so no remote row
+            // can appear; the arm exists to keep the match exhaustive.
+            Item::RemoteSession { .. } => {}
         }
     }
 
@@ -10085,6 +10094,12 @@ fn build_flat_items_by_org_groups_by_resolved_owner() {
                     membership.insert(inst.title.clone(), current_group.clone().unwrap());
                 }
             }
+            // Org grouping partitions local instances; this fixture configures
+            // no remotes, and a remote row could not be bucketed by owner
+            // anyway since its repo lives on another machine.
+            Item::RemoteSession { remote, id, .. } => {
+                panic!("unexpected remote row {remote}/{id} in an org-grouped tree")
+            }
         }
     }
 
@@ -10276,6 +10291,7 @@ fn project_grouping_sorts_sessions_by_attention_within_group() {
                     }
                 }
             }
+            Item::RemoteSession { .. } => {}
         }
     }
     assert_eq!(
@@ -11219,6 +11235,7 @@ fn group_by_toggle_preserves_selected_session() {
     match cursor_item {
         Item::Session { id, .. } => assert_eq!(id, &target_id),
         Item::Group { .. } => panic!("cursor landed on a group header, not the session"),
+        Item::RemoteSession { .. } => panic!("cursor landed on a remote row, not the session"),
     }
 }
 
@@ -11969,7 +11986,7 @@ fn archived_section_collapsed_hides_project_sub_folders() {
         .iter()
         .filter(|it| match it {
             Item::Group { path, .. } => is_within_archived_section(path),
-            Item::Session { .. } => false,
+            Item::Session { .. } | Item::RemoteSession { .. } => false,
         })
         .collect();
     assert_eq!(
@@ -19225,5 +19242,285 @@ mod daemon_status_apply_tests {
                 "a {label} row is sunk; the daemon overlay must not drive its status (#3201)"
             );
         }
+    }
+}
+
+/// Merged remote-session rows: a remote daemon's sessions mirrored into the
+/// local list. The invariant under test throughout is that a remote row is
+/// activatable but never addressable by a local operation.
+#[cfg(feature = "serve")]
+mod remote_rows_tests {
+    use super::*;
+    use crate::tui::home::remotes::{test_session, test_source};
+
+    fn add_session(view: &mut HomeView, title: &str) -> String {
+        let mut inst = Instance::new(title, "/tmp/test");
+        inst.source_profile = "test".to_string();
+        let id = inst.id.clone();
+        view.add_instance(inst);
+        id
+    }
+
+    /// Install one remote source holding `titles` and rebuild the tree.
+    fn with_remote(env: &mut TestEnv, name: &str, titles: &[(&str, &str, &str)]) {
+        env.view.remote_sources = vec![test_source(
+            name,
+            titles
+                .iter()
+                .map(|(id, title, status)| test_session(id, title, status))
+                .collect(),
+        )];
+        env.view.flat_items = env.view.build_flat_items();
+    }
+
+    fn cursor_to_first_remote_row(env: &mut TestEnv) {
+        let idx = env
+            .view
+            .flat_items
+            .iter()
+            .position(|i| matches!(i, Item::RemoteSession { .. }))
+            .expect("expected a remote row in flat_items");
+        env.view.cursor = idx;
+        env.view.update_selected();
+    }
+
+    #[test]
+    #[serial]
+    fn remote_sections_append_below_local_rows() {
+        let mut env = create_test_env_empty();
+        add_session(&mut env.view, "local-one");
+        with_remote(
+            &mut env,
+            "linuxbox",
+            &[
+                ("r1", "remote-one", "Running"),
+                ("r2", "remote-two", "Idle"),
+            ],
+        );
+
+        // The local row must come first: remote sections are a bottom shelf.
+        let first_local = env
+            .view
+            .flat_items
+            .iter()
+            .position(|i| matches!(i, Item::Session { .. }))
+            .expect("local row missing");
+        let first_remote_header = env
+            .view
+            .flat_items
+            .iter()
+            .position(|i| matches!(i, Item::Group { path, .. } if crate::session::is_remote_section_path(path)))
+            .expect("remote header missing");
+        assert!(
+            first_local < first_remote_header,
+            "remote section must sit below local rows, got {:?}",
+            env.view.flat_items
+        );
+        // Header plus both rows.
+        assert_eq!(
+            env.view
+                .flat_items
+                .iter()
+                .filter(|i| matches!(i, Item::RemoteSession { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn shelf_start_covers_remote_only_list() {
+        // With no local shelves present, the remote header is itself the
+        // start of the pinned bottom shelf. A `None` here would make the
+        // renderer treat remote rows as workspace rows.
+        let mut env = create_test_env_empty();
+        with_remote(&mut env, "box", &[("r1", "remote-one", "Idle")]);
+        assert_eq!(env.view.shelf_start(), Some(0));
+    }
+
+    #[test]
+    #[serial]
+    fn remote_row_selection_leaves_local_selection_unset() {
+        // The core safety property: every local keybinding gates on
+        // `selected_session` / `selected_group`, so both must stay clear.
+        let mut env = create_test_env_empty();
+        with_remote(&mut env, "linuxbox", &[("r1", "remote-one", "Waiting")]);
+        cursor_to_first_remote_row(&mut env);
+
+        assert_eq!(env.view.selected_session, None);
+        assert_eq!(env.view.selected_group, None);
+        assert_eq!(
+            env.view.selected_remote,
+            Some(("linuxbox".to_string(), "r1".to_string()))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn remote_section_header_does_not_arm_group_actions() {
+        // The synthetic header is not a real group: renaming or deleting it
+        // is meaningless, so `selected_group` must stay unset (same contract
+        // the Archived / Trash headers follow).
+        let mut env = create_test_env_empty();
+        with_remote(&mut env, "linuxbox", &[("r1", "remote-one", "Idle")]);
+        let idx = env
+            .view
+            .flat_items
+            .iter()
+            .position(|i| matches!(i, Item::Group { path, .. } if crate::session::is_remote_section_path(path)))
+            .expect("remote header missing");
+        env.view.cursor = idx;
+        env.view.update_selected();
+
+        assert_eq!(env.view.selected_group, None);
+        assert_eq!(env.view.selected_session, None);
+        assert_eq!(env.view.selected_remote, None);
+    }
+
+    #[test]
+    #[serial]
+    fn enter_on_remote_row_opens_remote_structured_view() {
+        let mut env = create_test_env_empty();
+        with_remote(&mut env, "linuxbox", &[("r1", "remote-one", "Running")]);
+        cursor_to_first_remote_row(&mut env);
+
+        assert_eq!(
+            env.view.activate_selected_session(),
+            Some(Action::OpenRemoteStructuredView {
+                remote: "linuxbox".to_string(),
+                session_id: "r1".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn moving_off_a_remote_row_clears_remote_selection() {
+        // Otherwise a stale `selected_remote` would keep Enter routed at the
+        // remote after the cursor moved onto a local row.
+        let mut env = create_test_env_empty();
+        let local_id = add_session(&mut env.view, "local-one");
+        with_remote(&mut env, "linuxbox", &[("r1", "remote-one", "Idle")]);
+        cursor_to_first_remote_row(&mut env);
+        assert!(env.view.selected_remote.is_some());
+
+        let local_idx = env
+            .view
+            .flat_items
+            .iter()
+            .position(|i| matches!(i, Item::Session { .. }))
+            .expect("local row missing");
+        env.view.cursor = local_idx;
+        env.view.update_selected();
+
+        assert_eq!(env.view.selected_remote, None);
+        assert_eq!(env.view.selected_session, Some(local_id));
+    }
+
+    #[test]
+    #[serial]
+    fn collapsing_a_remote_section_hides_its_rows() {
+        let mut env = create_test_env_empty();
+        with_remote(
+            &mut env,
+            "linuxbox",
+            &[("r1", "remote-one", "Idle"), ("r2", "remote-two", "Idle")],
+        );
+        assert!(env.view.toggle_remote_section("linuxbox"));
+        env.view.flat_items = env.view.build_flat_items();
+
+        assert!(!env
+            .view
+            .flat_items
+            .iter()
+            .any(|i| matches!(i, Item::RemoteSession { .. })));
+        // The header survives and keeps reporting the hidden count.
+        match env
+            .view
+            .flat_items
+            .iter()
+            .find(|i| matches!(i, Item::Group { path, .. } if crate::session::is_remote_section_path(path)))
+            .expect("header missing")
+        {
+            Item::Group { session_count, .. } => assert_eq!(*session_count, 2),
+            other => panic!("expected group header, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn empty_remote_section_still_renders_so_the_list_is_not_blank() {
+        // A configured remote with no sessions must keep the list non-empty,
+        // or the "No sessions yet" placeholder replaces the whole sidebar and
+        // hides the section (including its connection error).
+        let mut env = create_test_env_empty();
+        with_remote(&mut env, "offline", &[]);
+        assert!(env.view.has_remote_sources());
+        assert!(!env.view.has_instances());
+        assert_eq!(env.view.flat_items.len(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn remote_row_survives_a_refresh_that_adds_a_row_above() {
+        // `refresh_rows_preserving_selection` restores a remote cursor by
+        // (remote, id). Without that the cursor would drift on every poll
+        // that changed the row count.
+        let mut env = create_test_env_empty();
+        with_remote(
+            &mut env,
+            "linuxbox",
+            &[("r2", "beta", "Idle"), ("r3", "gamma", "Idle")],
+        );
+        cursor_to_first_remote_row(&mut env);
+        let selected = env.view.selected_remote.clone();
+
+        // A new session sorts above the selected one.
+        env.view.remote_sources = vec![test_source(
+            "linuxbox",
+            vec![
+                test_session("r1", "alpha", "Idle"),
+                test_session("r2", "beta", "Idle"),
+                test_session("r3", "gamma", "Idle"),
+            ],
+        )];
+        env.view.refresh_rows_preserving_selection();
+
+        assert_eq!(env.view.selected_remote, selected);
+        match &env.view.flat_items[env.view.cursor] {
+            Item::RemoteSession { id, .. } => assert_eq!(id, "r2"),
+            other => panic!("cursor drifted off the remote row: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn remote_rows_are_searchable_by_remote_name_and_project_path() {
+        let mut env = create_test_env_empty();
+        with_remote(&mut env, "linuxbox", &[("r1", "remote-one", "Idle")]);
+        let haystack = env
+            .view
+            .remote_search_haystack("linuxbox", "r1")
+            .expect("haystack missing");
+        assert!(haystack.contains("remote-one"));
+        assert!(haystack.contains("linuxbox"));
+        assert!(haystack.contains("/remote/repo"));
+    }
+
+    #[test]
+    #[serial]
+    fn profile_for_cursor_is_none_on_a_remote_row() {
+        // A remote session belongs to another machine's profile, so no
+        // profile-scoped local operation may resolve one.
+        let mut env = create_test_env_empty();
+        env.view.active_profile = None;
+        with_remote(&mut env, "linuxbox", &[("r1", "remote-one", "Idle")]);
+        let idx = env
+            .view
+            .flat_items
+            .iter()
+            .position(|i| matches!(i, Item::RemoteSession { .. }))
+            .expect("remote row missing");
+        assert_eq!(env.view.profile_for_cursor(idx), None);
     }
 }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -55,6 +55,11 @@ mod profile_lazy_creation;
 mod profile_picker;
 mod project_registry;
 mod purge_restore_race;
+/// Serve-gated to match the `aoe remote` subcommand itself, which needs the
+/// `serve` feature's client half to be useful and so is not compiled into a
+/// TUI-only binary.
+#[cfg(feature = "serve")]
+mod remote_cli;
 mod resume_fallback;
 mod sandbox;
 mod serve;

--- a/tests/e2e/remote_cli.rs
+++ b/tests/e2e/remote_cli.rs
@@ -1,0 +1,226 @@
+//! End-to-end coverage for `aoe remote`, the CLI half of merged remote
+//! sessions.
+//!
+//! Drives the real `aoe` binary as a subprocess (`run_cli`, no tmux, no
+//! network) against an isolated home, then asserts on the persisted
+//! `config.toml` and on what `list` prints. Every remote here points at a
+//! host that does not resolve, which is the point: these subcommands are
+//! config-only, so they must succeed without the other box existing.
+//!
+//! The assertions worth an e2e rather than a unit test are the ones about
+//! the real file and the real stdout: that the entry survives the
+//! serde round-trip through `config.toml` at all (the field is a
+//! `skip_serializing_if` map, so a broken annotation would silently drop
+//! it), that a token pasted into the URL is lifted out of the stored URL,
+//! and that no code path prints a stored token back to the terminal.
+
+use serial_test::parallel;
+
+use crate::harness::TuiTestHarness;
+
+fn config_path(h: &TuiTestHarness) -> std::path::PathBuf {
+    crate::harness::app_dir_in(h.home_path()).join("config.toml")
+}
+
+fn read_config(h: &TuiTestHarness) -> String {
+    let path = config_path(h);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+/// `remote list --json`, parsed. Uses the JSON form so assertions key off
+/// field names rather than the human table's spacing.
+fn list_json(h: &TuiTestHarness) -> serde_json::Value {
+    let out = h.run_cli(&["remote", "list", "--json"]);
+    assert!(
+        out.status.success(),
+        "remote list failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("remote list --json emitted invalid JSON")
+}
+
+fn stdout_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+#[parallel]
+fn remote_add_persists_and_lists() {
+    let h = TuiTestHarness::new("aoe_e2e_remote_add");
+
+    let add = h.run_cli(&["remote", "add", "linuxbox", "http://linuxbox.invalid:8080"]);
+    assert!(
+        add.status.success(),
+        "remote add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    // Adding without a token must say so: a silent success against an
+    // authenticated daemon would only surface later as an unreachable row.
+    let added = stdout_of(&add);
+    assert!(added.contains("Added remote 'linuxbox'"), "got: {added}");
+    assert!(added.contains("No token stored"), "got: {added}");
+
+    // The entry really round-trips through config.toml on disk.
+    let config = read_config(&h);
+    assert!(
+        config.contains("[remotes.linuxbox]"),
+        "config.toml is missing the remotes table:\n{config}"
+    );
+
+    let entries = list_json(&h);
+    let entries = entries.as_array().expect("list is an array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], "linuxbox");
+    assert_eq!(entries[0]["url"], "http://linuxbox.invalid:8080");
+    assert_eq!(entries[0]["enabled"], true);
+    assert_eq!(entries[0]["has_token"], false);
+}
+
+#[test]
+#[parallel]
+fn remote_list_never_prints_the_token() {
+    // `aoe remote list` output lands in bug reports and scrollback, so the
+    // token must not appear in either output form, and `has_token` must
+    // still report that one is stored.
+    let h = TuiTestHarness::new("aoe_e2e_remote_token");
+    let secret = "tok-do-not-leak-abc123";
+
+    let add = h.run_cli(&[
+        "remote",
+        "add",
+        "box",
+        "http://box.invalid:8080",
+        "--token",
+        secret,
+    ]);
+    assert!(add.status.success());
+    assert!(
+        !stdout_of(&add).contains(secret),
+        "remote add echoed the token back"
+    );
+
+    let plain = h.run_cli(&["remote", "list"]);
+    assert!(plain.status.success());
+    assert!(
+        !stdout_of(&plain).contains(secret),
+        "remote list leaked the token: {}",
+        stdout_of(&plain)
+    );
+
+    let json = list_json(&h);
+    assert!(
+        !json.to_string().contains(secret),
+        "remote list --json leaked the token"
+    );
+    assert_eq!(json[0]["has_token"], true);
+
+    // The token is stored, just never printed.
+    assert!(
+        read_config(&h).contains(secret),
+        "the token was not persisted at all"
+    );
+}
+
+#[test]
+#[parallel]
+fn remote_add_lifts_token_out_of_a_pasted_url() {
+    // `aoe url` on the remote emits `...?token=<t>`; pasting that whole
+    // string must not leave the credential sitting in the stored URL, which
+    // is the field `list` prints.
+    let h = TuiTestHarness::new("aoe_e2e_remote_pasted");
+    let secret = "url-embedded-token-xyz";
+
+    let add = h.run_cli(&[
+        "remote",
+        "add",
+        "pasted",
+        &format!("http://box.invalid:8080/?token={secret}"),
+    ]);
+    assert!(
+        add.status.success(),
+        "remote add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    // A token was found, so the no-token warning must not fire.
+    assert!(!stdout_of(&add).contains("No token stored"));
+
+    let json = list_json(&h);
+    assert_eq!(json[0]["url"], "http://box.invalid:8080");
+    assert_eq!(json[0]["has_token"], true);
+    assert!(!json.to_string().contains(secret));
+}
+
+#[test]
+#[parallel]
+fn remote_add_refuses_duplicate_without_force() {
+    let h = TuiTestHarness::new("aoe_e2e_remote_dup");
+    assert!(h
+        .run_cli(&["remote", "add", "dup", "http://a.invalid:8080"])
+        .status
+        .success());
+
+    let again = h.run_cli(&["remote", "add", "dup", "http://b.invalid:8080"]);
+    assert!(!again.status.success(), "duplicate add should fail");
+    let err = String::from_utf8_lossy(&again.stderr);
+    assert!(err.contains("--force"), "unhelpful error: {err}");
+
+    // The original URL must survive a refused add.
+    assert_eq!(list_json(&h)[0]["url"], "http://a.invalid:8080");
+
+    let forced = h.run_cli(&["remote", "add", "dup", "http://b.invalid:8080", "--force"]);
+    assert!(forced.status.success());
+    assert!(stdout_of(&forced).contains("Replaced remote 'dup'"));
+    assert_eq!(list_json(&h)[0]["url"], "http://b.invalid:8080");
+}
+
+#[test]
+#[parallel]
+fn remote_disable_enable_and_remove_round_trip() {
+    let h = TuiTestHarness::new("aoe_e2e_remote_toggle");
+    assert!(h
+        .run_cli(&["remote", "add", "box", "http://box.invalid:8080"])
+        .status
+        .success());
+
+    // Disable keeps the entry (and its URL) so re-enabling needs no retyping.
+    assert!(h.run_cli(&["remote", "disable", "box"]).status.success());
+    let json = list_json(&h);
+    assert_eq!(json[0]["enabled"], false);
+    assert_eq!(json[0]["url"], "http://box.invalid:8080");
+    assert!(stdout_of(&h.run_cli(&["remote", "list"])).contains("(disabled)"));
+
+    assert!(h.run_cli(&["remote", "enable", "box"]).status.success());
+    assert_eq!(list_json(&h)[0]["enabled"], true);
+
+    assert!(h.run_cli(&["remote", "remove", "box"]).status.success());
+    assert!(list_json(&h).as_array().expect("array").is_empty());
+    assert!(
+        stdout_of(&h.run_cli(&["remote", "list"])).contains("No remotes configured"),
+        "empty list should tell the user how to add one"
+    );
+
+    // Removing something that is gone is an error, not a silent no-op.
+    let gone = h.run_cli(&["remote", "remove", "box"]);
+    assert!(!gone.status.success());
+    assert!(String::from_utf8_lossy(&gone.stderr).contains("no remote named 'box'"));
+}
+
+#[test]
+#[parallel]
+fn remote_add_rejects_bad_names_and_urls() {
+    let h = TuiTestHarness::new("aoe_e2e_remote_validate");
+
+    // A '/' would collide with the section-path format the TUI uses to
+    // address a remote's synthetic group.
+    let slash = h.run_cli(&["remote", "add", "linux/box", "http://a.invalid:8080"]);
+    assert!(!slash.status.success());
+
+    let no_scheme = h.run_cli(&["remote", "add", "box", "a.invalid:8080"]);
+    assert!(!no_scheme.status.success());
+    assert!(String::from_utf8_lossy(&no_scheme.stderr).contains("http://"));
+
+    // Nothing was written by either failure.
+    assert!(list_json(&h).as_array().expect("array").is_empty());
+}

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -83,6 +83,13 @@ const PAGES = [
       "Set up Tailscale from scratch to reach your AOE TUI and web dashboard from any device on your tailnet.",
   },
   {
+    source: "docs/guides/remote-sessions.md",
+    dest: "guides/remote-sessions.md",
+    title: "Merged Remote Sessions",
+    description:
+      "Show sessions from another machine's aoe daemon in your local TUI, alongside your own.",
+  },
+  {
     source: "docs/guides/web/dashboard.md",
     dest: "guides/web/dashboard.md",
     title: "Dashboard & Workspaces",
@@ -432,6 +439,7 @@ const URL_MAP = {
   "docs/guides/web/settings.md": "/guides/web/settings/",
   "docs/guides/remote-phone-access.md": "/guides/remote-phone-access/",
   "docs/guides/tailscale.md": "/guides/tailscale/",
+  "docs/guides/remote-sessions.md": "/guides/remote-sessions/",
   "docs/guides/worktrees.md": "/guides/worktrees/",
   "docs/guides/agent-override.md": "/guides/agent-override/",
   "docs/guides/session-resume.md": "/guides/session-resume/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -53,6 +53,7 @@ export const docsNav: NavSection[] = [
       { title: "Settings & Profiles", href: "/guides/web/settings/", description: "Manage settings and configuration profiles from the web." },
       { title: "Remote Phone Access", href: "/guides/remote-phone-access/", description: "Expose the dashboard over HTTPS with QR pairing." },
       { title: "Tailscale Setup", href: "/guides/tailscale/", description: "Set up Tailscale from scratch for remote access to your AOE sessions." },
+      { title: "Merged Remote Sessions", href: "/guides/remote-sessions/", description: "See another machine's sessions in your local TUI." },
     ],
   },
   {


### PR DESCRIPTION
## Description

Adds `[remotes.<name>]` config entries whose structured-view sessions are mirrored into the local session list as read-only rows in their own pinned bottom-shelf section, sibling of Archived and Trash. Pressing Enter opens the remote session's transcript in the existing embedded structured view.

The motivation: if you run `aoe` locally and also have a Linux box running its own `aoe`, there is currently no way to see both sets of sessions in one place. You either keep two terminals open or SSH over and run a second TUI.

```
▼ ⇄ deadbox (0) unreachable: transport error
▼ ⇄ linuxbox (2)
 ⠿ fix-flaky-test
 ⠛ refactor-parser
```

Managed by `aoe remote add|list|remove|enable|disable`. The subcommands are config-only: nothing contacts the remote, so `add` works while the other box is still booting, and reachability is reported on the row itself, which is where you would look for it.

### The design decision worth reviewing

Remote rows are a new `Item::RemoteSession { remote, id, depth }` variant held in their own `remote_sources` collection, **not** synthesized `Instance`s in `HomeView::instances`.

Every local operation (stop, delete, worktree edit, diff, tmux attach) resolves its target through `instances`, against this machine's filesystem and tmux server. A synthesized `Instance` would make all of those silently addressable and wrong. Keeping remote rows behind a distinct variant means an operation that has not explicitly opted in cannot reach one at all, and adding the variant made the compiler enumerate all 14 decision sites rather than leaving me to find them by inspection. Selection uses a separate `selected_remote` field, so every local keybinding (which all gate on `selected_session`) is disarmed at once.

This is also why `Item::RemoteSession` and `append_remote_sections` are deliberately **not** `serve`-gated: the match arms then compile identically in both build configurations, so a TUI-only build cannot drift into a non-exhaustive match.

### Notes for the reviewer

- Terminal-view remote sessions are filtered out at fetch time, not render time: a remote tmux pane cannot be attached from this machine, so a row for one would advertise an action the TUI has no way to perform.
- The daemon serializes session status with `format!("{:?}", ...)`, not the lowercase serde repr, so `parse_api_status` parses tolerantly and degrades an unknown variant to `Unknown` rather than dropping the row.
- Refresh is 6s per remote with at most one request in flight each. The HTTP timeout is 15s, so without the in-flight guard a remote that black-holes packets would accumulate overlapping requests.
- `aoe remote list` reports `has_token: bool` and never the token, since its output ends up in issue reports and scrollback.
- `Config::remotes` intentionally bypasses the single-source settings schema, following the existing `Config::tools` precedent: the entries are user-named, so there is no fixed field for a widget to bind to.

### Known limitation

A stored token goes stale when the remote daemon restarts and rotates it. Local endpoints handle this by re-reading `serve.token`, but that file is on the other machine. Today you see `unreachable: unauthorized` and re-run `remote add --force`. Fixing it properly needs the daemon to expose a longer-lived credential for configured remotes, which felt like a separate change.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

`cargo fmt --check`, `cargo clippy --features serve,e2e-tests --all-targets` (7 warnings, all pre-existing and none in the added lines), `cargo test --features serve` (6142 passed, 0 failed), and `cargo test --features serve,e2e-tests --test e2e remote_cli` (6 passed) are all clean. `cargo xtask gen-docs` produces no diff. TUI-only `cargo check --all-targets` is clean, confirming the feature gating.

Docs: added `docs/guides/remote-sessions.md` and registered it in `website/scripts/sync-docs.mjs` (PAGES + URL_MAP) and `website/src/data/docsNav.ts`.

Screenshot: the sidebar section above is a real capture from a live TUI run against a second `aoe serve` daemon on port 8099, with `deadbox` pointed at a host that does not exist.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

No `web/` file is touched; the merged list is TUI-only.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Added `tests/e2e/remote_cli.rs`: 6 tests driving the real binary with no tmux and no network (every remote points at a `.invalid` host), covering the `config.toml` round-trip, `?token=` lifting, duplicate/`--force`, disable/enable/remove, validation rejections, and that no output path prints a stored token.

Plus 22 unit tests for the TUI half (section layout, shelf placement, selection safety, Enter dispatch, cursor preservation across a refresh, collapse, empty-section visibility, status parsing).

Two bugs found by running the real binary that the unit tests and the compiler both missed, each now locked in by a test:

1. With no local sessions, the "No sessions yet" placeholder painted over the whole sidebar, hiding the remote sections and their connection errors.
2. Enter did nothing on a remote row: the binding gates on `selected_session.is_some()` before dispatching, and remote rows deliberately leave that unset.

The one path not covered end to end is the embedded view actually connecting to a remote session. It reuses `EmbeddedView::connect(endpoint, session_id)` verbatim, identical to the local structured view with only the endpoint differing, and the Action dispatch is unit-tested, but the remote WebSocket handshake itself is not exercised by a test.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:**

Used for the implementation, the test suite, and this description. The design decision to model remote rows as a distinct `Item` variant rather than synthesized `Instance`s, and the choice of the daemon-client approach over an SSH exec target, were discussed and settled before any code was written.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `aoe remote` commands to add, list, remove, enable, and disable remote daemons.
- Added remote session configuration with safe token handling and URL validation.
- Added remote sessions to the TUI in a separate, read-only shelf.
- Added independent selection, search, collapse, status indicators, and structured-view access for remote sessions.
- Added refresh handling, connection-state reporting, terminal-session filtering, and protection against local actions targeting remote sessions.
- Added CLI and TUI tests for configuration, validation, lifecycle commands, token safety, persistence, and session behavior.
- Added CLI and user documentation for remote sessions.

## Benefits

Users can view structured sessions from configured remote daemons in the same TUI as local sessions. Remote sessions remain isolated from local operations, and connection failures do not remove existing session data.

A known limitation is that users must refresh tokens manually after a remote daemon rotates them.

## Technical details

- Added `Source::ConfiguredRemote`, `RemoteConfig`, `Item::RemoteSession`, and remote section helpers.
- Added asynchronous per-remote refreshes with in-flight request limits.
- Added tolerant status parsing with unknown values mapped to `Status::Unknown`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->