### PR TITLE
fix(web): fall back to main-thread highlighting when the diff worker fails to load

### DIFF
--- a/web/src/components/diff/pierre/DiffWorkerPoolProvider.tsx
+++ b/web/src/components/diff/pierre/DiffWorkerPoolProvider.tsx
@@ -1,14 +1,6 @@
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
-import type { ReactNode } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { useShikiTheme } from "../../../hooks/useShikiTheme";
-
-/**
- * Creates a Pierre highlighter worker. Vite bundles the worker entry from
- * `@pierre/diffs/worker/worker.js` when referenced via `new URL(..., import.meta.url)`.
- */
-function workerFactory(): Worker {
-  return new Worker(new URL("@pierre/diffs/worker/worker.js", import.meta.url), { type: "module" });
-}
 
 /**
  * Provides a shared off-main-thread highlighter worker pool for the diff
@@ -18,12 +10,54 @@ function workerFactory(): Worker {
  * with the new theme. When `Worker` is unavailable (SSR / jsdom tests) it
  * renders children directly; the diff components then highlight on the main
  * thread (`disableWorkerPool`), preserving correctness.
+ *
+ * The same bare-children fallback also engages when a worker fails to load.
+ * `@pierre/diffs@1.2.12` resolves each worker's init promise only on an
+ * `initialize` success message and its own `error` listener merely logs, so a
+ * worker that dies at load leaves `initialize()` pending forever while
+ * `isWorkingPool()` still reports healthy. The renderer then waits on a pool
+ * that will never drain and paints nothing, tab-wide, because the pool is a
+ * module-level singleton. See #3362.
+ *
+ * Swapping the provider for a fragment is what makes the recovery stick:
+ * `useFileDiffInstance` captures the pool reference once when the DOM node
+ * attaches, so only a subtree remount rebuilds the renderer without a pool.
+ * Unmounting also drops the library's instance count to zero, which
+ * terminates the poisoned singleton, so the next fresh mount builds a new
+ * pool. That is the retry; a retry loop here would just re-race the same
+ * broken worker.
+ *
+ * One known cost: the remount replaces the scroll container that
+ * `DiffFileViewer`'s scroll effect captured, so target-line positioning is
+ * lost for the file that was open when the worker died. The new container
+ * starts at the top, which is that effect's default anyway.
  */
 export function DiffWorkerPoolProvider({ children }: { children: ReactNode }) {
   const { theme } = useShikiTheme();
+  const [workerFailed, setWorkerFailed] = useState(false);
+
+  const workerFactory = useCallback(() => {
+    const worker = new Worker(new URL("@pierre/diffs/worker/worker.js", import.meta.url), { type: "module" });
+    // A host-side `error` here means the worker script never ran: the library's
+    // worker catches its own per-message failures and reports them as `error`
+    // messages instead. So this fires only for the fatal load case.
+    worker.addEventListener("error", () => setWorkerFailed(true), { once: true });
+    return worker;
+  }, []);
 
   if (typeof Worker === "undefined") {
     return <>{children}</>;
+  }
+
+  if (workerFailed) {
+    return (
+      <>
+        <div role="status" className="shrink-0 px-3 py-1 text-[11px] font-mono text-text-dim">
+          Highlighting on the main thread; the worker failed to load. Reload to retry.
+        </div>
+        {children}
+      </>
+    );
   }
 
   return (

--- a/web/src/components/diff/pierre/__tests__/DiffWorkerPoolProvider.test.tsx
+++ b/web/src/components/diff/pierre/__tests__/DiffWorkerPoolProvider.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// A highlighter worker that dies at load used to blank the diff pane forever:
+// `@pierre/diffs@1.2.12` never settles `initialize()` in that case, so the
+// renderer waits on a pool that will never drain. See #3362. The provider must
+// notice the worker error and drop the pool so the renderer falls back to
+// main-thread highlighting.
+//
+// `WorkerPoolContextProvider` is mocked to call the factory the way the real
+// pool does, since the real one only builds workers once a renderer triggers
+// initialization, which does not happen under jsdom.
+
+import { act, render, screen } from "@testing-library/react";
+import { useEffect, useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DiffWorkerPoolProvider } from "../DiffWorkerPoolProvider";
+
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  private listeners: Array<(event: Event) => void> = [];
+
+  constructor() {
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: (event: Event) => void) {
+    if (type === "error") this.listeners.push(cb);
+  }
+  removeEventListener() {}
+  terminate() {}
+
+  /** What the browser does when the worker script fails to load. */
+  failToLoad() {
+    for (const cb of this.listeners) cb(new Event("error"));
+  }
+}
+
+vi.mock("@pierre/diffs/react", () => ({
+  WorkerPoolContextProvider: ({
+    children,
+    poolOptions,
+  }: {
+    children: React.ReactNode;
+    poolOptions: { workerFactory: () => Worker };
+  }) => {
+    const built = useRef(false);
+    useEffect(() => {
+      if (built.current) return;
+      built.current = true;
+      poolOptions.workerFactory();
+    }, [poolOptions]);
+    return <div data-testid="worker-pool">{children}</div>;
+  },
+}));
+
+afterEach(() => {
+  FakeWorker.instances = [];
+  vi.unstubAllGlobals();
+});
+
+describe("DiffWorkerPoolProvider", () => {
+  it("drops the pool and says so when a worker fails to load", () => {
+    vi.stubGlobal("Worker", FakeWorker);
+    render(
+      <DiffWorkerPoolProvider>
+        <span>diff body</span>
+      </DiffWorkerPoolProvider>,
+    );
+
+    expect(screen.getByTestId("worker-pool")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(FakeWorker.instances).toHaveLength(1);
+
+    act(() => FakeWorker.instances[0].failToLoad());
+
+    // Pool gone, so the renderer remounts without it and highlights on the
+    // main thread; the diff itself still renders.
+    expect(screen.queryByTestId("worker-pool")).toBeNull();
+    expect(screen.getByText("diff body")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toContain("main thread");
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1748,7 +1748,8 @@
         "src/components/diff/find/changedLines.test.ts",
         "src/components/diff/find/FindBar.test.tsx",
         "src/components/diff/comments/extractSnippetFromContents.test.ts",
-        "src/components/diff/comments/anchorToContents.test.ts"
+        "src/components/diff/comments/anchorToContents.test.ts",
+        "src/components/diff/pierre/__tests__/DiffWorkerPoolProvider.test.tsx"
       ],
       "components": [
         "web/src/components/diff/find/FindBar.tsx",

--- a/web/tests/diff-syntax-highlight.spec.ts
+++ b/web/tests/diff-syntax-highlight.spec.ts
@@ -127,4 +127,20 @@ test.describe("Diff rendering (@pierre/diffs)", () => {
 
     await expect(page.getByText("some unknown format content").first()).toBeVisible({ timeout: 10000 });
   });
+
+  // #3362: a worker that fails to load used to hang the pool's initialize()
+  // forever while it still reported healthy, so the renderer waited on it and
+  // the pane stayed blank for every file until a full reload.
+  test("still renders the diff when the highlighter worker fails to load", async ({ page }) => {
+    await setupDiffMocks(page);
+    await page.route("**/assets/worker-*.js", (r) => r.abort());
+    await page.goto("/");
+    await openSessionAndWaitForDiffList(page);
+    await page.getByText("example.ts").first().click();
+
+    await expect(page.getByText("function greet").first()).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByRole("status").filter({ hasText: "main thread" })).toBeVisible();
+  });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The diff pane rendered a permanently blank body whenever the syntax-highlighting worker failed to load. The file header, the +/- counters, the unified/split toggle and the changed-file list all rendered normally, so the pane looked alive while showing nothing. Switching files did not help, toggling unified/split did not help, and only a full page reload recovered it. Hit in Firefox Developer Edition 154 while Chrome was fine against the same daemon at the same moment.

The bug is upstream, in `@pierre/diffs@1.2.12`. `WorkerPoolManager.initializeWorkers` resolves each worker's init promise only when that worker posts back an `initialize` success message, and the pool's own worker `error` listener does nothing but `console.error`. A worker that dies at load therefore leaves its init promise pending forever: `initialize()` never settles, `workersFailed` is never set (it is assigned only in the `catch`), and so `isWorkingPool()` keeps reporting the pool healthy. `DiffHunksRenderer` takes the worker branch on that basis and never reaches its main-thread fallback, while `drainQueue` returns early because the manager is not initialized. Nothing is ever painted. Because the pool is a module-level singleton, one poisoned instance blanks every file in the tab, which is why only a reload fixed it.

The fix is downstream and small. `DiffWorkerPoolProvider` now attaches an `error` listener in its worker factory and, on failure, renders its children without the pool provider. Swapping the provider for a fragment is what makes the recovery stick: `useFileDiffInstance` captures the pool reference once when its DOM node attaches, so only a subtree remount rebuilds the renderer pool-free. Unmounting the provider also drops the library's instance count to zero, which terminates the poisoned singleton, so the next fresh mount builds a new pool. That is the retry, and a retry loop in the provider would only re-race the same broken worker.

With no pool the renderer calls `asyncHighlight`, which lazily builds a main-thread highlighter on the JavaScript regex engine, so the fallback still highlights correctly and needs no wasm. The only real cost is main-thread tokenization on large diffs, so the pane also shows one muted line saying highlighting moved off the worker and a reload will retry.

A host-side `error` event is the right trigger rather than a timeout heuristic: the library's worker catches its own per-message failures and reports them as `error` messages instead, so this event fires only when the worker script never ran, which is exactly the fatal case.

One accepted cost, called out for reviewers: the fallback remount replaces the scroll container that `DiffFileViewer`'s scroll effect captured, so target-line positioning is lost for the file that was open at the moment the worker died. The new container starts at the top, which is that effect's own default. Every alternative shape considered replaced that node too, so this is documented in the provider rather than widened into the scroll effect.

Not fixed here: the Firefox-specific trigger that killed the worker in the first place. It is a separate question, and this change makes it non-fatal either way. The upstream defect is filed as pierrecomputer/pierre#1076; once the pool reports its own failure, this workaround can be deleted.

Closes #3362

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a session with changes in the web dashboard, click a file in the diff pane, confirm the diff renders as before with syntax highlighting.
- [ ] In devtools, block the highlighter worker chunk (Network request blocking on `*/assets/worker-*.js`), reload, then open a file in the diff pane. The diff renders instead of a blank pane, and a muted line reads "Highlighting on the main thread; the worker failed to load. Reload to retry."
- [ ] With the worker still blocked, click a second and third file. Each renders, with no page reload needed.
- [ ] Unblock the worker, reload, confirm the notice is gone and highlighting is back on the worker pool.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The one visual change is a single muted line of text that appears only in the failure path; its exact wording is asserted by both new tests.

Documentation: none warranted. There is no new setting, flag, or user-controllable behavior; the change is a failure-path fallback inside one component.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Both directions were proven rather than asserted green at the end:

- `web/tests/diff-syntax-highlight.spec.ts` aborts `**/assets/worker-*.js` to force the real failure, then asserts the diff content and the notice are visible. On the pre-fix bundle it fails because the diff content never appears at all, which is the reported bug reproduced in a browser.
- `web/src/components/diff/pierre/__tests__/DiffWorkerPoolProvider.test.tsx` drives the same transition at unit level. On the pre-fix provider it fails at the "pool is gone" assertion, since nothing was listening for the worker error.
- `web/tests/coverage-matrix.json` gains the new Vitest spec under the existing `right-panel.diff-render-and-find` surface, which already maps `DiffWorkerPoolProvider.tsx`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude (via Claude Code, the `/aoe-investigate` and `/aoe-implement` skills)

**Any Additional AI Details you'd like to share:**
Investigation, plan and implementation were drafted by Claude under my direction, including reading the shipped `@pierre/diffs` dist to find the root cause. I made the design calls, reviewed each commit, and the plan was pressure-tested against two other models before any code was written; their proposed alternatives (relocating the provider inside the virtualizer, and a timeout watchdog using `disableWorkerPool`) were both rejected with reasons recorded in the plan.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
