### PR TITLE
fix(session): resolve a stale agent_detect_as alias instead of freezing at Idle

### DIFF
--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1638,7 +1638,7 @@ async fn capture_session(profile: &str, args: CaptureArgs) -> Result<()> {
             }
         } else {
             tmux_session
-                .detect_status(profile, detection_tool)
+                .detect_status(profile, &detection_tool)
                 .unwrap_or_default()
         };
         let content = if args.strip_ansi {

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -31,13 +31,14 @@ mod v020_move_tui_branch_suffix_to_row_tag;
 mod v021_split_app_state_to_state_toml;
 mod v022_prune_tuning_settings;
 mod v023_clear_structured_container_error;
+mod v024_backfill_detect_as;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 23;
+const CURRENT_VERSION: u32 = 24;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -161,6 +162,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 23,
         name: "clear_structured_container_error",
         run: v023_clear_structured_container_error::run,
+    },
+    Migration {
+        version: 24,
+        name: "backfill_detect_as",
+        run: v024_backfill_detect_as::run,
     },
 ];
 

--- a/src/migrations/v024_backfill_detect_as.rs
+++ b/src/migrations/v024_backfill_detect_as.rs
@@ -18,11 +18,16 @@
 //! distrust it. Per `AGENTS.md > Data Migrations` the stored data gets fixed
 //! rather than accumulating read-side shims.
 //!
-//! The runtime fallback is not made redundant by this: `agent_detect_as` can be
-//! edited, renamed, or removed at any point after a session is built, so the
-//! staleness this heals is reachable again the moment a user renames a custom
-//! agent. The migration fixes the rows that exist; the fallback keeps the next
-//! ones correct.
+//! The runtime fallback is not made redundant by this: this is a one-shot, and
+//! a session built after it runs but before its tool is added to
+//! `[session.agent_detect_as]` lands in exactly the same state. The migration
+//! fixes the rows that exist; the fallback keeps the next ones correct.
+//!
+//! The converse is also true: because a non-empty stored alias wins over the
+//! registry, backfilling a row converts a value the fallback was tracking live
+//! into a fixed pin, so a later retarget or removal of the entry no longer
+//! reaches it. That is deliberate: it is the same state a session built with the
+//! entry in place would have had.
 //!
 //! ## Failure policy
 //!

--- a/src/migrations/v024_backfill_detect_as.rs
+++ b/src/migrations/v024_backfill_detect_as.rs
@@ -1,0 +1,245 @@
+//! Migration v024: backfill the `detect_as` status-detection alias onto
+//! sessions created while their tool had no `[session.agent_detect_as]` entry.
+//!
+//! `Instance::detect_as` is resolved once at session build and persisted. A
+//! session created before its custom agent was added to
+//! `[session.agent_detect_as]` therefore stores an empty alias forever, and
+//! nothing re-resolved it. With no alias, `status_rules::detection_tool`
+//! reports the custom tool name, which has neither configured rules nor a
+//! built-in detector, so `detect_status_from_content_in` returns its
+//! `Status::Idle` fallback on every pane capture: the session's status freezes
+//! at Idle and never moves to Running again.
+//!
+//! `status_rules::effective_detect_as` now consults the live config when the
+//! stored field is empty, so detection is already correct without this
+//! migration. This exists because `detect_as` has consumers beyond status
+//! detection (sandbox agent selection, hook install, container config), and
+//! leaving a field wrong on disk means every future reader has to know to
+//! distrust it. Per `AGENTS.md > Data Migrations` the stored data gets fixed
+//! rather than accumulating read-side shims.
+//!
+//! The runtime fallback is not made redundant by this: `agent_detect_as` can be
+//! edited, renamed, or removed at any point after a session is built, so the
+//! staleness this heals is reachable again the moment a user renames a custom
+//! agent. The migration fixes the rows that exist; the fallback keeps the next
+//! ones correct.
+//!
+//! ## Failure policy
+//!
+//! Per `AGENTS.md > Data Migrations`, a returned `Err` aborts boot. A
+//! sessions.json that fails to read or parse is logged and skipped: an
+//! unreadable or corrupt file must not block boot or spam every launch, and
+//! this backfill is best-effort, since the runtime fallback covers detection
+//! either way. Only `get_app_dir` and directory-read failures propagate.
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+/// `[session.agent_detect_as]` for a profile, resolved exactly as the runtime
+/// resolves it (global config merged with the profile's overrides) so a
+/// backfilled value matches what detection would have computed.
+type AliasLookup<'a> = dyn Fn(&str) -> HashMap<String, String> + 'a;
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir, &|profile| {
+        crate::session::profile_config::resolve_config_or_warn(profile)
+            .session
+            .agent_detect_as
+    })
+}
+
+pub(crate) fn run_in(app_dir: &Path, aliases_for: &AliasLookup) -> Result<()> {
+    let profiles_dir = app_dir.join("profiles");
+    if profiles_dir.exists() {
+        for entry in fs::read_dir(&profiles_dir)? {
+            let entry = entry?;
+            if !entry.path().is_dir() {
+                continue;
+            }
+            // The directory name is the profile name; a name that is not valid
+            // UTF-8 cannot be a profile, so it cannot own sessions to heal.
+            let Some(profile) = entry.file_name().to_str().map(str::to_string) else {
+                continue;
+            };
+            backfill(&entry.path().join("sessions.json"), &aliases_for(&profile))?;
+        }
+    }
+    // Legacy top-level sessions.json (pre-profiles layout). An empty profile
+    // name resolves to the default profile, matching `effective_profile`.
+    backfill(&app_dir.join("sessions.json"), &aliases_for(""))?;
+    Ok(())
+}
+
+/// Set `detect_as` on every session whose tool is aliased but whose stored
+/// alias is missing or empty. Sessions with an alias already stored are left
+/// alone: a non-empty value is a deliberate per-session pin, and overwriting it
+/// from config would undo any session the user re-targeted by hand.
+fn backfill(path: &Path, aliases: &HashMap<String, String>) -> Result<()> {
+    if !path.exists() || aliases.is_empty() {
+        return Ok(());
+    }
+    // Read failures are skipped for the same reason parse failures are: this is
+    // a best-effort backfill, and a permissions hiccup or non-UTF-8 file must
+    // not abort boot. `?` here would have propagated straight out of `run()`.
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(e) => {
+            debug!("v024: failed to read {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
+    let mut value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!("v024: failed to parse {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
+
+    let mut healed = 0usize;
+    if let Some(array) = value.as_array_mut() {
+        for instance in array.iter_mut() {
+            let Some(obj) = instance.as_object_mut() else {
+                continue;
+            };
+            // `detect_as` is `skip_serializing_if = "String::is_empty"`, so an
+            // absent field and an empty one are the same state.
+            let stored = obj.get("detect_as").and_then(|v| v.as_str()).unwrap_or("");
+            if !stored.is_empty() {
+                continue;
+            }
+            let Some(tool) = obj.get("tool").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(alias) = aliases.get(tool) else {
+                continue;
+            };
+            obj.insert(
+                "detect_as".to_string(),
+                serde_json::Value::String(alias.clone()),
+            );
+            healed += 1;
+        }
+    }
+
+    if healed > 0 {
+        crate::session::atomic_write(path, serde_json::to_string_pretty(&value)?.as_bytes())?;
+        info!(
+            "v024: backfilled detect_as on {healed} session(s) in {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn aliases(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn backfills_only_unaliased_rows_with_a_mapped_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(
+            &path,
+            r#"[
+                {"id":"a","tool":"claude-personal"},
+                {"id":"b","tool":"claude-personal","detect_as":""},
+                {"id":"c","tool":"claude-personal","detect_as":"codex"},
+                {"id":"d","tool":"codex-company"},
+                {"id":"e","tool":"claude"},
+                {"id":"f"}
+            ]"#,
+        )
+        .unwrap();
+
+        backfill(&path, &aliases(&[("claude-personal", "claude")])).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let arr = v.as_array().unwrap();
+        // absent alias + mapped tool -> filled (the bug footprint)
+        assert_eq!(arr[0]["detect_as"], "claude");
+        // empty alias is the same state as absent -> filled
+        assert_eq!(arr[1]["detect_as"], "claude");
+        // an alias already stored is a deliberate pin -> untouched
+        assert_eq!(arr[2]["detect_as"], "codex");
+        // tool with no config entry -> left for the runtime fallback to miss too
+        assert!(arr[3].get("detect_as").is_none());
+        // built-in tool -> never aliased
+        assert!(arr[4].get("detect_as").is_none());
+        // row without a tool -> untouched, not a panic
+        assert!(arr[5].get("detect_as").is_none());
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(&path, r#"[{"id":"a","tool":"claude-personal"}]"#).unwrap();
+        let map = aliases(&[("claude-personal", "claude")]);
+        backfill(&path, &map).unwrap();
+        let first = fs::read_to_string(&path).unwrap();
+        backfill(&path, &map).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), first);
+    }
+
+    #[test]
+    fn skips_unreadable_and_absent_and_unmapped() {
+        let dir = tempfile::tempdir().unwrap();
+        // Missing file.
+        backfill(&dir.path().join("nope.json"), &aliases(&[("a", "claude")])).unwrap();
+
+        // Corrupt file is left exactly as found.
+        let corrupt = dir.path().join("corrupt.json");
+        fs::write(&corrupt, "{ not valid json").unwrap();
+        backfill(&corrupt, &aliases(&[("a", "claude")])).unwrap();
+        assert_eq!(fs::read_to_string(&corrupt).unwrap(), "{ not valid json");
+
+        // No aliases configured means no rewrite at all.
+        let path = dir.path().join("sessions.json");
+        let row = r#"[{"id":"a","tool":"claude-personal"}]"#;
+        fs::write(&path, row).unwrap();
+        backfill(&path, &HashMap::new()).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), row);
+    }
+
+    #[test]
+    fn walks_profiles_and_legacy_layouts_with_per_profile_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        let work = dir.path().join("profiles").join("work");
+        fs::create_dir_all(&work).unwrap();
+        let row = r#"[{"id":"a","tool":"my-agent"}]"#;
+        fs::write(work.join("sessions.json"), row).unwrap();
+        fs::write(dir.path().join("sessions.json"), row).unwrap();
+
+        // Each profile resolves its own map, and the legacy file is asked for
+        // the default profile's (empty name).
+        run_in(dir.path(), &|profile| match profile {
+            "work" => aliases(&[("my-agent", "claude")]),
+            "" => aliases(&[("my-agent", "codex")]),
+            _ => HashMap::new(),
+        })
+        .unwrap();
+
+        let read = |p: std::path::PathBuf| -> serde_json::Value {
+            serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap()
+        };
+        assert_eq!(read(work.join("sessions.json"))[0]["detect_as"], "claude");
+        assert_eq!(
+            read(dir.path().join("sessions.json"))[0]["detect_as"],
+            "codex"
+        );
+    }
+}

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -6583,11 +6583,13 @@ impl Instance {
     /// file stat, plus one pane capture for Claude, gated on an actual
     /// transition, so steady-state polling pays nothing.
     fn log_status_transition(&self, prev: Status) {
-        let detection_tool = if self.detect_as.is_empty() {
-            &self.tool
-        } else {
-            &self.detect_as
-        };
+        // Resolved the same way the pane fallback resolves it, so the label and
+        // the `pane=` fingerprint describe the detector that actually ran. The
+        // ad-hoc `detect_as`-or-`tool` this used to do disagreed with the
+        // detector whenever the stored alias was stale, which is exactly the
+        // case a wrong-state report needs the log to be honest about.
+        let detection_tool =
+            tmux::status_rules::detection_tool(&self.source_profile, &self.tool, &self.detect_as);
         let hook = crate::hooks::read_hook_status(&self.id);
         let hook_age_ms = crate::hooks::read_hook_status_age(&self.id).map(|age| age.as_millis());
         if detection_tool == "claude" {
@@ -6778,10 +6780,15 @@ impl Instance {
         // hook reconciliation keeps the alias identity. The pane fallback
         // below instead prefers the session's own configured status rules
         // over the alias.
-        let hook_tool: &str = if self.detect_as.is_empty() {
+        let hook_alias = tmux::status_rules::effective_detect_as(
+            &self.source_profile,
+            &self.tool,
+            &self.detect_as,
+        );
+        let hook_tool: &str = if hook_alias.is_empty() {
             &self.tool
         } else {
-            &self.detect_as
+            &hook_alias
         };
 
         if let Some(hook_status) = crate::hooks::read_hook_status(&self.id) {
@@ -6870,7 +6877,7 @@ impl Instance {
             tmux::status_rules::detection_tool(&self.source_profile, &self.tool, &self.detect_as);
         let pane_content = session.capture_pane(50).unwrap_or_default();
         let detected =
-            tmux::detect_status_from_content_in(&self.source_profile, &pane_content, pane_tool);
+            tmux::detect_status_from_content_in(&self.source_profile, &pane_content, &pane_tool);
         tracing::trace!(target: "session.store",
             "status '{}': detected={:?}, cmd_override={}, custom_cmd={}",
             self.title,

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -1114,24 +1114,25 @@ pub async fn run_terminal_rename(
     };
 
     let tmux = crate::tmux::Session::new(session_id, &title)?;
-    let detect_tool = if detect_as.is_empty() {
-        tool.as_str()
-    } else {
-        detect_as.as_str()
-    };
+    // Same resolution the status poller uses: own status rules first, then the
+    // `agent_detect_as` alias, resolved through the live registry so a session
+    // whose alias entry landed after it was created is not stranded on the raw
+    // tool name here (which would skip `strip_agent_banner` and read the pane
+    // with no detector).
+    let detect_tool = crate::tmux::status_rules::detection_tool(profile, &tool, &detect_as);
 
     // Best-effort no-race: the poller fired on Running -> Idle, but the user may
     // have started another turn since. Only proceed while the pane still reads
     // idle; a later idle edge retries.
     if let Ok(content) = tmux.capture_pane(50) {
-        if crate::tmux::detect_status_from_content_in(profile, &content, detect_tool)
+        if crate::tmux::detect_status_from_content_in(profile, &content, &detect_tool)
             == crate::session::Status::Running
         {
             return Ok(());
         }
     }
 
-    let Some(context) = capture_terminal_context(&tmux, detect_tool) else {
+    let Some(context) = capture_terminal_context(&tmux, &detect_tool) else {
         tracing::debug!(target: "smart_rename", session = %session_id, "terminal skip: unusable pane capture");
         return Ok(());
     };

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -211,7 +211,10 @@ pub fn detect(profile: &str, tool: &str, clean_content: &str) -> Option<Status> 
 /// consults the registry the config resolve installed. A non-empty stored value
 /// still wins outright, keeping the hot path allocation-free for the sessions
 /// that have one and preserving the per-session pin for anything that rewrites
-/// the field directly.
+/// the field directly. That precedence bounds what this heals: a session whose
+/// stored alias is empty tracks the config live (an entry added, retargeted, or
+/// removed later all take effect on the next resolve), while a session that
+/// already has one is pinned to it until something rewrites the field.
 pub fn effective_detect_as<'a>(profile: &str, tool: &str, detect_as: &'a str) -> Cow<'a, str> {
     if !detect_as.is_empty() {
         return Cow::Borrowed(detect_as);

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -19,7 +19,12 @@
 //! (TUI boot, `aoe serve`, the session CLI) passes through, so editing the
 //! rules takes effect on the next config resolve instead of requiring the
 //! session to be re-created.
+//!
+//! The same registry carries `[session.agent_detect_as]`, for the same reason
+//! and with the same freshness guarantee: see [`effective_detect_as`] for why
+//! the copy persisted on each `Instance` cannot be the authority.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{OnceLock, RwLock};
 
@@ -49,6 +54,15 @@ type Registry = HashMap<(String, String), Vec<CompiledRule>>;
 fn registry() -> &'static RwLock<Registry> {
     static REGISTRY: OnceLock<RwLock<Registry>> = OnceLock::new();
     REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// `[session.agent_detect_as]` keyed the same way, so [`effective_detect_as`]
+/// can answer from the live config without the poll loop loading it.
+type Aliases = HashMap<(String, String), String>;
+
+fn aliases() -> &'static RwLock<Aliases> {
+    static ALIASES: OnceLock<RwLock<Aliases>> = OnceLock::new();
+    ALIASES.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
 fn hook_status_to_status(status: HookStatus) -> Status {
@@ -94,17 +108,35 @@ fn compile_rules(agent: &str, rules: &[StatusRule]) -> Vec<CompiledRule> {
     compiled
 }
 
-/// Install `profile`'s rules from `config`, replacing only that profile's
-/// entries and leaving every other profile's rules standing. Called on every
-/// config resolve, once per profile; an agent whose rules all fail to compile
-/// ends up with no entry (falling back to the built-in detector or Idle),
-/// matching the behavior of not configuring rules at all.
+/// Install `profile`'s rules and `agent_detect_as` aliases from `config`,
+/// replacing only that profile's entries and leaving every other profile's
+/// standing. Called on every config resolve, once per profile; an agent whose
+/// rules all fail to compile ends up with no entry (falling back to the
+/// built-in detector or Idle), matching the behavior of not configuring rules
+/// at all.
 pub fn install_from_config(profile: &str, config: &crate::session::Config) {
     // Normalize so an empty `source_profile` keys the same slot as the resolved
     // default profile; the lookup side (`detect` / `has_rules`) normalizes the
     // same way, so an unpopulated field degrades to the default profile's rules
     // instead of silently missing.
     let profile = crate::session::config::effective_profile(profile);
+
+    // Held in its own scope: `install_from_config` is the only place that
+    // writes both registries, and taking them one at a time keeps it that way.
+    {
+        let mut map = aliases().write().unwrap_or_else(|p| p.into_inner());
+        map.retain(|(p, _), _| p != &profile);
+        for (agent, target) in &config.session.agent_detect_as {
+            // Malformed entries are reported by `Config::validate`; skipping
+            // them here leaves the tool unaliased, which is what an absent
+            // entry would have done.
+            if agent.is_empty() || target.is_empty() {
+                continue;
+            }
+            map.insert((profile.clone(), agent.clone()), target.clone());
+        }
+    }
+
     let mut map = registry().write().unwrap_or_else(|p| p.into_inner());
     // Drop this profile's previous entries; other profiles' keys are untouched.
     map.retain(|(p, _), _| p != &profile);
@@ -164,17 +196,51 @@ pub fn detect(profile: &str, tool: &str, clean_content: &str) -> Option<Status> 
     Some(Status::Idle)
 }
 
+/// The `agent_detect_as` alias in force for `tool` under `profile`, or `""`
+/// when the tool is not aliased.
+///
+/// `Instance::detect_as` is resolved once at session build and persisted, so a
+/// session outlives the config that produced it: a `[session.agent_detect_as]`
+/// entry added, renamed, or removed after the session was created leaves the
+/// stored field stale, and an empty one is indistinguishable from "never had an
+/// alias". A session created in that window loses its detector entirely, since
+/// `detect_status_from_content_in` falls through to `Status::Idle` for a tool
+/// with neither rules nor a built-in, so its status freezes at Idle forever.
+///
+/// So the stored value is a cache, not the authority: when it is empty this
+/// consults the registry the config resolve installed. A non-empty stored value
+/// still wins outright, keeping the hot path allocation-free for the sessions
+/// that have one and preserving the per-session pin for anything that rewrites
+/// the field directly.
+pub fn effective_detect_as<'a>(profile: &str, tool: &str, detect_as: &'a str) -> Cow<'a, str> {
+    if !detect_as.is_empty() {
+        return Cow::Borrowed(detect_as);
+    }
+    let profile = crate::session::config::effective_profile(profile);
+    aliases()
+        .read()
+        .unwrap_or_else(|p| p.into_inner())
+        .get(&(profile, tool.to_string()))
+        .map(|alias| Cow::Owned(alias.clone()))
+        .unwrap_or(Cow::Borrowed(""))
+}
+
 /// The tool whose *pane* detection heuristics apply to a session: the
 /// session's own tool when it has configured rules, else the
 /// `agent_detect_as` alias when set, else the tool itself. Hook
 /// reconciliation deliberately does not use this helper: hooks are
 /// installed for the alias, so their reconcilers keep the alias identity
-/// (see `Instance::update_status_with_metadata`).
-pub fn detection_tool<'a>(profile: &str, tool: &'a str, detect_as: &'a str) -> &'a str {
-    if detect_as.is_empty() || has_rules(profile, tool) {
-        tool
+/// (see `Instance::update_status_with_metadata`), though they resolve that
+/// identity through [`effective_detect_as`] for the same staleness reason.
+pub fn detection_tool<'a>(profile: &str, tool: &'a str, detect_as: &'a str) -> Cow<'a, str> {
+    if has_rules(profile, tool) {
+        return Cow::Borrowed(tool);
+    }
+    let alias = effective_detect_as(profile, tool, detect_as);
+    if alias.is_empty() {
+        Cow::Borrowed(tool)
     } else {
-        detect_as
+        alias
     }
 }
 
@@ -205,6 +271,15 @@ mod tests {
             .entry(agent.to_string())
             .or_default()
             .status_rules = rules;
+        config
+    }
+
+    fn config_with_alias(agent: &str, target: &str) -> crate::session::Config {
+        let mut config = crate::session::Config::default();
+        config
+            .session
+            .agent_detect_as
+            .insert(agent.to_string(), target.to_string());
         config
     }
 
@@ -388,6 +463,69 @@ mod tests {
         // No rules: alias applies, and no alias means the tool itself.
         assert_eq!(detection_tool("default", "other-agent", "claude"), "claude");
         assert_eq!(detection_tool("default", "other-agent", ""), "other-agent");
+        install_from_config("default", &crate::session::Config::default());
+    }
+
+    /// A session built before its tool was added to `[session.agent_detect_as]`
+    /// persists an empty alias, which used to strand it on the `Status::Idle`
+    /// fallback forever. The stored value is a cache, so an empty one defers to
+    /// the config the resolve installed.
+    #[test]
+    fn effective_detect_as_falls_back_to_installed_config() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config("default", &config_with_alias("claude-personal", "claude"));
+
+        // (tool, stored detect_as, expected alias, expected detection tool)
+        let cases = [
+            // The bug: empty stored alias now resolves from config.
+            ("claude-personal", "", "claude", "claude"),
+            // A stored alias still wins, so a hand-pinned session is not
+            // retargeted by an unrelated config edit.
+            ("claude-personal", "codex", "codex", "codex"),
+            // A tool with no entry stays unaliased and detects as itself.
+            ("unmapped-agent", "", "", "unmapped-agent"),
+        ];
+        for (tool, stored, want_alias, want_detection) in cases {
+            assert_eq!(
+                effective_detect_as("default", tool, stored),
+                want_alias,
+                "alias for {tool:?} stored={stored:?}"
+            );
+            assert_eq!(
+                detection_tool("default", tool, stored),
+                want_detection,
+                "detection tool for {tool:?} stored={stored:?}"
+            );
+        }
+
+        // The fallback is scoped per profile like the rules are.
+        assert_eq!(
+            effective_detect_as("other-profile", "claude-personal", ""),
+            ""
+        );
+
+        install_from_config("default", &crate::session::Config::default());
+        // Cleared with its profile's install, so a removed entry stops applying.
+        assert_eq!(effective_detect_as("default", "claude-personal", ""), "");
+    }
+
+    /// Own rules outrank the alias whether the alias came from the stored field
+    /// or from the config fallback, so the fallback cannot silently take over an
+    /// agent the user wrote rules for.
+    #[test]
+    fn own_rules_outrank_the_config_fallback() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let mut config = config_with_alias("rules-agent", "claude");
+        config
+            .agents
+            .entry("rules-agent".to_string())
+            .or_default()
+            .status_rules = vec![rule(HookStatus::Running, Some("spin"), None)];
+        install_from_config("default", &config);
+
+        assert_eq!(effective_detect_as("default", "rules-agent", ""), "claude");
+        assert_eq!(detection_tool("default", "rules-agent", ""), "rules-agent");
+
         install_from_config("default", &crate::session::Config::default());
     }
 


### PR DESCRIPTION
## Description

A session whose custom agent gained its `[session.agent_detect_as]` entry *after*
the session was created has its status frozen at Idle forever. It never reports
Running again, so it never triggers a status change, a notification, or a
sound.

`Instance::detect_as` is resolved once at session build and persisted:

```rust
// src/cli/add.rs
instance.detect_as = config.session.agent_detect_as.get(&instance.tool).cloned().unwrap_or_default();
```

Nothing re-resolves it, so a session built during the window before the mapping
existed stores an empty alias permanently. With no alias,
`status_rules::detection_tool` reports the custom tool name, which has neither
configured status rules nor a built-in detector, and detection hits its default
arm:

```rust
// src/tmux/status_detection.rs
crate::agents::get_agent(tool)          // None for a custom agent name
    .map(|a| (a.detect_status)(&clean))
    .unwrap_or(Status::Idle)            // every pane capture returns Idle
```

Found from `session.status_change` logs, where the split is total: every
transition logged under the unaliased custom tool name lacks the `pane=`
fingerprint and only ever moves between Idle/Unknown/Starting, while every
transition under the resolved built-in name carries pane markers and moves
through Running normally.

```
# stranded: no pane detector at all
3ff5edb5a1f043c4 [claude-personal] Idle -> Unknown (hook=None hook_age_ms=None)
# healthy: same binary, same profile, alias resolved
2121ceeb63734f75 [claude] Idle -> Running (hook=None pane=spinner+esc_hint+empty_prompt+idle_footer)
```

### The fix

Carry `[session.agent_detect_as]` in the same process-global, profile-keyed
registry the status rules already use, installed by the same
`install_from_config` on every config resolve, and treat the persisted field as
a cache rather than the authority. A non-empty stored value still wins outright,
so the poll hot path stays allocation-free and a hand-pinned session keeps its
pin; an empty one consults the registry.

Four sites resolved the alias by hand and now share `effective_detect_as` /
`detection_tool`:

- **the pane detector** (`detection_tool`), the reported bug. Own status rules
  still outrank the alias, from either source.
- **hook reconciliation** (`hook_tool`), so `reconciles_running` /
  `reconciles_idle` fire for a stranded session whose hook file was written by a
  globally installed agent hook config.
- **the `session.status_change` log line**, whose label disagreed with the
  detector that actually ran. That line exists to make intermittent wrong-state
  reports diagnosable, so it is the last place that should be guessing.
- **`smart_rename::run_terminal_rename`**, which read the raw stored field and
  skipped the `has_rules` precedence. A stranded session reached
  `capture_terminal_context` under its custom tool name, where
  `strip_agent_banner`'s `"claude"` gate does not fire, and got titled from the
  agent's startup banner instead of the task. That path is *newly* reachable:
  before this fix the session never left Idle, so the Running -> Idle edge that
  triggers smart-rename never fired for it.

`detection_tool` returns `Cow<'a, str>` now; callers take a reference.

### Scope of the fallback

Worth being precise, because it bounds what this heals. A non-empty stored alias
returns before the registry is consulted, so the fallback covers **an entry
added after the session was built**. It does not un-strand a session whose
stored alias is set and whose config entry was later retargeted or removed;
that row stays pinned to what it stored until something rewrites the field.

### Why a fallback *and* a migration

`AGENTS.md` prefers migrations over read-side compat shims, so the stored field
gets fixed rather than distrusted forever by the consumers that have no fallback
of their own: `run_launch_hooks` (`instance.rs:4198`), `build_launch_command`
(`:4258`), and the sandbox `merge_hooks_into_selected_agent` path (`:5336`) all
call `get_agent(&self.detect_as)` directly. (`container_config::resolve_active_agent`
already falls back to live config, so it was never affected.)

The runtime fallback is not made redundant by the migration: the migration is a
one-shot, and a session built *after* it runs but before its tool is aliased
lands in exactly the same stranded state.

The converse interaction is real and deliberate: backfilling a row converts a
value the fallback was tracking live into a fixed pin, so a later retarget or
removal of the entry no longer reaches it. That is the same state a session
built with the entry already in place would have had.

### Migration verification

v024 was run through the real `aoe` binary against sandboxed app dirs
(`.schema_version=23`, a global `agent_detect_as` plus a profile overriding it,
hand-crafted `sessions.json` rows). Absent-alias and empty-alias rows were
filled; an already-pinned row, a built-in-tool row, an unmapped-tool row, and a
row with no tool were all left untouched; the profile-scoped row resolved to the
profile's target rather than the global one; `.schema_version` went to 24.

Separately, against a copy of a real app dir with 25 sessions across 5 profiles,
it changed exactly the two affected rows with session count, ordering, and every
other field byte-identical.

One cosmetic note: the rewrite sorts object keys, since `serde_json::Value` has
no `preserve_order` (confirmed via `cargo tree -e features -i serde_json`). v023
already behaves this way, and the data is machine-written and
struct-deserialized, so it is semantically inert; it does make the first run
produce a large textual diff of `sessions.json`.

### Known follow-ups, not addressed here

- v024 reaches config through `resolve_config_or_warn`, while `v015` and `v018`
  deliberately read raw TOML with the comment that "migrations run before the
  live process commits to the current `Config` schema". v024 is safe today only
  because it is ordered last. The cost is that a config problem degrades to
  `Config::default()`, backfills nothing for that profile, and still bumps the
  schema version, so the heal never retries. The runtime fallback covers
  detection for those rows regardless.
- `docs/guides/configuration.md:138` documents `agent_detect_as` without saying
  when an edit takes effect, while the `status_rules` row below it does. This PR
  gives `agent_detect_as` that property for sessions with no stored alias.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt --check`, `cargo clippy --all-targets` (clean on all touched files;
the 7 remaining warnings are pre-existing and in files this PR does not touch),
`cargo check --features serve`, and `cargo test` all pass — 4576 lib tests plus
the integration targets.

Note for anyone running the suite locally: `tui::dialogs::hooks_install::tests::test_content_shows_settings_path`
fails when `CLAUDE_CONFIG_DIR` is set in the ambient environment, which Claude
Code does. `env -u CLAUDE_CONFIG_DIR cargo test --lib` is green. That test is not
in this diff and the failure predates this branch.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is a pure function of config state and
  a stored field, and it is covered at the unit tier where it can actually fail:
  `effective_detect_as_falls_back_to_installed_config` (table over stored-empty /
  stored-set / unmapped, plus per-profile scoping and clearing on removal),
  `own_rules_outrank_the_config_fallback`, and four migration tests over
  hand-crafted old state. Reproducing it e2e would mean standing up a live agent,
  mutating config mid-session, and polling for a status flip, which buys no
  additional failure mode for ~2s on the serial e2e critical path.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:**

Used to read the `session.status_change` logs, isolate the stranded sessions,
trace the frozen-`detect_as` root cause, and write the fix, the migration, and
the tests. Reviewed by a second independent agent that had only the PR and the
repository, which caught the `smart_rename.rs` site, corrected the scope claim
about what the fallback heals, and reproduced the Idle-to-Running flip directly
rather than reasoning about it.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added profile-scoped runtime handling for `session.agent_detect_as`.
- Updated status detection, hook reconciliation, logging, pane fallback detection, and smart rename to use the effective agent alias.
- Preserved explicit session aliases while allowing empty values to follow current configuration.
- Added migration v024 to backfill aliases in existing session files.
- Added tests for fallback behavior, profile isolation, precedence, alias removal, and migration handling.
- Updated session capture to pass detected tools by reference.

## Benefits

Sessions now respond correctly when custom agent configuration changes. Existing session overrides remain intact. Profile-specific settings do not affect other profiles.

Formatting, clippy, check, and test commands pass, except for one unrelated pre-existing test failure.

## Technical details

The change adds `effective_detect_as` and updates `detection_tool` to support configured aliases. Migration v024 updates profile and legacy session files safely, preserves explicit aliases, and writes changes atomically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->