### PR TITLE
fix(config): never treat the global config.toml as a repo config

### DIFF
--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -271,10 +271,52 @@ const REPO_CONFIG_PATH: &str = ".agent-of-empires/config.toml";
 /// Legacy path (pre-1.1) for backwards compatibility.
 const LEGACY_REPO_CONFIG_PATH: &str = ".aoe/config.toml";
 
+/// The user's global `config.toml`, resolved without creating the app dir
+/// (unlike [`super::config::config_path`], which goes through `get_app_dir`).
+/// `None` when the app dir cannot be resolved at all; no collision is provable
+/// then, so the repo layer proceeds as before.
+fn global_config_path() -> Option<PathBuf> {
+    super::get_app_dir_path()
+        .ok()
+        .map(|dir| dir.join("config.toml"))
+}
+
+/// Whether a `<project>/.agent-of-empires/config.toml` is in fact the user's
+/// global `config.toml`. On macOS and Windows the app dir is
+/// `~/.agent-of-empires`, so a project path of `$HOME` makes the repo layer
+/// resolve onto the global config file by construction (#3400).
+///
+/// The containing directories are compared canonicalized (see
+/// [`normalize_path`]), so the collision is still caught when the project path
+/// reaches the app dir through a symlink or a non-canonical prefix such as
+/// `/tmp` vs `/private/tmp`. Canonicalizing the directory rather than the file
+/// matters on the save path, where the target file need not exist yet while the
+/// app dir always does.
+fn resolves_to_global_config(candidate: &Path) -> bool {
+    let Some(global) = global_config_path() else {
+        return false;
+    };
+    match (candidate.parent(), global.parent()) {
+        (Some(candidate_dir), Some(global_dir)) => {
+            candidate.file_name() == global.file_name()
+                && normalize_path(candidate_dir) == normalize_path(global_dir)
+        }
+        _ => false,
+    }
+}
+
 /// Load repo config from `<project_path>/.agent-of-empires/config.toml`.
 /// Falls back to the legacy `.aoe/config.toml` path with a deprecation warning.
 /// Returns `None` if neither file exists.
 pub fn load_repo_config(project_path: &Path) -> Result<Option<RepoConfig>> {
+    // An empty path is how a project-less session (scratch, see
+    // `super::builder::build_instance`) says "no repo". Joining onto it yields
+    // the *relative* `.agent-of-empires/config.toml`, which would otherwise
+    // read whatever directory the process was launched in.
+    if project_path.as_os_str().is_empty() {
+        return Ok(None);
+    }
+
     let config_path = project_path.join(REPO_CONFIG_PATH);
     let (config_path, is_legacy) = if config_path.exists() {
         (config_path, false)
@@ -286,6 +328,19 @@ pub fn load_repo_config(project_path: &Path) -> Result<Option<RepoConfig>> {
             return Ok(None);
         }
     };
+
+    // A project path of `$HOME` resolves this to the user's own global
+    // `config.toml` on macOS and Windows (#3400). That file is not a repo
+    // config: loading it re-merges the global layer onto itself and reports
+    // every global-only section as a rejected repo override. Decline, and log
+    // the path so the upstream caller that passed such a path is findable.
+    if resolves_to_global_config(&config_path) {
+        tracing::debug!(target: "session.store",
+            path = %config_path.display(),
+            "Skipping repo config: this project path resolves to the global config.toml"
+        );
+        return Ok(None);
+    }
 
     if is_legacy {
         tracing::warn!(target: "session.store",
@@ -328,11 +383,23 @@ pub fn load_repo_config(project_path: &Path) -> Result<Option<RepoConfig>> {
 /// If a legacy `.aoe/config.toml` exists, it is removed after a successful save
 /// to prevent stale config from silently reactivating.
 pub fn save_repo_config(project_path: &Path, config: &RepoConfig) -> Result<()> {
+    let config_path = project_path.join(REPO_CONFIG_PATH);
+    // The read side's collision (#3400) is destructive here: writing the
+    // repo-permitted subset over the global `config.toml` drops every
+    // global-only section. Refuse loudly rather than truncating the user's
+    // config; the caller surfaces the error.
+    if resolves_to_global_config(&config_path) {
+        anyhow::bail!(
+            "Refusing to save repo config to {}: that file is the global config.toml, \
+             not a repo config (this project path resolves onto the app dir)",
+            config_path.display()
+        );
+    }
+
     let config_dir = project_path.join(".agent-of-empires");
     fs::create_dir_all(&config_dir)
         .with_context(|| format!("Failed to create {}", config_dir.display()))?;
 
-    let config_path = project_path.join(REPO_CONFIG_PATH);
     // Sanitize here rather than trusting callers, so a field the merge path
     // would strip is never written to disk in the first place.
     let (allowed, rejected) = sanitize_repo_overrides(&config.overrides);

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -529,6 +529,15 @@ pub fn profile_to_repo_config(profile: &ProfileConfig) -> RepoConfig {
 /// matching the guard in `compute_volume_paths` (avoids `Repository::discover`
 /// walking up to an unrelated ancestor repo, e.g. a dotfile-managed `$HOME`).
 pub fn repo_config_source_path(project_path: &Path) -> PathBuf {
+    // An empty path means "no project repo" (scratch sessions, see
+    // `super::builder::build_instance`). Every probe below is relative to it,
+    // so it would interrogate the *launch directory* instead: a cwd whose
+    // `.git` is a file (a linked worktree) resolves to that worktree's main
+    // repo and hands `load_repo_config` a real path, putting back the repo
+    // layer that the empty path exists to suppress.
+    if project_path.as_os_str().is_empty() {
+        return PathBuf::new();
+    }
     if project_path.join(".git").exists() {
         if let Ok(main_repo) = crate::git::GitWorktree::find_main_repo(project_path) {
             return main_repo;

--- a/tests/integration/repo_config.rs
+++ b/tests/integration/repo_config.rs
@@ -311,6 +311,54 @@ bare_repo_path_template = "../{branch}"
     );
 }
 
+/// #3400: on macOS and Windows the app dir is `~/.agent-of-empires`, so a
+/// project path of `$HOME` makes `<project>/.agent-of-empires/config.toml`
+/// resolve to the user's own global config. Neither side of the repo layer may
+/// act on that file: reading it re-merges the global layer onto itself (and
+/// reports every global-only section as a rejected repo override), and saving
+/// truncates the global config to the repo-permitted subset.
+///
+/// A debug build namespaces the app dir (`.agent-of-empires-dev`), so `$HOME`
+/// alone cannot produce the collision here. Symlinking the project's
+/// `.agent-of-empires` at the app dir yields the identical resolved file, which
+/// is what both guards compare.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn test_project_path_that_resolves_to_global_config_is_not_a_repo_config() {
+    use agent_of_empires::session::repo_config::{load_repo_config, save_repo_config, RepoConfig};
+
+    let temp_home = TempDir::new().unwrap();
+    set_temp_home(temp_home.path());
+
+    let app_dir = agent_of_empires::session::get_app_dir().unwrap();
+    let global_config = app_dir.join("config.toml");
+    let global_content =
+        "[session]\ndefault_tool = \"claude\"\n\n[logging]\ndefault_level = \"debug\"\n";
+    fs::write(&global_config, global_content).unwrap();
+
+    let project = temp_home.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    std::os::unix::fs::symlink(&app_dir, project.join(".agent-of-empires")).unwrap();
+
+    assert!(
+        load_repo_config(&project).unwrap().is_none(),
+        "the global config.toml must not be loaded as a repo config layer"
+    );
+
+    let repo_config: RepoConfig = toml::from_str("[session]\ndefault_tool = \"codex\"\n").unwrap();
+    let err = save_repo_config(&project, &repo_config).unwrap_err();
+    assert!(
+        err.to_string().contains("global config.toml"),
+        "save should name the collision, got: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&global_config).unwrap(),
+        global_content,
+        "the global config must be left byte-identical"
+    );
+}
+
 /// Legacy `.aoe/config.toml` should still be loaded via backwards compat fallback.
 #[test]
 fn test_legacy_aoe_path_still_loads() {
@@ -366,5 +414,25 @@ on_create = ["echo legacy"]
         hooks.on_create,
         vec!["echo new"],
         "new path should take priority over legacy"
+    );
+}
+
+/// An empty project path means "this session has no project repo" (scratch
+/// sessions pass one, see `session::builder::build_instance`). It must carry no
+/// repo layer at all: `Path::new("")` joins to the *relative*
+/// `.agent-of-empires/config.toml`, which resolves against whatever directory
+/// the process happens to be running in.
+#[test]
+#[serial]
+fn test_empty_project_path_ignores_the_launch_directory() {
+    let tmp = setup_repo_config("[session]\ndefault_tool = \"codex\"\n");
+    let original_dir = std::env::current_dir().unwrap();
+    std::env::set_current_dir(tmp.path()).unwrap();
+    let loaded = agent_of_empires::session::repo_config::load_repo_config(std::path::Path::new(""));
+    std::env::set_current_dir(original_dir).unwrap();
+
+    assert!(
+        loaded.unwrap().is_none(),
+        "an empty project path must not pick up the launch directory's repo config"
     );
 }

--- a/tests/integration/repo_config.rs
+++ b/tests/integration/repo_config.rs
@@ -435,4 +435,34 @@ fn test_empty_project_path_ignores_the_launch_directory() {
         loaded.unwrap().is_none(),
         "an empty project path must not pick up the launch directory's repo config"
     );
+
+    // The real callers reach the loader through `repo_config_source_path`, and
+    // its `.git` probe is relative too. From a linked worktree (whose `.git` is
+    // a file) it resolves to that worktree's main repo, which would hand the
+    // loader a non-empty path and reinstate the repo layer.
+    let main = setup_repo_config("[session]\ndefault_tool = \"codex\"\n");
+    fs::create_dir_all(main.path().join(".git/worktrees/wt")).unwrap();
+    let worktree = TempDir::new().unwrap();
+    fs::write(
+        worktree.path().join(".git"),
+        format!("gitdir: {}/.git/worktrees/wt\n", main.path().display()),
+    )
+    .unwrap();
+
+    let original_dir = std::env::current_dir().unwrap();
+    std::env::set_current_dir(worktree.path()).unwrap();
+    let source =
+        agent_of_empires::session::repo_config::repo_config_source_path(std::path::Path::new(""));
+    let loaded = agent_of_empires::session::repo_config::load_repo_config(&source);
+    std::env::set_current_dir(original_dir).unwrap();
+
+    assert_eq!(
+        source,
+        std::path::PathBuf::new(),
+        "an empty project path must not resolve to the launch worktree's main repo"
+    );
+    assert!(
+        loaded.unwrap().is_none(),
+        "an empty project path must carry no repo layer from a worktree launch dir"
+    );
 }


### PR DESCRIPTION
## Description

Fixes #3400.

`repo_config_source_path()` returns a non-git project path unchanged and `load_repo_config()` joins `.agent-of-empires/config.toml` onto it. On macOS and Windows the app dir **is** `~/.agent-of-empires`, so a project path of `$HOME` makes the repo layer resolve onto the user's own global config file. Both sides of the repo layer now decline when the resolved file is the global `config.toml`.

**Read path.** Confirmed in the reporter's `debug.log`: 95 occurrences of `Ignoring repo config overrides that are not permitted at repo scope path=/Users/nbrake/.agent-of-empires/config.toml`, each naming all 45 global-only keys. The global layer was being merged onto itself as a "repo" layer.

**Write path (the issue flagged it as unproven).** It is reachable and it is destructive. `SettingsView::new` calls `load_repo_config(project_path)` for the selected session's path; editing any field in Repo scope sets `self.repo_config`, and Ctrl+S calls `save_repo_config(project_path, ..)`, which writes the sanitized (repo-permitted) subset. Instrumented against the pre-fix code, with the resolved file being the global config:

```
LOADED-AS-REPO: true
SAVE-RESULT: Ok(())
GLOBAL-AFTER:
[session]
default_tool = "codex"
```

The `[logging]` section that was in the file went away. That is silent data loss across ~45 settings. It requires a session rooted at `$HOME`, which is why it has not been hit in the wild: the reporter's log has zero occurrences of the sibling `Dropping repo config overrides ... before saving` message, so nothing was overwritten on that machine.

**Where the guard lives.** The issue suggested `repo_config_source_path()`. I put it in `load_repo_config` / `save_repo_config` instead, because the settings TUI calls both of those directly and never goes through `repo_config_source_path`, so a guard there would have missed exactly the destructive path. Directories are compared canonicalized, so a project path that reaches the app dir through a symlink is caught too.

## Which caller passes `$HOME` (the issue's open question)

`NewSessionDialog::new` (`src/tui/dialogs/new_session/mod.rs:445-456`) resolves config against `std::env::current_dir()` and prefills the path field with it. If the TUI was launched from `$HOME`, every open of the new-session dialog resolves the repo layer against `$HOME`, including the fork and new-from-selection paths, which construct the dialog first and only then `set_path()` to the real repo.

The log matches that shape exactly: every one of the 95 warnings is followed 2 to 11 seconds later by `git.worktree: worktree create: start` for an ordinary repo, one warning per creation. It also explains why `projects.json` has no `$HOME` entry: nothing is rooted at `$HOME`, the process cwd is leaking in as a provisional project path.

I did **not** change that call site. Resolving config for the path the dialog is prefilled with is what it is supposed to do; the defect was that `$HOME`'s "repo config" is the global config, which is what this PR fixes.

## Second defect found during the investigation

Scratch sessions pass `Path::new("")` to mean "no project repo", and `build_instance` claims that "`Path::new("")` makes `resolve_config_with_repo` skip the repo-config layer cleanly" (`src/session/builder.rs:487-489`). It does not: the join is relative, so `load_repo_config` was reading `.agent-of-empires/config.toml` from whatever directory the process was launched in. Verified with a probe against the pre-fix code (a repo config in the cwd loaded as `Some`). `aoe add --scratch` has an explicit comment about this same hazard and avoids it (`src/cli/add.rs:234-244`); the shared builder never got the fix.

`load_repo_config` now returns `None` for an empty path, which makes the builder's comment true without touching the builder, and covers every other caller that can produce one.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs describe this behavior)
- [ ] For UI changes: included screenshot or recording (n/a)

## Test Coverage Analysis

Two integration tests in `tests/integration/repo_config.rs`, both verified to fail against the pre-fix code:

- `test_project_path_that_resolves_to_global_config_is_not_a_repo_config`: read declines, save errors, and the global config is left byte-identical. A debug build namespaces the app dir as `.agent-of-empires-dev`, so `$HOME` alone cannot reproduce the collision under `cargo test`; the test symlinks the project's `.agent-of-empires` at the app dir, which produces the identical resolved file that both guards compare.
- `test_empty_project_path_ignores_the_launch_directory`: an empty project path does not pick up the launch directory's repo config.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the collision cannot be constructed through the real binary in a debug build (the dev namespace renames the app dir), so an e2e test could only assert the unchanged path. The integration tests cover both guards at the seam where they live.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus 5) via Claude Code

**Any Additional AI Details you'd like to share:** Investigation, patch, and tests drafted by Claude; the pre-fix data loss and the empty-path behavior were both reproduced by running instrumented tests against the unpatched code rather than reasoned about.

- [x] I am an AI Agent filling out this form (check box if true)
