### PR TITLE
feat(cli): add state and timestamps to `session show --json`

### DIFF
--- a/contrib/hermes-skill/SKILL.md
+++ b/contrib/hermes-skill/SKILL.md
@@ -138,11 +138,12 @@ aoe status -q   # just the waiting count (for scripting)
   "tool": "claude",
   "command": "claude",
   "status": "running",
+  "state": "live",
   "profile": "default"
 }
 ```
 
-`parent_session_id` is included only for sub-sessions.
+`parent_session_id` is included only for sub-sessions. `state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states, the same vocabulary `aoe list --json` uses; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON shape** (`aoe status --json`):
 ```json

--- a/contrib/hermes-skill/SKILL.md
+++ b/contrib/hermes-skill/SKILL.md
@@ -89,7 +89,7 @@ aoe list --json --state=live   # skip trashed and archived rows
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states; a trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
 
 ## Session Lifecycle
 
@@ -143,7 +143,7 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-`parent_session_id` is included only for sub-sessions. `state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states, the same vocabulary `aoe list --json` uses; `status` is the pane's live status and does not carry it, since an archived session can still be running.
+`parent_session_id` is included only for sub-sessions. `state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON shape** (`aoe status --json`):
 ```json

--- a/contrib/hermes-skill/SKILL.md
+++ b/contrib/hermes-skill/SKILL.md
@@ -89,7 +89,7 @@ aoe list --json --state=live   # skip trashed and archived rows
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently, and trashing leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it, so key off `state` rather than caching a timestamp. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
 
 ## Session Lifecycle
 
@@ -143,7 +143,7 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-`parent_session_id` is included only for sub-sessions. `state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`; `status` is the pane's live status and does not carry it, since an archived session can still be running.
+`parent_session_id` is included only for sub-sessions. `state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently, and `trash()` deliberately leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it (`aoe session restart`, `aoe send`, favourite, pin), so read the current `state` rather than caching a timestamp; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON shape** (`aoe status --json`):
 ```json

--- a/contrib/openclaw-skill/SKILL.md
+++ b/contrib/openclaw-skill/SKILL.md
@@ -141,9 +141,12 @@ aoe status -q   # just the waiting count (for scripting)
   "tool": "claude",
   "command": "claude",
   "status": "running",
+  "state": "live",
   "profile": "default"
 }
 ```
+
+`state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states, the same vocabulary `aoe list --json` uses; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON output shape** (`aoe status --json`):
 ```json

--- a/contrib/openclaw-skill/SKILL.md
+++ b/contrib/openclaw-skill/SKILL.md
@@ -92,7 +92,7 @@ aoe list --json --state=live
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently, and trashing leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it, so key off `state` rather than caching a timestamp. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
 
 ### Session lifecycle
 
@@ -146,7 +146,7 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-`state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`; `status` is the pane's live status and does not carry it, since an archived session can still be running.
+`state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently, and `trash()` deliberately leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it (`aoe session restart`, `aoe send`, favourite, pin), so read the current `state` rather than caching a timestamp; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON output shape** (`aoe status --json`):
 ```json

--- a/contrib/openclaw-skill/SKILL.md
+++ b/contrib/openclaw-skill/SKILL.md
@@ -92,7 +92,7 @@ aoe list --json --state=live
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states; a trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
 
 ### Session lifecycle
 
@@ -146,7 +146,7 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-`state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states, the same vocabulary `aoe list --json` uses; `status` is the pane's live status and does not carry it, since an archived session can still be running.
+`state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently and each persists once set, so a session archived and then trashed carries both and reports `trashed`; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON output shape** (`aoe status --json`):
 ```json

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -68,7 +68,7 @@ pub struct ListArgs {
 /// Derived from [`Instance::effective_bucket`] so the `Trashed > Archived >
 /// Active` precedence has exactly one definition: an archived row that is then
 /// trashed keeps its `archived_at` but reports `trashed`.
-fn state_tag(inst: &Instance) -> &'static str {
+pub(crate) fn state_tag(inst: &Instance) -> &'static str {
     match inst.effective_bucket() {
         SessionBucket::Trashed => "trashed",
         SessionBucket::Archived => "archived",

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -68,7 +68,7 @@ pub struct ListArgs {
 /// Derived from [`Instance::effective_bucket`] so the `Trashed > Archived >
 /// Active` precedence has exactly one definition: an archived row that is then
 /// trashed keeps its `archived_at` but reports `trashed`.
-pub(crate) fn state_tag(inst: &Instance) -> &'static str {
+pub(super) fn state_tag(inst: &Instance) -> &'static str {
     match inst.effective_bucket() {
         SessionBucket::Trashed => "trashed",
         SessionBucket::Archived => "archived",

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -337,11 +337,39 @@ struct SessionDetails {
     tool: String,
     command: String,
     status: String,
+    /// The same `live`/`archived`/`trashed` tag `aoe list --json` carries
+    /// (#3350/#3361), so a consumer does not have to fall back to `list` to
+    /// learn whether the session it just looked up is still around. `status`
+    /// cannot carry it: an archived session can be running, so the two are
+    /// independent and collapsing them loses one.
+    state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trashed_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    archived_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     agent_session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     parent_session_id: Option<String>,
     profile: String,
+}
+
+fn session_details(inst: &Instance, profile: &str) -> SessionDetails {
+    SessionDetails {
+        id: inst.id.clone(),
+        title: inst.title.clone(),
+        path: inst.project_path.clone(),
+        group: inst.group_path.clone(),
+        tool: inst.tool.clone(),
+        command: inst.command.clone(),
+        status: format!("{:?}", inst.status).to_lowercase(),
+        state: super::list::state_tag(inst),
+        trashed_at: inst.trashed_at,
+        archived_at: inst.archived_at,
+        agent_session_id: inst.agent_session_id.clone(),
+        parent_session_id: inst.parent_session_id.clone(),
+        profile: profile.to_string(),
+    }
 }
 
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
@@ -1555,19 +1583,7 @@ async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
     inst.self_heal_session_id(profile, &contended);
 
     if args.json {
-        let details = SessionDetails {
-            id: inst.id.clone(),
-            title: inst.title.clone(),
-            path: inst.project_path.clone(),
-            group: inst.group_path.clone(),
-            tool: inst.tool.clone(),
-            command: inst.command.clone(),
-            status: format!("{:?}", inst.status).to_lowercase(),
-            agent_session_id: inst.agent_session_id.clone(),
-            parent_session_id: inst.parent_session_id.clone(),
-            profile: storage.profile().to_string(),
-        };
-        super::output::print_json(&details)?;
+        super::output::print_json(&session_details(&inst, storage.profile()))?;
     } else {
         println!("Session: {}", inst.title);
         println!("  ID:      {}", inst.id);
@@ -1576,6 +1592,16 @@ async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
         println!("  Tool:    {}", inst.tool);
         println!("  Command: {}", inst.command);
         println!("  Status:  {:?}", inst.status);
+        // Only for a session that is not live: an archived or trashed row is
+        // otherwise indistinguishable here from a stopped one, and `status`
+        // cannot carry it (a session can be archived and running at once).
+        if let Some(at) = inst.trashed_at.or(inst.archived_at) {
+            println!(
+                "  State:   {} ({})",
+                super::list::state_tag(&inst),
+                at.to_rfc3339()
+            );
+        }
         println!("  Profile: {}", storage.profile());
         if let Some(parent_id) = &inst.parent_session_id {
             println!("  Parent:  {}", parent_id);
@@ -2809,5 +2835,51 @@ mod import_tests {
         assert!(already_imported(&instances, "id-1"));
         assert!(already_imported(&instances, "id-2"));
         assert!(!already_imported(&instances, "id-3"));
+    }
+}
+
+#[cfg(test)]
+mod show_json_tests {
+    use super::*;
+
+    /// #3350 gave `aoe list --json` a `state` tag and both timestamps;
+    /// `session show --json` was left behind, so a scripted consumer that
+    /// looked a session up by id could not tell an archived one from a live
+    /// one without a second `aoe list` shellout.
+    #[test]
+    fn show_json_exposes_state_and_archived_at_for_an_archived_row() {
+        let mut inst = Instance::new("z", "/repo");
+        inst.archive();
+        let details = session_details(&inst, "p");
+        assert_eq!(details.state, "archived");
+        assert!(details.archived_at.is_some());
+        assert!(details.trashed_at.is_none());
+    }
+
+    /// `trash()` deliberately leaves `archived_at` alone so a restore is
+    /// faithful, so both keys can be present at once and `state` reports
+    /// `trashed`: the same precedence `list --json` reports, from the same
+    /// `state_tag`.
+    #[test]
+    fn show_json_reports_trashed_for_a_row_that_was_archived_first() {
+        let mut inst = Instance::new("z", "/repo");
+        inst.archive();
+        inst.trash();
+        let details = session_details(&inst, "p");
+        assert_eq!(details.state, "trashed");
+        assert!(details.trashed_at.is_some());
+        assert!(details.archived_at.is_some());
+    }
+
+    /// A live row must serialize exactly as wide as it did before, so a
+    /// consumer parsing today's output sees one new key (`state`) and no
+    /// `null` timestamps.
+    #[test]
+    fn show_json_omits_absent_timestamps_and_keeps_state_live() {
+        let inst = Instance::new("z", "/repo");
+        let serialized = serde_json::to_string(&session_details(&inst, "p")).unwrap();
+        assert!(!serialized.contains("trashed_at"), "{serialized}");
+        assert!(!serialized.contains("archived_at"), "{serialized}");
+        assert!(serialized.contains("\"state\":\"live\""), "{serialized}");
     }
 }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2074,3 +2074,96 @@ fn test_cli_list_state_filter_and_json_shape() {
     assert_eq!(trashed[0]["state"], "trashed");
     assert!(trashed[0]["trashed_at"].is_string());
 }
+
+/// Companion to `test_cli_list_state_filter_and_json_shape` for the lookup
+/// path: a consumer that already holds the id should not have to fall back to
+/// a full `aoe list --json` to learn whether that session is still around.
+#[test]
+#[parallel]
+fn test_cli_session_show_json_carries_state() {
+    let h = TuiTestHarness::new("cli_show_state");
+    let project = h.project_path();
+
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "Show Probe"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let live: serde_json::Value = serde_json::from_slice(
+        &h.run_cli(&["session", "show", "Show Probe", "--json"])
+            .stdout,
+    )
+    .expect("session show --json must emit JSON");
+    assert_eq!(live["state"], "live");
+    assert!(live.get("trashed_at").is_none());
+    assert!(live.get("archived_at").is_none());
+
+    let rm = h.run_cli(&["rm", "Show Probe"]);
+    assert!(
+        rm.status.success(),
+        "aoe rm failed: {}",
+        String::from_utf8_lossy(&rm.stderr)
+    );
+
+    let trashed: serde_json::Value = serde_json::from_slice(
+        &h.run_cli(&["session", "show", "Show Probe", "--json"])
+            .stdout,
+    )
+    .expect("session show --json must emit JSON for a trashed row");
+    assert_eq!(trashed["state"], "trashed");
+    assert!(trashed["trashed_at"].is_string());
+}
+
+/// The archived half of the same contract, and the precedence between the two
+/// states: `trash()` deliberately keeps `archived_at`, so a row that was
+/// archived first must still report `trashed`.
+#[test]
+#[parallel]
+fn test_cli_session_show_json_reports_archived_and_precedence() {
+    let h = TuiTestHarness::new("cli_show_archived");
+    let project = h.project_path();
+
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "Archive Probe"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let archive = h.run_cli(&["session", "archive", "Archive Probe"]);
+    assert!(
+        archive.status.success(),
+        "aoe session archive failed: {}",
+        String::from_utf8_lossy(&archive.stderr)
+    );
+
+    let archived: serde_json::Value = serde_json::from_slice(
+        &h.run_cli(&["session", "show", "Archive Probe", "--json"])
+            .stdout,
+    )
+    .expect("session show --json must emit JSON for an archived row");
+    assert_eq!(archived["state"], "archived");
+    assert!(archived["archived_at"].is_string());
+    assert!(archived.get("trashed_at").is_none());
+
+    let rm = h.run_cli(&["rm", "Archive Probe"]);
+    assert!(
+        rm.status.success(),
+        "aoe rm failed: {}",
+        String::from_utf8_lossy(&rm.stderr)
+    );
+
+    let both: serde_json::Value = serde_json::from_slice(
+        &h.run_cli(&["session", "show", "Archive Probe", "--json"])
+            .stdout,
+    )
+    .expect("session show --json must emit JSON for an archived, trashed row");
+    assert_eq!(
+        both["state"], "trashed",
+        "trashed outranks archived, and archived_at survives the trash"
+    );
+    assert!(both["trashed_at"].is_string());
+    assert!(both["archived_at"].is_string());
+}


### PR DESCRIPTION

## Description

#3350, shipped as #3361, taught `aoe list --json` a `state` tag plus
`trashed_at` and `archived_at`, so a scripted consumer can tell a trashed or
archived row from a live one. The lookup path was left behind:
`SessionDetails` in `src/cli/session.rs` carries none of the three, so
`aoe session show --json <id>` cannot answer the question `aoe list --json` now
answers, and a script that already holds an id has to shell out to a full
listing and filter it back down.

This adds the same three keys, with the same vocabulary and the same source of
truth: `state_tag` is reused from `cli::list` rather than re-derived, so the
`Trashed > Archived > Active` precedence keeps exactly one definition and an
archived row that is then trashed reports `trashed` on both surfaces. `status`
cannot carry this, because a session can be archived and running at the same
time.

Both timestamps keep `skip_serializing_if = "Option::is_none"`, so a live row
gains exactly one key (`state`) over today's output and no `null`s.

The human-readable `session show` gains a `State:` line, printed only when the
session is not live, so its output is unchanged for every live session.

The JSON construction moves out of `show_session` into `session_details`, so it
can be asserted without standing up storage, mirroring `session_json` in
`cli::list`.

## Tests

Three unit tests in `cli::session`, mirroring the ones #3361 added for
`cli::list`: an archived row reports `state: "archived"` with `archived_at` and
no `trashed_at`; a row archived and then trashed reports `trashed` with both
stamps present; a live row serializes with `"state":"live"` and neither
timestamp key.

Two e2e tests in `tests/e2e/cli.rs`, companions to
`test_cli_list_state_filter_and_json_shape` for the lookup path: one drives
`aoe rm` and asserts `live` with no timestamps before, `trashed` with a
`trashed_at` after; the other drives `aoe session archive`, asserts `archived`
with `archived_at` and no `trashed_at`, then trashes the same row and asserts
`state` reports `trashed` with both stamps present, since `trash()` deliberately
keeps `archived_at` so a restore is faithful.

`contrib/hermes-skill/SKILL.md` and `contrib/openclaw-skill/SKILL.md` document
the literal `session show --json` object, and #3361 updated both when it changed
`list --json`; both gain `state` and the sentence describing the vocabulary.
`cargo xtask check-skill` validates frontmatter and `aoe <subcommand>` paths, not
the JSON blocks, so nothing in CI would have caught this.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary: both `contrib/*/SKILL.md`
      files that document the `session show --json` shape carry `state`.
      `docs/cli/reference.md` is generated from clap help and no flag changed,
      so it is unaffected
- [x] For UI changes: N/A

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` (two)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:** A downstream patch had added
`archived_at` to both `list --json` and `session show --json` before #3361
landed. The `list` half is now redundant, and upstream's shipped shape is wider
than ours was, so only the `show` half is offered here and it follows #3361's
vocabulary rather than the downstream one.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

- Added `state`, `trashed_at`, and `archived_at` to `aoe session show --json`.
- Added lifecycle state to human-readable output for non-live sessions.
- Reused the state vocabulary and `Trashed > Archived > Active` precedence from `aoe list --json`.
- Clarified that archive and trash timestamps are independent and not durable state indicators.
- Added unit and end-to-end tests for live, archived, trashed, and archived-then-trashed sessions.

## Benefits

- Provides consistent lifecycle information across CLI commands.
- Preserves `archived_at` when an archived session is trashed.
- Separates lifecycle state from live pane status.
- Improves confidence through focused test coverage.

## Potential enhancement

- Document state precedence in the main CLI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->