### PR TITLE
fix(tmux): read Claude's folder-trust prompt as waiting, not idle

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -504,8 +504,15 @@ pub(crate) fn claude_pane_is_ambiguous_typed_prompt(raw_content: &str) -> bool {
 /// menu. Requiring both keeps an assistant-authored numbered list from being
 /// mistaken for a prompt. `recent_lower` is the lowercased join of `recent`.
 fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
+    // The folder-trust prompt phrases its question without either stock
+    // opener, so a first launch in a new directory read as Idle and never
+    // reached the waiting count. Only the question is matched: its option
+    // label ("yes, i trust this folder", which the Antigravity detector below
+    // does carry) sits on a numbered-choice line, so matching that instead
+    // would let one quoted line satisfy both halves of the guard.
     let has_question = recent_lower.contains("do you want to")
-        || recent_lower.contains("would you like to proceed");
+        || recent_lower.contains("would you like to proceed")
+        || recent_lower.contains("is this a project you created or one you trust");
     has_question
         && recent
             .iter()
@@ -2610,6 +2617,50 @@ enter to select · esc to cancel";
         // turn's live spinner, so the fresh idle must read as Running.
         let pane = "✶ Working… (4s · ↓ 88 tokens)\n  esc to interrupt";
         assert_eq!(reconcile_claude_idle_hook_status(pane), Status::Running);
+    }
+
+    /// Verbatim `tmux capture-pane -p` of a claude pane parked at the
+    /// folder-trust prompt, 2026-08-15. `aoe status` read `0 waiting` while
+    /// this was on screen.
+    const CLAUDE_FOLDER_TRUST_PROMPT: &str = "\
+ Accessing workspace:
+ /tmp/scratch/exp
+ Quick safety check: Is this a project you created or one you trust? (Like your
+ own code, a well-known open source project, or work from your team). If not,
+ take a moment to review what's in this folder first.
+ Claude Code'll be able to read, edit, and execute files here.
+ Security guide
+ \u{276f} 1. Yes, I trust this folder
+   2. No, exit
+";
+
+    /// The trust prompt's option label is menu text, so matching it as the
+    /// question would collapse the two-signal guard: an assistant quoting the
+    /// option while working renders both signals on one line.
+    const CLAUDE_ASSISTANT_QUOTING_THE_TRUST_OPTION: &str = "\
+ I found the folder-trust handling in src/tmux/status_detection.rs. The two
+ menu options Claude renders are:
+   1. Yes, I trust this folder
+   2. No, exit
+ The detector matches those against the numbered-choice helper.
+ \u{2726} Working... (12s \u{b7} \u{2193} 431 tokens)
+   esc to interrupt
+";
+
+    #[test]
+    fn claude_assistant_quoting_the_trust_option_is_not_waiting() {
+        assert_eq!(
+            detect_claude_status(CLAUDE_ASSISTANT_QUOTING_THE_TRUST_OPTION),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn claude_folder_trust_prompt_is_waiting() {
+        assert_eq!(
+            detect_claude_status(CLAUDE_FOLDER_TRUST_PROMPT),
+            Status::Waiting
+        );
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -497,11 +497,13 @@ pub(crate) fn claude_pane_is_ambiguous_typed_prompt(raw_content: &str) -> bool {
     })
 }
 
-/// Claude renders a blocking approval prompt when a tool needs the user's
-/// permission (Bash command, file edit, plan exit, ...). Every variant pairs
-/// a yes/no question ("Do you want to proceed?", "Do you want to make this
-/// edit to <file>?", "Would you like to proceed?") with a numbered choice
-/// menu. Requiring both keeps an assistant-authored numbered list from being
+/// Claude renders a blocking numbered-choice prompt when it needs an answer
+/// before it can continue: a tool asking permission (Bash command, file edit,
+/// plan exit, ...), and the first-run folder-trust check, which is not a tool
+/// permission at all. Every variant pairs a question ("Do you want to
+/// proceed?", "Do you want to make this edit to <file>?", "Would you like to
+/// proceed?", "Is this a project you created or one you trust?") with a
+/// numbered choice menu. Requiring both keeps an assistant-authored numbered list from being
 /// mistaken for a prompt. `recent_lower` is the lowercased join of `recent`.
 fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
     // The folder-trust prompt phrases its question without either stock
@@ -512,7 +514,16 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
     // would let one quoted line satisfy both halves of the guard.
     let has_question = recent_lower.contains("do you want to")
         || recent_lower.contains("would you like to proceed")
-        || recent_lower.contains("is this a project you created or one you trust");
+        // Collapsed, unlike the two arms above: this phrase is 46 characters of
+        // prose, so Claude word-wraps it in a narrow pane and `recent_lower` is
+        // a newline join, which breaks a plain `contains`. AoE produces that
+        // width band itself (a side-by-side preview is roughly viewport minus
+        // `list_width` + 2, so a viewport between `STACKED_BREAKPOINT` and
+        // ~106 lands in it). `||` short-circuits, so the allocation is only
+        // paid once the two cheap arms have missed. Same reason
+        // `claude_pane_has_running_signal` collapses its footer hints.
+        || collapse_ascii_whitespace(recent_lower)
+            .contains("is this a project you created or one you trust");
     has_question
         && recent
             .iter()
@@ -2643,15 +2654,52 @@ enter to select · esc to cancel";
    1. Yes, I trust this folder
    2. No, exit
  The detector matches those against the numbered-choice helper.
- \u{2726} Working... (12s \u{b7} \u{2193} 431 tokens)
+ \u{2736} Working\u{2026} (12s \u{b7} \u{2193} 431 tokens)
    esc to interrupt
 ";
 
     #[test]
     fn claude_assistant_quoting_the_trust_option_is_not_waiting() {
+        // Pinned, not implied: the fixture rendered its spinner with ASCII
+        // dots, which `claude_line_is_active_spinner` does not match, so the
+        // `Running` below came from the interrupt hint alone and the fixture
+        // did not model the working session its name claims. Raised by njbrake
+        // in review.
+        assert!(
+            CLAUDE_ASSISTANT_QUOTING_THE_TRUST_OPTION
+                .lines()
+                .any(claude_line_is_active_spinner),
+            "fixture must carry a live spinner",
+        );
         assert_eq!(
             detect_claude_status(CLAUDE_ASSISTANT_QUOTING_THE_TRUST_OPTION),
             Status::Running
+        );
+    }
+
+    /// The same prompt as Claude wraps it once the pane is too narrow to hold
+    /// the question on one line. `recent_lower` is a newline join, so the
+    /// unwrapped `contains` misses here and the pane read `Idle` again - the
+    /// bug this whole change exists to fix, in the width band AoE's own
+    /// side-by-side preview produces. Raised by njbrake in review.
+    const CLAUDE_FOLDER_TRUST_PROMPT_WRAPPED: &str = "\
+ Accessing workspace:
+ /tmp/scratch/exp
+ Quick safety check: Is this a project you created or one you
+ trust? (Like your own code, a well-known open source project,
+ or work from your team). If not, take a moment to review what's
+ in this folder first.
+ Claude Code'll be able to read, edit, and execute files here.
+ Security guide
+ \u{276f} 1. Yes, I trust this folder
+   2. No, exit
+";
+
+    #[test]
+    fn claude_folder_trust_prompt_wrapped_is_waiting() {
+        assert_eq!(
+            detect_claude_status(CLAUDE_FOLDER_TRUST_PROMPT_WRAPPED),
+            Status::Waiting
         );
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -573,7 +573,7 @@ fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool
 
 /// How many lines a wrapped option label may occupy. It is 24 characters, and
 /// every viewport `responsive.rs` documents (~26 and up, so a 22-column
-/// stacked pane) wraps it onto two. Four is slack, not a measured bound — where
+/// stacked pane) wraps it onto two. Four is slack, not a measured bound; where
 /// exactly it fails depends on a wrap model this file has no evidence for, and
 /// the 30-non-empty-line window drops the question phrase before the label
 /// budget binds anyway. Kept at four because the cost of slack is a wider
@@ -609,7 +609,7 @@ const CLAUDE_TRUST_LABEL_WRAP_LINES: usize = 4;
 ///   on screen still matches.
 ///
 /// All need the question phrase in the same window. Narrowing further wants a
-/// position anchor, not another substring rule — three substring attempts in
+/// position anchor, not another substring rule; three substring attempts in
 /// this series have each been falsified by the next reader.
 fn claude_has_trust_option_label(recent: &[&str]) -> bool {
     recent.iter().enumerate().any(|(start, line)| {
@@ -2908,7 +2908,7 @@ enter to select · esc to cancel";
 
     /// A `cat -n` / `nl` echo of this file's own fixture. It is rejected by the
     /// option-text requirement, not by anything that recognises the `  2812 `
-    /// prefix — the anchor row the block opens on is ` 1. an unrelated list
+    /// prefix; the anchor row the block opens on is ` 1. an unrelated list
     /// item`, whose text does not start with the label.
     ///
     /// The `>` blockquote and `grep -n` (`N:content`, no space) cases live in

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -550,7 +550,8 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
 /// question never carries. Both are matched on the collapsed join rather than
 /// on a single line: the menu row wraps too (`1. Yes, I trust this folder`
 /// with its cursor is 30 columns, so the stacked preview loses it below a
-/// viewport of 34 and `responsive.rs` documents viewports down to ~26), and
+/// viewport of 34 on the stacked path, or 37 with the sidebar collapsed, and
+/// `responsive.rs` documents viewports down to ~26), and
 /// anchoring the label to one line reintroduces the same wrap miss the
 /// collapse exists to fix. The cheap numbered-choice line scan gates the
 /// allocation.
@@ -560,15 +561,51 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
 /// together, reads Waiting. `"do you want to"` has the same exposure on
 /// `main`; scoping the signals to one prompt block is a separate change.
 fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool {
-    if !recent
-        .iter()
-        .any(|line| claude_line_is_numbered_choice(line))
-    {
-        return false;
-    }
-    let collapsed = collapse_ascii_whitespace(recent_lower);
-    collapsed.contains("is this a project you created or one you trust")
-        && collapsed.contains("yes, i trust this folder")
+    claude_has_trust_option_label(recent)
+        && collapse_ascii_whitespace(recent_lower)
+            .contains("is this a project you created or one you trust")
+}
+
+/// How many lines a wrapped option label may occupy. Its longest word is six
+/// characters, so even the ~16-column pane at the bottom of `responsive.rs`'s
+/// documented range needs no more than this.
+const CLAUDE_TRUST_LABEL_WRAP_LINES: usize = 4;
+
+/// The trust prompt's option label, matched over the choice row *and its
+/// wrapped continuations* rather than a single line or the whole window.
+///
+/// Both extremes fail. A single-line match loses the label as soon as the pane
+/// is narrow enough to wrap it, which is the band this whole change is about.
+/// Collapsing the entire window instead finds the label anywhere, including in
+/// ordinary prose, and that costs the anti-echo property the rest of this file
+/// relies on: a pane merely *describing* the prompt would satisfy it, and since
+/// a blocking rule outranks the running signal, an actively generating turn
+/// would report Waiting. Measured, when the match was window-wide: a pane with
+/// a live spinner, a live token counter and `esc to interrupt` flipped
+/// Running -> Waiting on prose alone, and a second one spliced the label out of
+/// two unrelated lines.
+///
+/// Anchoring to the block that starts at a numbered-choice line keeps the
+/// wrap tolerance and restores the anchor: prose that mentions the label
+/// without rendering it as a menu row never enters the haystack.
+///
+/// Residual, and deliberately not closed: prose that puts the label within
+/// `CLAUDE_TRUST_LABEL_WRAP_LINES` lines *after* a numbered-choice line still
+/// matches. That shape is a rendered menu row by any structural reading, so
+/// there is nothing left to distinguish it here.
+fn claude_has_trust_option_label(recent: &[&str]) -> bool {
+    recent.iter().enumerate().any(|(start, line)| {
+        if !claude_line_is_numbered_choice(line) {
+            return false;
+        }
+        let next_choice = recent[start + 1..]
+            .iter()
+            .position(|l| claude_line_is_numbered_choice(l))
+            .map_or(recent.len(), |offset| start + 1 + offset);
+        let end = next_choice.min(start + CLAUDE_TRUST_LABEL_WRAP_LINES);
+        collapse_ascii_whitespace(&recent[start..end].join("\n").to_lowercase())
+            .contains("yes, i trust this folder")
+    })
 }
 
 /// Claude's `AskUserQuestion` tool renders an interactive selection UI: an
@@ -2776,9 +2813,12 @@ enter to select · esc to cancel";
         assert_eq!(detect_claude_status(while_generating), Status::Running);
     }
 
-    /// The prompt on a 22-column pane (the stacked preview at the ~26-column
-    /// viewport `responsive.rs` documents): the option label wraps too, so a
-    /// label match anchored to the numbered-choice line misses it.
+    /// The prompt on an 18-column pane, i.e. the stacked preview at a
+    /// 22-column viewport (`responsive.rs` documents viewports down to ~26,
+    /// so this is below the documented floor and deliberately so). The option
+    /// label wraps too, which a label match anchored to a single
+    /// numbered-choice line misses. Abridged, not verbatim: the trailing prose
+    /// and the `Security guide` row are dropped to keep the fixture short.
     const CLAUDE_FOLDER_TRUST_PROMPT_NARROW: &str = "\
  Quick safety
  check: Is this a
@@ -2799,6 +2839,52 @@ enter to select · esc to cancel";
             detect_claude_status(CLAUDE_FOLDER_TRUST_PROMPT_NARROW),
             Status::Waiting
         );
+    }
+
+    /// The label match is anchored to the choice block, not the whole window.
+    /// Window-wide collapsing found the label in ordinary prose, and because a
+    /// blocking rule outranks the running signal these all reported `Waiting`
+    /// on an actively generating turn.
+    #[test]
+    fn claude_trust_label_in_prose_is_not_a_prompt() {
+        let label_in_prose = "\
+\u{25cf} The prompt asks: Is this a project you created or one you trust?
+ The highlighted option reads Yes, I trust this folder.
+ 1. the first arm
+ 2. the second arm
+ \u{2736} Working\u{2026} (12s \u{b7} \u{2193} 431 tokens)
+   esc to interrupt
+";
+        assert_eq!(detect_claude_status(label_in_prose), Status::Running);
+
+        let label_spliced_from_two_lines = "\
+ \u{25cf} the answer the user gives is Yes,
+ I trust this folder more than the upstream mirror. Is this a project
+ you created or one you trust? was the wording.
+ 1. unrelated
+ \u{2736} Working\u{2026} (3s)
+   esc to interrupt
+";
+        assert_eq!(
+            detect_claude_status(label_spliced_from_two_lines),
+            Status::Running
+        );
+    }
+
+    /// Echoed content carries a prefix (`+`, `\u{23bf}`, `>`, line numbers), so
+    /// it fails `claude_line_is_numbered_choice` and never opens a block. A
+    /// window-wide collapse threw that away; this pins it.
+    #[test]
+    fn claude_echoed_trust_fixture_is_not_a_prompt() {
+        let echoed = "\
+  2812 \u{276f} 1. Yes, I trust this folder
+  2813   2. No, exit
+\u{25cf} That is the fixture. Is this a project you created or one you trust?
+ 1. an unrelated list item
+ \u{2736} Working\u{2026} (4s)
+   esc to interrupt
+";
+        assert_eq!(detect_claude_status(echoed), Status::Running);
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -497,13 +497,14 @@ pub(crate) fn claude_pane_is_ambiguous_typed_prompt(raw_content: &str) -> bool {
     })
 }
 
-/// Claude renders a blocking numbered-choice prompt when it needs an answer
-/// before it can continue: a tool asking permission (Bash command, file edit,
-/// plan exit, ...), and the first-run folder-trust check, which is not a tool
-/// permission at all. Every variant pairs a question ("Do you want to
-/// proceed?", "Do you want to make this edit to <file>?", "Would you like to
-/// proceed?", "Is this a project you created or one you trust?") with a
-/// numbered choice menu. Requiring both keeps an assistant-authored numbered list from being
+/// The blocking prompts this rule covers: a tool asking permission (Bash
+/// command, file edit, plan exit, ...), and the first-run folder-trust check,
+/// which is not a tool permission at all. Each of those pairs a question
+/// ("Do you want to proceed?", "Do you want to make this edit to <file>?",
+/// "Would you like to proceed?", "Is this a project you created or one you
+/// trust?") with a numbered choice menu. It does NOT cover every prompt Claude
+/// blocks on: `AskUserQuestion` carries none of these phrasings and has its
+/// own detector below. Requiring both keeps an assistant-authored numbered list from being
 /// mistaken for a prompt. `recent_lower` is the lowercased join of `recent`.
 fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
     // The folder-trust prompt phrases its question without either stock
@@ -514,20 +515,46 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
     // would let one quoted line satisfy both halves of the guard.
     let has_question = recent_lower.contains("do you want to")
         || recent_lower.contains("would you like to proceed")
-        // Collapsed, unlike the two arms above: this phrase is 46 characters of
-        // prose, so Claude word-wraps it in a narrow pane and `recent_lower` is
-        // a newline join, which breaks a plain `contains`. AoE produces that
-        // width band itself (a side-by-side preview is roughly viewport minus
-        // `list_width` + 2, so a viewport between `STACKED_BREAKPOINT` and
-        // ~106 lands in it). `||` short-circuits, so the allocation is only
-        // paid once the two cheap arms have missed. Same reason
-        // `claude_pane_has_running_signal` collapses its footer hints.
-        || collapse_ascii_whitespace(recent_lower)
-            .contains("is this a project you created or one you trust");
+        || claude_has_folder_trust_question(recent, recent_lower);
     has_question
         && recent
             .iter()
             .any(|line| claude_line_is_numbered_choice(line))
+}
+
+/// The folder-trust question, including when Claude has word-wrapped it.
+///
+/// It is 46 characters of prose, so a narrow pane breaks it across lines and
+/// `recent_lower` is a newline join, which defeats a plain `contains`. AoE
+/// produces the affected widths itself: the side-by-side preview pane is
+/// `viewport - list_width - 4` (borders plus the block's horizontal padding),
+/// so with the default `list_width` of 35 the question only fits unwrapped
+/// from a viewport of about 107 up. Below `STACKED_BREAKPOINT` the stacked
+/// layout gives `viewport - 4`, which fits from 72 up, so the wrapped case
+/// covers viewports up to 71 as well as 80..=106 — the phone range in
+/// `responsive.rs` included.
+///
+/// Collapsing whitespace is how `claude_pane_has_running_signal` handles the
+/// same wrap problem, but its safety argument does NOT carry over and that is
+/// the trap here: its comment notes that false joins across unrelated lines
+/// "only bias toward Running, the safe direction". This match biases toward
+/// Waiting, which outranks Running, so a collapsed-only match would let an
+/// actively generating turn that merely renders this question across a line
+/// break report Waiting. Measured, before the option-label requirement below
+/// was added: a pane with a live spinner, a live token counter and
+/// `esc to interrupt` flipped Running -> Waiting.
+///
+/// So the collapsed form is paired with the prompt's own option label on a
+/// numbered-choice line. Prose that quotes the question does not also render
+/// the menu row, and the label alone cannot stand in for the question, so both
+/// halves still need distinct content on distinct lines. The label check runs
+/// first because it is a cheap line scan; the collapse only allocates once a
+/// real menu row is already on screen.
+fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool {
+    recent.iter().any(|line| {
+        claude_line_is_numbered_choice(line) && line.to_lowercase().contains("trust this folder")
+    }) && collapse_ascii_whitespace(recent_lower)
+        .contains("is this a project you created or one you trust")
 }
 
 /// Claude's `AskUserQuestion` tool renders an interactive selection UI: an
@@ -2660,16 +2687,22 @@ enter to select · esc to cancel";
 
     #[test]
     fn claude_assistant_quoting_the_trust_option_is_not_waiting() {
-        // Pinned, not implied: the fixture rendered its spinner with ASCII
-        // dots, which `claude_line_is_active_spinner` does not match, so the
-        // `Running` below came from the interrupt hint alone and the fixture
-        // did not model the working session its name claims. Raised by njbrake
-        // in review.
+        // Pinned, not implied. The fixture's spinner line failed to match for
+        // TWO independent reasons: it used ASCII dots rather than U+2026, and
+        // its frame char was U+2726, which is not in `CLAUDE_SPINNER_CHARS`.
+        // Both are fixed above. `Running` still did not rest on the interrupt
+        // hint alone - the live token counter is a second signal - so both are
+        // asserted here rather than left to the verdict. Raised by njbrake in
+        // review.
         assert!(
             CLAUDE_ASSISTANT_QUOTING_THE_TRUST_OPTION
                 .lines()
                 .any(claude_line_is_active_spinner),
             "fixture must carry a live spinner",
+        );
+        assert!(
+            has_claude_live_token_counter(CLAUDE_ASSISTANT_QUOTING_THE_TRUST_OPTION),
+            "fixture must carry a live token counter",
         );
         assert_eq!(
             detect_claude_status(CLAUDE_ASSISTANT_QUOTING_THE_TRUST_OPTION),
@@ -2694,6 +2727,40 @@ enter to select · esc to cancel";
  \u{276f} 1. Yes, I trust this folder
    2. No, exit
 ";
+
+    /// The collapsed match joins across newlines, and unlike
+    /// `claude_pane_has_running_signal`'s collapse it biases toward Waiting,
+    /// which outranks Running. Without the option-label requirement these all
+    /// read `Waiting`; the last one is an actively generating turn.
+    #[test]
+    fn claude_wrapped_trust_question_in_prose_is_not_a_prompt() {
+        let quoted_across_a_break = "\
+\u{25cf} The detector asks: Is this a project you created or
+ one you trust? That phrase is the third arm.
+ 1. the first arm
+ 2. the second arm
+";
+        assert_eq!(detect_claude_status(quoted_across_a_break), Status::Idle);
+
+        let unrelated_lines_that_join = "\
+ Q: what is this
+ a project you created or one you trust is one you can vouch for.
+ 1. yes
+";
+        assert_eq!(
+            detect_claude_status(unrelated_lines_that_join),
+            Status::Idle
+        );
+
+        let while_generating = "\
+\u{25cf} The detector asks: Is this a project you created or
+ one you trust? That phrase is the third arm.
+ 1. the first arm
+ \u{2736} Working\u{2026} (12s \u{b7} \u{2193} 431 tokens)
+   esc to interrupt
+";
+        assert_eq!(detect_claude_status(while_generating), Status::Running);
+    }
 
     #[test]
     fn claude_folder_trust_prompt_wrapped_is_waiting() {

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -567,33 +567,35 @@ fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool
 }
 
 /// How many lines a wrapped option label may occupy. It is 24 characters, and
-/// the narrowest layout `responsive.rs` documents (a ~26 viewport, so a
-/// 22-column stacked pane) wraps it onto two; four leaves room down to a
-/// 10-column pane, below which the label is lost.
+/// every viewport `responsive.rs` documents (~26 and up, so a 22-column
+/// stacked pane) wraps it onto two. Four is slack beyond that, not a measured
+/// bound: it holds down to an 11-column pane and loses the label at 10, both
+/// of which need viewports below the documented floor. Kept at four because
+/// the cost of slack here is a wider splice window, which requirement 2 above
+/// already bounds.
 const CLAUDE_TRUST_LABEL_WRAP_LINES: usize = 4;
 
 /// The trust prompt's option label, matched over the choice row *and its
-/// wrapped continuations*, and required to be the option's own text.
+/// wrapped continuations*, and required to start the option's own text.
 ///
-/// Three things are load-bearing, each closing a false positive that was
-/// measured on a pane carrying a live spinner, a live token counter and
-/// `esc to interrupt`, i.e. an actively generating turn reported as blocked:
+/// Two requirements, each closing a false positive measured on a pane carrying
+/// a live spinner, a live token counter and `esc to interrupt` — an actively
+/// generating turn reported as blocked on the user:
 ///
-/// 1. The block is anchored to a choice row. Collapsing the whole window
-///    instead finds the label in ordinary prose.
-/// 2. The row must carry no echo prefix. `claude_line_is_numbered_choice`
-///    strips a leading `>`, so a markdown blockquote quoting this prompt opened
-///    a block; line-number prefixes from `grep -n` output did the same when
-///    they fell inside a block another row had opened.
-/// 3. The label must START the option text. Without that, a numbered *prose*
-///    list whose item happens to be followed by the label two lines down
-///    matches - "1. read the prompt, which asks ..." then "the highlighted
-///    option is Yes, I trust this folder" - which is not a menu row by any
-///    reading.
+/// 1. The row must be a choice row with no `>` ahead of the number.
+///    Collapsing the whole window instead found the label in ordinary prose,
+///    and `claude_line_is_numbered_choice` tolerates a leading `>`, so a
+///    markdown blockquote quoting this prompt opened a block.
+/// 2. The label must START the option text. Without it, a numbered *prose*
+///    list matches when the label merely appears a line or two below the item.
 ///
-/// What remains reachable: prose that renders a genuine-looking menu row whose
-/// option text begins with the label. That is a rendered menu row, and nothing
-/// structural separates it from one.
+/// What remains reachable, stated as measured rather than as a shape argument:
+/// `starts_with` admits anything after the label, so `1. Yes, I trust this
+/// folder is what you pick at the first-run check` matches; and the four-line
+/// block still lets the label be spliced across a row and its follower. Both
+/// need the question phrase in the same window. Narrowing further wants a
+/// position anchor, not another substring rule — three attempts at substring
+/// rules in this series have each been falsified.
 fn claude_has_trust_option_label(recent: &[&str]) -> bool {
     recent.iter().enumerate().any(|(start, line)| {
         let Some(option) = claude_trust_choice_option_text(line) else {
@@ -604,13 +606,8 @@ fn claude_has_trust_option_label(recent: &[&str]) -> bool {
             .position(|l| claude_line_is_numbered_choice(l))
             .map_or(recent.len(), |offset| start + 1 + offset);
         let end = next_choice.min(start + CLAUDE_TRUST_LABEL_WRAP_LINES);
-        let continuations: Vec<&str> = recent[start + 1..end]
-            .iter()
-            .copied()
-            .filter(|l| claude_line_is_unechoed(l))
-            .collect();
         let joined = std::iter::once(option)
-            .chain(continuations)
+            .chain(recent[start + 1..end].iter().copied())
             .collect::<Vec<_>>()
             .join(" ")
             .to_lowercase();
@@ -629,17 +626,6 @@ fn claude_trust_choice_option_text(line: &str) -> Option<&str> {
         return None;
     }
     Some(chars.as_str().trim_start())
-}
-
-/// A line that is pane content rather than content echoed inside it. Echoed
-/// rows carry a prefix: a `grep -n` line number, a diff `+`, a tool-result
-/// `⎿`, or a blockquote `>`.
-fn claude_line_is_unechoed(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    !trimmed.starts_with(['+', '⎿', '>'])
-        && !trimmed
-            .split_once(char::is_whitespace)
-            .is_some_and(|(head, _)| !head.is_empty() && head.chars().all(|c| c.is_ascii_digit()))
 }
 
 /// Claude's `AskUserQuestion` tool renders an interactive selection UI: an
@@ -2935,6 +2921,8 @@ enter to select · esc to cancel";
 ";
         assert_eq!(detect_claude_status(blockquote), Status::Running);
 
+        // Defended by requirement 2, not by any echo filter: the anchor row is
+        // ` 1. an unrelated list item`, whose option text fails `starts_with`.
         let echoed_after_a_list = "\
 \u{25cf} That is the fixture. Is this a project you created or one you trust?
  1. an unrelated list item

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -509,10 +509,11 @@ pub(crate) fn claude_pane_is_ambiguous_typed_prompt(raw_content: &str) -> bool {
 fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
     // The folder-trust prompt phrases its question without either stock
     // opener, so a first launch in a new directory read as Idle and never
-    // reached the waiting count. Only the question is matched: its option
+    // reached the waiting count. Its arm needs the question AND the option
     // label ("yes, i trust this folder", which the Antigravity detector below
-    // does carry) sits on a numbered-choice line, so matching that instead
-    // would let one quoted line satisfy both halves of the guard.
+    // also carries): the label alone sits on a numbered-choice line, so
+    // matching it on its own would let one quoted line satisfy both halves of
+    // the guard.
     let has_question = recent_lower.contains("do you want to")
         || recent_lower.contains("would you like to proceed")
         || claude_has_folder_trust_question(recent, recent_lower);
@@ -531,7 +532,7 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
 /// so with the default `list_width` of 35 the question only fits unwrapped
 /// from a viewport of about 107 up. Below `STACKED_BREAKPOINT` the stacked
 /// layout gives `viewport - 4`, which fits from 72 up, so the wrapped case
-/// covers viewports up to 71 as well as 80..=106 — the phone range in
+/// covers viewports up to 71 as well as 80..=106, the phone range in
 /// `responsive.rs` included.
 ///
 /// Collapsing whitespace is how `claude_pane_has_running_signal` handles the
@@ -544,17 +545,30 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
 /// was added: a pane with a live spinner, a live token counter and
 /// `esc to interrupt` flipped Running -> Waiting.
 ///
-/// So the collapsed form is paired with the prompt's own option label on a
-/// numbered-choice line. Prose that quotes the question does not also render
-/// the menu row, and the label alone cannot stand in for the question, so both
-/// halves still need distinct content on distinct lines. The label check runs
-/// first because it is a cheap line scan; the collapse only allocates once a
-/// real menu row is already on screen.
+/// So the collapsed form is paired with the prompt's own option label, which
+/// the question alone never implies and which prose reproducing only the
+/// question never carries. Both are matched on the collapsed join rather than
+/// on a single line: the menu row wraps too (`1. Yes, I trust this folder`
+/// with its cursor is 30 columns, so the stacked preview loses it below a
+/// viewport of 34 and `responsive.rs` documents viewports down to ~26), and
+/// anchoring the label to one line reintroduces the same wrap miss the
+/// collapse exists to fix. The cheap numbered-choice line scan gates the
+/// allocation.
+///
+/// This is still the shared two-signal guard, so it inherits that guard's
+/// known limit: a turn that quotes the whole prompt, question and menu row
+/// together, reads Waiting. `"do you want to"` has the same exposure on
+/// `main`; scoping the signals to one prompt block is a separate change.
 fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool {
-    recent.iter().any(|line| {
-        claude_line_is_numbered_choice(line) && line.to_lowercase().contains("trust this folder")
-    }) && collapse_ascii_whitespace(recent_lower)
-        .contains("is this a project you created or one you trust")
+    if !recent
+        .iter()
+        .any(|line| claude_line_is_numbered_choice(line))
+    {
+        return false;
+    }
+    let collapsed = collapse_ascii_whitespace(recent_lower);
+    collapsed.contains("is this a project you created or one you trust")
+        && collapsed.contains("yes, i trust this folder")
 }
 
 /// Claude's `AskUserQuestion` tool renders an interactive selection UI: an
@@ -2760,6 +2774,31 @@ enter to select · esc to cancel";
    esc to interrupt
 ";
         assert_eq!(detect_claude_status(while_generating), Status::Running);
+    }
+
+    /// The prompt on a 22-column pane (the stacked preview at the ~26-column
+    /// viewport `responsive.rs` documents): the option label wraps too, so a
+    /// label match anchored to the numbered-choice line misses it.
+    const CLAUDE_FOLDER_TRUST_PROMPT_NARROW: &str = "\
+ Quick safety
+ check: Is this a
+ project you
+ created or one
+ you trust? (Like
+ your own code, a
+ well-known open
+ source project.)
+ \u{276f} 1. Yes, I trust
+   this folder
+   2. No, exit
+";
+
+    #[test]
+    fn claude_folder_trust_prompt_narrow_is_waiting() {
+        assert_eq!(
+            detect_claude_status(CLAUDE_FOLDER_TRUST_PROMPT_NARROW),
+            Status::Waiting
+        );
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -566,46 +566,80 @@ fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool
             .contains("is this a project you created or one you trust")
 }
 
-/// How many lines a wrapped option label may occupy. Its longest word is six
-/// characters, so even the ~16-column pane at the bottom of `responsive.rs`'s
-/// documented range needs no more than this.
+/// How many lines a wrapped option label may occupy. It is 24 characters, and
+/// the narrowest layout `responsive.rs` documents (a ~26 viewport, so a
+/// 22-column stacked pane) wraps it onto two; four leaves room down to a
+/// 10-column pane, below which the label is lost.
 const CLAUDE_TRUST_LABEL_WRAP_LINES: usize = 4;
 
 /// The trust prompt's option label, matched over the choice row *and its
-/// wrapped continuations* rather than a single line or the whole window.
+/// wrapped continuations*, and required to be the option's own text.
 ///
-/// Both extremes fail. A single-line match loses the label as soon as the pane
-/// is narrow enough to wrap it, which is the band this whole change is about.
-/// Collapsing the entire window instead finds the label anywhere, including in
-/// ordinary prose, and that costs the anti-echo property the rest of this file
-/// relies on: a pane merely *describing* the prompt would satisfy it, and since
-/// a blocking rule outranks the running signal, an actively generating turn
-/// would report Waiting. Measured, when the match was window-wide: a pane with
-/// a live spinner, a live token counter and `esc to interrupt` flipped
-/// Running -> Waiting on prose alone, and a second one spliced the label out of
-/// two unrelated lines.
+/// Three things are load-bearing, each closing a false positive that was
+/// measured on a pane carrying a live spinner, a live token counter and
+/// `esc to interrupt`, i.e. an actively generating turn reported as blocked:
 ///
-/// Anchoring to the block that starts at a numbered-choice line keeps the
-/// wrap tolerance and restores the anchor: prose that mentions the label
-/// without rendering it as a menu row never enters the haystack.
+/// 1. The block is anchored to a choice row. Collapsing the whole window
+///    instead finds the label in ordinary prose.
+/// 2. The row must carry no echo prefix. `claude_line_is_numbered_choice`
+///    strips a leading `>`, so a markdown blockquote quoting this prompt opened
+///    a block; line-number prefixes from `grep -n` output did the same when
+///    they fell inside a block another row had opened.
+/// 3. The label must START the option text. Without that, a numbered *prose*
+///    list whose item happens to be followed by the label two lines down
+///    matches - "1. read the prompt, which asks ..." then "the highlighted
+///    option is Yes, I trust this folder" - which is not a menu row by any
+///    reading.
 ///
-/// Residual, and deliberately not closed: prose that puts the label within
-/// `CLAUDE_TRUST_LABEL_WRAP_LINES` lines *after* a numbered-choice line still
-/// matches. That shape is a rendered menu row by any structural reading, so
-/// there is nothing left to distinguish it here.
+/// What remains reachable: prose that renders a genuine-looking menu row whose
+/// option text begins with the label. That is a rendered menu row, and nothing
+/// structural separates it from one.
 fn claude_has_trust_option_label(recent: &[&str]) -> bool {
     recent.iter().enumerate().any(|(start, line)| {
-        if !claude_line_is_numbered_choice(line) {
+        let Some(option) = claude_trust_choice_option_text(line) else {
             return false;
-        }
+        };
         let next_choice = recent[start + 1..]
             .iter()
             .position(|l| claude_line_is_numbered_choice(l))
             .map_or(recent.len(), |offset| start + 1 + offset);
         let end = next_choice.min(start + CLAUDE_TRUST_LABEL_WRAP_LINES);
-        collapse_ascii_whitespace(&recent[start..end].join("\n").to_lowercase())
-            .contains("yes, i trust this folder")
+        let continuations: Vec<&str> = recent[start + 1..end]
+            .iter()
+            .copied()
+            .filter(|l| claude_line_is_unechoed(l))
+            .collect();
+        let joined = std::iter::once(option)
+            .chain(continuations)
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase();
+        collapse_ascii_whitespace(&joined).starts_with("yes, i trust this folder")
     })
+}
+
+/// The option text of an unechoed numbered choice: `❯ 1. Yes` -> `Yes`.
+/// Only the `❯` cursor is tolerated ahead of the number. A `>` is not, because
+/// that is how a markdown blockquote and quoted terminal output render.
+fn claude_trust_choice_option_text(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix('❯').map_or(trimmed, str::trim_start);
+    let mut chars = rest.chars();
+    if !matches!(chars.next(), Some('1'..='9')) || !matches!(chars.next(), Some('.')) {
+        return None;
+    }
+    Some(chars.as_str().trim_start())
+}
+
+/// A line that is pane content rather than content echoed inside it. Echoed
+/// rows carry a prefix: a `grep -n` line number, a diff `+`, a tool-result
+/// `⎿`, or a blockquote `>`.
+fn claude_line_is_unechoed(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    !trimmed.starts_with(['+', '⎿', '>'])
+        && !trimmed
+            .split_once(char::is_whitespace)
+            .is_some_and(|(head, _)| !head.is_empty() && head.chars().all(|c| c.is_ascii_digit()))
 }
 
 /// Claude's `AskUserQuestion` tool renders an interactive selection UI: an
@@ -2885,6 +2919,41 @@ enter to select · esc to cancel";
    esc to interrupt
 ";
         assert_eq!(detect_claude_status(echoed), Status::Running);
+    }
+
+    /// The three shapes a whole-window or bare-line anchor let through, each
+    /// an actively generating turn that reported `Waiting`.
+    #[test]
+    fn claude_trust_label_outside_a_menu_row_is_not_a_prompt() {
+        let blockquote = "\
+\u{25cf} Here is what the docs show:
+> 1. Yes, I trust this folder
+> 2. No, exit
+\u{25cf} And the question was: Is this a project you created or one you trust?
+ \u{273b} Working\u{2026} (12s \u{b7} \u{2193} 431 tokens)
+   esc to interrupt
+";
+        assert_eq!(detect_claude_status(blockquote), Status::Running);
+
+        let echoed_after_a_list = "\
+\u{25cf} That is the fixture. Is this a project you created or one you trust?
+ 1. an unrelated list item
+  2812 \u{276f} 1. Yes, I trust this folder
+  2813   2. No, exit
+ \u{273b} Working\u{2026} (4s)
+   esc to interrupt
+";
+        assert_eq!(detect_claude_status(echoed_after_a_list), Status::Running);
+
+        let numbered_prose_plan = "\
+\u{25cf} The plan:
+ 1. read the prompt, which asks: Is this a project you created or one you trust?
+ the highlighted option is Yes, I trust this folder
+ and then we proceed.
+ \u{273b} Working\u{2026} (9s)
+   esc to interrupt
+";
+        assert_eq!(detect_claude_status(numbered_prose_plan), Status::Running);
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -568,11 +568,11 @@ fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool
 
 /// How many lines a wrapped option label may occupy. It is 24 characters, and
 /// every viewport `responsive.rs` documents (~26 and up, so a 22-column
-/// stacked pane) wraps it onto two. Four is slack beyond that, not a measured
-/// bound: it holds down to an 11-column pane and loses the label at 10, both
-/// of which need viewports below the documented floor. Kept at four because
-/// the cost of slack here is a wider splice window, which requirement 2 above
-/// already bounds.
+/// stacked pane) wraps it onto two. Four is slack, not a measured bound — where
+/// exactly it fails depends on a wrap model this file has no evidence for, and
+/// the 30-non-empty-line window drops the question phrase before the label
+/// budget binds anyway. Kept at four because the cost of slack is a wider
+/// splice window, which the option-text requirement already bounds.
 const CLAUDE_TRUST_LABEL_WRAP_LINES: usize = 4;
 
 /// The trust prompt's option label, matched over the choice row *and its
@@ -589,13 +589,21 @@ const CLAUDE_TRUST_LABEL_WRAP_LINES: usize = 4;
 /// 2. The label must START the option text. Without it, a numbered *prose*
 ///    list matches when the label merely appears a line or two below the item.
 ///
-/// What remains reachable, stated as measured rather than as a shape argument:
-/// `starts_with` admits anything after the label, so `1. Yes, I trust this
-/// folder is what you pick at the first-run check` matches; and the four-line
-/// block still lets the label be spliced across a row and its follower. Both
-/// need the question phrase in the same window. Narrowing further wants a
-/// position anchor, not another substring rule — three attempts at substring
-/// rules in this series have each been falsified.
+/// What remains reachable, each measured rather than argued:
+///
+/// - a verbatim menu row quoted in prose, or echoed by `cat`/`less`/a diff
+///   context line (one leading space, eaten by `trim_start`). This is the
+///   broadest class and needs no trailing prose and no splice.
+/// - `starts_with` admits anything after the label, so `1. Yes, I trust this
+///   folder is what you pick at the first-run check` matches.
+/// - a splice across the whole four-line block, not merely a row and its
+///   follower. Blank rows do not consume the budget: `with_claude_recent_pane`
+///   drops empty lines before the window, so a splice separated by blank lines
+///   on screen still matches.
+///
+/// All need the question phrase in the same window. Narrowing further wants a
+/// position anchor, not another substring rule — three substring attempts in
+/// this series have each been falsified by the next reader.
 fn claude_has_trust_option_label(recent: &[&str]) -> bool {
     recent.iter().enumerate().any(|(start, line)| {
         let Some(option) = claude_trust_choice_option_text(line) else {
@@ -2891,9 +2899,12 @@ enter to select · esc to cancel";
         );
     }
 
-    /// Echoed content carries a prefix (`+`, `\u{23bf}`, `>`, line numbers), so
-    /// it fails `claude_line_is_numbered_choice` and never opens a block. A
-    /// window-wide collapse threw that away; this pins it.
+    /// Echoed rows are rejected by the anchor, but not uniformly, and the `>`
+    /// case is the one worth knowing: `claude_line_is_numbered_choice` STRIPS a
+    /// leading `>`, so a blockquote row is a valid numbered choice to it. What
+    /// rejects the blockquote here is `claude_trust_choice_option_text`, which
+    /// tolerates only `❯`. A `grep -n` prefix (`N:content`, no space) is not
+    /// rejected as an echo at all; that pane fails on the option text instead.
     #[test]
     fn claude_echoed_trust_fixture_is_not_a_prompt() {
         let echoed = "\

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -560,6 +560,11 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
 /// known limit: a turn that quotes the whole prompt, question and menu row
 /// together, reads Waiting. `"do you want to"` has the same exposure on
 /// `main`; scoping the signals to one prompt block is a separate change.
+/// Note for anyone hardening the shared guard later: for THIS arm the trailing
+/// `any(claude_line_is_numbered_choice)` in `claude_has_approval_prompt` is
+/// already implied, because `claude_trust_choice_option_text` succeeding is
+/// strictly stronger than that predicate. The trust path is one anchored
+/// signal plus one substring, not two independent ones.
 fn claude_has_folder_trust_question(recent: &[&str], recent_lower: &str) -> bool {
     claude_has_trust_option_label(recent)
         && collapse_ascii_whitespace(recent_lower)
@@ -578,9 +583,11 @@ const CLAUDE_TRUST_LABEL_WRAP_LINES: usize = 4;
 /// The trust prompt's option label, matched over the choice row *and its
 /// wrapped continuations*, and required to start the option's own text.
 ///
-/// Two requirements, each closing a false positive measured on a pane carrying
-/// a live spinner, a live token counter and `esc to interrupt` — an actively
-/// generating turn reported as blocked on the user:
+/// Two requirements, each closing a false positive measured on an actively
+/// generating pane. The requirement-1 fixture carries a live spinner, a live
+/// token counter and `esc to interrupt`; the requirement-2 fixtures carry a
+/// live spinner alone, which is enough, since a blocking rule outranks every
+/// running signal:
 ///
 /// 1. The row must be a choice row with no `>` ahead of the number.
 ///    Collapsing the whole window instead found the label in ordinary prose,
@@ -2899,12 +2906,17 @@ enter to select · esc to cancel";
         );
     }
 
-    /// Echoed rows are rejected by the anchor, but not uniformly, and the `>`
-    /// case is the one worth knowing: `claude_line_is_numbered_choice` STRIPS a
-    /// leading `>`, so a blockquote row is a valid numbered choice to it. What
-    /// rejects the blockquote here is `claude_trust_choice_option_text`, which
-    /// tolerates only `❯`. A `grep -n` prefix (`N:content`, no space) is not
-    /// rejected as an echo at all; that pane fails on the option text instead.
+    /// A `cat -n` / `nl` echo of this file's own fixture. It is rejected by the
+    /// option-text requirement, not by anything that recognises the `  2812 `
+    /// prefix — the anchor row the block opens on is ` 1. an unrelated list
+    /// item`, whose text does not start with the label.
+    ///
+    /// The `>` blockquote and `grep -n` (`N:content`, no space) cases live in
+    /// `claude_trust_label_outside_a_menu_row_is_not_a_prompt`. Worth knowing
+    /// which rejects what: `claude_line_is_numbered_choice` STRIPS a leading
+    /// `>`, so a blockquote row is a valid numbered choice to it, and only
+    /// `claude_trust_choice_option_text` (which tolerates just `❯`) turns it
+    /// away.
     #[test]
     fn claude_echoed_trust_fixture_is_not_a_prompt() {
         let echoed = "\


### PR DESCRIPTION
## Description

Claude's first-run folder-trust prompt read `Idle`, so a session parked on it
never reached the waiting count. `claude_has_approval_prompt` matched only the
two stock openers (`do you want to`, `would you like to proceed`), and the trust
prompt phrases its question without either.

**This has grown past its original one-line shape during review** — the
description below describes what the branch actually does now, not what it did
when it was opened.

### What it does

Two conjuncts, both required:

1. **The question**, matched on the whitespace-collapsed window. It is 46
   characters of prose, so Claude word-wraps it in a narrow pane and
   `recent_lower` is a newline join, which defeats a plain `contains`. AoE
   produces the affected widths itself: side-by-side preview is
   `viewport − list_width − 4`, so the question only fits unwrapped from a
   viewport of 107 up; stacked is `viewport − 4`, fitting from 72. The wrapped
   band is therefore `≤71` and `80..=106`.
2. **The option label**, matched over the choice row *and its wrapped
   continuations*, and required to start the option's own text. The row must
   carry no `>` — `claude_line_is_numbered_choice` strips one, so a markdown
   blockquote quoting this prompt would otherwise open a block.

The label conjunct is not decoration. Collapsing the window for the question
alone let ordinary prose match: a generating turn that renders the question
across a line break, with any numbered line on screen, reported `Waiting` with
a live spinner and `esc to interrupt` visible. That is the opposite of the bug
being fixed, and a blocking rule outranks every running signal, so it sticks.

### Known limit, stated rather than claimed away

A turn that reproduces a real menu row verbatim — quoting it, or echoing it via
`cat`/`less`/a diff context line — still reads `Waiting`. `starts_with` also
admits trailing prose after the label. Both need the question phrase in the
same window. Prefixed echoes (`grep -n`, diff `+`, `⎿`) are rejected, but by
the option-text requirement rather than by any echo filter.

Narrowing further wants a position anchor, not another substring rule. Three
substring attempts during this review were each falsified by the next reader,
which is why the limit is documented in the code rather than papered over.

### Not addressed here

CodeRabbit raised that the two halves of the shared guard are matched
independently anywhere in the window, so an assistant's numbered list plus
`do you want to` can read `Waiting`. That reproduces on `main` today through
the pre-existing arm, so it is out of scope here and filed separately.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed; the detector is
      internal and has no user-facing surface)
- [x] For UI changes: N/A

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: an e2e would need a real Claude parked at a
      first-run trust prompt, which the harness cannot reproduce. The eight unit
      tests this branch adds cover the prompt verbatim, re-wrapped at two
      widths, and five prose/echo shapes that must NOT match.

Three fixtures, honestly labelled: one verbatim `tmux capture-pane -p`, one
re-wrap of it, one abridged narrow variant.

```
$ cargo test --lib claude_folder_trust
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 4602 filtered out
```

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Every commit here after the first is a response to review — yours, CodeRabbit's,
or an adversarial pass run over the branch before offering it. That pass has
repeatedly found claims in this description and in the commit messages that did
not survive re-derivation; this description has been rewritten because the
previous version described a design the branch abandoned, and stated that the
option label was deliberately *not* matched while the code required it.

- [x] I am an AI Agent filling out this form (check box if true)
