### PR TITLE
chore(deps): keep pre-1.0 web packages out of the grouped minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,6 +97,15 @@ updates:
           - "react-dom"
           - "tailwindcss"
           - "@tailwindcss/*"
+          # Pre-1.0 packages: a minor bump is a breaking change by semver
+          # convention, but dependabot still classifies it as "minor" and so
+          # would group it with the routine updates. Excluding them gives each
+          # its own PR, so one breaking library cannot hold the rest hostage.
+          # In #3394, @assistant-ui/react 0.14 to 0.15 dropped three hooks and
+          # blocked 15 unrelated bumps behind a red build.
+          - "@assistant-ui/*"
+          - "eslint-plugin-react-refresh"
+          - "oxfmt"
         update-types: ["minor", "patch"]
     ignore:
       - dependency-name: "react"


### PR DESCRIPTION
## Description

Dependabot classifies `0.14 -> 0.15` as a plain `minor`, so a 0.x package whose minors are breaking by convention lands inside the `web-minor-patch` group and takes the whole group down with it. In #3394 that was `@assistant-ui/react`: its 0.15 bump dropped `useComposerRuntime`, `useThreadRuntime`, and `useMessage`, failed `npm run build`, and blocked 15 unrelated updates behind 11 red jobs.

Excluding the 0.x packages from the group gives each its own PR, so one breaking library cannot hold the routine bumps hostage.

Note that grouping conditions are pattern plus `update-types` only, with no version-range predicate, so an explicit exclusion list is the only way to express this. It needs a line when a new 0.x dep is added or an existing one reaches 1.0. `/web` is the only npm directory with 0.x deps today; `website`, `acp-worker/aoe-agent`, and `acp-worker/test-shim` are all 1.0+.

`oxfmt` and `eslint-plugin-react-refresh` are excluded on the same reasoning: an oxfmt minor can change formatting output and fail the repo-wide `format:check` gate.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Dependabot config is not executable by the test suite, so there is nothing to assert beyond the file parsing. I verified it parses and that the group resolves to the intended exclusion list.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any Additional AI Details you would like to share:**

Written while triaging #3394, where the grouping problem surfaced. Reasoning and decisions are @njbrake's; the prose is the model's.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Dependabot to exclude `@assistant-ui/*`, `eslint-plugin-react-refresh`, and `oxfmt` from grouped web dependency updates.
- Dependabot will create separate pull requests for these packages.
- This prevents breaking 0.x updates and repository-wide formatting or check changes from blocking unrelated updates.

## Benefit

Dependency updates remain smaller, more focused, and easier to review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->