### PR TITLE
fix(logging): keep expected git failures and disabled plugins out of WARN

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -40,6 +40,15 @@ Top-level roots:
 - **debug**: frequent / per-operation detail (every git invocation, every signal)
 - **trace**: per-byte / per-message firehose (`terminal.ws.bytes`, ACP JSON-RPC transport)
 
+An outcome the call site has already classified as expected is **debug**, even
+when it is a failure underneath: a best-effort `git worktree unlock` that finds
+nothing to unlock, or a plugin that is not launching because the user switched
+it off. Those are the configuration and the code working as intended, and at
+warn they crowd out the failures nobody chose. Where a shared helper cannot
+tell the two apart, give it a quiet variant the classifying caller opts into
+(`git::command::run_git_quiet`) rather than dropping the record entirely; the
+stderr summary is what makes a surprise diagnosable later.
+
 ## Env variables
 
 Resolved once at startup in `LogConfig::from_env`:

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -5773,6 +5773,15 @@ fn map_acp_config_option(
         SessionConfigOptionCategory::Mode => ConfigOptionCategory::Mode,
         SessionConfigOptionCategory::Model => ConfigOptionCategory::Model,
         SessionConfigOptionCategory::ThoughtLevel => ConfigOptionCategory::ThoughtLevel,
+        // "Model-related configuration parameter", a sibling of `Model`
+        // rather than another model picker (an adapter ships both), so it
+        // must not collapse into `ConfigOptionCategory::Model`. Nothing
+        // renders it specially yet, so it carries its upstream wire name
+        // through the generic `Other` arm instead of the `Other("")` the
+        // catch-all below used to produce (#3403).
+        SessionConfigOptionCategory::ModelConfig => {
+            ConfigOptionCategory::Other("model_config".to_string())
+        }
         SessionConfigOptionCategory::Other(s) => ConfigOptionCategory::Other(s),
         // The schema enum is `#[non_exhaustive]`, so this arm is required
         // to compile. Unknown category *names* arrive via the untagged
@@ -9891,6 +9900,44 @@ async fn handle_elicitation_request(
 mod tests {
     use super::*;
     use rusqlite::Connection;
+    use tracing_test::traced_test;
+
+    /// `ModelConfig` is a category upstream already names, so it must map
+    /// through the explicit arm: the catch-all's "bump claude-agent-acp"
+    /// warning is for variants this build has genuinely never seen, and it
+    /// discards the category name on the way past (#3403).
+    #[traced_test]
+    #[test]
+    fn model_config_category_maps_without_the_unknown_variant_warning() {
+        use agent_client_protocol::schema::v1::{
+            SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
+        };
+        tracing::callsite::rebuild_interest_cache();
+        let mapped = map_acp_config_option(
+            SessionConfigOption::select(
+                "reasoning-effort",
+                "Reasoning effort",
+                "high",
+                vec![SessionConfigSelectOption::new("high", "High")],
+            )
+            .category(SessionConfigOptionCategory::ModelConfig),
+        )
+        .expect("a select option maps");
+        assert_eq!(
+            mapped.category,
+            ConfigOptionCategory::Other("model_config".to_string())
+        );
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|l| l.contains("unknown SessionConfigOptionCategory"))
+                .count()
+            {
+                0 => Ok(()),
+                n => Err(format!("expected no unknown-category warning, got {n}")),
+            }
+        });
+    }
 
     /// The steer wire contract (#2805). `sessionId` must be camelCase and
     /// the `_meta` opt-in must be spelled exactly as the adapter reads it:

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -325,7 +325,10 @@ pub fn deinit_submodules_if_present(worktree_path: &Path) {
     if !worktree_path.join(".gitmodules").exists() {
         return;
     }
-    let output = super::command::run_git(worktree_path, ["submodule", "deinit", "-f", "--all"]);
+    // `run_git_quiet`: every outcome below is already classified and logged
+    // here at DEBUG, so a second WARN from the wrapper would only be noise.
+    let output =
+        super::command::run_git_quiet(worktree_path, ["submodule", "deinit", "-f", "--all"]);
     match output {
         Ok(o) if o.status.success() => {
             tracing::debug!(target: "git.worktree",

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -20,6 +20,31 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
+    run(cwd, args, false)
+}
+
+/// [`run_git`] for callers that have already classified a non-zero exit as
+/// an expected, no-op outcome (`git worktree unlock` on an entry that is
+/// already unlocked, `git submodule deinit` on a checkout with nothing
+/// initialised). Identical apart from the failure log, which drops to DEBUG
+/// so the routine case stops competing with real warnings in `debug.log`.
+///
+/// Only for call sites that discard or already diagnose the failure
+/// themselves. A caller that turns a non-zero exit into an error keeps
+/// [`run_git`], so the WARN stays with the failure it explains.
+pub fn run_git_quiet<I, S>(cwd: &Path, args: I) -> std::io::Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    run(cwd, args, true)
+}
+
+fn run<I, S>(cwd: &Path, args: I, quiet: bool) -> std::io::Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
     let argv: Vec<std::ffi::OsString> = args.into_iter().map(|a| a.as_ref().to_owned()).collect();
     let redacted: Vec<String> = argv.iter().map(|a| redact(a.as_os_str())).collect();
     let start = Instant::now();
@@ -48,14 +73,25 @@ where
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stderr_summary: String = stderr.chars().take(200).collect();
-        tracing::warn!(
-            target: "git.command",
-            args = ?redacted,
-            exit = output.status.code(),
-            duration_ms = dur,
-            stderr_summary = %stderr_summary,
-            "git command failed"
-        );
+        if quiet {
+            tracing::debug!(
+                target: "git.command",
+                args = ?redacted,
+                exit = output.status.code(),
+                duration_ms = dur,
+                stderr_summary = %stderr_summary,
+                "git command failed (expected by caller)"
+            );
+        } else {
+            tracing::warn!(
+                target: "git.command",
+                args = ?redacted,
+                exit = output.status.code(),
+                duration_ms = dur,
+                stderr_summary = %stderr_summary,
+                "git command failed"
+            );
+        }
     }
     Ok(output)
 }
@@ -77,6 +113,40 @@ fn redact(arg: &OsStr) -> String {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+    use tracing_test::traced_test;
+
+    /// The same failing command is a WARN through `run_git` and a DEBUG
+    /// through `run_git_quiet`; the quiet variant must not drop the record
+    /// entirely, since the stderr summary is what makes a surprise
+    /// diagnosable.
+    #[traced_test]
+    #[test]
+    fn run_git_quiet_demotes_expected_failure_to_debug() {
+        let tmp = tempfile::tempdir().unwrap();
+        tracing::callsite::rebuild_interest_cache();
+        // Not a repository, so `git worktree unlock` exits non-zero: the
+        // shape `unlock_worktree` classifies as a harmless no-op.
+        let args = ["worktree", "unlock", "/nonexistent"];
+        let loud = run_git(tmp.path(), args).expect("git should spawn");
+        let quiet = run_git_quiet(tmp.path(), args).expect("git should spawn");
+        assert!(!loud.status.success());
+        assert!(!quiet.status.success());
+
+        logs_assert(|lines: &[&str]| {
+            let failures = |level: &str| {
+                lines
+                    .iter()
+                    .filter(|l| l.contains(level) && l.contains("git command failed"))
+                    .count()
+            };
+            match (failures("WARN"), failures("DEBUG")) {
+                (1, 1) => Ok(()),
+                (w, d) => Err(format!(
+                    "expected 1 warn and 1 debug failure line, got {w}/{d}"
+                )),
+            }
+        });
+    }
 
     #[test]
     fn redact_strips_basic_userinfo() {

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -883,12 +883,14 @@ impl GitWorktree {
     /// `git worktree unlock` resolves the entry from the admin side, so it
     /// still clears the lock when the checkout directory is already gone, and a
     /// non-zero exit (already unlocked, or no such worktree) is a harmless
-    /// no-op rather than an error.
+    /// no-op rather than an error. That classification is why the call goes
+    /// through `run_git_quiet`: the routine non-zero exit belongs at DEBUG,
+    /// not in the WARN stream.
     pub fn unlock_worktree(&self, path: &Path) {
         let Some(path_str) = path.to_str() else {
             return;
         };
-        let _ = super::command::run_git(&self.repo_path, ["worktree", "unlock", path_str]);
+        let _ = super::command::run_git_quiet(&self.repo_path, ["worktree", "unlock", path_str]);
     }
 
     /// Convert a worktree's .git file from absolute to relative path.

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -89,6 +89,23 @@ struct WorkerTable {
     next_supervisor_id: u64,
 }
 
+/// Level and reason for a runtime-declaring plugin that boot will not launch.
+///
+/// A plugin switched off in settings is the configuration doing exactly what
+/// the user asked for, so it belongs at DEBUG; it was ~13% of one user's WARN
+/// volume over ten days (#3403). The other reasons are states nobody chose
+/// (a stale grant, a manifest the host rejected) and keep their WARN, which
+/// is the whole point of logging the zero-launch case.
+fn inactive_launch_diagnostic(enabled: bool, granted: bool) -> (tracing::Level, &'static str) {
+    if !enabled {
+        (tracing::Level::DEBUG, "disabled")
+    } else if !granted {
+        (tracing::Level::WARN, "ungranted; awaiting reapproval")
+    } else {
+        (tracing::Level::WARN, "inactive")
+    }
+}
+
 /// The plugin worker host, owned by the daemon for its lifetime.
 pub struct PluginHost {
     api: Arc<HostApiState>,
@@ -217,7 +234,7 @@ impl PluginHost {
     /// launch path; the daemon calls it at startup and the web enable/disable
     /// handler calls it to recover a worker without a full restart.
     pub async fn start(self: &Arc<Self>, registry: &PluginRegistry) {
-        self.log_start_observability(registry);
+        Self::log_start_observability(registry);
         self.reconcile(registry).await;
     }
 
@@ -227,7 +244,10 @@ impl PluginHost {
     /// reason buried in `load_errors` (surfaced only in the plugin manager UI),
     /// so the daemon log shows a silent zero-launch. Boot-only: reconcile does
     /// not re-log this on every enable/disable.
-    fn log_start_observability(&self, registry: &PluginRegistry) {
+    ///
+    /// Takes the registry rather than `&self` so the level classification is
+    /// unit-testable without standing up a host.
+    fn log_start_observability(registry: &PluginRegistry) {
         for err in registry.load_errors() {
             tracing::warn!(
                 target: "plugin.host",
@@ -236,19 +256,15 @@ impl PluginHost {
         }
         for p in registry.all() {
             if p.manifest.runtime.is_some() && !p.active() {
-                let reason = if !p.enabled {
-                    "disabled"
-                } else if !p.granted {
-                    "ungranted; awaiting reapproval"
+                let (level, reason) = inactive_launch_diagnostic(p.enabled, p.granted);
+                let msg = "plugin declares a runtime but is inactive; not launching a worker";
+                // `tracing` resolves the level at the callsite, so the two
+                // levels need two macro invocations.
+                if level == tracing::Level::DEBUG {
+                    tracing::debug!(target: "plugin.host", plugin = %p.id(), reason, "{msg}");
                 } else {
-                    "inactive"
-                };
-                tracing::warn!(
-                    target: "plugin.host",
-                    plugin = %p.id(),
-                    reason,
-                    "plugin declares a runtime but is inactive; not launching a worker"
-                );
+                    tracing::warn!(target: "plugin.host", plugin = %p.id(), reason, "{msg}");
+                }
             }
         }
     }
@@ -813,6 +829,31 @@ mod tests {
     use super::*;
     use crate::plugin::host_api::PluginRpcContext;
     use serde_json::json;
+
+    /// Only the user-chosen "off" state drops out of the WARN stream; a
+    /// stale grant or any other inactive state stays a warning, because
+    /// nobody asked for it.
+    #[test]
+    fn inactive_launch_diagnostic_warns_only_on_unchosen_states() {
+        let cases = [
+            (false, false, tracing::Level::DEBUG, "disabled"),
+            (false, true, tracing::Level::DEBUG, "disabled"),
+            (
+                true,
+                false,
+                tracing::Level::WARN,
+                "ungranted; awaiting reapproval",
+            ),
+            (true, true, tracing::Level::WARN, "inactive"),
+        ];
+        for (enabled, granted, level, reason) in cases {
+            assert_eq!(
+                inactive_launch_diagnostic(enabled, granted),
+                (level, reason),
+                "enabled={enabled} granted={granted}"
+            );
+        }
+    }
 
     /// Spawn the single stdin-writer task `serve_connection` now expects, and
     /// return its sender (mirrors what `spawn_once` wires in production).


### PR DESCRIPTION
## Description

Fixes #3403.

About 13% of the WARN volume in the reporter's `debug.log` was expected, documented, no-op behavior. Three changes, all narrow:

**1. `run_git_quiet` for callers that already classified the failure.** `run_git` warns on every non-zero exit, so `unlock_worktree`'s "a non-zero exit is a harmless no-op" doc comment never reached the logger: 100+ `git worktree unlock` WARNs in ten days. The new variant is `run_git` with the failure log at DEBUG, so the stderr summary is still on disk for a real surprise but stops competing with warnings.

I audited every `run_git` call site rather than converting broadly. Two qualify:

| Call site | Why |
| --- | --- |
| `GitWorktree::unlock_worktree` | Discards the result; already documented as best-effort and idempotent |
| `git::cleanup::deinit_submodules_if_present` | Documented best-effort; already logs its own non-zero branch at DEBUG with "continuing", so the WARN was a duplicate at the wrong level |

Everything else keeps `run_git`. `branch_exists` (`show-ref` exit 1) and `branch_upstream` were the near misses: both classify one specific non-zero outcome, but both also turn other exits into a caller-visible error, and a caller that surfaces the failure should keep the WARN that explains it. `delete_branch`'s `branch -d` likewise, since the "unmerged" retry is a step toward an error, not a no-op.

**2. `plugin.host` "inactive; not launching a worker" with `reason=disabled` drops to DEBUG.** A plugin switched off in settings is the configuration doing what the user asked. The other reasons (`ungranted; awaiting reapproval`, `inactive`) are states nobody chose and keep their WARN, so the audit still makes a zero-launch boot non-silent for anything worth investigating. The level choice moved into a small `inactive_launch_diagnostic` helper so it is testable without standing up a host.

**3. The real warning, included here rather than split out.** `unknown SessionConfigOptionCategory ... variant=ModelConfig` (31 occurrences) needed no dependency bump: the pinned `agent-client-protocol-schema` (1.4.0, via 1.3.0 in `Cargo.lock`) already names `ModelConfig`, so it just needed the match arm the warning text asks for. It maps to `ConfigOptionCategory::Other("model_config")`, **not** `Model`: upstream documents it as "model-related configuration parameter", a sibling of the model picker rather than a second one, and an adapter can ship both. Nothing renders it specially today, so the practical change is that these options now carry their upstream wire name instead of the catch-all's `Other("")`. No web change: the TS `ConfigOptionCategory` is already `"mode" | "model" | "thought_level" | (string & {})`.

Docs: added a short paragraph to `docs/development/logging.md` under Levels, so the next person adding a best-effort subprocess call has the rule written down rather than inferring it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Three unit tests, one per behavior:

- `git::command::tests::run_git_quiet_demotes_expected_failure_to_debug` runs the same failing command through both entry points and asserts one WARN and one DEBUG, which also pins that the quiet variant does not drop the record entirely.
- `plugin::host::tests::inactive_launch_diagnostic_warns_only_on_unchosen_states` is a four-row table over `(enabled, granted)`.
- `acp::acp_client::tests::model_config_category_maps_without_the_unknown_variant_warning` asserts the mapping and that no unknown-category warning is emitted.

`cargo fmt` clean; `cargo clippy --all-targets --features serve` produces no new warnings (same 8 pre-existing as `main`). `cargo test --features serve --lib`: 6080 passed, 1 failed. The failure is `tui::dialogs::hooks_install::tests::test_content_shows_settings_path`, which reproduces identically on unmodified `main` in this environment (it reads real host agent config); it is untouched by this diff. The container-backed tests were skipped locally because Docker was unresponsive on the machine, also unrelated to the diff.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The `ModelConfig` arm changes a broadcast field value (`""` -> `"model_config"`) for a category nothing renders specially; the TS type already accepts any string and no component branches on it.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Skipped a test, because: log level is not observable from an e2e screen assertion, and the unit tests above fail if either level regresses.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Implementation and the call-site audit were done by Claude Code working from the issue.

- [x] I am an AI Agent filling out this form (check box if true)
