### PR TITLE
fix(acp): accept standard session/load response

### DIFF
--- a/docs/development/playwright.md
+++ b/docs/development/playwright.md
@@ -60,7 +60,7 @@ Per-test isolation: fresh `mkdtemp` `HOME` with `XDG_CONFIG_HOME` / `TMPDIR` / `
 
 ## Fake ACP agent (`web/tests/helpers/fakeAcpAgent.mjs`)
 
-Structured view specs need a deterministic ACP agent (the real `claude` depends on credentials and emits non-deterministic output). The fake speaks a minimal slice of the Agent Client Protocol over newline-delimited JSON-RPC 2.0: `initialize` returns protocolVersion 1 + capabilities; `session/new` and `session/load` return a deterministic id; `session/prompt` consumes one entry from the script file (`FAKE_ACP_SCRIPT` env, default emits one `agent_message_chunk` then stops), emits its `session/update` notifications, then responds with `stopReason`; `session/setMode` emits `current_mode_changed`; `session/cancel` emits `stopped {stopReason: "cancelled"}`; everything else returns `-32601`.
+Structured view specs need a deterministic ACP agent (the real `claude` depends on credentials and emits non-deterministic output). The fake speaks a minimal slice of the Agent Client Protocol over newline-delimited JSON-RPC 2.0: `initialize` returns protocolVersion 1 + capabilities; `session/new` returns a deterministic id; `session/load` restores the requested id and omits it from the response when impersonating Codex; `session/prompt` consumes one entry from the script file (`FAKE_ACP_SCRIPT` env, default emits one `agent_message_chunk` then stops), emits its `session/update` notifications, then responds with `stopReason`; `session/setMode` emits `current_mode_changed`; `session/cancel` emits `stopped {stopReason: "cancelled"}`; everything else returns `-32601`.
 
 Script file shape:
 

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -1284,7 +1284,7 @@ impl RunnerShared {
         Ok(result)
     }
 
-    /// Run (once) or replay (from cache) the session-creation request the
+    /// Run (once) or replay (from cache) the session-establishment request the
     /// runner now owns. `method` is `session/new|load|fork`. Caches
     /// `(acp_session_id, raw result)`; later calls replay the cache. `Ok`
     /// carries `(acp_session_id, result)`; `Err` is the raw JSON-RPC error
@@ -1299,15 +1299,11 @@ impl RunnerShared {
             return Ok(cached);
         }
         let response = self
-            .agent_request(agent_stdin, method, request)
+            .agent_request(agent_stdin, method, request.clone())
             .await
             .ok_or_else(|| transport_error(&format!("agent closed before answering {method}")))?;
         let result = handshake_result(&response)?;
-        let acp_session_id = result
-            .get("sessionId")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| transport_error(&format!("{method} response missing sessionId")))?
-            .to_string();
+        let acp_session_id = established_session_id(method, &request, &result)?;
         let cached = (acp_session_id, result);
         self.handshake.lock().await.session = Some(cached.clone());
         Ok(cached)
@@ -1413,6 +1409,48 @@ fn handshake_result(response: &serde_json::Value) -> Result<serde_json::Value, s
         .get("result")
         .cloned()
         .ok_or_else(|| transport_error("response had neither result nor error"))
+}
+
+/// Resolve the session identity established by a successful session request.
+/// New and fork create an identity, so their response must provide it. Load
+/// reopens the identity named by the request; ACP's `LoadSessionResponse` does
+/// not contain a session id. Some agents include one as an extension, which is
+/// accepted only when it agrees with the requested identity.
+fn established_session_id(
+    method: &str,
+    request: &serde_json::Value,
+    result: &serde_json::Value,
+) -> Result<String, serde_json::Value> {
+    match method {
+        "session/load" => {
+            let requested = request
+                .get("sessionId")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| transport_error("session/load request missing sessionId"))?;
+            let result = result
+                .as_object()
+                .ok_or_else(|| transport_error("session/load response result was not an object"))?;
+            if let Some(returned) = result.get("sessionId") {
+                let returned = returned.as_str().ok_or_else(|| {
+                    transport_error("session/load response sessionId was not a string")
+                })?;
+                if returned != requested {
+                    return Err(transport_error(
+                        "session/load response sessionId did not match request",
+                    ));
+                }
+            }
+            Ok(requested.to_string())
+        }
+        "session/new" | "session/fork" => result
+            .get("sessionId")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| transport_error(&format!("{method} response missing sessionId")))
+            .map(str::to_string),
+        _ => Err(transport_error(&format!(
+            "unsupported session establishment method {method}"
+        ))),
+    }
 }
 
 /// A synthetic JSON-RPC error object for a runner-side transport failure
@@ -2033,6 +2071,88 @@ mod tests {
             parse_response_any_id(br#"{"jsonrpc":"2.0","id":1,"method":"m","params":{}}"#),
             None
         );
+    }
+
+    #[test]
+    fn established_session_id_is_method_sensitive() {
+        let cases = [
+            (
+                "session/new",
+                serde_json::json!({}),
+                serde_json::json!({"sessionId": "new-id"}),
+                Ok("new-id"),
+            ),
+            (
+                "session/new",
+                serde_json::json!({}),
+                serde_json::json!({}),
+                Err("session/new response missing sessionId"),
+            ),
+            (
+                "session/fork",
+                serde_json::json!({"sessionId": "parent-id"}),
+                serde_json::json!({"sessionId": "fork-id"}),
+                Ok("fork-id"),
+            ),
+            (
+                "session/fork",
+                serde_json::json!({"sessionId": "parent-id"}),
+                serde_json::json!({}),
+                Err("session/fork response missing sessionId"),
+            ),
+            (
+                "session/load",
+                serde_json::json!({"sessionId": "existing-id"}),
+                serde_json::json!({"configOptions": []}),
+                Ok("existing-id"),
+            ),
+            (
+                "session/load",
+                serde_json::json!({"sessionId": "existing-id"}),
+                serde_json::json!({"sessionId": "existing-id"}),
+                Ok("existing-id"),
+            ),
+            (
+                "session/load",
+                serde_json::json!({"sessionId": "existing-id"}),
+                serde_json::json!({"sessionId": "different-id"}),
+                Err("session/load response sessionId did not match request"),
+            ),
+            (
+                "session/load",
+                serde_json::json!({}),
+                serde_json::json!({}),
+                Err("session/load request missing sessionId"),
+            ),
+            (
+                "session/load",
+                serde_json::json!({"sessionId": "existing-id"}),
+                serde_json::json!({"sessionId": 42}),
+                Err("session/load response sessionId was not a string"),
+            ),
+            (
+                "session/load",
+                serde_json::json!({"sessionId": "existing-id"}),
+                serde_json::json!(null),
+                Err("session/load response result was not an object"),
+            ),
+            (
+                "session/resume",
+                serde_json::json!({}),
+                serde_json::json!({}),
+                Err("unsupported session establishment method session/resume"),
+            ),
+        ];
+
+        for (method, request, result, expected) in cases {
+            match (established_session_id(method, &request, &result), expected) {
+                (Ok(actual), Ok(expected)) => assert_eq!(actual, expected, "{method}"),
+                (Err(actual), Err(expected)) => {
+                    assert_eq!(actual["message"], expected, "{method}")
+                }
+                (actual, expected) => panic!("{method}: got {actual:?}, expected {expected:?}"),
+            }
+        }
     }
 
     /// #2979: a daemon-driven relay `session/new` (conversation reset)

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -381,6 +381,145 @@ for line in sys.stdin:
     );
 }
 
+/// A standard `session/load` response has no `sessionId`: the requested id is
+/// already the identity being reopened. Codex also streams historical updates
+/// before answering the load. The runner must accept that response, retain the
+/// requested id for cancel, and replay the raw response from its handshake
+/// cache without issuing either a second load or a fallback session/new.
+#[test]
+fn runner_load_uses_requested_id_and_caches_response() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    let scratch = Scratch::new("hsload");
+    let home = scratch.0.join("home");
+    let xdg = scratch.0.join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+
+    let agent_log = scratch.0.join("agent-methods.log");
+    let fake_agent =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("web/tests/helpers/fakeAcpAgent.mjs");
+
+    let session_id = "shsload1";
+    let workers = app_dir(&home, &xdg).join("acp-workers");
+    let socket = workers.join(format!("{session_id}.sock"));
+    let control = workers.join(format!("{session_id}.control.sock"));
+    let record = workers.join(format!("{session_id}.json"));
+
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let _child = KillOnDrop(
+        Command::new(bin)
+            .args([
+                "__acp-runner",
+                "--socket",
+                socket.to_str().unwrap(),
+                "--session-id",
+                session_id,
+                "--agent-name",
+                "fake-codex-acp",
+                "--cwd",
+                home.to_str().unwrap(),
+                "--",
+                "node",
+                fake_agent.to_str().unwrap(),
+            ])
+            .env("HOME", &home)
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("FAKE_ACP_DEBUG_LOG", &agent_log)
+            .env("FAKE_ACP_IMPERSONATE", "codex")
+            .env("FAKE_ACP_LOAD_REPLAY", "old agent answer")
+            .env("FAKE_ACP_LOAD_REPLAY_USER", "old user prompt")
+            .env("FAKE_ACP_LOAD_REPLAY_BEFORE_RESPONSE", "1")
+            .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
+            .spawn()
+            .expect("spawn acp runner"),
+    );
+
+    wait_for(&record, "registry record");
+    wait_for(&control, "control socket");
+
+    {
+        let mut ctl = UnixStream::connect(&control).expect("connect control socket");
+        ctl.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+        assert_eq!(read_frame(&mut ctl)["kind"], "hello");
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "attach", "control_protocol_version": 2}),
+        );
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({
+                "kind": "establish_session",
+                "method": "session/load",
+                "request": {"sessionId": "existing-session", "cwd": home.to_str().unwrap()}
+            }),
+        );
+
+        let ready = read_frame(&mut ctl);
+        assert_eq!(ready["kind"], "session_ready", "load must succeed: {ready}");
+        assert_eq!(ready["acp_session_id"], "existing-session");
+        assert!(ready["result"].get("sessionId").is_none());
+
+        write_frame(&mut ctl, &serde_json::json!({"kind": "cancel"}));
+    }
+
+    // Reattach and repeat the handshake inputs. Both responses must come from
+    // the runner cache, preserving the original raw load result and id.
+    {
+        let mut ctl = UnixStream::connect(&control).expect("reconnect control socket");
+        ctl.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+        assert_eq!(read_frame(&mut ctl)["kind"], "hello");
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "attach", "control_protocol_version": 2}),
+        );
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({
+                "kind": "establish_session",
+                "method": "session/load",
+                "request": {"sessionId": "existing-session", "cwd": home.to_str().unwrap()}
+            }),
+        );
+        let ready = read_frame(&mut ctl);
+        assert_eq!(ready["kind"], "session_ready");
+        assert_eq!(ready["acp_session_id"], "existing-session");
+        assert!(ready["result"].get("sessionId").is_none());
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let methods = loop {
+        let methods = std::fs::read_to_string(&agent_log).unwrap_or_default();
+        if methods.contains("session/cancel sessionId=existing-session")
+            || Instant::now() >= deadline
+        {
+            break methods;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    assert_eq!(
+        methods
+            .lines()
+            .filter(|line| line.contains("handleRequest method=session/load"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        methods
+            .lines()
+            .filter(|line| line.contains("handleRequest method=session/new"))
+            .count(),
+        0
+    );
+    assert!(
+        methods
+            .lines()
+            .any(|line| line.contains("session/cancel sessionId=existing-session")),
+        "cancel must address the loaded session: {methods:?}"
+    );
+}
+
 /// #2976 Phase B regression: when the agent answers `session/new` with a
 /// JSON-RPC error, the runner forwards the FULL error object (including
 /// `data`) in `HandshakeFailed`, so the daemon can reconstruct the crate

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -6,7 +6,7 @@
 //
 //   initialize          -> return protocolVersion + agentCapabilities
 //   session/new         -> return a deterministic sessionId
-//   session/load        -> same shape; lets structured view's Resume mode work
+//   session/load        -> restore the requested id; Codex omits it from the response
 //   session/prompt      -> emit scripted session/update notifications,
 //                          then return a stop response. Script entries
 //                          with `sessionUpdate: "permission_request"`
@@ -506,7 +506,7 @@ function resolveAgentInfo() {
     return { name: "OpenCode", version: "1.16.0" };
   }
   if (process.env.FAKE_ACP_IMPERSONATE === "codex") {
-    return { name: "@agentclientprotocol/codex-acp", version: "1.1.4" };
+    return { name: "@agentclientprotocol/codex-acp", version: "1.1.9" };
   }
   if (STEERING_ENABLED) {
     return { ...INITIALIZE_RESULT.agentInfo, version: STEERING_MIN_VERSION };
@@ -658,41 +658,49 @@ async function handleRequest(msg) {
       // session/new and session/load *response*, not as a subsequent
       // notification. The structured view's acp_client reads the response
       // field and emits Event::ConfigOptionsUpdated. See #1403.
-      const result = { sessionId };
+      // LoadSessionResponse has no sessionId field. Keep Claude's historical
+      // extension for its existing fixtures, but model pinned codex-acp's
+      // standard response shape when this fake explicitly impersonates Codex.
+      const result = method === "session/load" && process.env.FAKE_ACP_IMPERSONATE === "codex" ? {} : { sessionId };
       const configOptions = buildSessionConfigOptions(sessionId);
       if (configOptions) result.configOptions = configOptions;
       const modes = buildSessionModes(sessionId);
       if (modes) result.modes = modes;
-      sendResult(id, result);
       // Test hook for the import flow (#2276): on session/load, replay a
       // deterministic transcript chunk the way claude-agent-acp re-emits
       // prior history during a load. Lets the import spec assert the
       // imported transcript renders (seed-not-suppressed), while a normal
-      // reattach would drop it. Only on load, deferred after the response.
+      // reattach would drop it.
       const loadReplay = process.env.FAKE_ACP_LOAD_REPLAY;
-      if (method === "session/load" && loadReplay) {
-        setImmediate(() => {
-          // Replay a prior USER turn first (claude-agent-acp emits
-          // user_message_chunk for historical user messages), then the
-          // assistant reply, so the import spec can assert both render.
-          const userReplay = process.env.FAKE_ACP_LOAD_REPLAY_USER;
-          if (userReplay) {
-            sendNotification("session/update", {
-              sessionId,
-              update: {
-                sessionUpdate: "user_message_chunk",
-                content: { type: "text", text: userReplay },
-              },
-            });
-          }
+      const replayLoadHistory = () => {
+        // Replay a prior USER turn first (claude-agent-acp emits
+        // user_message_chunk for historical user messages), then the
+        // assistant reply, so the import spec can assert both render.
+        const userReplay = process.env.FAKE_ACP_LOAD_REPLAY_USER;
+        if (userReplay) {
           sendNotification("session/update", {
             sessionId,
             update: {
-              sessionUpdate: "agent_message_chunk",
-              content: { type: "text", text: loadReplay },
+              sessionUpdate: "user_message_chunk",
+              content: { type: "text", text: userReplay },
             },
           });
+        }
+        sendNotification("session/update", {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: loadReplay },
+          },
         });
+      };
+      const replayBeforeResponse = process.env.FAKE_ACP_LOAD_REPLAY_BEFORE_RESPONSE === "1";
+      if (method === "session/load" && loadReplay && replayBeforeResponse) {
+        replayLoadHistory();
+      }
+      sendResult(id, result);
+      if (method === "session/load" && loadReplay && !replayBeforeResponse) {
+        setImmediate(replayLoadHistory);
       }
       return;
     }
@@ -895,6 +903,7 @@ async function main() {
       // calls.
       if (msg.method === "session/cancel") {
         const sid = msg.params?.sessionId;
+        fakeDebug(`session/cancel sessionId=${sid ?? ""}`);
         if (sid) cancelFlags.set(sid, true);
       } else {
         process.stderr.write(`[fakeAcpAgent] received notification: ${msg.method}\n`);


### PR DESCRIPTION
## Description

Structured View could reset a resumed conversation after an idle worker restart even when `session/load` had succeeded.

The detached runner used the same identity rule for `session/new`, `session/load`, and `session/fork`: it required every successful response to contain `result.sessionId`.

That is not valid for `session/load`. ACP's standard `LoadSessionResponse` does not contain a session id; the identity being reopened is already supplied by the request. In particular, the pinned Codex ACP adapter can successfully load the requested conversation and replay its history, then return load metadata without repeating `sessionId`.

AoE therefore did this on a valid Codex resume:

1. send `session/load` with the persisted ACP session id;
2. receive the old conversation history from the adapter;
3. receive a successful load response without `sessionId`;
4. reject that response locally as `session/load response missing sessionId`;
5. clear the persisted id and fall back to `session/new`;
6. surface a conversation context reset.

This change makes session identity establishment method-sensitive:

- `session/new`: the response must provide the newly-created `sessionId`.
- `session/fork`: the response must provide the forked `sessionId`.
- `session/load`: the established identity comes from the request's `sessionId`; a response `sessionId` is optional, and if an adapter includes that extension it must match the requested id.

The runner still caches the untouched raw response alongside the established identity, so reattachment can replay the original load result while runner-owned operations such as `session/cancel` address the loaded session.

The Codex fake-agent path now models the standard load response shape by omitting `sessionId`, and the development documentation was corrected accordingly.

### Regression coverage

Added a real `aoe __acp-runner` integration regression that:

- loads an existing synthetic session;
- models Codex-style historical notifications arriving before the load response;
- accepts a successful load result with no `sessionId`;
- establishes the requested session id;
- verifies `session/cancel` targets that id;
- reattaches and verifies the cached raw result remains usable and still has no synthesized `sessionId`;
- verifies exactly one `session/load` and zero fallback `session/new` calls.

The method-level table test also covers new/fork required IDs, load without a response ID, matching and mismatching load extensions, malformed IDs/results, missing request identity, and unsupported methods.

### Manual reproduction / verification

I also verified the original failure and the fix against real dormant Codex Structured View sessions.

Before the fix, an idle-auto-stopped session successfully replayed its old history during `session/load`, then AoE rejected the successful response for the missing response `sessionId` and created a fresh session.

After the fix, a separate real session was allowed to auto-stop after 3600 seconds idle and was then resumed from Structured View. AoE used `session/load` with the persisted ACP session id, reported the load as successful, retained the same id, and continued the prior conversation. A follow-up asking Codex to describe its previous work without using tools returned the earlier session's specific work and final commit state.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No visual UI behavior changed, so there is no screenshot or recording.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the failure is in the detached runner's ACP session-establishment handshake, not browser behavior. The new `tests/acp_runner_control.rs` regression drives the real `aoe __acp-runner` process and directly asserts the broken load, cache, reattach, cancel, and no-fallback behavior. A Playwright story would exercise the same mechanism at a higher layer without adding a distinct failure mode.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this changes ACP session lifecycle inside the detached runner, and the real-runner integration test exercises that boundary directly without requiring TUI interaction or a CLI user story.

### Verification

Passed locally:

- `cargo test --features serve --test acp_runner_control`
- `cargo test --features serve --lib established_session_id_is_method_sensitive`
- `cargo test --features serve --test integration acp_effort_respawn::pinned_effort_applied_on_session_load`
- `cargo fmt --check`
- `cargo clippy --features serve --all-targets`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`
- `git diff --check`
- `umask 077 && cargo test --features serve -- --quiet`

The full private-umask serve suite passed. The library result was 6,228 passed / 2 ignored; the main integration target was 164 passed / 5 ignored, with the remaining integration and doc-test targets also passing.

(`cargo test --features serve` under the host's `umask 002` initially hit existing login-store permission tests; rerunning those and the full suite under the private `umask 077` expected by those tests passed.)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex CLI (GPT-5.6 Sol) for investigation, implementation, and validation; Claude Code (Claude Opus 5) for an independent read-only code review.

**Any Additional AI Details you'd like to share:**

I reproduced the failure in real AoE Structured View sessions, preserved the pre-fix logs, and directed the investigation around the observed `session/load` behavior. Codex traced the runner and pinned adapter contracts, implemented the fix, and added the regression coverage.

I then had Claude Opus independently review the exact change, including the ACP identity semantics, runner cache/reattach behavior, cancel addressing, adapter compatibility, and test coverage. That review found no P0/P1/P2 issues; I applied only its small non-blocking test-coverage and documentation follow-ups.

Finally, I manually verified a real idle-auto-stopped Codex session resumed after the fix with the same persisted ACP session id and retained its prior conversational context.

I have reviewed the resulting change and can respond to reviewer questions directly.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed ACP `session/load` handling in the detached runner.
- Reused the requested session ID when the load response does not include one.
- Kept strict session ID checks for `session/new` and `session/fork`.
- Preserved load responses for reattachment without creating a new session.
- Updated the fake ACP agent and development documentation to match the standard response format.
- Added regression coverage for resumption, cancellation, response caching, and reconnect behavior.

## Benefits

Valid ACP session resumptions now succeed. Reconnected sessions retain their history and avoid unnecessary fallback session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->