### PR TITLE
fix(session): resolve Claude's config dir per profile when reading its state

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -258,7 +258,7 @@ pub(crate) fn agent_settings_path_display_for_host_environment(
 /// session's host environment list and falling back to AoE's own env so a var
 /// exported in the shell that launched `aoe` (and thus inherited by the agent)
 /// is honored too. Empty values are treated as unset.
-fn resolve_config_dir_override(var: &str, host_env: &[String]) -> Option<String> {
+pub(crate) fn resolve_config_dir_override(var: &str, host_env: &[String]) -> Option<String> {
     crate::session::environment::resolve_host_environment_value(host_env, var)
         .or_else(|| std::env::var(var).ok())
         .filter(|v| !v.is_empty())

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -2038,6 +2038,7 @@ pub async fn acp_enable(
                 !crate::session::capture::claude_host_transcript_confirmed_absent(
                     &instance.project_path,
                     sid,
+                    &instance.profile_host_environment(),
                 )
             })
             .unwrap_or(false);

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -2038,7 +2038,7 @@ pub async fn acp_enable(
                 !crate::session::capture::claude_host_transcript_confirmed_absent(
                     &instance.project_path,
                     sid,
-                    &instance.profile_host_environment(),
+                    &instance.resolved_host_environment(),
                 )
             })
             .unwrap_or(false);

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -61,10 +61,11 @@ fn claude_home_for_host_environment(host_env: &[String]) -> Result<PathBuf> {
 
 /// The `CLAUDE_CONFIG_DIR` value the launched pane will see, if any: the
 /// session's host environment wins, then AoE's own env. Empty is unset.
+///
+/// Shares [`crate::hooks::resolve_config_dir_override`] with the hook-install
+/// path so the read side and the write side cannot drift on precedence.
 fn claude_config_dir_override(host_env: &[String]) -> Option<String> {
-    crate::session::environment::resolve_host_environment_value(host_env, "CLAUDE_CONFIG_DIR")
-        .or_else(|| std::env::var("CLAUDE_CONFIG_DIR").ok())
-        .filter(|value| !value.is_empty())
+    crate::hooks::resolve_config_dir_override("CLAUDE_CONFIG_DIR", host_env)
 }
 
 /// Resolve a path to a comparable identity: canonicalize when the directory

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -39,6 +39,34 @@ fn resolve_agent_home(env_var: Option<&str>, default_subdir: &str) -> Result<Pat
         .join(default_subdir))
 }
 
+/// Resolve the Claude config dir the *launched pane* will see.
+///
+/// The launch path injects the session's profile-scoped `environment` entries
+/// into the pane, so a profile pinning `CLAUDE_CONFIG_DIR` makes the agent read
+/// and write a config tree that is not `~/.claude`. Every host-side read of
+/// Claude's on-disk state has to resolve the same way or it inspects a tree the
+/// agent never touches: the transcript probe then reports a real conversation
+/// absent, and the project-dir scan can hand back a conversation belonging to
+/// another profile that happens to share the cwd. See #3399.
+///
+/// Precedence mirrors [`crate::hooks::agent_settings_path_in`]: the session's
+/// host environment first, then AoE's own env (a var exported in the shell that
+/// launched `aoe` is inherited by the agent too), then `~/.claude`.
+fn claude_home_for_host_environment(host_env: &[String]) -> Result<PathBuf> {
+    match claude_config_dir_override(host_env) {
+        Some(dir) => Ok(PathBuf::from(dir)),
+        None => resolve_agent_home(None, ".claude"),
+    }
+}
+
+/// The `CLAUDE_CONFIG_DIR` value the launched pane will see, if any: the
+/// session's host environment wins, then AoE's own env. Empty is unset.
+fn claude_config_dir_override(host_env: &[String]) -> Option<String> {
+    crate::session::environment::resolve_host_environment_value(host_env, "CLAUDE_CONFIG_DIR")
+        .or_else(|| std::env::var("CLAUDE_CONFIG_DIR").ok())
+        .filter(|value| !value.is_empty())
+}
+
 /// Resolve a path to a comparable identity: canonicalize when the directory
 /// exists, otherwise fall back to lexical `.`/`..` normalization so a
 /// historical unnormalized spelling (a pre-#2858 worktree `project_path` like
@@ -86,15 +114,20 @@ pub(crate) fn encode_claude_project_path(project_path: &str) -> String {
 }
 
 /// Capture Claude Code session ID from the most recently active project directory,
-/// falling back to `~/.claude.json` if the dir scan result is stale.
+/// falling back to `.claude.json` if the dir scan result is stale.
+///
+/// `host_env` is the session's profile-scoped host environment, which selects
+/// the config tree both reads resolve against (see
+/// [`claude_home_for_host_environment`]).
 ///
 /// Used as a fallback when hooks don't fire (e.g. after `/clear` or `/new`).
 pub(crate) fn capture_claude_session_id(
     project_path: &str,
     known_session_id: Option<&str>,
     exclusion: &HashSet<String>,
+    host_env: &[String],
 ) -> Result<String> {
-    let claude_home = resolve_agent_home(Some("CLAUDE_CONFIG_DIR"), ".claude")?;
+    let claude_home = claude_home_for_host_environment(host_env)?;
     let canonical = canonicalize_or_raw(project_path);
 
     if let Some((id, modified)) =
@@ -106,16 +139,16 @@ pub(crate) fn capture_claude_session_id(
         }
     }
 
-    if let Some(id) = read_claude_json_session_id(&canonical) {
+    let claude_json_path = claude_json_path(&claude_home, host_env);
+    if let Some(id) = read_claude_json_session_id(&claude_json_path, &canonical) {
         if exclusion.contains(&id) {
             return Err(anyhow::anyhow!(
                 "claude.json lastSessionId {} is excluded (claimed by another instance)",
                 id
             ));
         }
-        let claude_json = dirs::home_dir()
-            .map(|h| h.join(".claude.json"))
-            .and_then(|p| std::fs::metadata(&p).ok())
+        let claude_json = std::fs::metadata(&claude_json_path)
+            .ok()
             .and_then(|m| m.modified().ok());
         let is_fresh = claude_json
             .and_then(|t| t.elapsed().ok())
@@ -131,13 +164,20 @@ pub(crate) fn capture_claude_session_id(
 /// Whether we can affirmatively prove Claude has *no* persisted transcript for
 /// `session_id` under `project_path` on the host filesystem.
 ///
-/// Claude only writes `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` once a
+/// Claude only writes `<config>/projects/<encoded-cwd>/<uuid>.jsonl` once a
 /// conversation has real content. A session AoE minted a UUID for but that was
 /// killed before the first prompt (an "empty thread") therefore has a stored
 /// `agent_session_id` that never hit disk, and `claude --resume <uuid>` on it
 /// fails with "No conversation found" every time. Callers use this to launch
 /// such an id as a fresh pinned session (`--session-id <uuid>`) instead of a
 /// guaranteed-to-fail `--resume`.
+///
+/// `<config>` is resolved from the session's profile-scoped `host_env`, the
+/// same way the launch path resolves it (see
+/// [`claude_home_for_host_environment`]). Probing the default `~/.claude` for a
+/// profile pinned elsewhere would report every real conversation absent and
+/// downgrade it to `--session-id <uuid>`, which the agent rejects as already in
+/// use, killing the pane outright. See #3399.
 ///
 /// Returns `true` ONLY when the Claude home resolves and the transcript file is
 /// confirmed missing. Any uncertainty (home dir unresolved) returns `false` so
@@ -148,8 +188,9 @@ pub(crate) fn capture_claude_session_id(
 pub(crate) fn claude_host_transcript_confirmed_absent(
     project_path: &str,
     session_id: &str,
+    host_env: &[String],
 ) -> bool {
-    let Ok(claude_home) = resolve_agent_home(Some("CLAUDE_CONFIG_DIR"), ".claude") else {
+    let Ok(claude_home) = claude_home_for_host_environment(host_env) else {
         return false;
     };
     let canonical = canonicalize_or_raw(project_path);
@@ -240,10 +281,22 @@ fn scan_claude_project_dir(
     Ok(best)
 }
 
-/// Read `lastSessionId` from `~/.claude.json` for a given project path.
-fn read_claude_json_session_id(project_path: &Path) -> Option<String> {
-    let claude_json = dirs::home_dir()?.join(".claude.json");
-    let content = std::fs::read_to_string(&claude_json).ok()?;
+/// Where Claude keeps `.claude.json` for the config tree at `claude_home`.
+///
+/// It sits *inside* the dir when `CLAUDE_CONFIG_DIR` selects it, but next to
+/// (not inside) the default `~/.claude`, so the default case cannot be derived
+/// from `claude_home` alone.
+fn claude_json_path(claude_home: &Path, host_env: &[String]) -> PathBuf {
+    if claude_config_dir_override(host_env).is_some() {
+        claude_home.join(".claude.json")
+    } else {
+        claude_home.with_file_name(".claude.json")
+    }
+}
+
+/// Read `lastSessionId` from `.claude.json` for a given project path.
+fn read_claude_json_session_id(claude_json: &Path, project_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(claude_json).ok()?;
     let content = content.trim();
     if content.is_empty() {
         return None;
@@ -267,7 +320,9 @@ fn read_claude_json_session_id(project_path: &Path) -> Option<String> {
 /// 1. Read `/tmp/aoe-hooks-<euid>/<instance_id>/session_id` (written by Claude's
 ///    `SessionStart` / `UserPromptSubmit` hooks). When present and ≤ 5 min
 ///    old, return it and skip the disk scan.
-/// 2. Otherwise scan `~/.claude/projects/<encoded-path>/`. The scan uses
+/// 2. Otherwise scan `<config>/projects/<encoded-path>/`, where `<config>` is
+///    the session's profile-scoped Claude config dir (`host_env`), so a
+///    same-cwd peer in another profile is never a candidate. The scan uses
 ///    `compose_exclusion(instance_id, extra_excludes)` to skip UUIDs claimed
 ///    by peers via tmux env, and the `last_known` mutex to anchor this
 ///    closure to its own session even when a peer's jsonl is more recent.
@@ -278,6 +333,7 @@ pub(crate) fn claude_poll_fn(
     known_session_id: Option<String>,
     instance_id: String,
     extra_excludes: HashSet<String>,
+    host_env: Vec<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     let last_known = std::sync::Mutex::new(known_session_id);
     move || {
@@ -304,6 +360,7 @@ pub(crate) fn claude_poll_fn(
             &project_path,
             current_known.as_deref(),
             &exclusion,
+            &host_env,
         )
         .map_err(|e| tracing::debug!(target: "session.capture", "Claude disk scan failed: {}", e))
         .ok()
@@ -2917,7 +2974,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new(), &[]);
         assert_eq!(result.unwrap(), uuid_new);
 
         match old_val {
@@ -2951,23 +3008,79 @@ mod tests {
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
         assert!(
-            !claude_host_transcript_confirmed_absent("/tmp/myproject", present),
+            !claude_host_transcript_confirmed_absent("/tmp/myproject", present, &[]),
             "a transcript on disk (even stale) must not be reported absent"
         );
         assert!(
-            claude_host_transcript_confirmed_absent("/tmp/myproject", missing),
+            claude_host_transcript_confirmed_absent("/tmp/myproject", missing, &[]),
             "an unwritten sid must be reported confirmed-absent"
         );
         // A project dir that was never created is also confirmed-absent.
         assert!(claude_host_transcript_confirmed_absent(
             "/tmp/never-opened-project",
-            present
+            present,
+            &[]
         ));
 
         match old_val {
             Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
             None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
         }
+    }
+
+    /// #3399: both Claude reads resolve the config dir the launched pane will
+    /// see, so two profiles sharing a cwd each see only their own conversation.
+    /// Against the default tree neither transcript exists, so the probe would
+    /// call every real conversation absent and downgrade it to `--session-id`,
+    /// and the project-dir scan would hand back the other profile's sid.
+    #[test]
+    #[serial]
+    fn claude_reads_resolve_the_profile_scoped_config_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = "/tmp/aoe-3399-shared-cwd";
+        let personal_sid = "11111111-1111-4111-8111-111111111111";
+        let work_sid = "22222222-2222-4222-8222-222222222222";
+        let mut homes = Vec::new();
+        for (name, sid) in [("personal", personal_sid), ("work", work_sid)] {
+            let home = tmp.path().join(format!("claude-{name}"));
+            let dir = home
+                .join("projects")
+                .join(encode_claude_project_path(project));
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join(format!("{sid}.jsonl")), "data\n").unwrap();
+            homes.push(vec![format!("CLAUDE_CONFIG_DIR={}", home.display())]);
+        }
+        let (personal_env, work_env) = (&homes[0], &homes[1]);
+
+        // The process-level dir stands in for "no profile override", and holds
+        // neither conversation.
+        let _guard = EnvGuard::set(&[("CLAUDE_CONFIG_DIR", tmp.path().join("claude-default"))]);
+
+        for (env, own, other) in [
+            (personal_env, personal_sid, work_sid),
+            (work_env, work_sid, personal_sid),
+        ] {
+            assert!(
+                !claude_host_transcript_confirmed_absent(project, own, env),
+                "{own} lives in this profile's config dir and must read as present"
+            );
+            assert!(
+                claude_host_transcript_confirmed_absent(project, other, env),
+                "{other} belongs to the other profile and must not read as present"
+            );
+            assert_eq!(
+                capture_claude_session_id(project, None, &HashSet::new(), env).unwrap(),
+                own,
+                "the project-dir scan must only see this profile's conversations"
+            );
+        }
+
+        // No profile override falls back to AoE's own env, which sees neither.
+        assert!(claude_host_transcript_confirmed_absent(
+            project,
+            personal_sid,
+            &[]
+        ));
     }
 
     #[test]
@@ -2993,29 +3106,32 @@ mod tests {
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", None, &HashSet::new()).unwrap(),
+            capture_claude_session_id("/tmp/myproject", None, &HashSet::new(), &[]).unwrap(),
             uuid_b
         );
 
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_a), &HashSet::new()).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(uuid_a), &HashSet::new(), &[])
+                .unwrap(),
             uuid_b
         );
 
         let exclusion: HashSet<String> = std::iter::once(uuid_b.to_string()).collect();
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_a), &exclusion).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(uuid_a), &exclusion, &[]).unwrap(),
             uuid_a
         );
 
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_b), &HashSet::new()).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(uuid_b), &HashSet::new(), &[])
+                .unwrap(),
             uuid_b
         );
 
         let absent = "99999999-9999-9999-9999-999999999999";
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(absent), &HashSet::new()).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(absent), &HashSet::new(), &[])
+                .unwrap(),
             uuid_b
         );
 
@@ -3050,7 +3166,8 @@ mod tests {
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_known), &HashSet::new()).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(uuid_known), &HashSet::new(), &[])
+                .unwrap(),
             uuid_fresh
         );
 
@@ -3090,6 +3207,7 @@ mod tests {
             Some(uuid_startup.to_string()),
             "test-instance-promote-last-known".to_string(),
             extra_excludes,
+            Vec::new(),
         );
 
         assert_eq!(poll().as_deref(), Some(uuid_post_fork));
@@ -3120,7 +3238,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new(), &[]);
         assert!(result.is_err(), "Agent files should not be picked up");
 
         match old_val {
@@ -3152,7 +3270,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new(), &[]);
         assert!(result.is_err(), "Stale session file should be rejected");
         assert!(
             result
@@ -3178,7 +3296,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new(), &[]);
         assert!(result.is_err(), "Empty dir should return error");
 
         match old_val {
@@ -5456,6 +5574,7 @@ mod tests {
             None,
             instance_id.to_string(),
             HashSet::new(),
+            Vec::new(),
         );
         assert_eq!(poll().as_deref(), Some(sidecar_uuid));
 
@@ -5513,6 +5632,7 @@ mod tests {
             None,
             instance_id.to_string(),
             HashSet::new(),
+            Vec::new(),
         );
         assert_eq!(poll().as_deref(), Some(disk_uuid));
 
@@ -5546,7 +5666,7 @@ mod tests {
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_anchor), &HashSet::new())
+            capture_claude_session_id("/tmp/myproject", Some(uuid_anchor), &HashSet::new(), &[])
                 .unwrap(),
             uuid_active
         );

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -6079,9 +6079,8 @@ impl Instance {
     /// being handed an id AoE already had stored (step 1 or step 3). Healthy
     /// launches on real agents pay `RESUME_PROBE_POST_SHELL_GRACE` (~2s) once
     /// on cold start; warm sessions and brand-new ones pay nothing.
-    /// Shell-wrapper
-    /// command overrides pay the full `RESUME_PROBE_MAX` (~3s) on every
-    /// healthy resume because `is_pane_running_shell` never clears for
+    /// Shell-wrapper command overrides pay the full `RESUME_PROBE_MAX` (~3s) on
+    /// every healthy resume because `is_pane_running_shell` never clears for
     /// them; see `probe_settle`. When the failure path fires, add
     /// `kill_clean` (~100ms macOS grace) before returning.
     ///
@@ -6236,12 +6235,18 @@ impl Instance {
     /// already in use") rather than a generic failure. tmux appends its own
     /// `Pane is dead (status N)` banner below that output; skip it, since the
     /// caller already knows the pane died.
+    ///
+    /// `capture_pane` captures with `-e`, so the agent's line still carries the
+    /// SGR sequences it was printed with (an agent error line is routinely red).
+    /// Strip them before this lands in `last_error`, which is persisted and
+    /// rendered as plain text by the TUI and the dashboard; stripping first also
+    /// keeps the banner filter working when `remain-on-exit-format` is styled.
     fn dead_pane_detail(&self) -> String {
         self.tmux_session()
             .ok()
             .and_then(|session| session.capture_pane(20).ok())
             .and_then(|output| {
-                output
+                crate::tmux::utils::strip_ansi(&output)
                     .lines()
                     .rev()
                     .map(str::trim)

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2597,12 +2597,23 @@ impl Instance {
 
     /// Resolve the effective `environment` list for this session's profile,
     /// falling back to the global list when the profile has no override.
-    pub(crate) fn profile_host_environment(&self) -> Vec<String> {
+    fn profile_host_environment(&self) -> Vec<String> {
         let profile = self.effective_profile();
         super::profile_config::resolve_config_or_warn(&profile).environment
     }
 
-    fn omp_host_environment(&self) -> Vec<String> {
+    /// The host environment the agent process will actually see: the static
+    /// profile `environment` list with every `before_session`-minted key
+    /// dropped, then the minted pairs appended. This is the same precedence
+    /// `build_launch_command` applies to the pane, so anything that has to
+    /// agree with the launched agent about a variable's value must read it
+    /// here rather than from `profile_host_environment` alone.
+    ///
+    /// Minted pairs are `#[serde(skip)]` runtime state, so outside a launch
+    /// (a poller repair, a daemon-side read of a stored row) this degrades to
+    /// the profile list. That is the best available answer: the minted values
+    /// are deliberately not persisted because they may be short-lived secrets.
+    pub(crate) fn resolved_host_environment(&self) -> Vec<String> {
         let mut environment = super::environment::drop_shadowed_host_entries(
             self.profile_host_environment(),
             &self.pending_host_env,
@@ -2649,7 +2660,7 @@ impl Instance {
             )
         } else {
             resolve_omp_store_layout_with_environment(
-                &self.omp_host_environment(),
+                &self.resolved_host_environment(),
                 &self.project_path,
                 options,
             )
@@ -2704,9 +2715,12 @@ impl Instance {
         if launched_at_ms == 0 || self.is_sandboxed() {
             return None;
         }
-        let layout =
-            resolve_omp_store_layout(&self.omp_host_environment(), &self.project_path, options)
-                .ok()?;
+        let layout = resolve_omp_store_layout(
+            &self.resolved_host_environment(),
+            &self.project_path,
+            options,
+        )
+        .ok()?;
         Some(OmpCaptureMetadata {
             layout,
             launched_at_ms,
@@ -3005,7 +3019,7 @@ impl Instance {
                 && super::capture::claude_host_transcript_confirmed_absent(
                     &self.project_path,
                     &stored,
-                    &self.profile_host_environment(),
+                    &self.resolved_host_environment(),
                 )
             {
                 tracing::info!(
@@ -3126,7 +3140,7 @@ impl Instance {
                         &self.project_path,
                         None,
                         &exclusion,
-                        &self.profile_host_environment(),
+                        &self.resolved_host_environment(),
                     )
                     .ok()
                 }
@@ -4446,7 +4460,9 @@ impl Instance {
                 // true absence, so tmux's frozen server environment cannot
                 // select another OMP store. The in-pane fingerprint still
                 // detects login-file drift.
-                env.extend(omp_host_routing_environment(&self.omp_host_environment()));
+                env.extend(omp_host_routing_environment(
+                    &self.resolved_host_environment(),
+                ));
             }
             (
                 result.0,
@@ -5598,7 +5614,7 @@ impl Instance {
                         initial_known.clone(),
                         instance_id.clone(),
                         extra_excludes.clone(),
-                        self.profile_host_environment(),
+                        self.resolved_host_environment(),
                     ))
                 }
             }
@@ -13525,6 +13541,33 @@ mod tests {
                          must resume with --resume, not launch fresh-pinned"
                     );
                 }
+
+                // A `before_session` hook minting CLAUDE_CONFIG_DIR is the
+                // documented account-switcher pattern, and its value wins over
+                // the profile's on the launched pane. Reading the shadowed
+                // profile value here would resolve a config dir the agent
+                // never opens, reintroducing the same downgrade.
+                let (shadowed_profile, other_sid) = (cases[0].0, cases[1].1);
+                let mut inst = Instance::new("minted-switcher", project_path);
+                inst.source_profile = shadowed_profile.to_string();
+                inst.tool = "claude".to_string();
+                inst.agent_session_id = Some(other_sid.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+                inst.pending_host_env = vec![(
+                    "CLAUDE_CONFIG_DIR".to_string(),
+                    temp.path()
+                        .join(format!(".claude-{}", cases[1].0))
+                        .to_string_lossy()
+                        .into_owned(),
+                )];
+
+                let (acquired, is_existing) = inst.acquire_session_id();
+                assert_eq!(acquired.as_deref(), Some(other_sid));
+                assert!(
+                    is_existing,
+                    "a before_session-minted CLAUDE_CONFIG_DIR must win over the \
+                     profile's, matching what the launch injects into the pane"
+                );
             }
 
             #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -265,7 +265,8 @@ pub(crate) enum ResumeAttemptPolicy {
 /// `start_with_resume_fallback` matches on `Existing` to gate the Tier-1
 /// settle probe; without the gate, fresh Claude launches mislabel as
 /// `StartOutcome::Resumed` because `acquire_session_id` always assigns a
-/// UUID for Claude.
+/// UUID for Claude. `Fresh` carries its own probe gate for the launches that
+/// pin an already-stored id (see `pinned_prior_sid`).
 #[must_use]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LaunchSidOutcome {
@@ -275,10 +276,21 @@ pub enum LaunchSidOutcome {
     Existing { sid: String },
     /// `acquire_session_id` returned a fresh sid (Claude UUID generation)
     /// or `None`. No prior conversation continued.
-    Fresh,
+    Fresh {
+        /// Set when the fresh launch pinned an id the session already had
+        /// stored, rather than a UUID minted for a brand-new conversation:
+        /// the #2700 empty-thread downgrade (`--session-id <sid>`) and a fork
+        /// (whose child id is pre-generated at creation). Both can die on the
+        /// spot, for a live id or an unresolvable parent, so both are worth
+        /// probing; a genuinely new session cannot and skips the probe.
+        /// See #3399.
+        pinned_prior_sid: Option<String>,
+    },
     /// `start_with_size_opts` short-circuited before `apply_session_flags`
-    /// ran: structured view-mode session, or pre-existing tmux pane (kill_clean
-    /// cache race). `agent_session_id` was not mutated this call.
+    /// ran: structured view-mode session, or a pre-existing tmux pane that is
+    /// still alive (kill_clean cache race). `agent_session_id` was not mutated
+    /// this call. A pre-existing *dead* pane is not skipped; it is torn down
+    /// and relaunched (#3399).
     Skipped,
 }
 
@@ -2585,7 +2597,7 @@ impl Instance {
 
     /// Resolve the effective `environment` list for this session's profile,
     /// falling back to the global list when the profile has no override.
-    fn profile_host_environment(&self) -> Vec<String> {
+    pub(crate) fn profile_host_environment(&self) -> Vec<String> {
         let profile = self.effective_profile();
         super::profile_config::resolve_config_or_warn(&profile).environment
     }
@@ -2993,6 +3005,7 @@ impl Instance {
                 && super::capture::claude_host_transcript_confirmed_absent(
                     &self.project_path,
                     &stored,
+                    &self.profile_host_environment(),
                 )
             {
                 tracing::info!(
@@ -3109,7 +3122,13 @@ impl Instance {
                     )
                     .ok()
                 } else {
-                    capture_claude_session_id(&self.project_path, None, &exclusion).ok()
+                    capture_claude_session_id(
+                        &self.project_path,
+                        None,
+                        &exclusion,
+                        &self.profile_host_environment(),
+                    )
+                    .ok()
                 }
             }
             "opencode" => {
@@ -3968,9 +3987,22 @@ impl Instance {
             .acquire_instance_lifecycle_lock(&self.id)
             .context("failed to acquire instance launch lock")?;
         self.reconcile_from_disk();
-        if self.is_structured() || self.tmux_session()?.exists() {
+        if self.is_structured() {
             return Ok(LaunchSidOutcome::Skipped);
         }
+        // A `remain-on-exit` corpse still owns the tmux name, so plain
+        // `exists()` reads a crashed agent as a running session and start
+        // becomes a silent no-op the caller reports as success. Recreate the
+        // pane instead, the way restart already does. See #3399.
+        let session = self.tmux_session()?;
+        let corpse_pane = if session.exists() {
+            if !session.is_pane_dead() {
+                return Ok(LaunchSidOutcome::Skipped);
+            }
+            true
+        } else {
+            false
+        };
         self.acquire_lifecycle_reservation(
             &storage,
             LifecycleOperation::Launch,
@@ -4000,12 +4032,14 @@ impl Instance {
                 return Err(error);
             }
         };
-        let result = self
-            .spawn_prepared_launch(size, &profile, prepared)
-            .and_then(|outcome| {
-                self.commit_lifecycle_launch(&storage, false)?;
-                Ok(outcome)
-            });
+        let result = (|| {
+            if corpse_pane {
+                self.kill_clean_locked()?;
+            }
+            let outcome = self.spawn_prepared_launch(size, &profile, prepared)?;
+            self.commit_lifecycle_launch(&storage, false)?;
+            Ok(outcome)
+        })();
         if let Err(error) = result {
             self.fail_reserved_launch(&storage, &error, true);
             return Err(error);
@@ -4120,6 +4154,11 @@ impl Instance {
         } else {
             None
         };
+        // Read before `finalize_launch`, which may replace `agent_session_id`.
+        let pinned_prior_sid = self
+            .agent_session_id
+            .clone()
+            .filter(|sid| prepared.expected_prior_sid.as_deref() == Some(sid.as_str()));
 
         tracing::debug!(
             target: "session.store",
@@ -4208,7 +4247,7 @@ impl Instance {
 
         Ok(match launch_sid {
             Some(sid) => LaunchSidOutcome::Existing { sid },
-            None => LaunchSidOutcome::Fresh,
+            None => LaunchSidOutcome::Fresh { pinned_prior_sid },
         })
     }
 
@@ -5559,6 +5598,7 @@ impl Instance {
                         initial_known.clone(),
                         instance_id.clone(),
                         extra_excludes.clone(),
+                        self.profile_host_environment(),
                     ))
                 }
             }
@@ -6005,6 +6045,11 @@ impl Instance {
     ///      `resume_probe_failed_sid` loop-breaker, and return
     ///      `StartOutcome::ResumeFailed`. A dead pane is not proof that the
     ///      sid is invalid, so this path must not clear it or launch fresh.
+    ///   3. A launch that pins an already-stored id without resuming it
+    ///      (`--session-id <sid>`, or a fork's pre-generated child id) is
+    ///      probed the same way, but a death there fails the call outright
+    ///      rather than arming the resume loop-breaker: nothing was resumed,
+    ///      so there is no resume to break. See `probe_pinned_fresh_launch`.
     ///
     /// `resume_policy` gates step 1: `HonorAutoResumeSetting` additionally
     /// requires `SessionConfig::auto_resume_on_restart`; `Allow` always
@@ -6014,10 +6059,11 @@ impl Instance {
     /// `StartOutcome::FreshAfterFailedResume` instead of repeating the same
     /// doomed probe. See #2609.
     ///
-    /// Latency: only fires the probe when `--resume <sid>` is being passed
-    /// to a freshly-created tmux session. Healthy resumes on real agents
-    /// pay `RESUME_PROBE_POST_SHELL_GRACE` (~2s) once on cold start;
-    /// warm sessions and non-resume launches pay nothing. Shell-wrapper
+    /// Latency: only fires the probe when a freshly-created tmux session is
+    /// being handed an id AoE already had stored (step 1 or step 3). Healthy
+    /// launches on real agents pay `RESUME_PROBE_POST_SHELL_GRACE` (~2s) once
+    /// on cold start; warm sessions and brand-new ones pay nothing.
+    /// Shell-wrapper
     /// command overrides pay the full `RESUME_PROBE_MAX` (~3s) on every
     /// healthy resume because `is_pane_running_shell` never clears for
     /// them; see `probe_settle`. When the failure path fires, add
@@ -6143,19 +6189,69 @@ impl Instance {
         None
     }
 
+    /// Fail the launch when a fresh-but-pinned start (`--session-id <sid>` on
+    /// an id the session already had stored) died inside the probe window.
+    ///
+    /// The agent rejects a `--session-id` it considers live ("Session ID ... is
+    /// already in use") and exits at once. `remain-on-exit` then holds the dead
+    /// pane, so the tmux name stays claimed and every later start sees an
+    /// existing session and no-ops without saying why. Returning `Err` routes
+    /// through `fail_reserved_launch`, which tears the corpse down and records
+    /// the pane's own message on the session. See #3399.
+    ///
+    /// Latency: the same window a resume attempt pays (~2s to settle, 3s max),
+    /// on the two launch shapes that can carry a doomed id. A brand-new
+    /// session never reaches here.
+    fn probe_pinned_fresh_launch(&mut self, sid: &str) -> Result<()> {
+        let probe = self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL);
+        if matches!(probe, Ok(ProbeResult::Alive)) {
+            return Ok(());
+        }
+        self.stop_poller();
+        self.session_id_poller = None;
+        probe?;
+        let detail = self.dead_pane_detail();
+        anyhow::bail!("agent exited immediately when pinned to session id {sid}{detail}")
+    }
+
+    /// Last line of the agent's own output in the dead pane, as a ": <line>"
+    /// suffix for an error message. `remain-on-exit` keeps the content
+    /// readable, so this surfaces the agent's diagnosis ("Session ID ... is
+    /// already in use") rather than a generic failure. tmux appends its own
+    /// `Pane is dead (status N)` banner below that output; skip it, since the
+    /// caller already knows the pane died.
+    fn dead_pane_detail(&self) -> String {
+        self.tmux_session()
+            .ok()
+            .and_then(|session| session.capture_pane(20).ok())
+            .and_then(|output| {
+                output
+                    .lines()
+                    .rev()
+                    .map(str::trim)
+                    .find(|line| !line.is_empty() && !line.starts_with("Pane is dead"))
+                    .map(|line| format!(": {line}"))
+            })
+            .unwrap_or_default()
+    }
+
     fn finish_resume_launch(
         &mut self,
         launch_outcome: LaunchSidOutcome,
         skipped_failed_resume_sid: Option<String>,
         profile: &str,
     ) -> Result<StartOutcome> {
-        let attempted_sid = match launch_outcome {
+        let (attempted_sid, pinned_prior_sid) = match launch_outcome {
             LaunchSidOutcome::Existing { sid } if should_attempt_resume(Some(&sid), &self.tool) => {
-                Some(sid)
+                (Some(sid), None)
             }
-            _ => None,
+            LaunchSidOutcome::Fresh { pinned_prior_sid } => (None, pinned_prior_sid),
+            _ => (None, None),
         };
         let Some(stale_sid) = attempted_sid else {
+            if let Some(sid) = pinned_prior_sid {
+                self.probe_pinned_fresh_launch(&sid)?;
+            }
             return Ok(match skipped_failed_resume_sid {
                 Some(sid) => StartOutcome::FreshAfterFailedResume { sid },
                 None => StartOutcome::Fresh,
@@ -12328,7 +12424,8 @@ mod tests {
             let end = source.find("pub fn ensure_pane_ready").unwrap();
             let fallback_source = &source[start..end];
 
-            assert!(fallback_source.contains("let attempted_sid = match launch_outcome"));
+            assert!(fallback_source
+                .contains("let (attempted_sid, pinned_prior_sid) = match launch_outcome"));
             assert!(fallback_source.contains("LaunchSidOutcome::Existing { sid }"));
             assert!(
                 !fallback_source.contains("should_attempt_resume(self.agent_session_id.as_deref()")
@@ -13368,6 +13465,66 @@ mod tests {
                     "a real (if idle) transcript on disk must resume with --resume"
                 );
                 assert_eq!(inst.agent_session_id.as_deref(), Some(stored));
+            }
+
+            /// #3399: two sessions share a `project_path` but sit in profiles
+            /// pinned to different `CLAUDE_CONFIG_DIR`s. Each must resume its
+            /// own conversation. Resolving the default `~/.claude` instead
+            /// reports both transcripts absent and downgrades every launch to
+            /// `--session-id <sid>`, which the agent rejects as already in use.
+            #[test]
+            #[serial]
+            fn same_cwd_sessions_resume_their_own_profile_scoped_conversation() {
+                let temp = tempdir().unwrap();
+                let _guard = claude_home_guard(&temp);
+
+                let project_path = "/tmp/aoe-test-3399-shared-cwd";
+                let cases = [
+                    ("aoe-3399-personal", "11111111-1111-4111-8111-111111111111"),
+                    ("aoe-3399-work", "22222222-2222-4222-8222-222222222222"),
+                ];
+                for (profile, sid) in cases {
+                    let claude_home = temp.path().join(format!(".claude-{profile}"));
+                    let dir = claude_home
+                        .join("projects")
+                        .join(encode_claude_project_path(project_path));
+                    fs::create_dir_all(&dir).unwrap();
+                    // Older than the live-capture window, so the mtime scan
+                    // stays out of it and the transcript gate is what decides.
+                    write_jsonl_with_mtime(
+                        &dir.join(format!("{sid}.jsonl")),
+                        SystemTime::now() - Duration::from_secs(3600),
+                    );
+
+                    let config_path = crate::session::get_profile_dir_path(profile)
+                        .unwrap()
+                        .join("config.toml");
+                    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+                    fs::write(
+                        &config_path,
+                        format!(
+                            "environment = [\"CLAUDE_CONFIG_DIR={}\"]\n",
+                            claude_home.display()
+                        ),
+                    )
+                    .unwrap();
+                }
+
+                for (profile, sid) in cases {
+                    let mut inst = Instance::new(profile, project_path);
+                    inst.source_profile = profile.to_string();
+                    inst.tool = "claude".to_string();
+                    inst.agent_session_id = Some(sid.to_string());
+                    inst.resume_intent = ResumeIntent::Default;
+
+                    let (acquired, is_existing) = inst.acquire_session_id();
+                    assert_eq!(acquired.as_deref(), Some(sid));
+                    assert!(
+                        is_existing,
+                        "{profile}: transcript under the profile's own CLAUDE_CONFIG_DIR \
+                         must resume with --resume, not launch fresh-pinned"
+                    );
+                }
             }
 
             #[test]

--- a/tests/integration/session_id_acquisition.rs
+++ b/tests/integration/session_id_acquisition.rs
@@ -1,9 +1,10 @@
 //! `start_with_size_opts` must return `LaunchSidOutcome::Skipped` when the
 //! tmux session already exists, short-circuiting before `apply_session_flags`.
 
-use agent_of_empires::session::{Instance, LaunchSidOutcome};
+use agent_of_empires::session::{GroupTree, Instance, LaunchSidOutcome, Status, Storage};
 use agent_of_empires::tmux;
 use serial_test::serial;
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
 use crate::common::{setup_temp_home, tmux_socket};
@@ -19,6 +20,26 @@ impl Drop for TmuxCleanup<'_> {
             .arg(tmux_socket())
             .args(["kill-session", "-t", self.0])
             .output();
+    }
+}
+
+/// Set an env var for the test body and restore its prior value on drop.
+struct EnvRestore(&'static str, Option<std::ffi::OsString>);
+
+impl EnvRestore {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let prev = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self(key, prev)
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        match self.1.take() {
+            Some(prev) => std::env::set_var(self.0, prev),
+            None => std::env::remove_var(self.0),
+        }
     }
 }
 
@@ -71,4 +92,151 @@ fn start_with_size_opts_returns_skipped_when_pane_preexists() {
         LaunchSidOutcome::Skipped,
         "preexisting pane must short-circuit before apply_session_flags"
     );
+}
+
+/// #3399: an agent that dies on launch leaves a `remain-on-exit` corpse pane
+/// that still owns the tmux name. Reading that as a running session made every
+/// later start return `Skipped`, so `aoe session start` printed "Started" and
+/// launched nothing. A dead pane must be torn down and relaunched.
+#[test]
+#[serial]
+fn start_with_size_opts_relaunches_a_dead_pane() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not on PATH");
+        return;
+    }
+    let temp = setup_temp_home();
+    let workdir = temp.path().join("workdir");
+    std::fs::create_dir_all(&workdir).expect("create workdir");
+
+    // Records one line per launch, then exits so the pane becomes a corpse.
+    let launches = temp.path().join("launches");
+    let agent = temp.path().join("dying-agent");
+    std::fs::write(
+        &agent,
+        format!(
+            "#!/bin/sh\necho launched >> '{}'\nexit 3\n",
+            launches.display()
+        ),
+    )
+    .expect("write dying agent");
+    std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod dying agent");
+
+    let mut inst = Instance::new("F1Corpse", workdir.to_str().unwrap());
+    inst.tool = "claude".to_string();
+    inst.command = agent.to_string_lossy().to_string();
+    let session_name = tmux::Session::generate_name(&inst.id, &inst.title);
+    let _cleanup = TmuxCleanup(&session_name);
+
+    let storage = Storage::new_unwatched("default").expect("open storage");
+    storage
+        .update(|instances, groups| {
+            *instances = vec![inst.clone()];
+            *groups = GroupTree::new_with_groups(std::slice::from_ref(&inst), &[]).get_all_groups();
+            Ok(())
+        })
+        .expect("seed storage");
+
+    let _ = inst
+        .start_with_size_opts(None, false)
+        .expect("first start must launch");
+    let session = tmux::Session::from_name(&session_name);
+    assert!(
+        wait_until(|| session.is_pane_dead()),
+        "the dying agent should have left a corpse pane"
+    );
+
+    let outcome = inst
+        .start_with_size_opts(None, false)
+        .expect("second start must launch over the corpse");
+    assert_ne!(
+        outcome,
+        LaunchSidOutcome::Skipped,
+        "a dead pane must not short-circuit start as if the agent were running"
+    );
+    assert!(
+        wait_until(|| launch_count(&launches) >= 2),
+        "second start must actually relaunch the agent; launches={}",
+        launch_count(&launches)
+    );
+}
+
+/// #3399: a fresh launch that pins an id the session already had stored
+/// (`--session-id <sid>`, the empty-thread downgrade) dies at once when the
+/// agent considers that id taken. Surface the pane's own error on the session
+/// instead of leaving a corpse behind a successful-looking return.
+#[test]
+#[serial]
+fn restart_surfaces_a_pinned_fresh_launch_that_dies() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not on PATH");
+        return;
+    }
+    let temp = setup_temp_home();
+    // The transcript probe reads this dir; an empty one is what makes the
+    // stored sid launch fresh-pinned rather than with `--resume`. Restored on
+    // drop: unlike `HOME`, this var is not part of `setup_temp_home`'s set, so
+    // leaking it would point every later test at a deleted tempdir.
+    let _claude_home = EnvRestore::set("CLAUDE_CONFIG_DIR", temp.path().join(".claude"));
+    let workdir = temp.path().join("workdir");
+    std::fs::create_dir_all(&workdir).expect("create workdir");
+
+    let agent = temp.path().join("id-taken-agent");
+    std::fs::write(
+        &agent,
+        "#!/bin/sh\necho 'Error: Session ID is already in use.'\nexit 1\n",
+    )
+    .expect("write agent");
+    std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755)).expect("chmod agent");
+
+    let mut inst = Instance::new("F1Pinned", workdir.to_str().unwrap());
+    inst.tool = "claude".to_string();
+    inst.command = agent.to_string_lossy().to_string();
+    inst.agent_session_id = Some(VALID_CLAUDE_UUID.to_string());
+    let session_name = tmux::Session::generate_name(&inst.id, &inst.title);
+    let _cleanup = TmuxCleanup(&session_name);
+
+    let storage = Storage::new_unwatched("default").expect("open storage");
+    storage
+        .update(|instances, groups| {
+            *instances = vec![inst.clone()];
+            *groups = GroupTree::new_with_groups(std::slice::from_ref(&inst), &[]).get_all_groups();
+            Ok(())
+        })
+        .expect("seed storage");
+
+    let error = inst
+        .restart_with_size_opts(None, false)
+        .expect_err("a launch that died in the probe window must not report success");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("already in use"),
+        "the pane's own diagnosis must reach the caller, got {message:?}"
+    );
+    assert_eq!(inst.status, Status::Error);
+    assert!(
+        wait_until(|| !tmux::Session::from_name(&session_name).exists()),
+        "the corpse pane must be torn down so a later start is not a no-op"
+    );
+}
+
+fn launch_count(path: &std::path::Path) -> usize {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .count()
+}
+
+/// Poll `check` for up to 5s. tmux state (pane death, the relaunch) settles
+/// asynchronously after the call that triggers it returns.
+fn wait_until(check: impl Fn() -> bool) -> bool {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if check() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    check()
 }

--- a/tests/integration/session_id_acquisition.rs
+++ b/tests/integration/session_id_acquisition.rs
@@ -182,10 +182,13 @@ fn restart_surfaces_a_pinned_fresh_launch_that_dies() {
     let workdir = temp.path().join("workdir");
     std::fs::create_dir_all(&workdir).expect("create workdir");
 
+    // Print the line in red: `capture_pane` captures with `-e`, so an agent
+    // whose error is styled (every real one is) would otherwise splice raw SGR
+    // sequences into the persisted `last_error`.
     let agent = temp.path().join("id-taken-agent");
     std::fs::write(
         &agent,
-        "#!/bin/sh\necho 'Error: Session ID is already in use.'\nexit 1\n",
+        "#!/bin/sh\nprintf '\\033[31mError: Session ID is already in use.\\033[0m\\n'\nexit 1\n",
     )
     .expect("write agent");
     std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755)).expect("chmod agent");
@@ -213,6 +216,10 @@ fn restart_surfaces_a_pinned_fresh_launch_that_dies() {
     assert!(
         message.contains("already in use"),
         "the pane's own diagnosis must reach the caller, got {message:?}"
+    );
+    assert!(
+        !message.contains('\u{1b}'),
+        "the persisted error must be plain text, got {message:?}"
     );
     assert_eq!(inst.status, Status::Error);
     assert!(


### PR DESCRIPTION
## Description

The launch path injects a profile's `CLAUDE_CONFIG_DIR` into the pane, but every host-side read of Claude's on-disk state resolved AoE's own environment instead, so for any profile pinned to a non-default config dir the two disagreed.

The read that broke is #2700's empty-thread guard. It checks whether `<config>/projects/<encoded-cwd>/<sid>.jsonl` exists and, when confirmed missing, launches `--session-id <sid>` instead of a doomed `--resume <sid>`. Looking in `~/.claude` for a profile whose transcripts live elsewhere made that check report every real conversation absent, so every launch was downgraded. The pane, which does have the right config dir, then found the conversation, saw the id was taken, and exited:

```
Error: Session ID 5fed8d3a-... is already in use.
Pane is dead (status 1)
```

The reporter had 13 of 15 sessions in the profile unstartable. Their configuration is correct: #1042 removed the `[claude] config_dir` field and pointed users at the environment variable, and `docs/guides/configuration.md` calls the per-session config-dir switch the canonical use case for `before_session` hooks.

Two things made it silent rather than merely broken, both fixed here:

1. A launch that pins an already-stored id without resuming it (the #2700 downgrade, or a fork's pre-generated child id) was never probed, so an instant death went unnoticed.
2. `remain-on-exit` left the dead pane owning the tmux name, so `start` read it as a running session and returned early. `aoe session start` printed `Started` and launched nothing.

### What changed

**Read path.** The transcript probe, the project-dir scan (`capture_claude_session_id`, behind retroactive capture and the live poller), and the `.claude.json` `lastSessionId` fallback all resolve through the config dir the launch injects. That last one moves inside the dir when the variable is set but sits next to the default `~/.claude` when it isn't, verified against a live install.

Resolution uses the full launch environment, not just the profile's static `environment` list: profile entries with `before_session`-minted keys dropped, then the minted pairs, which is the precedence `build_launch_command` applies to the pane. `omp_host_environment` already computed this and is generalized to `resolved_host_environment`. Minted pairs are `#[serde(skip)]` by design, so a read outside a launch degrades to the profile list.

**Failure visibility.** `LaunchSidOutcome::Fresh` now carries `pinned_prior_sid`; those launches get the same settle probe a resume gets. A death returns `Err`, which routes through the existing `fail_reserved_launch` to tear down the corpse and record the pane's own error line on the session. Brand-new sessions skip the probe and pay nothing. Separately, `start` no longer treats a dead pane as a running session.

### Notes for reviewers

- The `Existing`-only probe gate from #2465 is preserved in intent: pinned-fresh launches probe but still return `StartOutcome::Fresh`, never `Resumed`.
- The `Skipped` cache-race guard still holds. A stale-cached `exists()` pairs with a live `is_pane_dead()` query that errors on a killed session and returns false, so it still short-circuits.
- The pinned-fresh error path has no `resume_probe_failed_sid` equivalent, so a repeated manual restart repeats the error. Reusing the loop-breaker would force a fresh sid and silently abandon the conversation, which seemed worse than an honest repeat. Startup recovery cannot spin on it: the per-boot ledger attempts each session at most once.
- Out of scope, worth its own issue: `install_json_host_hooks` / `install_codex_host_hooks` still resolve via the profile list alone, so a minted config dir puts hooks in the wrong `settings.json`. That is a write path, so I left it alone here.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: covered one tier down, where the assertions are stronger and cost about 1.8s total instead of an e2e slot. `start_with_size_opts_relaunches_a_dead_pane` and `restart_surfaces_a_pinned_fresh_launch_that_dies` in `tests/integration/session_id_acquisition.rs` drive real tmux panes through the actual launch path, which is where both lifecycle changes live. The config-dir resolution is covered by two unit tests. All four were confirmed red against the pre-fix tree.

Four tests, each verified to fail without the fix:

| Test | Tier | Covers |
| --- | --- | --- |
| `claude_reads_resolve_the_profile_scoped_config_dir` | unit | both reads resolve per-profile; same cwd, two config dirs |
| `same_cwd_sessions_resume_their_own_profile_scoped_conversation` | unit | the issue's requested regression test, plus the `before_session`-minted override |
| `start_with_size_opts_relaunches_a_dead_pane` | integration | a corpse pane no longer short-circuits start |
| `restart_surfaces_a_pinned_fresh_launch_that_dies` | integration | the pane's error reaches the caller, session lands in `Error`, corpse torn down |

`cargo fmt`, `cargo clippy --all-targets --features serve,e2e-tests`, `cargo test --features serve --tests`, and the e2e suite were run. Remaining failures are identical to clean `main` in my container (running as root defeats two read-only-dir fixtures, and an ambient `CLAUDE_CONFIG_DIR` breaks a few tests that do not pin it). The e2e failure set is byte-identical to `main`. `cargo xtask gen-docs` produces no diff.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Investigation, implementation, and tests were done by Claude Opus 5 in back-and-forth with @njbrake. The first pass resolved only the static profile `environment` list; a review pass caught that it missed `before_session`-minted values, which is the documented pattern for exactly this scenario, and the second commit fixes that. Prior decisions in this area (#1042, #2465, #2612, #3230) were read before changing them, and the notes above record which ones are preserved and where this PR knowingly diverges.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Resolve Claude session state from each profile’s complete launch environment, including values created by `before_session` hooks.
- Use the resolved configuration directory for transcript checks, project scans, polling, and `.claude.json` fallback reads.
- Relaunch dead `remain-on-exit` panes instead of treating them as active sessions.
- Report pane errors when fresh launches fail and remove dead panes after failure.
- Strip ANSI escape sequences from persisted pane error details.
- Share configuration-directory override resolution between session launches and hooks.
- Add unit and integration tests for profile isolation, runtime overrides, dead-pane recovery, and failed launches.

## Benefits

- Prevents profiles with the same working directory from selecting the wrong Claude session state.
- Makes launch failures visible and easier to diagnose.
- Improves recovery from dead panes.
- Keeps configuration-directory precedence consistent across session launches and hooks.

## Further enhancement

- Expand coverage to other launch hooks and environment-dependent session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->