### PR TITLE
fix(core): enforce session rename uniqueness

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -83,10 +83,10 @@ tie_workdir_to_name = true
 
 When tied:
 
-- Renaming a session (TUI rename, web inline rename, `aoe session rename`, or `PATCH /api/sessions/{id}`) moves the worktree directory to the title's path-safe slug first, then sets the title only if the move succeeds, so the two cannot drift on a partial failure.
+- Renaming a session (TUI rename, web inline rename, `aoe session rename`, or `PATCH /api/sessions/{id}`) moves the worktree directory to the title's path-safe slug before committing the title. A failed move leaves the title unchanged. A metadata failure after a successful move is reported as a partial failure.
 - The git branch is never swept in by a title rename by default. To rename it too, check "Also rename git branch" in the TUI rename dialog, pass `--rename-branch` to `aoe session rename`, or send `rename_branch: true` to the PATCH. It stays opt-in because a branch may carry an upstream or an open PR; the TUI toggle warns when the branch tracks a remote, since the remote branch (and any open PR) won't follow the local rename.
 - A tied rename that relocates the worktree directory, or renames its branch, needs a stopped session: moving or re-pointing a live checkout is unsafe, so it is refused with a clear message while the session is active. Stop the session, or disable the setting, to relabel it freely.
-- A title-only rename whose title slugs to the directory the session already has moves nothing, so `PATCH /api/sessions/{id}` accepts it even while the session runs and leaves a live structured-view worker alone. If `rename_branch: true` would rename the current branch, the PATCH still requires the session to stop. The TUI rename and `aoe session rename` still ask you to stop the session first.
+- A title-only rename whose slug leaves the directory unchanged moves no checkout. `PATCH /api/sessions/{id}` and `aoe session rename` accept it while the session runs unless `rename_branch: true` would change the branch. The PATCH also leaves a live structured-view worker alone. The TUI requires a stopped session for a title-changing tied rename.
 - Naming collapses into the single rename action: the standalone "edit workdir name" affordance is hidden (TUI and web) and the standalone CLI / REST workdir-name edit is rejected, since the directory now follows the title.
 
 Toggle the setting off (TUI settings, web settings, or the toml above) to relabel sessions freely while running and to edit the directory name independently of the title.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -8,7 +8,10 @@ use std::path::PathBuf;
 use crate::containers;
 use crate::session::builder;
 use crate::session::repo_config;
-use crate::session::{civilizations, GroupTree, Instance, SandboxInfo, Storage};
+use crate::session::{
+    acquire_title_mutation_lock, civilizations, duplicate_session_error, is_duplicate_session,
+    GroupTree, Instance, SandboxInfo, Storage,
+};
 
 /// Parse one `--repo-base <repo>=<branch>` pair. Split on the first `=` so a
 /// branch containing one still parses.
@@ -633,7 +636,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // The title was resolved before worktree creation (so a tied session could
     // seed its directory leaf from it); run the path-dependent duplicate check
     // now that `path` points at the final worktree/workspace directory.
-    if is_duplicate_session(&instances, &final_title, path.to_str().unwrap_or("")) {
+    if is_duplicate_session(&instances, &final_title, path.to_str().unwrap_or(""), None) {
         cleanup_partial_session(
             &path,
             worktree_info_opt.as_ref(),
@@ -1116,11 +1119,34 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         return Err(e);
     }
 
+    // Hooks and all slow preparation are complete. Serialize only the final
+    // authoritative identity check and insert so a concurrent add or rename
+    // cannot commit the same `(title, project_path)` pair.
+    let _title_lock = match acquire_title_mutation_lock() {
+        Ok(lock) => lock,
+        Err(error) => {
+            cleanup_partial_session(
+                &path,
+                instance.worktree_info.as_ref(),
+                instance.workspace_info.as_ref(),
+                args.create_branch,
+                if instance.scratch {
+                    Some(std::path::Path::new(&instance.project_path))
+                } else {
+                    None
+                },
+                instance.sandbox_info.as_ref().map(|_| instance.id.as_str()),
+            );
+            return Err(error);
+        }
+    };
+
     let persist_result = storage.update(|all_instances, groups| {
         if is_duplicate_session(
-            all_instances,
+            all_instances.iter(),
             &instance.title,
             instance.project_path.as_str(),
+            None,
         ) {
             return Ok(false);
         }
@@ -1165,6 +1191,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             return Err(e);
         }
     }
+    drop(_title_lock);
 
     println!("✓ Added session: {}", final_title);
     println!("  Profile: {}", storage.profile());

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -9,7 +9,7 @@ use crate::containers;
 use crate::session::builder;
 use crate::session::repo_config;
 use crate::session::{
-    acquire_title_mutation_lock, civilizations, duplicate_session_error, is_duplicate_session,
+    acquire_session_identity_lock, civilizations, duplicate_session_error, is_duplicate_session,
     GroupTree, Instance, SandboxInfo, Storage,
 };
 
@@ -1122,7 +1122,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // Hooks and all slow preparation are complete. Serialize only the final
     // authoritative identity check and insert so a concurrent add or rename
     // cannot commit the same `(title, project_path)` pair.
-    let _title_lock = match acquire_title_mutation_lock() {
+    let _identity_lock = match acquire_session_identity_lock() {
         Ok(lock) => lock,
         Err(error) => {
             cleanup_partial_session(
@@ -1191,7 +1191,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             return Err(e);
         }
     }
-    drop(_title_lock);
+    drop(_identity_lock);
 
     println!("✓ Added session: {}", final_title);
     println!("  Profile: {}", storage.profile());
@@ -1442,29 +1442,6 @@ fn cleanup_partial_session(
             let _ = std::fs::remove_dir_all(scratch);
         }
     }
-}
-
-pub(crate) fn find_duplicate_session<'a>(
-    instances: &'a [Instance],
-    title: &str,
-    path: &str,
-) -> Option<&'a Instance> {
-    let normalized_path = path.trim_end_matches('/');
-    instances.iter().find(|instance| {
-        instance.title == title && instance.project_path.trim_end_matches('/') == normalized_path
-    })
-}
-
-pub fn is_duplicate_session(instances: &[Instance], title: &str, path: &str) -> bool {
-    find_duplicate_session(instances, title, path).is_some()
-}
-
-pub(crate) fn duplicate_session_error(title: &str) -> anyhow::Error {
-    anyhow::anyhow!(
-        "Session already exists with same title and path: {}\n\
-         Tip: use a different --title or remove the existing session first",
-        title
-    )
 }
 
 /// Sync mirror of `Supervisor::pick_agent_for_tool` so add-time

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 
 use crate::session::{
-    acquire_title_mutation_lock, duplicate_session_error, is_duplicate_session, GroupTree,
+    acquire_session_identity_lock, duplicate_session_error, is_duplicate_session, GroupTree,
     Instance, LifecycleOperation, ResumeIntent, StartOutcome, Storage,
 };
 
@@ -1728,7 +1728,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     // The initial load only resolves the requested row. Serialize every
     // identity-changing rename from the fresh duplicate check through git/tmux
     // effects and the durable commit.
-    let _title_lock = acquire_title_mutation_lock()?;
+    let _identity_lock = acquire_session_identity_lock()?;
     let (authoritative_instances, _groups) = storage.load_with_groups()?;
     let inst = authoritative_instances
         .iter()
@@ -1749,16 +1749,12 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     // the two cannot drift. Decided per-session from the resolved setting.
     let config = crate::session::profile_config::resolve_config_or_warn(profile);
     let tied = inst.tie_workdir_applies(config.session.tie_workdir_to_name);
-    let tied_edit = tied && (title_changed || args.rename_branch);
+    let tied_edit = tied && (args.title.is_some() || args.rename_branch);
     let duplicate_path = if tied_edit {
-        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
-        crate::session::worktree_edit::target_worktree_path(
+        crate::session::worktree_edit::derived_worktree_path(
             std::path::Path::new(&inst.project_path),
-            &leaf,
+            &effective_title,
         )
-        .unwrap_or_else(|| std::path::PathBuf::from(&inst.project_path))
-        .to_string_lossy()
-        .into_owned()
     } else {
         inst.project_path.clone()
     };
@@ -1783,31 +1779,34 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
             .worktree_info
             .clone()
             .expect("tie_workdir_applies implies worktree_info is Some");
-        // Persisted status can lag the live tmux pane; moving a running
-        // worktree is unsafe, so recompute before enforcing the gate.
-        let mut live = inst.clone();
-        live.source_profile = profile.to_string();
-        crate::tmux::refresh_session_cache();
-        live.update_status();
         let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
-        // A sandbox session's container keeps the worktree dir mounted even
-        // while the agent is Idle, so `git worktree move` would fail. The gate
-        // drops a merely-stopped container to free the mount and only reports
-        // held for a live one, which the user has to stop. Gated on the
-        // directory actually moving so a branch-only rename does not discard a
-        // container for a move that never happens.
         let moves_worktree = crate::session::worktree_edit::worktree_move_required(
             std::path::Path::new(&current_path),
             &leaf,
         );
-        if live.status.blocks_worktree_edit()
-            || (moves_worktree
+        let renames_branch = crate::session::worktree_edit::worktree_branch_rename_required(
+            &worktree_info,
+            &leaf,
+            args.rename_branch,
+        );
+        let is_sandboxed = inst.is_sandboxed();
+        if moves_worktree || renames_branch {
+            // Persisted status can lag the live tmux pane; recompute only when
+            // the request will mutate the checkout. A cwd/branch-stable title
+            // no-op must remain valid for an active session.
+            let mut live = inst.clone();
+            live.source_profile = profile.to_string();
+            crate::tmux::refresh_session_cache();
+            live.update_status();
+            let container_holds = !live.status.blocks_worktree_edit()
+                && moves_worktree
                 && crate::session::worktree_edit::ensure_sandbox_container_released(
                     &id,
-                    live.is_sandboxed(),
-                ))
-        {
-            bail!("Stop the session before renaming it: its worktree directory moves to match the new name. Disable session.tie_workdir_to_name to relabel a running session.");
+                    is_sandboxed,
+                );
+            if live.status.blocks_worktree_edit() || container_holds {
+                bail!("Stop the session before renaming its worktree directory or branch. Disable session.tie_workdir_to_name to relabel a running session.");
+            }
         }
         match crate::session::worktree_edit::edit_worktree_workdir(
             crate::session::worktree_edit::WorktreeEditRequest {
@@ -1825,7 +1824,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
                 if outcome.new_path != std::path::Path::new(&current_path) {
                     crate::session::worktree_edit::discard_sandbox_container_after_move(
                         &id,
-                        live.is_sandboxed(),
+                        is_sandboxed,
                     );
                 }
                 new_path = Some(outcome.new_path.to_string_lossy().to_string());
@@ -1890,7 +1889,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         return Err(e);
     }
 
-    drop(_title_lock);
+    drop(_identity_lock);
     if let Some(path) = &new_path {
         println!("✓ Worktree moved to: {}", path);
         if let Some(branch) = &new_branch {
@@ -2750,9 +2749,14 @@ mod set_color_tests {
 #[cfg(test)]
 mod rename_tests {
     use super::{rename_session, RenameArgs};
-    use crate::session::{Instance, Storage};
+    use crate::session::{Instance, Status, Storage};
     use serial_test::serial;
 
+    // Three duplicate-identity behaviors kept in one test on purpose: they
+    // share the costly setup that forces `#[serial]` (an isolated app dir plus
+    // a process-global `tie_workdir_to_name` config flip), so splitting them
+    // into three serial tests would triple that setup and the critical-path
+    // serial time for no added coverage. Each behavior asserts independently.
     #[tokio::test]
     #[serial]
     async fn rename_rejects_duplicate_pair_but_allows_group_only_change() {
@@ -2805,14 +2809,11 @@ mod rename_tests {
         // In tied mode the duplicate identity uses the derived destination
         // path, not the row's current worktree path. The collision must reject
         // before any git side effect is attempted.
-        crate::session::config::update_config(|config| {
-            config.session.tie_workdir_to_name = true;
-        })
-        .unwrap();
+        let _tie_guard = crate::session::test_support::TieWorkdirToNameGuard::set(true);
         let existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
-        let mut tied = Instance::new("throwaway", "/tmp/worktrees/throwaway");
+        let mut tied = Instance::new("main branch", "/tmp/worktrees/drifted");
         tied.worktree_info = Some(crate::session::WorktreeInfo {
-            branch: "throwaway".to_string(),
+            branch: "drifted".to_string(),
             main_repo_path: "/tmp/repo".to_string(),
             managed_by_aoe: true,
             created_at: chrono::Utc::now(),
@@ -2846,13 +2847,53 @@ mod rename_tests {
             .into_iter()
             .find(|instance| instance.id == tied_id)
             .unwrap();
-        assert_eq!(tied.title, "throwaway");
-        assert_eq!(tied.project_path, "/tmp/worktrees/throwaway");
+        assert_eq!(tied.title, "main branch");
+        assert_eq!(tied.project_path, "/tmp/worktrees/drifted");
+
+        // An explicit unchanged title still enters tied mode so a drifted
+        // directory can be repaired. When the directory and branch are already
+        // stable, however, it is a true no-op and must remain valid even if the
+        // persisted session is active.
+        let mut active = Instance::new("Main Branch", "/tmp/worktrees/main-branch");
+        active.status = Status::Running;
+        active.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "main-branch".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+        let active_id = active.id.clone();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![active];
+                Ok(())
+            })
+            .unwrap();
+
+        rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(active_id.clone()),
+                title: Some("Main Branch".to_string()),
+                group: None,
+                rename_branch: false,
+            },
+        )
+        .await
+        .expect("active cwd-stable title no-op must succeed");
+        let active = storage
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|instance| instance.id == active_id)
+            .unwrap();
+        assert_eq!(active.title, "Main Branch");
+        assert_eq!(active.project_path, "/tmp/worktrees/main-branch");
     }
 }
 
 #[cfg(all(test, feature = "serve"))]
-
 mod acp_reject_tests {
     use super::{set_session_id, SetSessionIdArgs};
     use crate::session::{Instance, Storage};

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -6,7 +6,8 @@ use serde::Serialize;
 use std::collections::HashSet;
 
 use crate::session::{
-    GroupTree, Instance, LifecycleOperation, ResumeIntent, StartOutcome, Storage,
+    acquire_title_mutation_lock, duplicate_session_error, is_duplicate_session, GroupTree,
+    Instance, LifecycleOperation, ResumeIntent, StartOutcome, Storage,
 };
 
 #[derive(Subcommand)]
@@ -1723,8 +1724,17 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     };
 
     let id = inst.id.clone();
-    let old_title = inst.title.clone();
 
+    // The initial load only resolves the requested row. Serialize every
+    // identity-changing rename from the fresh duplicate check through git/tmux
+    // effects and the durable commit.
+    let _title_lock = acquire_title_mutation_lock()?;
+    let (authoritative_instances, _groups) = storage.load_with_groups()?;
+    let inst = authoritative_instances
+        .iter()
+        .find(|instance| instance.id == id)
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
+    let old_title = inst.title.clone();
     let effective_title = args
         .title
         .clone()
@@ -1739,10 +1749,35 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     // the two cannot drift. Decided per-session from the resolved setting.
     let config = crate::session::profile_config::resolve_config_or_warn(profile);
     let tied = inst.tie_workdir_applies(config.session.tie_workdir_to_name);
+    let tied_edit = tied && (title_changed || args.rename_branch);
+    let duplicate_path = if tied_edit {
+        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
+        crate::session::worktree_edit::target_worktree_path(
+            std::path::Path::new(&inst.project_path),
+            &leaf,
+        )
+        .unwrap_or_else(|| std::path::PathBuf::from(&inst.project_path))
+        .to_string_lossy()
+        .into_owned()
+    } else {
+        inst.project_path.clone()
+    };
+    let pair_changed = title_changed
+        || duplicate_path.trim_end_matches('/') != inst.project_path.trim_end_matches('/');
+    if pair_changed
+        && is_duplicate_session(
+            authoritative_instances.iter(),
+            &effective_title,
+            &duplicate_path,
+            Some(&id),
+        )
+    {
+        return Err(duplicate_session_error(&effective_title));
+    }
 
     let mut new_path: Option<String> = None;
     let mut new_branch: Option<String> = None;
-    if tied && (title_changed || args.rename_branch) {
+    if tied_edit {
         let current_path = inst.project_path.clone();
         let worktree_info = inst
             .worktree_info
@@ -1751,6 +1786,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         // Persisted status can lag the live tmux pane; moving a running
         // worktree is unsafe, so recompute before enforcing the gate.
         let mut live = inst.clone();
+        live.source_profile = profile.to_string();
         crate::tmux::refresh_session_cache();
         live.update_status();
         let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
@@ -1804,9 +1840,8 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         bail!("--rename-branch only applies to a tied aoe-managed worktree session (session.tie_workdir_to_name)");
     }
 
-    // Phase 2 (unlocked): tmux rename if the title changed. Side effect on
-    // the running tmux server, fast but external state, do it outside the
-    // closure.
+    // External effects deliberately remain under the app-wide title lock but
+    // outside the short profile Storage lock.
     if title_changed {
         let tmux_session = crate::tmux::Session::new(&id, &old_title)?;
         if tmux_session.exists() {
@@ -1819,11 +1854,8 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         }
     }
 
-    // Phase 3 (locked): persist the new title and (optional) new group.
-    // Re-resolve by id under the lock so concurrent mutations to other
-    // sessions are preserved. `create_group` is idempotent and only runs
-    // when the closure actually mutated `group_path`, so `groups.json` is
-    // rewritten only on real group changes (cf. `update`'s diff check).
+    // Persist by id under the profile lock while retaining the title lock.
+    // Concurrent mutations to unrelated fields and groups are preserved.
     let persist = storage.update(|instances, groups| {
         let inst = instances
             .iter_mut()
@@ -1858,6 +1890,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         return Err(e);
     }
 
+    drop(_title_lock);
     if let Some(path) = &new_path {
         println!("✓ Worktree moved to: {}", path);
         if let Some(branch) = &new_branch {
@@ -2714,7 +2747,112 @@ mod set_color_tests {
     }
 }
 
+#[cfg(test)]
+mod rename_tests {
+    use super::{rename_session, RenameArgs};
+    use crate::session::{Instance, Storage};
+    use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn rename_rejects_duplicate_pair_but_allows_group_only_change() {
+        let _guard = crate::session::test_support::isolate_app_dir();
+        let storage = Storage::new_unwatched("rename-duplicate").unwrap();
+        let existing = Instance::new("main branch", "/tmp/repo/");
+        let target = Instance::new("throwaway", "/tmp/repo");
+        let target_id = target.id.clone();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![existing, target];
+                Ok(())
+            })
+            .unwrap();
+
+        let error = rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(target_id.clone()),
+                title: Some("main branch".to_string()),
+                group: None,
+                rename_branch: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Session already exists with same title and path"));
+
+        rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(target_id.clone()),
+                title: None,
+                group: Some("work".to_string()),
+                rename_branch: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let instances = storage.load().unwrap();
+        let target = instances
+            .iter()
+            .find(|instance| instance.id == target_id)
+            .unwrap();
+        assert_eq!(target.title, "throwaway");
+        assert_eq!(target.group_path, "work");
+        // In tied mode the duplicate identity uses the derived destination
+        // path, not the row's current worktree path. The collision must reject
+        // before any git side effect is attempted.
+        crate::session::config::update_config(|config| {
+            config.session.tie_workdir_to_name = true;
+        })
+        .unwrap();
+        let existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
+        let mut tied = Instance::new("throwaway", "/tmp/worktrees/throwaway");
+        tied.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "throwaway".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+        let tied_id = tied.id.clone();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![existing, tied];
+                Ok(())
+            })
+            .unwrap();
+
+        let error = rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(tied_id.clone()),
+                title: Some("main branch".to_string()),
+                group: None,
+                rename_branch: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Session already exists with same title and path"));
+        let tied = storage
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|instance| instance.id == tied_id)
+            .unwrap();
+        assert_eq!(tied.title, "throwaway");
+        assert_eq!(tied.project_path, "/tmp/worktrees/throwaway");
+    }
+}
+
 #[cfg(all(test, feature = "serve"))]
+
 mod acp_reject_tests {
     use super::{set_session_id, SetSessionIdArgs};
     use crate::session::{Instance, Storage};

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -14,7 +14,8 @@ use serde::{Deserialize, Serialize};
 use crate::git::error::GitError;
 use crate::session::config::SessionConfig;
 use crate::session::{
-    EnsureReadyError, EnsureReadyOutcome, Instance, LifecycleOperation, Status, Storage,
+    duplicate_session_error, is_duplicate_session, EnsureReadyError, EnsureReadyOutcome, Instance,
+    LifecycleOperation, Status, Storage,
 };
 
 use super::validate_display_label;
@@ -1085,6 +1086,42 @@ fn apply_session_title_rename(inst: &mut Instance, title: String) {
     inst.title = title;
 }
 
+/// Publish only fields owned by the rename transaction onto the current cache
+/// row. Watchers and user actions may have advanced every other field while the
+/// blocking git and storage work ran. Identity fields that the rename did not
+/// change are reconciled from the authoritative disk snapshot only while the
+/// cache still matches the live baseline captured at the start of the request.
+struct SessionRenameCachePatch<'a> {
+    title: &'a str,
+    initial_path: &'a str,
+    initial_branch: Option<&'a str>,
+    authoritative_path: &'a str,
+    authoritative_branch: Option<&'a str>,
+    renamed_path: Option<&'a str>,
+    renamed_branch: Option<&'a str>,
+}
+
+fn apply_session_rename_cache_patch(inst: &mut Instance, patch: SessionRenameCachePatch<'_>) {
+    inst.title = patch.title.to_string();
+    if let Some(path) = patch.renamed_path {
+        inst.project_path = path.to_string();
+    } else if inst.project_path == patch.initial_path {
+        inst.project_path = patch.authoritative_path.to_string();
+    }
+    let cached_branch = inst
+        .worktree_info
+        .as_ref()
+        .map(|worktree| worktree.branch.as_str());
+    let branch = match patch.renamed_branch {
+        Some(branch) => Some(branch),
+        None if cached_branch == patch.initial_branch => patch.authoritative_branch,
+        None => None,
+    };
+    if let (Some(worktree), Some(branch)) = (inst.worktree_info.as_mut(), branch) {
+        worktree.branch = branch.to_string();
+    }
+}
+
 /// Quiesce a structured-view worker before its worktree directory is moved.
 /// A live ACP worker is pinned to the current cwd; `git worktree move` pulls
 /// that directory out, the worker crashes, and the supervisor respawns it at
@@ -1209,20 +1246,65 @@ pub async fn rename_session(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let (worktree_info, current_path, status, profile, is_sandboxed, is_structured) = {
+    let live = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return super::session_not_found();
         };
-        (
-            inst.worktree_info.clone(),
-            inst.project_path.clone(),
-            inst.status,
-            inst.source_profile.clone(),
-            inst.is_sandboxed(),
-            inst.is_structured(),
-        )
+        inst.clone()
     };
+    let profile = live.source_profile.clone();
+    let profile_for_load = profile.clone();
+    let file_watch = state.file_watch.clone();
+    // Acquiring an app-wide flock may wait on another process, so never do it
+    // on a Tokio worker. Keep the guard through external effects, persistence,
+    // and cache publication; profile Storage locks are always nested beneath it.
+    let _title_lock = match tokio::task::spawn_blocking(crate::session::acquire_title_mutation_lock)
+        .await
+    {
+        Ok(Ok(lock)) => lock,
+        Ok(Err(error)) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to acquire title mutation lock");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+        Err(error) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Title mutation lock task failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    let disk_instances = match tokio::task::spawn_blocking(move || {
+        Storage::new(&profile_for_load, file_watch)?.load()
+    })
+    .await
+    {
+        Ok(Ok(instances)) => instances,
+        Ok(Err(error)) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to load authoritative session state before rename");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+        Err(error) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Session reload task failed before rename");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    let Some(mut fresh) = disk_instances
+        .iter()
+        .find(|instance| instance.id == id)
+        .cloned()
+    else {
+        return super::session_not_found();
+    };
+    fresh.source_profile.clone_from(&profile);
+    fresh.merge_runtime_from_reload(&live);
+    let current_title = fresh.title.clone();
+    let worktree_info = fresh.worktree_info.clone();
+    let current_path = fresh.project_path.clone();
+    let current_branch = worktree_info
+        .as_ref()
+        .map(|worktree| worktree.branch.clone());
+    let status = fresh.status;
+    let is_sandboxed = fresh.is_sandboxed();
+    let is_structured = fresh.is_structured();
 
     // Tied mode (#1927): renaming an aoe-managed worktree session also moves
     // its directory leaf to match the title, so title and dir cannot drift.
@@ -1230,6 +1312,33 @@ pub async fn rename_session(
         .session
         .tie_workdir_to_name
         && worktree_info.as_ref().is_some_and(|w| w.managed_by_aoe);
+    let duplicate_path = if tied {
+        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&title);
+        crate::session::worktree_edit::target_worktree_path(
+            std::path::Path::new(&current_path),
+            &leaf,
+        )
+        .unwrap_or_else(|| std::path::PathBuf::from(&current_path))
+        .to_string_lossy()
+        .into_owned()
+    } else {
+        current_path.clone()
+    };
+    let pair_changed = title != current_title
+        || duplicate_path.trim_end_matches('/') != current_path.trim_end_matches('/');
+    if pair_changed
+        && is_duplicate_session(disk_instances.iter(), &title, &duplicate_path, Some(&id))
+    {
+        let message = duplicate_session_error(&title).to_string();
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "duplicate_session",
+                "message": message,
+            })),
+        )
+            .into_response();
+    }
 
     // What to write to disk + memory once any git side effect has landed.
     let mut new_path: Option<String> = None;
@@ -1358,13 +1467,14 @@ pub async fn rename_session(
         match storage {
             Ok(storage) => tokio::task::spawn_blocking(move || {
                 storage.update(|instances, _groups| {
-                    if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
-                        if let Some(path) = new_path_clone.as_deref() {
-                            apply_worktree_name_edit(inst, path, new_branch_clone.as_deref());
-                        }
-                        apply_session_title_rename(inst, title_clone);
+                    let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) else {
+                        return Ok(false);
+                    };
+                    if let Some(path) = new_path_clone.as_deref() {
+                        apply_worktree_name_edit(inst, path, new_branch_clone.as_deref());
                     }
-                    Ok(())
+                    apply_session_title_rename(inst, title_clone);
+                    Ok(true)
                 })
             })
             .await
@@ -1373,32 +1483,57 @@ pub async fn rename_session(
             Err(e) => Err(e.to_string()),
         }
     };
-    if let Err(e) = persisted {
-        tracing::error!(target: "http.api.sessions", session = %id, "Failed to save after rename: {e}");
-        // Persist-first: never fall through to mutate in-memory state on a
-        // failed write, or the rename silently reverts on restart. When a dir
-        // move already landed, say so; otherwise it is a plain title persist.
-        let message = if new_path.is_some() {
-            "Worktree was moved on disk, but persisting the new session metadata failed"
-        } else {
-            "Persisting the renamed session failed"
-        };
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": "persist_failed", "message": message })),
-        )
-            .into_response();
+    match persisted {
+        Ok(true) => {}
+        Ok(false) => return super::session_not_found(),
+        Err(e) => {
+            tracing::error!(target: "http.api.sessions", session = %id, "Failed to save after rename: {e}");
+            // Persist-first: never fall through to mutate in-memory state on a
+            // failed write, or the rename silently reverts on restart. When a
+            // dir move already landed, say so; otherwise it is a plain title
+            // persist.
+            let message = if new_path.is_some() {
+                "Worktree was moved on disk, but persisting the new session metadata failed"
+            } else {
+                "Persisting the renamed session failed"
+            };
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "persist_failed", "message": message })),
+            )
+                .into_response();
+        }
     }
 
+    let published_path = new_path.as_deref().unwrap_or(&current_path);
+    let renamed_path = new_path
+        .as_deref()
+        .filter(|path| *path != current_path.as_str());
+    let published_branch = new_branch.as_deref().or(current_branch.as_deref());
+    let renamed_branch = new_branch
+        .as_deref()
+        .filter(|branch| current_branch.as_deref() != Some(*branch));
+    let initial_branch = live
+        .worktree_info
+        .as_ref()
+        .map(|worktree| worktree.branch.as_str());
     let mut response = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
             return super::session_not_found();
         };
-        if let Some(path) = new_path.as_deref() {
-            apply_worktree_name_edit(inst, path, new_branch.as_deref());
-        }
-        apply_session_title_rename(inst, title.clone());
+        apply_session_rename_cache_patch(
+            inst,
+            SessionRenameCachePatch {
+                title: &title,
+                initial_path: &live.project_path,
+                initial_branch,
+                authoritative_path: published_path,
+                authoritative_branch: published_branch,
+                renamed_path,
+                renamed_branch,
+            },
+        );
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen())
     };
     // Single-session responses are not run through list_sessions' overlay, so
@@ -1406,6 +1541,7 @@ pub async fn rename_session(
     // trusts the mutation response would see a managed worktree claim it is
     // untied until the next list refresh.
     response.tie_workdir_to_name = tied;
+    drop(_title_lock);
 
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
@@ -7350,6 +7486,209 @@ pub async fn serve_session_artifact(Path((id, path)): Path<(String, String)>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rename_session_rejects_duplicate_title_and_path() {
+        use axum::body::to_bytes;
+
+        let _guard = crate::session::test_support::isolate_app_dir();
+        let mut existing = Instance::new("main branch", "/tmp/repo/");
+        existing.source_profile = "default".to_string();
+        let mut target = Instance::new("throwaway", "/tmp/repo");
+        target.source_profile = "default".to_string();
+        let target_id = target.id.clone();
+        let storage = Storage::new_unwatched("default").unwrap();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![existing.clone(), target.clone()];
+                Ok(())
+            })
+            .unwrap();
+        let mut stale_existing = existing;
+        stale_existing.title = "previous title".to_string();
+        let mut stale_target = target;
+        stale_target.project_path = "/tmp/stale".to_string();
+        let state =
+            crate::server::test_support::build_test_app_state(vec![stale_existing, stale_target]);
+
+        let response = rename_session(
+            State(state.clone()),
+            Path(target_id.clone()),
+            Ok(Json(RenameSessionBody {
+                title: "main branch".to_string(),
+                rename_branch: false,
+            })),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = to_bytes(response.into_body(), 2048).await.unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("duplicate_session"));
+        assert_eq!(
+            state
+                .instances
+                .read()
+                .await
+                .iter()
+                .find(|instance| instance.id == target_id)
+                .unwrap()
+                .title,
+            "throwaway"
+        );
+        storage
+            .update(|instances, _groups| {
+                instances
+                    .iter_mut()
+                    .find(|instance| instance.id != target_id)
+                    .unwrap()
+                    .title = "other".to_string();
+                Ok(())
+            })
+            .unwrap();
+        // A user action can advance the live cache while the disk snapshot the
+        // rename will persist still has the older row. Publication must patch
+        // only rename-owned identity fields, not replace this favorite.
+        state
+            .instances
+            .write()
+            .await
+            .iter_mut()
+            .find(|instance| instance.id == target_id)
+            .unwrap()
+            .favorite();
+        let response = rename_session(
+            State(state.clone()),
+            Path(target_id.clone()),
+            Ok(Json(RenameSessionBody {
+                title: "main branch".to_string(),
+                rename_branch: false,
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let instances = state.instances.read().await;
+        let target = instances
+            .iter()
+            .find(|instance| instance.id == target_id)
+            .unwrap();
+        assert_eq!(target.title, "main branch");
+        assert_eq!(target.project_path, "/tmp/repo");
+        assert_eq!(target.source_profile, "default");
+        assert!(
+            target.is_favorited(),
+            "newer cached user action must survive rename publication"
+        );
+
+        drop(instances);
+
+        // A tied rename can reconcile a drifted directory even when the title
+        // is unchanged, so uniqueness must be checked against that final path.
+        crate::session::config::update_config(|config| {
+            config.session.tie_workdir_to_name = true;
+        })
+        .unwrap();
+        let mut existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
+        existing.source_profile = "default".to_string();
+        let mut drifted = Instance::new("main branch", "/tmp/worktrees/drifted");
+        drifted.source_profile = "default".to_string();
+        drifted.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "main-branch".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+        let drifted_id = drifted.id.clone();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![existing.clone(), drifted.clone()];
+                Ok(())
+            })
+            .unwrap();
+        let state = crate::server::test_support::build_test_app_state(vec![existing, drifted]);
+
+        let response = rename_session(
+            State(state),
+            Path(drifted_id),
+            Ok(Json(RenameSessionBody {
+                title: "main branch".to_string(),
+                rename_branch: false,
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn concurrent_renames_commit_only_one_same_identity_pair() {
+        let _guard = crate::session::test_support::isolate_app_dir();
+        let mut first = Instance::new("first", "/tmp/shared");
+        first.source_profile = "default".to_string();
+        let mut second = Instance::new("second", "/tmp/shared/");
+        second.source_profile = "default".to_string();
+        let first_id = first.id.clone();
+        let second_id = second.id.clone();
+        let storage = Storage::new_unwatched("default").unwrap();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![first.clone(), second.clone()];
+                Ok(())
+            })
+            .unwrap();
+        let state = crate::server::test_support::build_test_app_state(vec![first, second]);
+
+        let first_rename = rename_session(
+            State(state.clone()),
+            Path(first_id),
+            Ok(Json(RenameSessionBody {
+                title: "shared title".to_string(),
+                rename_branch: false,
+            })),
+        );
+        let second_rename = rename_session(
+            State(state.clone()),
+            Path(second_id),
+            Ok(Json(RenameSessionBody {
+                title: "shared title".to_string(),
+                rename_branch: false,
+            })),
+        );
+        let (first_response, second_response) = tokio::join!(first_rename, second_rename);
+        let statuses = [
+            first_response.into_response().status(),
+            second_response.into_response().status(),
+        ];
+        assert_eq!(
+            statuses
+                .iter()
+                .filter(|status| **status == StatusCode::OK)
+                .count(),
+            1
+        );
+        assert_eq!(
+            statuses
+                .iter()
+                .filter(|status| **status == StatusCode::CONFLICT)
+                .count(),
+            1
+        );
+        assert_eq!(
+            storage
+                .load()
+                .unwrap()
+                .iter()
+                .filter(|instance| {
+                    instance.title == "shared title"
+                        && instance.project_path.trim_end_matches('/') == "/tmp/shared"
+                })
+                .count(),
+            1
+        );
+    }
 
     // #2536: the workspace-delete order must tear down record-only siblings
     // first and the shared-worktree owner last, so a sibling failure can never
@@ -8757,6 +9096,81 @@ mod tests {
         assert_eq!(
             inst.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
             Some("feature/test")
+        );
+    }
+
+    #[test]
+    fn title_only_rename_cache_patch_preserves_newer_path_and_branch() {
+        let mut cached = make_test_instance();
+        cached.title = "Old title".to_string();
+        cached.project_path = "/tmp/worktrees/concurrent".to_string();
+        cached.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "concurrent-branch".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+
+        apply_session_rename_cache_patch(
+            &mut cached,
+            SessionRenameCachePatch {
+                title: "New title",
+                initial_path: "/tmp/worktrees/initial",
+                initial_branch: Some("initial-branch"),
+                authoritative_path: "/tmp/worktrees/earlier-snapshot",
+                authoritative_branch: Some("earlier-snapshot-branch"),
+                renamed_path: None,
+                renamed_branch: None,
+            },
+        );
+
+        assert_eq!(cached.title, "New title");
+        assert_eq!(cached.project_path, "/tmp/worktrees/concurrent");
+        assert_eq!(
+            cached
+                .worktree_info
+                .as_ref()
+                .map(|worktree| worktree.branch.as_str()),
+            Some("concurrent-branch")
+        );
+        let response = SessionResponse::from_instance(&cached, false);
+        assert_eq!(response.title, "New title");
+    }
+
+    #[test]
+    fn tied_rename_cache_patch_publishes_owned_path_and_branch() {
+        let mut cached = make_test_instance();
+        cached.project_path = "/tmp/worktrees/concurrent".to_string();
+        cached.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "concurrent-branch".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+
+        apply_session_rename_cache_patch(
+            &mut cached,
+            SessionRenameCachePatch {
+                title: "New title",
+                initial_path: "/tmp/worktrees/initial",
+                initial_branch: Some("initial-branch"),
+                authoritative_path: "/tmp/worktrees/renamed",
+                authoritative_branch: Some("renamed-branch"),
+                renamed_path: Some("/tmp/worktrees/renamed"),
+                renamed_branch: Some("renamed-branch"),
+            },
+        );
+
+        assert_eq!(cached.title, "New title");
+        assert_eq!(cached.project_path, "/tmp/worktrees/renamed");
+        assert_eq!(
+            cached
+                .worktree_info
+                .as_ref()
+                .map(|worktree| worktree.branch.as_str()),
+            Some("renamed-branch")
         );
     }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1101,22 +1101,48 @@ struct SessionRenameCachePatch<'a> {
     renamed_branch: Option<&'a str>,
 }
 
+/// Reconcile one identity field the rename transaction does not own, returning
+/// the value to write or `None` to keep the current cached value.
+///
+/// `renamed` is `Some` when the rename explicitly changed the field and always
+/// wins. Otherwise the field is adopted from the `authoritative` disk snapshot
+/// only while the live `cached` value still equals the `baseline` captured at
+/// the start of the request; if a watcher or user action advanced it since,
+/// `None` is returned so the newer cached value survives. `path` and `branch`
+/// share this exact rule, so both route through here.
+fn reconcile_unowned_identity<'a>(
+    cached: Option<&str>,
+    baseline: Option<&str>,
+    authoritative: Option<&'a str>,
+    renamed: Option<&'a str>,
+) -> Option<&'a str> {
+    match renamed {
+        Some(_) => renamed,
+        None if cached == baseline => authoritative,
+        None => None,
+    }
+}
+
 fn apply_session_rename_cache_patch(inst: &mut Instance, patch: SessionRenameCachePatch<'_>) {
     inst.title = patch.title.to_string();
-    if let Some(path) = patch.renamed_path {
+    if let Some(path) = reconcile_unowned_identity(
+        Some(inst.project_path.as_str()),
+        Some(patch.initial_path),
+        Some(patch.authoritative_path),
+        patch.renamed_path,
+    ) {
         inst.project_path = path.to_string();
-    } else if inst.project_path == patch.initial_path {
-        inst.project_path = patch.authoritative_path.to_string();
     }
     let cached_branch = inst
         .worktree_info
         .as_ref()
         .map(|worktree| worktree.branch.as_str());
-    let branch = match patch.renamed_branch {
-        Some(branch) => Some(branch),
-        None if cached_branch == patch.initial_branch => patch.authoritative_branch,
-        None => None,
-    };
+    let branch = reconcile_unowned_identity(
+        cached_branch,
+        patch.initial_branch,
+        patch.authoritative_branch,
+        patch.renamed_branch,
+    );
     if let (Some(worktree), Some(branch)) = (inst.worktree_info.as_mut(), branch) {
         worktree.branch = branch.to_string();
     }
@@ -1259,16 +1285,18 @@ pub async fn rename_session(
     // Acquiring an app-wide flock may wait on another process, so never do it
     // on a Tokio worker. Keep the guard through external effects, persistence,
     // and cache publication; profile Storage locks are always nested beneath it.
-    let _title_lock = match tokio::task::spawn_blocking(crate::session::acquire_title_mutation_lock)
-        .await
+    let _identity_lock = match tokio::task::spawn_blocking(
+        crate::session::acquire_session_identity_lock,
+    )
+    .await
     {
         Ok(Ok(lock)) => lock,
         Ok(Err(error)) => {
-            tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to acquire title mutation lock");
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to acquire session identity lock");
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
         Err(error) => {
-            tracing::error!(target: "http.api.sessions", session = %id, %error, "Title mutation lock task failed");
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Session identity lock task failed");
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
     };
@@ -1308,19 +1336,16 @@ pub async fn rename_session(
 
     // Tied mode (#1927): renaming an aoe-managed worktree session also moves
     // its directory leaf to match the title, so title and dir cannot drift.
-    let tied = crate::session::profile_config::resolve_config_or_warn(&profile)
-        .session
-        .tie_workdir_to_name
-        && worktree_info.as_ref().is_some_and(|w| w.managed_by_aoe);
+    let tied = fresh.tie_workdir_applies(
+        crate::session::profile_config::resolve_config_or_warn(&profile)
+            .session
+            .tie_workdir_to_name,
+    );
     let duplicate_path = if tied {
-        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&title);
-        crate::session::worktree_edit::target_worktree_path(
+        crate::session::worktree_edit::derived_worktree_path(
             std::path::Path::new(&current_path),
-            &leaf,
+            &title,
         )
-        .unwrap_or_else(|| std::path::PathBuf::from(&current_path))
-        .to_string_lossy()
-        .into_owned()
     } else {
         current_path.clone()
     };
@@ -1485,7 +1510,17 @@ pub async fn rename_session(
     };
     match persisted {
         Ok(true) => {}
-        Ok(false) => return super::session_not_found(),
+        Ok(false) => {
+            if let Some(path) = new_path.as_deref() {
+                tracing::warn!(
+                    target: "http.api.sessions",
+                    session = %id,
+                    moved_to = %path,
+                    "session row was removed by a peer after the worktree move landed; the moved directory is unreferenced"
+                );
+            }
+            return super::session_not_found();
+        }
         Err(e) => {
             tracing::error!(target: "http.api.sessions", session = %id, "Failed to save after rename: {e}");
             // Persist-first: never fall through to mutate in-memory state on a
@@ -1541,7 +1576,7 @@ pub async fn rename_session(
     // trusts the mutation response would see a managed worktree claim it is
     // untied until the next list refresh.
     response.tie_workdir_to_name = tied;
-    drop(_title_lock);
+    drop(_identity_lock);
 
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
@@ -7486,9 +7521,24 @@ pub async fn serve_session_artifact(Path((id, path)): Path<(String, String)>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn build_rename_test_state(
+        persisted: Vec<Instance>,
+        cached: Vec<Instance>,
+    ) -> (Storage, std::sync::Arc<crate::server::AppState>) {
+        let storage = Storage::new_unwatched("default").unwrap();
+        storage
+            .update(|instances, _groups| {
+                *instances = persisted;
+                Ok(())
+            })
+            .unwrap();
+        let state = crate::server::test_support::build_test_app_state(cached);
+        (storage, state)
+    }
+
     #[tokio::test]
     #[serial_test::serial]
-    async fn rename_session_rejects_duplicate_title_and_path() {
+    async fn rename_session_rejects_duplicate_and_preserves_newer_cache() {
         use axum::body::to_bytes;
 
         let _guard = crate::session::test_support::isolate_app_dir();
@@ -7497,19 +7547,12 @@ mod tests {
         let mut target = Instance::new("throwaway", "/tmp/repo");
         target.source_profile = "default".to_string();
         let target_id = target.id.clone();
-        let storage = Storage::new_unwatched("default").unwrap();
-        storage
-            .update(|instances, _groups| {
-                *instances = vec![existing.clone(), target.clone()];
-                Ok(())
-            })
-            .unwrap();
-        let mut stale_existing = existing;
+        let mut stale_existing = existing.clone();
         stale_existing.title = "previous title".to_string();
-        let mut stale_target = target;
+        let mut stale_target = target.clone();
         stale_target.project_path = "/tmp/stale".to_string();
-        let state =
-            crate::server::test_support::build_test_app_state(vec![stale_existing, stale_target]);
+        let (storage, state) =
+            build_rename_test_state(vec![existing, target], vec![stale_existing, stale_target]);
 
         let response = rename_session(
             State(state.clone()),
@@ -7536,6 +7579,7 @@ mod tests {
                 .title,
             "throwaway"
         );
+
         storage
             .update(|instances, _groups| {
                 instances
@@ -7567,6 +7611,7 @@ mod tests {
         )
         .await
         .into_response();
+
         assert_eq!(response.status(), StatusCode::OK);
         let instances = state.instances.read().await;
         let target = instances
@@ -7580,15 +7625,13 @@ mod tests {
             target.is_favorited(),
             "newer cached user action must survive rename publication"
         );
+    }
 
-        drop(instances);
-
-        // A tied rename can reconcile a drifted directory even when the title
-        // is unchanged, so uniqueness must be checked against that final path.
-        crate::session::config::update_config(|config| {
-            config.session.tie_workdir_to_name = true;
-        })
-        .unwrap();
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rename_session_rejects_tied_drifted_path_collision() {
+        let _guard = crate::session::test_support::isolate_app_dir();
+        let _tie_guard = crate::session::test_support::TieWorkdirToNameGuard::set(true);
         let mut existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
         existing.source_profile = "default".to_string();
         let mut drifted = Instance::new("main branch", "/tmp/worktrees/drifted");
@@ -7601,13 +7644,10 @@ mod tests {
             base_branch: None,
         });
         let drifted_id = drifted.id.clone();
-        storage
-            .update(|instances, _groups| {
-                *instances = vec![existing.clone(), drifted.clone()];
-                Ok(())
-            })
-            .unwrap();
-        let state = crate::server::test_support::build_test_app_state(vec![existing, drifted]);
+        let (_storage, state) = build_rename_test_state(
+            vec![existing.clone(), drifted.clone()],
+            vec![existing, drifted],
+        );
 
         let response = rename_session(
             State(state),
@@ -7619,6 +7659,7 @@ mod tests {
         )
         .await
         .into_response();
+
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 
@@ -9221,8 +9262,10 @@ mod tests {
             base_branch: None,
         });
 
-        let state =
-            crate::server::test_support::build_test_app_state(vec![title_only, branch_only]);
+        let (_storage, state) = build_rename_test_state(
+            vec![title_only.clone(), branch_only.clone()],
+            vec![title_only, branch_only],
+        );
         state.acp_supervisor.test_insert_worker(&title_id).await;
 
         // The title changes, but its slug already matches both the cwd leaf
@@ -9353,7 +9396,7 @@ mod tests {
                 base_branch: None,
             });
 
-            let state = crate::server::test_support::build_test_app_state(vec![inst]);
+            let (_storage, state) = build_rename_test_state(vec![inst.clone()], vec![inst]);
             state.acp_supervisor.test_insert_worker(case.id).await;
 
             let _ = rename_session(

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4666,9 +4666,8 @@ impl Instance {
     }
 
     fn install_codex_host_hooks(&self, events: &[crate::agents::ResolvedHookEvent]) {
-        match crate::hooks::codex_hooks_json_path_for_host_environment(
-            &self.profile_host_environment(),
-        ) {
+        let environment = self.resolved_host_environment();
+        match crate::hooks::codex_hooks_json_path_for_host_environment(&environment) {
             Ok(hooks_path) => {
                 if let Err(e) = crate::hooks::install_hooks(
                     &hooks_path,
@@ -4692,10 +4691,8 @@ impl Instance {
         // Install hooks in the agent's host settings file, honoring a
         // config-dir override env var (e.g. CLAUDE_CONFIG_DIR) so hooks
         // land where the agent actually reads them.
-        match crate::hooks::agent_settings_path_for_host_environment(
-            hook_cfg,
-            &self.profile_host_environment(),
-        ) {
+        let environment = self.resolved_host_environment();
+        match crate::hooks::agent_settings_path_for_host_environment(hook_cfg, &environment) {
             Ok(settings_path) => {
                 if let Err(e) = crate::hooks::install_hooks(
                     &settings_path,
@@ -7577,27 +7574,36 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
     false
 }
 
-/// Whether another session already owns the exact title and normalized path.
+/// Find another session that owns the exact title and normalized path.
 ///
 /// `exclude_id` lets mutation paths ignore the row being renamed.
-pub(crate) fn is_duplicate_session<'a>(
+pub(crate) fn find_duplicate_session<'a>(
     instances: impl IntoIterator<Item = &'a Instance>,
     title: &str,
     path: &str,
     exclude_id: Option<&str>,
-) -> bool {
+) -> Option<&'a Instance> {
     let normalized_path = path.trim_end_matches('/');
-    instances.into_iter().any(|inst| {
+    instances.into_iter().find(|inst| {
         exclude_id != Some(inst.id.as_str())
             && inst.project_path.trim_end_matches('/') == normalized_path
             && inst.title == title
     })
 }
 
+pub(crate) fn is_duplicate_session<'a>(
+    instances: impl IntoIterator<Item = &'a Instance>,
+    title: &str,
+    path: &str,
+    exclude_id: Option<&str>,
+) -> bool {
+    find_duplicate_session(instances, title, path, exclude_id).is_some()
+}
+
 pub(crate) fn duplicate_session_error(title: &str) -> anyhow::Error {
     anyhow::anyhow!(
         "Session already exists with same title and path: {}\n\
-         Tip: use a different --title or remove the existing session first",
+         Tip: use a different title or remove the existing session first",
         title
     )
 }
@@ -7665,6 +7671,7 @@ mod tests {
         for (name, pane, expected) in cases {
             assert_eq!(summarize_error_from_pane(pane), expected, "{name}");
         }
+    }
 
     #[test]
     fn duplicate_session_normalizes_path_and_excludes_self() {
@@ -7978,18 +7985,22 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn test_codex_hook_installer_uses_profile_codex_home() {
+    fn test_codex_hook_installer_uses_resolved_codex_home() {
         let tmp = tempfile::TempDir::new().unwrap();
         let _codex_home_guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
 
-        let codex_home = tmp.path().join("profile-codex-home");
+        let profile_codex_home = tmp.path().join("profile-codex-home");
+        let resolved_codex_home = tmp.path().join("before-session-codex-home");
         let profile_dir = crate::session::get_profile_dir("codex-profile").unwrap();
         std::fs::write(
             profile_dir.join("config.toml"),
-            format!("environment = [\"CODEX_HOME={}\"]\n", codex_home.display()),
+            format!(
+                "environment = [\"CODEX_HOME={}\"]\n",
+                profile_codex_home.display()
+            ),
         )
         .unwrap();
 
@@ -7997,13 +8008,18 @@ mod tests {
         inst.tool = "codex".to_string();
         inst.detect_as = "codex".to_string();
         inst.source_profile = "codex-profile".to_string();
+        inst.pending_host_env = vec![(
+            "CODEX_HOME".to_string(),
+            resolved_codex_home.to_string_lossy().into_owned(),
+        )];
         inst.install_agent_status_hooks(crate::agents::get_agent(&inst.detect_as));
 
-        let hooks_path = codex_home.join("hooks.json");
+        let hooks_path = resolved_codex_home.join("hooks.json");
         let hooks = std::fs::read_to_string(hooks_path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&hooks).unwrap();
         assert!(parsed["hooks"]["PreToolUse"].is_array());
         assert!(hooks.contains("aoe-hooks"));
+        assert!(!profile_codex_home.join("hooks.json").exists());
         assert!(!tmp.path().join(".codex").join("hooks.json").exists());
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1945,20 +1945,27 @@ impl Instance {
     ///
     /// `status` and `idle_entered_at` ARE generation-governed: a strictly newer
     /// disk snapshot (a peer's `commit_reserved_lifecycle_status`) must win over
-    /// the stale in-memory copy. `last_error`/`last_error_check` are NOT: no
-    /// lifecycle writer (`reserve_/commit_/advance_lifecycle_generation`)
-    /// produces an authoritative peer value for them. The only on-disk value is
-    /// the one `reconcile_from_disk` round-trips back from this same in-memory
-    /// poller state, so there is nothing to defer to and the in-memory value
-    /// always wins. Gating it on the generation would let an unrelated
-    /// generation bump (stop/unarchive, which pass `status: None`) discard a
-    /// freshly poller-derived `TMUX_SESSION_GONE_ERROR`, leaving the row stuck
-    /// at `Error`+`None`.
+    /// the stale in-memory copy. `last_error`/`last_error_check`,
+    /// `ever_confirmed_present`, and
+    /// `unknown_since` are NOT generation-governed: no lifecycle writer
+    /// (`reserve_/commit_/advance_lifecycle_generation`) produces an
+    /// authoritative peer value for them. The reachability sentinels are
+    /// serde-skipped, and the only on-disk error value is the one
+    /// `reconcile_from_disk` round-trips back from this same in-memory poller
+    /// state. The in-memory values therefore always win. Gating them on the
+    /// generation would let an unrelated bump discard a poller's confirmed
+    /// reachability and unknown streak, or a freshly derived
+    /// `TMUX_SESSION_GONE_ERROR`, leaving the row stuck at `Error`+`None`.
     pub(crate) fn merge_runtime_from_reload(&mut self, previous: &Self) {
         if self.lifecycle_generation <= previous.lifecycle_generation {
             self.status = previous.status;
             self.idle_entered_at = previous.idle_entered_at;
         }
+        // Reachability sentinels are runtime-only just like poller errors. A
+        // lifecycle generation bump does not make serde-skipped defaults from
+        // disk authoritative.
+        self.ever_confirmed_present = previous.ever_confirmed_present;
+        self.unknown_since = previous.unknown_since;
         self.last_error = previous.last_error.clone();
         self.last_error_check = previous.last_error_check;
         self.last_start_time = previous.last_start_time;
@@ -7570,6 +7577,31 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
     false
 }
 
+/// Whether another session already owns the exact title and normalized path.
+///
+/// `exclude_id` lets mutation paths ignore the row being renamed.
+pub(crate) fn is_duplicate_session<'a>(
+    instances: impl IntoIterator<Item = &'a Instance>,
+    title: &str,
+    path: &str,
+    exclude_id: Option<&str>,
+) -> bool {
+    let normalized_path = path.trim_end_matches('/');
+    instances.into_iter().any(|inst| {
+        exclude_id != Some(inst.id.as_str())
+            && inst.project_path.trim_end_matches('/') == normalized_path
+            && inst.title == title
+    })
+}
+
+pub(crate) fn duplicate_session_error(title: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Session already exists with same title and path: {}\n\
+         Tip: use a different --title or remove the existing session first",
+        title
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -7633,6 +7665,26 @@ mod tests {
         for (name, pane, expected) in cases {
             assert_eq!(summarize_error_from_pane(pane), expected, "{name}");
         }
+
+    #[test]
+    fn duplicate_session_normalizes_path_and_excludes_self() {
+        let first = Instance::new("main", "/tmp/repo/");
+        let second = Instance::new("other", "/tmp/repo");
+        let instances = vec![first.clone(), second.clone()];
+
+        assert!(is_duplicate_session(&instances, "main", "/tmp/repo", None));
+        assert!(!is_duplicate_session(
+            &instances,
+            "main",
+            "/tmp/repo/",
+            Some(&first.id)
+        ));
+        assert!(!is_duplicate_session(
+            &instances,
+            "other",
+            "/tmp/elsewhere",
+            None
+        ));
     }
 
     #[test]
@@ -8989,6 +9041,22 @@ mod tests {
         // last_error is runtime-only: the in-memory poller value survives even a
         // newer generation, since no lifecycle writer persists last_error.
         assert_eq!(reloaded.last_error.as_deref(), Some("old observation"));
+    }
+
+    #[test]
+    fn runtime_reload_preserves_reachability_sentinels_across_generation_bump() {
+        let mut previous = Instance::new("session", "/tmp/test");
+        previous.lifecycle_generation = 3;
+        previous.ever_confirmed_present = true;
+        let unknown_since = std::time::Instant::now() - std::time::Duration::from_secs(2);
+        previous.unknown_since = Some(unknown_since);
+
+        let mut reloaded = Instance::new("session", "/tmp/test");
+        reloaded.lifecycle_generation = 4;
+        reloaded.merge_runtime_from_reload(&previous);
+
+        assert!(reloaded.ever_confirmed_present);
+        assert_eq!(reloaded.unknown_since, Some(unknown_since));
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -73,16 +73,18 @@ pub use groups::{
     TRASH_SECTION_PATH,
 };
 pub(crate) use instance::ResumeAttemptPolicy;
+pub(crate) use instance::{
+    duplicate_session_error, is_duplicate_session, persist_omp_session_to_storage,
+    persist_session_to_storage, PassiveStatusPatch, ResumeIntent, SidWrite,
+    NEWER_GENERATION_BUSY_REASON,
+};
 pub use instance::{
     is_valid_session_color, EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome,
     LifecycleOperation, LifecycleReservation, LifecycleReservationError, PluginCreateIdempotency,
     SandboxInfo, SessionBucket, StartOutcome, Status, TerminalInfo, View, WorkspaceInfo,
     WorkspaceRepo, WorktreeInfo, SESSION_COLORS, TMUX_SESSION_GONE_ERROR,
 };
-pub(crate) use instance::{
-    persist_omp_session_to_storage, persist_session_to_storage, PassiveStatusPatch, ResumeIntent,
-    SidWrite, NEWER_GENERATION_BUSY_REASON,
-};
+pub(crate) use storage::acquire_title_mutation_lock;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -74,9 +74,9 @@ pub use groups::{
 };
 pub(crate) use instance::ResumeAttemptPolicy;
 pub(crate) use instance::{
-    duplicate_session_error, is_duplicate_session, persist_omp_session_to_storage,
-    persist_session_to_storage, PassiveStatusPatch, ResumeIntent, SidWrite,
-    NEWER_GENERATION_BUSY_REASON,
+    duplicate_session_error, find_duplicate_session, is_duplicate_session,
+    persist_omp_session_to_storage, persist_session_to_storage, PassiveStatusPatch, ResumeIntent,
+    SidWrite, NEWER_GENERATION_BUSY_REASON,
 };
 pub use instance::{
     is_valid_session_color, EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome,
@@ -84,7 +84,7 @@ pub use instance::{
     SandboxInfo, SessionBucket, StartOutcome, Status, TerminalInfo, View, WorkspaceInfo,
     WorkspaceRepo, WorktreeInfo, SESSION_COLORS, TMUX_SESSION_GONE_ERROR,
 };
-pub(crate) use storage::acquire_title_mutation_lock;
+pub(crate) use storage::acquire_session_identity_lock;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -935,16 +935,16 @@ fn apply_terminal_title(
             if let Some(title) = &new_title {
                 let should_write = title_is_auto_overwritable(&instances[index])
                     && instances[index].title != *title;
-                // `is_duplicate_session` scans every instance and does not skip
-                // this session by id, so the `title != current` half of
-                // `should_write` is what keeps a session from reading its own
-                // row as the collision. Self-exclusion by id lives in the manual
-                // rename predicate (#3411), which owns the shared surfaces.
+                // Manual and automatic rename paths share one domain predicate;
+                // exclude this row explicitly so the uniqueness contract does
+                // not depend on `should_write` remaining title-sensitive.
+                let path = instances[index].project_path.clone();
                 let duplicate = should_write
-                    && crate::cli::add::is_duplicate_session(
-                        instances,
+                    && crate::session::is_duplicate_session(
+                        instances.iter(),
                         title,
-                        &instances[index].project_path,
+                        &path,
+                        Some(&id),
                     );
                 if duplicate {
                     tracing::warn!(target: "smart_rename", session = %id, title = %title, "skipped duplicate auto-title");
@@ -1452,19 +1452,18 @@ mod serve {
                 else {
                     return Ok(false);
                 };
-                // Skip a no-op rename: when the generated title already equals
-                // the current one there is nothing to write, and this same
-                // `title != current` guard is what excludes this session from
-                // its own duplicate scan below, since `is_duplicate_session`
-                // matches by (title, path) with no id filter. Id-based
-                // self-exclusion lives in the manual rename predicate (#3411).
+                // Manual and automatic rename paths share one domain predicate;
+                // exclude this row explicitly so a future no-op policy change
+                // cannot make the row collide with itself.
                 let should_write = title_is_auto_overwritable(&instances[index])
                     && instances[index].title != title_owned;
+                let path = instances[index].project_path.clone();
                 let duplicate = should_write
-                    && crate::cli::add::is_duplicate_session(
-                        instances,
+                    && crate::session::is_duplicate_session(
+                        instances.iter(),
                         &title_owned,
-                        &instances[index].project_path,
+                        &path,
+                        Some(&id_owned),
                     );
                 if duplicate {
                     tracing::warn!(target: "smart_rename", session = %id_owned, title = %title_owned, "skipped duplicate auto-title");
@@ -1572,7 +1571,7 @@ mod serve {
             ];
             for (title, path, expected) in cases {
                 assert_eq!(
-                    crate::cli::add::is_duplicate_session(&instances, title, path),
+                    crate::session::is_duplicate_session(instances.iter(), title, path, None),
                     expected,
                     "title {title:?} path {path:?}"
                 );

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -43,16 +43,23 @@
 //! `save_groups` helpers were removed entirely. This keeps it structurally
 //! impossible to bypass the locks.
 //!
-//! Lock-ordering rule across the process: server callers MUST drop
-//! `AppState.instances` (tokio RwLock) before acquiring `Storage`'s
-//! per-profile mutex via `tokio::task::spawn_blocking(... storage.update)`.
-//! The flock can park on a wedged peer for arbitrary time; holding the
-//! tokio RwLock across the wait would block every other reader/writer of
-//! `AppState.instances` and park the worker thread. The cross-process
-//! `flock` is acquired AFTER the in-process mutex and released BEFORE it
-//! (RAII drop order). The closure passed to `update` is
-//! `FnOnce(...) -> Result<R>` and cannot await, so `std::sync::Mutex` is
-//! safe across the body even on the tokio runtime.
+//! Lock-ordering rule across the process: a title mutation that can change or
+//! create a `(title, project_path)` pair MUST first acquire the app-wide title
+//! mutation flock, then acquire any profile `Storage` lock. The title lock is
+//! global so a profile-changing rename never needs to hold two profile locks at
+//! once. It stays held through the authoritative duplicate check, external
+//! rename effects, persistence, and cache publication. `aoe add` acquires it
+//! only after hooks, around its final check and insert. Code must never acquire
+//! the title lock while holding a profile `Storage` lock.
+//!
+//! Server callers MUST drop `AppState.instances` (tokio RwLock) before
+//! acquiring either flock via `tokio::task::spawn_blocking`. A flock can park
+//! on a wedged peer for arbitrary time; holding the tokio RwLock across the
+//! wait would block every other reader/writer and park the worker thread. The
+//! cross-process storage flock is acquired AFTER the in-process mutex and
+//! released BEFORE it (RAII drop order). The closure passed to `update` is
+//! `FnOnce(...) -> Result<R>` and cannot await, so `std::sync::Mutex` is safe
+//! across the body even on the tokio runtime.
 //! Session launch callers additionally hold a per-instance lifecycle flock.
 //! The only permitted order is lifecycle flock, then the short-lived storage
 //! mutex/flock taken by `update`; a caller that already holds a lifecycle lock
@@ -95,6 +102,10 @@ const WORKSPACE_LOCK_FILENAME: &str = ".workspace-ordering.lock";
 /// Sidecar lock prefix for one session's launch lifecycle. The validated
 /// instance id is appended verbatim, yielding one lock per (profile, instance).
 const INSTANCE_LIFECYCLE_LOCK_PREFIX: &str = ".instance-lifecycle-";
+/// Sidecar lock for every mutation that can create or change a session's
+/// `(title, project_path)` identity. It lives at app scope because TUI renames
+/// can move a row between profiles.
+const TITLE_MUTATION_LOCK_FILENAME: &str = ".title-mutation.lock";
 
 /// Emit a tracing warn if the cross-process `flock` is held by a peer for
 /// longer than this. Surfaces a wedged peer in `aoe logs` instead of a
@@ -365,6 +376,14 @@ pub(crate) fn acquire_storage_flock(dir: &Path, name: &str) -> Result<StorageFlo
         }
     }
     Ok(StorageFlock { file })
+}
+/// Acquire the app-wide session title-mutation lock.
+///
+/// Callers must take this before loading authoritative profile storage and
+/// retain it through duplicate validation, external rename effects, durable
+/// writes, and any in-memory cache publication. See the module lock order.
+pub(crate) fn acquire_title_mutation_lock() -> Result<StorageFlock> {
+    acquire_storage_flock(&get_app_dir()?, TITLE_MUTATION_LOCK_FILENAME)
 }
 
 pub struct Storage {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -43,14 +43,15 @@
 //! `save_groups` helpers were removed entirely. This keeps it structurally
 //! impossible to bypass the locks.
 //!
-//! Lock-ordering rule across the process: a title mutation that can change or
-//! create a `(title, project_path)` pair MUST first acquire the app-wide title
-//! mutation flock, then acquire any profile `Storage` lock. The title lock is
-//! global so a profile-changing rename never needs to hold two profile locks at
-//! once. It stays held through the authoritative duplicate check, external
-//! rename effects, persistence, and cache publication. `aoe add` acquires it
-//! only after hooks, around its final check and insert. Code must never acquire
-//! the title lock while holding a profile `Storage` lock.
+//! Lock-ordering rule across the process: a mutation that can change or create
+//! a `(title, project_path)` pair MUST first acquire the app-wide session
+//! identity flock via `acquire_session_identity_lock`, then acquire any profile
+//! `Storage` lock. The identity lock is global so a profile-changing rename
+//! never needs to hold two profile locks at once. It stays held through the
+//! authoritative duplicate check, external rename effects, persistence, and
+//! cache publication. `aoe add` acquires it only after hooks, around its final
+//! check and insert. Code must never acquire the identity lock while holding a
+//! profile `Storage` lock.
 //!
 //! Server callers MUST drop `AppState.instances` (tokio RwLock) before
 //! acquiring either flock via `tokio::task::spawn_blocking`. A flock can park
@@ -105,7 +106,9 @@ const INSTANCE_LIFECYCLE_LOCK_PREFIX: &str = ".instance-lifecycle-";
 /// Sidecar lock for every mutation that can create or change a session's
 /// `(title, project_path)` identity. It lives at app scope because TUI renames
 /// can move a row between profiles.
-const TITLE_MUTATION_LOCK_FILENAME: &str = ".title-mutation.lock";
+/// The historical filename is retained so mixed-version processes still
+/// coordinate during an upgrade.
+const SESSION_IDENTITY_LOCK_FILENAME: &str = ".title-mutation.lock";
 
 /// Emit a tracing warn if the cross-process `flock` is held by a peer for
 /// longer than this. Surfaces a wedged peer in `aoe logs` instead of a
@@ -377,13 +380,35 @@ pub(crate) fn acquire_storage_flock(dir: &Path, name: &str) -> Result<StorageFlo
     }
     Ok(StorageFlock { file })
 }
-/// Acquire the app-wide session title-mutation lock.
+/// Acquire the app-wide session identity-mutation lock.
 ///
 /// Callers must take this before loading authoritative profile storage and
 /// retain it through duplicate validation, external rename effects, durable
 /// writes, and any in-memory cache publication. See the module lock order.
-pub(crate) fn acquire_title_mutation_lock() -> Result<StorageFlock> {
-    acquire_storage_flock(&get_app_dir()?, TITLE_MUTATION_LOCK_FILENAME)
+///
+/// Held across slow external effects. The tied worktree rename path
+/// (`session::worktree_edit::edit_worktree_workdir`) runs `git branch -m` and
+/// `git worktree move`, and the callers refresh tmux state, all while this
+/// cross-process `flock` is held so duplicate validation and durable commit
+/// are one transaction with no TOCTOU window. Those git effects are therefore
+/// bounded (`WORKTREE_MUTATION_TIMEOUT` in `git::worktree`): a stalled
+/// filesystem turns into a surfaced error instead of pinning the lock, and
+/// thus every peer `aoe` process, indefinitely. The `flock` itself is released
+/// by the kernel on process exit, so a crashed holder cannot wedge peers
+/// either.
+///
+/// Scope deliberately left OUTSIDE this lock, so `(title, project_path)`
+/// uniqueness is NOT a global invariant:
+///   - `session::smart_rename` rewrites a structured session's title from a
+///     detached one-shot without taking this lock (it only ever touches the
+///     title, never the worktree directory), so it can land a title that
+///     collides with another row.
+///   - Session-creation surfaces other than the guarded `aoe add` / rename
+///     paths (imports, restores, ACP-driven creation) do not serialize through
+///     here. The lock guarantees the add/rename endpoints cannot *introduce* a
+///     duplicate; it does not retroactively dedup rows created elsewhere.
+pub(crate) fn acquire_session_identity_lock() -> Result<StorageFlock> {
+    acquire_storage_flock(&get_app_dir()?, SESSION_IDENTITY_LOCK_FILENAME)
 }
 
 pub struct Storage {

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -192,6 +192,54 @@ impl Drop for EnvGuard {
     }
 }
 
+/// Restores the process-global tied-worktree setting even when a test panics.
+///
+/// Declare this after the app-directory isolation guard. Rust drops locals in
+/// reverse declaration order, and this guard's `Drop` must restore the setting
+/// while `HOME` and `XDG_CONFIG_HOME` still point at the test configuration.
+#[must_use = "TieWorkdirToNameGuard restores config on Drop"]
+pub(crate) struct TieWorkdirToNameGuard {
+    previous: bool,
+    _lock: Option<MutexGuard<'static, ()>>,
+}
+
+impl TieWorkdirToNameGuard {
+    pub(crate) fn set(enabled: bool) -> Self {
+        let lock = acquire_env_lock();
+        let previous = super::config::load_config()
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+            .session
+            .tie_workdir_to_name;
+        let guard = Self {
+            previous,
+            _lock: lock,
+        };
+        super::config::update_config(|config| {
+            config.session.tie_workdir_to_name = enabled;
+        })
+        .unwrap();
+        guard
+    }
+}
+
+impl Drop for TieWorkdirToNameGuard {
+    fn drop(&mut self) {
+        if let Err(error) = super::config::update_config(|config| {
+            config.session.tie_workdir_to_name = self.previous;
+        }) {
+            tracing::warn!(
+                target: "session.test",
+                "failed to restore tie_workdir_to_name after test: {error}"
+            );
+        }
+        if self._lock.is_some() {
+            ENV_LOCK_HELD.with(|held| held.set(false));
+        }
+    }
+}
+
 /// RAII guard: isolates `HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME`
 /// for one test; restores them on `Drop`. See the
 /// [module documentation](crate::session::test_support) for the

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -56,6 +56,23 @@ pub(crate) fn target_worktree_path(current_path: &Path, new_name: &str) -> Optio
     Some(parent.join(new_leaf))
 }
 
+/// The tied-rename destination directory for `title`, as a string: the path
+/// [`edit_worktree_workdir`] would move `current_path` to, or `current_path`
+/// unchanged when it has no parent to rename within.
+///
+/// Single source for the destination the duplicate-identity check keys on
+/// across the CLI, server, and TUI rename paths: it slugs `title` to a
+/// sibling leaf ([`worktree_leaf_from_title`]) and resolves the move target
+/// ([`target_worktree_path`]), so the uniqueness gate always tests the exact
+/// path the directory would land on rather than the row's current path.
+pub(crate) fn derived_worktree_path(current_path: &Path, title: &str) -> String {
+    let leaf = worktree_leaf_from_title(title);
+    target_worktree_path(current_path, &leaf)
+        .unwrap_or_else(|| current_path.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// Whether a workdir edit for `new_name` would actually move the worktree
 /// directory.
 ///

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -50,7 +50,7 @@ pub fn worktree_leaf_from_title(title: &str) -> String {
 /// The single source of truth for the sanitizer chain (git-ref sanitizer, then
 /// the path-safe one) so [`worktree_move_required`] cannot drift from the
 /// operation it gates.
-fn target_worktree_path(current_path: &Path, new_name: &str) -> Option<PathBuf> {
+pub(crate) fn target_worktree_path(current_path: &Path, new_name: &str) -> Option<PathBuf> {
     let parent = current_path.parent()?;
     let new_leaf = sanitize_branch_name(&git_sanitize_branch_name(new_name));
     Some(parent.join(new_leaf))

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4388,10 +4388,11 @@ impl HomeView {
                         // was provisional.
                         *groups = GroupTree::new_with_groups(instances, groups).get_all_groups();
                     }
-                    if let Some(owner) = crate::cli::add::find_duplicate_session(
-                        instances,
+                    if let Some(owner) = crate::session::find_duplicate_session(
+                        instances.iter(),
                         &instance.title,
                         &instance.project_path,
+                        None,
                     ) {
                         return Ok(CreationCommit::Duplicate(Box::new(owner.clone())));
                     }
@@ -4414,7 +4415,7 @@ impl HomeView {
                         );
                         self.info_dialog = Some(InfoDialog::sized_to_fit(
                             "Creation Failed",
-                            &crate::cli::add::duplicate_session_error(&instance.title).to_string(),
+                            &crate::session::duplicate_session_error(&instance.title).to_string(),
                         ));
                         self.new_dialog = None;
                         if let Err(error) = self.reload() {
@@ -4432,10 +4433,11 @@ impl HomeView {
                             ));
                         }
                         Ok(instances) => {
-                            let owner = crate::cli::add::find_duplicate_session(
+                            let owner = crate::session::find_duplicate_session(
                                 &instances,
                                 &instance.title,
                                 &instance.project_path,
+                                None,
                             )
                             .cloned();
                             cleanup_creation_resources(

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -2,7 +2,7 @@
 
 use crate::session::builder::{self, InstanceParams};
 use crate::session::{
-    acquire_title_mutation_lock, duplicate_session_error, is_duplicate_session, list_profiles,
+    acquire_session_identity_lock, duplicate_session_error, is_duplicate_session, list_profiles,
     GroupTree, Instance, Item, LifecycleOperation, Status, Storage,
 };
 use crate::tui::deletion_poller::DeletionRequest;
@@ -1115,7 +1115,7 @@ impl HomeView {
             // The app-wide guard covers profile-changing renames too, so the
             // authoritative target-profile check and both profile writes are
             // one identity transaction without nesting profile locks.
-            let _title_lock = acquire_title_mutation_lock()?;
+            let _identity_lock = acquire_session_identity_lock()?;
             let stored = if let Some(storage) = self.storages.get(&current_profile) {
                 storage.load()?
             } else {
@@ -1155,15 +1155,10 @@ impl HomeView {
             let tied = self.tie_workdir_applies_for(&id);
             let tied_edit = tied && (current_title != effective_title || rename_branch);
             let duplicate_path = if tied_edit {
-                let leaf =
-                    crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
-                crate::session::worktree_edit::target_worktree_path(
+                crate::session::worktree_edit::derived_worktree_path(
                     std::path::Path::new(&previous.project_path),
-                    &leaf,
+                    &effective_title,
                 )
-                .unwrap_or_else(|| std::path::PathBuf::from(&previous.project_path))
-                .to_string_lossy()
-                .into_owned()
             } else {
                 previous.project_path.clone()
             };

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -2,7 +2,8 @@
 
 use crate::session::builder::{self, InstanceParams};
 use crate::session::{
-    list_profiles, GroupTree, Instance, Item, LifecycleOperation, Status, Storage,
+    acquire_title_mutation_lock, duplicate_session_error, is_duplicate_session, list_profiles,
+    GroupTree, Instance, Item, LifecycleOperation, Status, Storage,
 };
 use crate::tui::deletion_poller::DeletionRequest;
 use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, InfoDialog, NewSessionData};
@@ -1106,11 +1107,29 @@ impl HomeView {
         if let Some(id) = &self.selected_session {
             let id = id.clone();
 
-            // Get current values for comparison
-            let (current_title, current_group) = self
+            let live = self
                 .get_instance(&id)
-                .map(|i| (i.title.clone(), i.group_path.clone()))
-                .unwrap_or_default();
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+            let current_profile = live.source_profile.clone();
+            // The app-wide guard covers profile-changing renames too, so the
+            // authoritative target-profile check and both profile writes are
+            // one identity transaction without nesting profile locks.
+            let _title_lock = acquire_title_mutation_lock()?;
+            let stored = if let Some(storage) = self.storages.get(&current_profile) {
+                storage.load()?
+            } else {
+                Storage::new(&current_profile, self.file_watch.clone())?.load()?
+            };
+            let mut previous = stored
+                .into_iter()
+                .find(|instance| instance.id == id)
+                .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+            previous.source_profile.clone_from(&current_profile);
+            previous.merge_runtime_from_reload(&live);
+            self.instances.insert(id.clone(), previous.clone());
+            let current_title = previous.title.clone();
+            let current_group = previous.group_path.clone();
 
             // Determine effective title (keep current if empty)
             let effective_title = if new_title.is_empty() {
@@ -1125,6 +1144,53 @@ impl HomeView {
                 Some(g) => g.to_string(),      // Set new (empty string means ungroup)
             };
 
+            let target_profile = new_profile.unwrap_or(&current_profile);
+            if target_profile != current_profile {
+                let profiles = list_profiles()?;
+                if !profiles.contains(&target_profile.to_string()) {
+                    anyhow::bail!("Profile '{}' does not exist", target_profile);
+                }
+            }
+
+            let tied = self.tie_workdir_applies_for(&id);
+            let tied_edit = tied && (current_title != effective_title || rename_branch);
+            let duplicate_path = if tied_edit {
+                let leaf =
+                    crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
+                crate::session::worktree_edit::target_worktree_path(
+                    std::path::Path::new(&previous.project_path),
+                    &leaf,
+                )
+                .unwrap_or_else(|| std::path::PathBuf::from(&previous.project_path))
+                .to_string_lossy()
+                .into_owned()
+            } else {
+                previous.project_path.clone()
+            };
+            let pair_changed = current_title != effective_title
+                || target_profile != current_profile
+                || duplicate_path.trim_end_matches('/')
+                    != previous.project_path.trim_end_matches('/');
+            if pair_changed {
+                let candidates = if let Some(storage) = self.storages.get(target_profile) {
+                    storage.load()?
+                } else {
+                    Storage::new(target_profile, self.file_watch.clone())?.load()?
+                };
+                if is_duplicate_session(
+                    candidates.iter(),
+                    &effective_title,
+                    &duplicate_path,
+                    Some(&id),
+                ) {
+                    self.info_dialog = Some(crate::tui::dialogs::InfoDialog::new(
+                        "Rename Failed",
+                        &duplicate_session_error(&effective_title).to_string(),
+                    ));
+                    return Ok(());
+                }
+            }
+
             // Tied mode (#1927): a worktree session's directory leaf follows
             // its title, so move the directory in lockstep before persisting
             // the new title. The move is gated on a stopped session; a running
@@ -1135,9 +1201,7 @@ impl HomeView {
             // Fire when the title changed (dir follows it) OR the user opted to
             // rename the branch (which may be requested even with the title
             // unchanged, to bring a drifted branch back in line with the dir).
-            if (current_title != effective_title || rename_branch)
-                && self.tie_workdir_applies_for(&id)
-            {
+            if tied_edit {
                 let snapshot = self.get_instance(&id).map(|i| {
                     (
                         i.worktree_info.clone(),
@@ -1226,17 +1290,7 @@ impl HomeView {
 
             // Handle profile change (move session to different profile)
             if let Some(target_profile) = new_profile {
-                let current_profile = self
-                    .get_instance(&id)
-                    .map(|i| i.source_profile.clone())
-                    .unwrap_or_else(|| self.config_profile());
                 if target_profile != current_profile {
-                    // Validate target profile exists
-                    let profiles = list_profiles()?;
-                    if !profiles.contains(&target_profile.to_string()) {
-                        anyhow::bail!("Profile '{}' does not exist", target_profile);
-                    }
-
                     // Get the instance to move
                     let mut instance = self
                         .get_instance(&id)

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6167,6 +6167,12 @@ fn test_group_delete_dialog_scoped_to_owning_profile() {
     );
 }
 
+// Four rename-collision behaviors (untied duplicate-pair reject, group-only
+// change allowed, tied derived-destination collision, cross-profile target
+// collision) share one test because they need the same `#[serial]`-forcing
+// setup: an isolated home, multiple `HomeView`/`Storage` instances, and a
+// process-global `tie_workdir_to_name` flip. Splitting would multiply that
+// setup and the serial critical-path time; each behavior asserts independently.
 #[test]
 #[serial]
 fn test_rename_selected_rejects_all_identity_collisions_and_allows_group_only_change() {
@@ -6224,10 +6230,7 @@ fn test_rename_selected_rejects_all_identity_collisions_and_allows_group_only_ch
 
     // Tied routing derives the destination path from the new title. Reject a
     // collision on that final pair before attempting the git worktree move.
-    crate::session::config::update_config(|config| {
-        config.session.tie_workdir_to_name = true;
-    })
-    .unwrap();
+    let tie_guard = crate::session::test_support::TieWorkdirToNameGuard::set(true);
     let derived_existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
     let mut tied_target = Instance::new("throwaway", "/tmp/worktrees/throwaway");
     tied_target.worktree_info = Some(crate::session::WorktreeInfo {
@@ -6260,6 +6263,8 @@ fn test_rename_selected_rejects_all_identity_collisions_and_allows_group_only_ch
         .unwrap();
     assert_eq!(tied_target.title, "throwaway");
     assert_eq!(tied_target.project_path, "/tmp/worktrees/throwaway");
+
+    drop(tie_guard);
 
     // Moving between profiles checks the authoritative target storage, not
     // only the source profile or unified-view cache.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6167,6 +6167,144 @@ fn test_group_delete_dialog_scoped_to_owning_profile() {
     );
 }
 
+#[test]
+#[serial]
+fn test_rename_selected_rejects_all_identity_collisions_and_allows_group_only_change() {
+    let temp = TempDir::new().unwrap();
+    let _guard = setup_test_home(&temp);
+    let storage = Storage::new_unwatched("test").unwrap();
+    let existing = Instance::new("main branch", "/tmp/repo/");
+    let target = Instance::new("throwaway", "/tmp/stale");
+    let target_id = target.id.clone();
+    storage
+        .update(|instances, _groups| {
+            *instances = vec![existing, target];
+            Ok(())
+        })
+        .unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.selected_session = Some(target_id.clone());
+    storage
+        .update(|instances, _groups| {
+            instances
+                .iter_mut()
+                .find(|instance| instance.id == target_id)
+                .unwrap()
+                .project_path = "/tmp/repo".to_string();
+            Ok(())
+        })
+        .unwrap();
+
+    view.rename_selected("main branch", None, None, false)
+        .unwrap();
+    assert!(view.info_dialog.is_some());
+    assert_eq!(view.get_instance(&target_id).unwrap().title, "throwaway");
+    assert_eq!(
+        view.get_instance(&target_id).unwrap().project_path,
+        "/tmp/repo"
+    );
+
+    view.info_dialog = None;
+    view.rename_selected("", Some("work"), None, false).unwrap();
+    assert!(view.info_dialog.is_none());
+    assert_eq!(view.get_instance(&target_id).unwrap().group_path, "work");
+    let stored = storage.load().unwrap();
+    let target = stored
+        .iter()
+        .find(|instance| instance.id == target_id)
+        .unwrap();
+    assert_eq!(target.title, "throwaway");
+    assert_eq!(target.group_path, "work");
+
+    // Tied routing derives the destination path from the new title. Reject a
+    // collision on that final pair before attempting the git worktree move.
+    crate::session::config::update_config(|config| {
+        config.session.tie_workdir_to_name = true;
+    })
+    .unwrap();
+    let derived_existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
+    let mut tied_target = Instance::new("throwaway", "/tmp/worktrees/throwaway");
+    tied_target.worktree_info = Some(crate::session::WorktreeInfo {
+        branch: "throwaway".to_string(),
+        main_repo_path: "/tmp/repo".to_string(),
+        managed_by_aoe: true,
+        created_at: chrono::Utc::now(),
+        base_branch: None,
+    });
+    let tied_id = tied_target.id.clone();
+    storage
+        .update(|instances, _groups| {
+            *instances = vec![derived_existing, tied_target];
+            Ok(())
+        })
+        .unwrap();
+    view.reload().unwrap();
+    view.selected_session = Some(tied_id.clone());
+    view.info_dialog = None;
+    view.rename_selected("main branch", None, None, false)
+        .unwrap();
+    assert!(
+        view.info_dialog.is_some(),
+        "tied derived-destination collision must be rejected"
+    );
+    let tied_stored = storage.load().unwrap();
+    let tied_target = tied_stored
+        .iter()
+        .find(|instance| instance.id == tied_id)
+        .unwrap();
+    assert_eq!(tied_target.title, "throwaway");
+    assert_eq!(tied_target.project_path, "/tmp/worktrees/throwaway");
+
+    // Moving between profiles checks the authoritative target storage, not
+    // only the source profile or unified-view cache.
+    let alpha = Storage::new_unwatched("alpha").unwrap();
+    let beta = Storage::new_unwatched("beta").unwrap();
+    let source = Instance::new("source", "/tmp/profile-collision");
+    let source_id = source.id.clone();
+    alpha
+        .update(|instances, _groups| {
+            *instances = vec![source];
+            Ok(())
+        })
+        .unwrap();
+    beta.update(|instances, _groups| {
+        *instances = vec![Instance::new("occupied", "/tmp/profile-collision")];
+        Ok(())
+    })
+    .unwrap();
+    let mut unified = HomeView::new(
+        None,
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    unified.selected_session = Some(source_id.clone());
+    unified
+        .rename_selected("occupied", None, Some("beta"), false)
+        .unwrap();
+    assert!(
+        unified.info_dialog.is_some(),
+        "target-profile identity collision must be rejected"
+    );
+    assert_eq!(
+        alpha
+            .load()
+            .unwrap()
+            .iter()
+            .find(|instance| instance.id == source_id)
+            .unwrap()
+            .title,
+        "source"
+    );
+    assert_eq!(beta.load().unwrap().len(), 1);
+}
+
 /// Changing a session's profile via the rename dialog must prune the
 /// source profile's now-empty group, just like the restart-with-edits
 /// path does. Without the prune the source keeps an empty group with the

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -85,7 +85,7 @@ fn test_cli_add_duplicate_errors_and_preserves_original_command() {
     let stderr = String::from_utf8_lossy(&duplicate.stderr);
     assert!(
         stderr.contains("Session already exists with same title and path")
-            && stderr.contains("different --title"),
+            && stderr.contains("different title"),
         "duplicate error should identify the collision and offer remediation.\nstderr: {stderr}"
     );
 

--- a/web/src/components/session-wizard/__tests__/ProjectStep.recents-normalize.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.recents-normalize.test.tsx
@@ -2,7 +2,7 @@
 // `collectRecentProjects` (#1843). Two sessions on the same project that
 // differ only by a trailing `/` must collapse to a single Recent entry
 // with a summed session count, mirroring the backend's dedup convention
-// (`src/cli/add.rs` is_duplicate_session, `src/server/api/sessions.rs`
+// (`src/session/instance.rs` is_duplicate_session, `src/server/api/sessions.rs`
 // workspace_id_for_session, both `trim_end_matches('/')`).
 //
 // Sits next to ProjectStep.workspace.test.tsx (#1645) and

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -85,7 +85,7 @@ export function collectRecentProjects(sessions: SessionResponse[]): RecentProjec
     // workspace from one path, so keep them out of the list entirely.
     if (s.workspace_repos.length > 0) continue;
     // Normalize the trailing slash before keying, mirroring the backend's
-    // dedup convention (`src/cli/add.rs` is_duplicate_session and
+    // dedup convention (`src/session/instance.rs` is_duplicate_session and
     // `src/server/api/sessions.rs` workspace_id_for_session both
     // `trim_end_matches('/')`). Without this, `/foo/bar` and `/foo/bar/`
     // become two separate entries with split session counts. The `|| "/"`


### PR DESCRIPTION
## Description

Closes #3389.

Enforces profile-local uniqueness for `(title, project_path)` across `aoe add` and the CLI, REST, and TUI manual rename paths. Validation uses authoritative storage, excludes the row being renamed, normalizes trailing slashes, and checks a tied worktree's derived destination path before effects. An app-wide identity flock closes the cross-process validation-to-commit race.

The worktree guide now distinguishes cwd-stable title changes from directory or branch mutations and reports the partial-failure boundary precisely.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No layout change; the TUI uses its existing error dialog.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: server tests cover duplicate rejection and cache publication; the dashboard already surfaces PATCH failures.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: focused in-module tests invoke the real rename operations against isolated profile storage before any tmux effect.

## Dependencies

Merge #3457 first. This branch contains #3457 so it remains synchronized with `main`; #3425 depends on this PR.

## Validation

Head: `cc99ebf3`, based on `upstream/main` `91e33702`.

- `cargo test duplicate_session_normalizes_path_and_excludes_self -- --nocapture`: 1 passed
- Cumulative stack on #3427: `cargo test --features serve`, 6,645 passed and 8 ignored
- Cumulative stack on #3427: `cargo clippy --features serve --lib --bins -- -D warnings`
- `cargo fmt --check`

CI status was not checked in this update.

## Risks

Uniqueness remains profile-local. Imports and restore paths outside guarded add and rename flows are unchanged.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you'd like to share:** Implementation, validation, conflict resolution, and review assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
