### PR TITLE
fix(session): require a transcript on disk before emitting --resume

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2876,7 +2876,7 @@ mod tests {
     /// jsonl is older than the 5-minute live-capture window, so
     /// `capture_claude_session_id` falls past the dir scan, plus a
     /// `.claude.json` naming `last_session_id` for that directory. Returns the
-    /// project path and the encoded transcript dir.
+    /// encoded transcript dir.
     fn claude_json_fallback_home(
         temp: &tempfile::TempDir,
         project_path: &str,

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -154,7 +154,23 @@ pub(crate) fn capture_claude_session_id(
         let is_fresh = claude_json
             .and_then(|t| t.elapsed().ok())
             .is_some_and(|age| age <= Duration::from_secs(5 * 60));
-        if is_fresh && Uuid::parse_str(&id).is_ok() {
+        // `is_fresh` is the mtime of `.claude.json` itself, which any live
+        // Claude anywhere rewrites, so it says nothing about when *this*
+        // directory's `lastSessionId` was set and a value months old still
+        // reads as fresh. And unlike the dir scan above, which can only return
+        // ids it found as files, this slot can name a UUID no transcript was
+        // ever written for. Requiring the conversation to exist is what keeps
+        // `--resume` off an id Claude answers with "No conversation found",
+        // which leaves the pane dead on every restart from then on.
+        //
+        // The cost is the short window after `/clear` or `/new` where the slot
+        // names a thread Claude has not written to yet: the arm declines it,
+        // and the dir scan picks the new id up once content lands. Resuming it
+        // in that window would fail anyway.
+        if is_fresh
+            && Uuid::parse_str(&id).is_ok()
+            && !claude_host_transcript_confirmed_absent(&canonical.to_string_lossy(), &id, host_env)
+        {
             return Ok(id);
         }
     }
@@ -2855,6 +2871,120 @@ mod tests {
     use super::*;
     use crate::session::test_support::EnvGuard;
     use serial_test::serial;
+
+    /// Scaffold for the `.claude.json` fallback arm: a project dir whose only
+    /// jsonl is older than the 5-minute live-capture window, so
+    /// `capture_claude_session_id` falls past the dir scan, plus a
+    /// `.claude.json` naming `last_session_id` for that directory. Returns the
+    /// project path and the encoded transcript dir.
+    fn claude_json_fallback_home(
+        temp: &tempfile::TempDir,
+        project_path: &str,
+        stale_transcript: &str,
+        last_session_id: &str,
+    ) -> std::path::PathBuf {
+        let dir = temp
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join(encode_claude_project_path(
+                &canonicalize_or_raw(project_path).to_string_lossy(),
+            ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let jsonl = dir.join(format!("{stale_transcript}.jsonl"));
+        std::fs::write(&jsonl, "").unwrap();
+        let f = std::fs::File::options().write(true).open(&jsonl).unwrap();
+        f.set_times(
+            std::fs::FileTimes::new()
+                .set_modified(std::time::SystemTime::now() - Duration::from_secs(3600)),
+        )
+        .unwrap();
+
+        // Placed and keyed the way production reads it. `.claude.json` sits
+        // *inside* the config dir when `CLAUDE_CONFIG_DIR` selects it (#3410),
+        // which this fixture sets, and the `projects` key is canonicalized: on
+        // macOS `/tmp` is a symlink, so a raw key would miss and the reject
+        // case below would pass without ever reaching the gate.
+        std::fs::write(
+            temp.path().join(".claude").join(".claude.json"),
+            serde_json::json!({
+                "projects": {
+                    canonicalize_or_raw(project_path).to_string_lossy().to_string():
+                        { "lastSessionId": last_session_id }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        dir
+    }
+
+    fn claude_json_env(temp: &tempfile::TempDir) -> EnvGuard {
+        EnvGuard::set(&[
+            ("HOME", temp.path().to_path_buf()),
+            ("CLAUDE_CONFIG_DIR", temp.path().join(".claude")),
+        ])
+    }
+
+    /// `.claude.json`'s `lastSessionId` is one slot per *directory*, and the
+    /// freshness gate around it reads the mtime of `.claude.json` itself,
+    /// which any live Claude rewrites, so a months-old value still passes.
+    /// Handing that id out for `--resume` when no transcript backs it is a
+    /// guaranteed "No conversation found" and a dead pane on every restart.
+    #[test]
+    #[serial]
+    fn claude_json_fallback_rejects_sid_with_no_transcript() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_path = "/tmp/aoe-test-claude-json-phantom";
+        let _guard = claude_json_env(&temp);
+        claude_json_fallback_home(
+            &temp,
+            project_path,
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "11111111-2222-3333-4444-555555555555",
+        );
+
+        let err = capture_claude_session_id(project_path, None, &HashSet::new(), &[])
+            .expect_err("a lastSessionId with no transcript must not be captured");
+        assert!(
+            err.to_string().contains("No active Claude session found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Companion: the arm still works when the named conversation exists. Only
+    /// the phantom case is rejected, so a genuinely idle session in a
+    /// single-session directory is still recoverable through this path.
+    #[test]
+    #[serial]
+    fn claude_json_fallback_accepts_sid_with_transcript() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_path = "/tmp/aoe-test-claude-json-real";
+        let named = "11111111-2222-3333-4444-555555555555";
+        let _guard = claude_json_env(&temp);
+        let dir = claude_json_fallback_home(
+            &temp,
+            project_path,
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            named,
+        );
+        // Same stale mtime as the decoy, so the dir scan still falls through
+        // and this is reached via the `.claude.json` arm, not the scan.
+        let jsonl = dir.join(format!("{named}.jsonl"));
+        std::fs::write(&jsonl, "").unwrap();
+        let f = std::fs::File::options().write(true).open(&jsonl).unwrap();
+        f.set_times(
+            std::fs::FileTimes::new()
+                .set_modified(std::time::SystemTime::now() - Duration::from_secs(3600)),
+        )
+        .unwrap();
+
+        assert_eq!(
+            capture_claude_session_id(project_path, None, &HashSet::new(), &[]).unwrap(),
+            named
+        );
+    }
 
     /// Pin a modification time so mtime ordering in tests never depends on the
     /// host filesystem's timestamp resolution. Opened read-only, which lets the

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -122,6 +122,10 @@ pub(crate) fn encode_claude_project_path(project_path: &str) -> String {
 /// [`claude_home_for_host_environment`]).
 ///
 /// Used as a fallback when hooks don't fire (e.g. after `/clear` or `/new`).
+/// Both arms only ever yield an id with a transcript on disk: the dir scan by
+/// construction, and the `.claude.json` arm because it is gated on one. A
+/// freshly cleared thread is therefore declined until its first content lands,
+/// which is the one case this narrows.
 pub(crate) fn capture_claude_session_id(
     project_path: &str,
     known_session_id: Option<&str>,

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2876,6 +2876,10 @@ mod tests {
     use crate::session::test_support::EnvGuard;
     use serial_test::serial;
 
+    /// Well before the 5-minute live-capture window, in the same absolute-epoch
+    /// form the other mtime-ordering tests in this module pin.
+    const STALE_JSONL_MTIME: u64 = 1_700_000_000;
+
     /// Scaffold for the `.claude.json` fallback arm: a project dir whose only
     /// jsonl is older than the 5-minute live-capture window, so
     /// `capture_claude_session_id` falls past the dir scan, plus a
@@ -2898,12 +2902,7 @@ mod tests {
 
         let jsonl = dir.join(format!("{stale_transcript}.jsonl"));
         std::fs::write(&jsonl, "").unwrap();
-        let f = std::fs::File::options().write(true).open(&jsonl).unwrap();
-        f.set_times(
-            std::fs::FileTimes::new()
-                .set_modified(std::time::SystemTime::now() - Duration::from_secs(3600)),
-        )
-        .unwrap();
+        set_mtime_secs(&jsonl, STALE_JSONL_MTIME);
 
         // Placed and keyed the way production reads it. `.claude.json` sits
         // *inside* the config dir when `CLAUDE_CONFIG_DIR` selects it (#3410),
@@ -2977,12 +2976,7 @@ mod tests {
         // and this is reached via the `.claude.json` arm, not the scan.
         let jsonl = dir.join(format!("{named}.jsonl"));
         std::fs::write(&jsonl, "").unwrap();
-        let f = std::fs::File::options().write(true).open(&jsonl).unwrap();
-        f.set_times(
-            std::fs::FileTimes::new()
-                .set_modified(std::time::SystemTime::now() - Duration::from_secs(3600)),
-        )
-        .unwrap();
+        set_mtime_secs(&jsonl, STALE_JSONL_MTIME);
 
         assert_eq!(
             capture_claude_session_id(project_path, None, &HashSet::new(), &[]).unwrap(),

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2991,17 +2991,24 @@ impl Instance {
         }
 
         if let Some(stored) = self.agent_session_id.clone() {
-            if let Some(fresh) = self.capture_freshest_session_id() {
-                tracing::info!(
-                    target: "session.store",
-                    stale = %stored,
-                    fresh = %fresh,
-                    tool = %self.tool,
-                    "Replacing stored session id with fresher live observation"
-                );
-                self.agent_session_id = Some(fresh.clone());
-                return (Some(fresh), true);
-            }
+            // Rebinding rather than returning early runs the observation
+            // through the same empty-thread downgrade as the stored id below.
+            // The SessionStart hook fires before Claude writes any content, so
+            // the sidecar can legitimately name a thread with no transcript.
+            let stored = match self.capture_freshest_session_id() {
+                Some(fresh) => {
+                    tracing::info!(
+                        target: "session.store",
+                        stale = %stored,
+                        fresh = %fresh,
+                        tool = %self.tool,
+                        "Replacing stored session id with fresher live observation"
+                    );
+                    self.agent_session_id = Some(fresh.clone());
+                    fresh
+                }
+                None => stored,
+            };
             // A stored Claude sid with no transcript on disk is not resumable:
             // Claude minted the UUID at first launch but nothing was ever
             // written (an empty thread killed before the first prompt), so
@@ -13418,6 +13425,50 @@ mod tests {
                 assert_eq!(sid.as_deref(), Some(live));
                 assert!(is_existing);
                 assert_eq!(inst.agent_session_id.as_deref(), Some(live));
+            }
+
+            /// The empty-thread downgrade must cover an id that arrived as a
+            /// live observation, not just one loaded from storage: SessionStart
+            /// fires before Claude writes any content, so the sidecar can name
+            /// a thread with no transcript, and `--resume` on it is a dead pane
+            /// on every restart.
+            #[test]
+            #[serial]
+            fn observed_sid_without_transcript_downgrades_to_fresh() {
+                let temp = tempdir().unwrap();
+                let _guard = claude_home_guard(&temp);
+
+                let project_path = "/tmp/aoe-test-observed-no-transcript";
+                let claude_dir = temp
+                    .path()
+                    .join(".claude")
+                    .join("projects")
+                    .join(encode_claude_project_path(project_path));
+                fs::create_dir_all(&claude_dir).unwrap();
+
+                let stored = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+                let empty_thread = "11111111-2222-3333-4444-555555555555";
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{stored}.jsonl")),
+                    SystemTime::now() - Duration::from_secs(120),
+                );
+                // No .jsonl for `empty_thread`.
+
+                let mut inst = Instance::new("verify-observed-no-transcript", project_path);
+                inst.tool = "claude".to_string();
+                inst.agent_session_id = Some(stored.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let dir = super::write_sidecar(&inst.id, empty_thread);
+                let (sid, is_existing) = inst.acquire_session_id();
+                std::fs::remove_dir_all(&dir).ok();
+
+                assert_eq!(sid.as_deref(), Some(empty_thread));
+                assert!(
+                    !is_existing,
+                    "an observed sid with no transcript must launch as \
+                     --session-id, never --resume"
+                );
             }
 
             // An empty Claude thread killed before its first prompt has a


### PR DESCRIPTION

## Description

`claude --resume <sid>` fails with "No conversation found" when nothing was ever
written for `<sid>`, and the session lands in the "resume failed for sid ...;
preserved for explicit retry" state, so the pane is dead on every restart from
then on. Two paths on `main` can hand `acquire_session_id` exactly such an id.

**1. The `.claude.json` fallback arm** (`src/session/capture.rs`, in
`capture_claude_session_id`). `lastSessionId` is one slot per directory, and the
freshness gate around it reads the mtime of `.claude.json` itself, which any
live Claude anywhere rewrites. A months-dead id therefore passes the gate, and
every session rooted at that directory adopts it at once. Unlike the directory
scan above it, which can only return ids it found as files, this slot can name a
UUID no transcript was ever written for.

This gates the arm on the transcript being confirmed present, reusing the
existing `claude_host_transcript_confirmed_absent` (`capture.rs:148` on `main`).
Existence only, no mtime window, so an idle but real conversation still resumes.
The companion test asserts the arm still returns the id when the conversation
does exist.

What this costs, stated rather than left for review to find: the arm is
documented as the fallback for `/clear` and `/new`, and in the window where the
new thread has a `lastSessionId` but no jsonl yet, the arm now declines. The dir
scan picks the new id up as soon as content lands, and resuming it during that
window would have failed anyway, so the gap is short and self-healing.

**2. The observed-sid path** (`src/session/instance.rs`, in
`acquire_session_id_with`, not the `acquire_session_id` wrapper above it). The
empty-thread downgrade below it already covers a sid
loaded from storage, but a sid that arrived as a live observation returned early
and skipped it. The SessionStart hook fires before Claude writes any content, so
the sidecar can legitimately name a thread with no transcript. Rebinding rather
than returning early runs the observation through the same downgrade, and the
session launches with `--session-id <sid>` instead of `--resume <sid>`, which
succeeds.

## Reproduction

Measured on this branch, rebased onto `upstream/main` @ `d2b76ff1`, with the
two behaviour hunks withheld and then restored on the same tree:

    # behaviour withheld, tests applied
    cargo test --offline --lib -- --test-threads=1 \
      observed_sid_without_transcript_downgrades_to_fresh \
      claude_json_fallback_rejects_sid_with_no_transcript \
      claude_json_fallback_accepts_sid_with_transcript

    claude_json_fallback_rejects_sid_with_no_transcript
      panicked: a lastSessionId with no transcript must not be captured:
      "11111111-2222-3333-4444-555555555555"
    observed_sid_without_transcript_downgrades_to_fresh
      panicked: an observed sid with no transcript must launch as --session-id,
      never --resume
    test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 4597 filtered out; finished in 0.00s

    # behaviour restored, same tree, same invocation
    test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 4597 filtered out; finished in 0.01s

The one test that passes either way is
`claude_json_fallback_accepts_sid_with_transcript`, the companion asserting the
arm is narrowed rather than removed. It carries a second job: the reject test
alone cannot distinguish "the gate declined the id" from "the id was never read
at all", so if the fixture ever stopped reaching the arm, this companion is what
fails. That is also why its `.claude.json` key is canonicalized the way
`read_claude_json_session_id` reads it.

For an observed sid that *does* have a transcript, hunk 2 is behaviour
identical: same returned tuple, same `agent_session_id` write, same log line.
The rebinding only changes the case the downgrade below was already written for.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed: no CLI surface or
      config change)
- [x] For UI changes: N/A

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: both paths are inside session-id acquisition and
      are asserted by three unit tests that build the `.claude` layout on disk.
      An e2e would have to fabricate the same layout and then read back the
      launched command line, which is what the unit tests already do without a
      real agent.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:** Carried downstream since
2026-08-15 and re-verified against current `main` before being offered.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents startup from using `--resume` when the session has no transcript.
- Confirms fallback and observed session IDs against profile-specific transcript files.
- Uses `--session-id` for sessions without transcripts.
- Adds regression tests for missing, existing, stale, and profile-specific transcripts.

## Benefits

- Prevents Claude’s “No conversation found” error.
- Allows affected panes to restart correctly.
- Preserves recovery for sessions with existing transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->