### PR TITLE
fix(logging): put method and route template on http.request completion

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -24,7 +24,7 @@ Top-level roots:
 | `tui` | Key dispatch, screen transitions, dialog lifecycle, sampled render diagnostics. |
 | `session` | Session/profile/group CRUD, terminal capture, heartbeat, storage IO. |
 | `tmux` | tmux invocations, cache refresh, status detection, pane CRUD. |
-| `http` | Axum request span and one completion event per request, both carrying `request_id`/`method`/`path`/`status`/`latency_ms`, plus per-route events. `path` is the matched route template (`/api/sessions/{id}`), never the raw URI, so session ids and the query-string auth token stay out of the log. |
+| `http` | Axum request span (`request_id`/`method`/`path`) and one completion event per request repeating those plus `status`/`latency_ms`, plus per-route events. `path` is the matched route template (`/api/sessions/{id}`), never the raw URI, so session ids and the query-string auth token stay out of the log. A client-supplied `X-Request-Id` is echoed only when it is a short alphanumeric token; anything else is replaced by a generated uuid. |
 | `serve` | `aoe serve` startup, PID/URL file IO, tunnel up/down, signal shutdown. |
 | `hooks` | Agent hook install/uninstall, status-file lifecycle, hook command + watcher failures. |
 | `sound` | Notification sound download/install and per-event playback. |

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -24,7 +24,7 @@ Top-level roots:
 | `tui` | Key dispatch, screen transitions, dialog lifecycle, sampled render diagnostics. |
 | `session` | Session/profile/group CRUD, terminal capture, heartbeat, storage IO. |
 | `tmux` | tmux invocations, cache refresh, status detection, pane CRUD. |
-| `http` | Axum request span (`request_id`/`method`/`path`/`status`/`latency_ms`) + per-route events. |
+| `http` | Axum request span and one completion event per request, both carrying `request_id`/`method`/`path`/`status`/`latency_ms`, plus per-route events. `path` is the matched route template (`/api/sessions/{id}`), never the raw URI, so session ids and the query-string auth token stay out of the log. |
 | `serve` | `aoe serve` startup, PID/URL file IO, tunnel up/down, signal shutdown. |
 | `hooks` | Agent hook install/uninstall, status-file lifecycle, hook command + watcher failures. |
 | `sound` | Notification sound download/install and per-event playback. |

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -513,7 +513,11 @@ pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
 /// `http_request{request_id=... method=GET path=...}` prefixes on every
 /// downstream event. The full default formatter is still available when
 /// the user opts in via the settings toggle.
-struct NoSpanFormat;
+///
+/// `pub(crate)` so tests elsewhere can render events exactly the way a
+/// default-configured daemon writes them, which is the only rendering in
+/// which a missing event field is actually observable.
+pub(crate) struct NoSpanFormat;
 
 impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for NoSpanFormat
 where

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2033,7 +2033,10 @@ fn build_router(state: Arc<AppState>) -> Router {
 }
 
 /// Placeholder logged in place of a route template when axum matched no
-/// route (the SPA fallback, and 404/405 responses). The raw URI is never
+/// route: the SPA fallback, and the 405 that fallback returns for a
+/// non-GET method. A request whose *path* matched a registered route still
+/// carries its template even when the method router rejects it, because
+/// axum matches on path before it dispatches on method. The raw URI is never
 /// substituted here: it is attacker- or user-controlled text, and the whole
 /// point of [`log_route`] is that only strings we wrote ourselves reach the
 /// log file.
@@ -2053,6 +2056,29 @@ fn log_route(request: &axum::extract::Request) -> &str {
         .extensions()
         .get::<axum::extract::MatchedPath>()
         .map_or(UNMATCHED_ROUTE, |m| m.as_str())
+}
+
+/// Longest client-supplied `X-Request-Id` we are willing to echo. A
+/// correlation token needs far less; anything longer is a caller padding
+/// every one of its log lines.
+const MAX_CLIENT_REQUEST_ID: usize = 64;
+
+/// Whether a client-supplied `X-Request-Id` can be reused verbatim.
+///
+/// Held to the same rule as [`log_route`]. `request_id` is a field of the
+/// completion event, so it renders under the default `show_spans = false`
+/// formatter, and `HeaderValue::to_str` accepts any visible ASCII, spaces
+/// and `=` included. An unfiltered value therefore lets an unauthenticated
+/// caller (the event fires outside the auth layer) forge `status=` and
+/// `path=` pairs on the very line #3402 added for triage, or pad every 4xx
+/// line to churn the file through rotation. Anything outside a bounded
+/// token charset is replaced by a generated uuid.
+fn is_log_safe_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_CLIENT_REQUEST_ID
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
 }
 
 /// Middleware that wraps every request in an `http.request` span with a
@@ -2082,6 +2108,7 @@ async fn http_request_span(
         .headers()
         .get("x-request-id")
         .and_then(|v| v.to_str().ok())
+        .filter(|v| is_log_safe_request_id(v))
         .map(str::to_string)
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let method = request.method().clone();
@@ -7212,10 +7239,16 @@ mod tests {
 
             let line = take_line();
             for expected in [level, path_field, status, "method=GET", "request_id="] {
-                assert!(line.contains(expected), "{uri}: want {expected:?}, got {line}");
+                assert!(
+                    line.contains(expected),
+                    "{uri}: want {expected:?}, got {line}"
+                );
             }
             for secret in [TOKEN, SESSION] {
-                assert!(!line.contains(secret), "{uri}: leaked {secret:?} into {line}");
+                assert!(
+                    !line.contains(secret),
+                    "{uri}: leaked {secret:?} into {line}"
+                );
             }
         }
 
@@ -7245,7 +7278,40 @@ mod tests {
             "real router: got {line}"
         );
         for secret in [TOKEN, SESSION] {
-            assert!(!line.contains(secret), "real router leaked {secret:?}: {line}");
+            assert!(
+                !line.contains(secret),
+                "real router leaked {secret:?}: {line}"
+            );
+        }
+
+        // `request_id` is client-supplied, and it lands on the same line as
+        // `path`, so it is held to the same rule. `HeaderValue::to_str`
+        // admits spaces and `=`, so an unfiltered header forges fields on
+        // the line #3402 added for triage. (header value, echoed verbatim?)
+        let overlong = "x".repeat(MAX_CLIENT_REQUEST_ID + 1);
+        let ids: [(&str, bool); 3] = [
+            ("forged status=200 path=/pwned", false),
+            (overlong.as_str(), false),
+            // A uuid, which is what the dashboard's fetch interceptor sends.
+            ("6f1c2b7e-0f2a-4a1e-9d3c-2b8f5a0c7d11", true),
+        ];
+        for (header, echoed) in ids {
+            let app = axum::Router::new()
+                .route("/api/sessions", axum::routing::get(|| async { "[]" }))
+                .layer(axum::middleware::from_fn(http_request_span));
+            let req = axum::http::Request::builder()
+                .uri("/api/sessions")
+                .header("x-request-id", header)
+                .body(axum::body::Body::empty())
+                .unwrap();
+            app.oneshot(req).await.unwrap();
+            let line = take_line();
+            assert_eq!(
+                line.contains(&format!("request_id={header}")),
+                echoed,
+                "{header:?}: got {line}"
+            );
+            assert!(line.contains("request_id="), "no request id at all: {line}");
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2032,11 +2032,42 @@ fn build_router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+/// Placeholder logged in place of a route template when axum matched no
+/// route (the SPA fallback, and 404/405 responses). The raw URI is never
+/// substituted here: it is attacker- or user-controlled text, and the whole
+/// point of [`log_route`] is that only strings we wrote ourselves reach the
+/// log file.
+const UNMATCHED_ROUTE: &str = "<unmatched>";
+
+/// Route template for a request, for logging only.
+///
+/// Deliberately never the raw URI. `aoe serve` puts the auth token in the
+/// URL's query string, path segments carry session ids, and `debug.log` is a
+/// file users paste into issue reports. `MatchedPath` is the template we
+/// registered in [`build_router`] (`/api/sessions/{id}/acp/replay`), a
+/// compile-time constant with no request data in it, so logging it cannot
+/// leak a token or an id no matter what the client sent. Axum fills the
+/// extension during routing, before any `Router::layer` middleware runs.
+fn log_route(request: &axum::extract::Request) -> &str {
+    request
+        .extensions()
+        .get::<axum::extract::MatchedPath>()
+        .map_or(UNMATCHED_ROUTE, |m| m.as_str())
+}
+
 /// Middleware that wraps every request in an `http.request` span with a
 /// generated or echoed `X-Request-Id`, then emits one completion event at
 /// the level matching the response status. Logs fired inside the request
 /// (auth middleware, route handlers, downstream `tracing` events) inherit
 /// the span fields, so a single grep on `request_id` reconstructs the call.
+///
+/// The completion event repeats `request_id`, `method`, and `path` as its
+/// own fields rather than relying on the span: `[logging].show_spans` is
+/// `false` by default, which drops the span prefix from the rendered line
+/// and used to leave `completed status=500 latency_ms=0` with nothing to
+/// identify the request (#3402). For the same reason the event is emitted
+/// outside the span, so enabling `show_spans` prints each field once
+/// instead of twice.
 ///
 /// Successful completions (2xx/3xx) emit at `debug`, not `info`: the web
 /// UI polls `/api/sessions` every ~2s, so an info-level success log here
@@ -2054,27 +2085,40 @@ async fn http_request_span(
         .map(str::to_string)
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let method = request.method().clone();
-    let path = request.uri().path().to_string();
+    let route = log_route(&request).to_string();
     let span = tracing::debug_span!(
         target: "http.request",
         "http_request",
         request_id = %rid,
         method = %method,
-        path = %path,
+        path = %route,
     );
     let start = std::time::Instant::now();
-    let mut response = next.run(request).instrument(span.clone()).await;
+    let mut response = next.run(request).instrument(span).await;
     let latency_ms = start.elapsed().as_millis() as u64;
     let status = response.status().as_u16();
-    span.in_scope(|| {
-        if status >= 500 {
-            tracing::error!(target: "http.request", status, latency_ms, "completed");
-        } else if status >= 400 {
-            tracing::warn!(target: "http.request", status, latency_ms, "completed");
-        } else {
-            tracing::debug!(target: "http.request", status, latency_ms, "completed");
-        }
-    });
+    // `tracing` resolves the level at compile time, so the branches cannot
+    // share one call site; the macro keeps the field list written once.
+    macro_rules! completed {
+        ($level:ident) => {
+            tracing::$level!(
+                target: "http.request",
+                request_id = %rid,
+                method = %method,
+                path = %route,
+                status,
+                latency_ms,
+                "completed"
+            )
+        };
+    }
+    if status >= 500 {
+        completed!(error);
+    } else if status >= 400 {
+        completed!(warn);
+    } else {
+        completed!(debug);
+    }
     if let Ok(value) = rid.parse() {
         response.headers_mut().insert("x-request-id", value);
     }
@@ -7076,6 +7120,133 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::FORBIDDEN);
+    }
+
+    /// `MakeWriter` sink so the request-log test can read back exactly the
+    /// bytes a daemon would have appended to `debug.log`.
+    #[derive(Clone)]
+    struct LogSink(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for LogSink {
+        fn write(&mut self, src: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(src);
+            Ok(src.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// #3402: the `http.request` completion line must identify the request.
+    /// It is rendered with the default `show_spans = false` formatter, which
+    /// drops span fields, so `request_id` / `method` / `path` have to be
+    /// fields of the event itself. `path` is the route template, never the
+    /// raw URI: `aoe serve` ships its auth token in the query string and
+    /// session ids sit in path segments, and neither may reach the log.
+    #[tokio::test]
+    async fn http_request_log_identifies_request_without_leaking_uri() {
+        use tower::ServiceExt;
+        const TOKEN: &str = "super-secret-token";
+        const SESSION: &str = "sess-9f3a";
+
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let sink = LogSink(buf.clone());
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_writer(move || sink.clone())
+            .with_ansi(false)
+            .event_format(crate::logging::NoSpanFormat)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // (request URI, expected level, expected `path` field, expected status)
+        let cases = [
+            (
+                format!("/api/sessions/{SESSION}/acp/replay?token={TOKEN}"),
+                "ERROR",
+                "path=/api/sessions/{id}/acp/replay",
+                "status=500",
+            ),
+            (
+                format!("/api/sessions?token={TOKEN}"),
+                "DEBUG",
+                "path=/api/sessions",
+                "status=200",
+            ),
+            // No route matched, so there is no template to log and the raw
+            // URI must not be substituted for one.
+            (
+                format!("/nope/{SESSION}?token={TOKEN}"),
+                "WARN",
+                "path=<unmatched>",
+                "status=404",
+            ),
+        ];
+
+        // Drains the sink and returns the one `http.request` completion line,
+        // ignoring whatever else the request happened to log.
+        let take_line = || {
+            let mut sink = buf.lock().unwrap();
+            let log = String::from_utf8(sink.clone()).unwrap();
+            sink.clear();
+            log.lines()
+                .find(|l| l.contains("http.request"))
+                .unwrap_or_else(|| panic!("no http.request line in {log}"))
+                .to_string()
+        };
+
+        for (uri, level, path_field, status) in cases {
+            let app = axum::Router::new()
+                .route(
+                    "/api/sessions/{id}/acp/replay",
+                    axum::routing::get(|| async { axum::http::StatusCode::INTERNAL_SERVER_ERROR }),
+                )
+                .route("/api/sessions", axum::routing::get(|| async { "[]" }))
+                .fallback(|| async { axum::http::StatusCode::NOT_FOUND })
+                .layer(axum::middleware::from_fn(http_request_span));
+            let req = axum::http::Request::builder()
+                .uri(&uri)
+                .body(axum::body::Body::empty())
+                .unwrap();
+            app.oneshot(req).await.unwrap();
+
+            let line = take_line();
+            for expected in [level, path_field, status, "method=GET", "request_id="] {
+                assert!(line.contains(expected), "{uri}: want {expected:?}, got {line}");
+            }
+            for secret in [TOKEN, SESSION] {
+                assert!(!line.contains(secret), "{uri}: leaked {secret:?} into {line}");
+            }
+        }
+
+        // The cases above pin the middleware itself; this pins its position in
+        // the real stack, where a template exists only because axum routes the
+        // request before any `Router::layer` middleware runs. The token in the
+        // query string is wrong, so auth rejects it: exactly the 4xx a triager
+        // greps for, and the one request shape that carries a secret.
+        let state = test_support::build_test_app_state_with_policy(
+            Vec::new(),
+            vecs(&["localhost"]),
+            vecs(&["http://localhost:8080"]),
+            Some("real-token".to_string()),
+        );
+        let req = axum::http::Request::builder()
+            .uri(format!("/api/sessions/{SESSION}/acp/replay?token={TOKEN}"))
+            .header("host", "localhost")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        test_support::build_router_for_test(state)
+            .oneshot(req)
+            .await
+            .unwrap();
+        let line = take_line();
+        assert!(
+            line.contains("path=/api/sessions/{id}/acp/replay"),
+            "real router: got {line}"
+        );
+        for secret in [TOKEN, SESSION] {
+            assert!(!line.contains(secret), "real router leaked {secret:?}: {line}");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

`http.request` completion lines in `debug.log` were unactionable:

```
ERROR http.request: completed status=500 latency_ms=0
 WARN http.request: completed status=401 latency_ms=0
```

The middleware already put `request_id` / `method` / `path` on the enclosing
span, but `[logging].show_spans` is `false` by default and that formatter drops
the span prefix, so the rendered line carried only a status and a latency. A 500
in a user's log could only be located by correlating timestamps against
neighbouring spans.

The completion event now carries `request_id`, `method`, and `path` as its own
fields, so it survives the default formatter:

```
ERROR http.request: completed request_id=... method=POST path=/api/sessions/{id}/acp/force-stop status=500 latency_ms=3
```

`path` is the axum `MatchedPath` route template, never the raw URI. That is a
privacy requirement, not a nicety: `aoe serve` ships its auth token in the URL
(`serve.url`) and session ids sit in path segments, and `debug.log` is a file
users paste into issue reports. The template is a compile-time constant
registered in `build_router`, so no request-controlled text reaches the field no
matter what the client sends. Requests that match no route (SPA fallback,
404/405) log the constant `<unmatched>` rather than falling back to the raw URI.

Two smaller consequences of the same change:

- The span's `path` field is now the template too, so turning `show_spans` on no
  longer stamps a real session id onto every downstream event's prefix.
- The event is emitted outside the span instead of via `span.in_scope`, so
  `show_spans = true` prints each field once instead of twice.

Status-class levels (5xx `error`, 4xx `warn`, else `debug`) were already correct
and are unchanged.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Skipped a test, because: this is a log-field change in the serve request
  middleware. It is covered by a unit test that renders events through the same
  `NoSpanFormat` formatter a default-configured daemon uses, which is the only
  rendering in which the missing fields were observable; an e2e test would cost
  ~2s of serial CI time to assert the same string.

One table-driven unit test (`http_request_log_identifies_request_without_leaking_uri`)
covers the behavior:

- 500 on `/api/sessions/{id}/acp/replay`, 200 on `/api/sessions`, and an
  unmatched URI, each asserting level, `method`, `path`, `status`, and
  `request_id` on the rendered line.
- Every case sends `?token=super-secret-token` and a session id in the path, and
  asserts neither reaches the line.
- A final leg runs the same request through the real `build_router` stack, which
  is what proves the middleware sits where `MatchedPath` is populated.

Verified the test fails on the unfixed code with exactly the log line from the
issue:

```
want "path=/api/sessions/{id}/acp/replay",
got ... ERROR http.request: completed status=500 latency_ms=0
```

Checks run: `cargo fmt`, `cargo clippy --features serve --all-targets` (clean for
the touched files), `cargo test --features serve --no-fail-fast`.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:**
Investigation, implementation, and tests drafted with Claude Code and reviewed
before opening.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3402
