### PR TITLE
fix(web): let diff comments send to a dormant session, and say why when Send is blocked

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -774,10 +774,18 @@ function AppContent({
   // DiffFileViewer, so the store is lifted here and threaded to both.
   const diffComments = useDiffComments(activeSessionId);
   const commentsEnabled = activeSession?.view === "structured";
-  const commentSendEnabled = commentsEnabled && activeSession?.acp_worker_state === "running";
+  // Sending does not require a live worker: the diff-comments handler runs the
+  // same auto-wake as a plain composer prompt (touch_and_wake_if_sunk +
+  // trigger_resume_background, #1748), so an archived / snoozed / idle-dormant
+  // session respawns its worker on send instead of sinking the prompt. A
+  // trashed session is the one exception: the reconciler never resumes it, so
+  // there is nothing to drain into.
+  const commentSendEnabled = commentsEnabled && !activeSession?.trashed_at;
+  // Every disabled state names its cause and what the user can do about it: a
+  // tooltip that only says "unavailable" leaves them staring at a dead button.
   const commentSendDisabledReason = !commentsEnabled
-    ? "Diff comments require an acp session"
-    : "Acp worker is not running";
+    ? "Diff comments can only be sent from the agent view. Switch this session to the agent view first."
+    : "This session is in the trash. Restore it to send comments to the agent.";
   const commentsIsMultiRepo = (activeSession?.workspace_repos.length ?? 0) > 0;
   const [sendDialogOpen, setSendDialogOpen] = useState(false);
 

--- a/web/src/components/DiffPane.tsx
+++ b/web/src/components/DiffPane.tsx
@@ -17,7 +17,7 @@ interface Props {
   commentsEnabled: boolean;
   commentsCount: number;
   commentsSendEnabled: boolean;
-  commentsSendDisabledReason?: string;
+  commentsSendDisabledReason: string;
   onOpenSendDialog: () => void;
   onDiscardAllComments: () => void;
 }

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -38,7 +38,7 @@ interface Props {
   onDiffRefresh: () => void;
   commentsEnabled: boolean;
   commentSendEnabled: boolean;
-  commentSendDisabledReason?: string;
+  commentSendDisabledReason: string;
   diffComments: ReturnType<typeof useDiffComments>;
   commentsIsMultiRepo: boolean;
   sendDialogOpen: boolean;

--- a/web/src/components/diff/comments/CommentsBanner.tsx
+++ b/web/src/components/diff/comments/CommentsBanner.tsx
@@ -34,16 +34,25 @@ export function CommentsBanner({ count, sendEnabled, sendDisabledReason, onSend,
         >
           Discard all
         </button>
-        {/* Tooltip, not the native `title`: a `disabled` button receives no
-            pointer events, so the browser never shows its `title` and the
-            reason the send is blocked stays invisible. The Tooltip's hover
-            handlers live on the wrapper span, which is not disabled. */}
+        {/* Tooltip, not the native `title`: the browser never renders a
+            `title` on a button it won't send pointer events to, so the reason
+            the send is blocked stayed invisible. `aria-disabled` rather than
+            `disabled` for the same reason one rung up: a natively disabled
+            button is not focusable, so a keyboard user could never reach the
+            explanation at all. The button stays in the tab order, announces
+            itself as disabled, and `onSend` guards the click. */}
         <Tooltip text={sendEnabled ? "Send comments to agent" : sendDisabledReason} multiline>
           <button
             type="button"
-            onClick={onSend}
-            disabled={!sendEnabled}
-            className="px-2 py-0.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
+            onClick={() => {
+              if (sendEnabled) onSend();
+            }}
+            aria-disabled={!sendEnabled}
+            className={`px-2 py-0.5 rounded-md transition-colors ${
+              sendEnabled
+                ? "bg-brand-600 text-white hover:bg-brand-500 cursor-pointer"
+                : "bg-surface-700 text-text-dim cursor-not-allowed"
+            }`}
           >
             Send
           </button>

--- a/web/src/components/diff/comments/CommentsBanner.tsx
+++ b/web/src/components/diff/comments/CommentsBanner.tsx
@@ -1,15 +1,19 @@
+import { Tooltip } from "../../Tooltip";
+
 interface Props {
   count: number;
   sendEnabled: boolean;
-  sendDisabledReason?: string;
+  /** Required, and phrased as cause + remedy: this is the only place the user
+   *  ever learns why the Send button is dead. */
+  sendDisabledReason: string;
   onSend: () => void;
   onDiscardAll: () => void;
 }
 
 /** Floating chip rendered above the right-panel diff list. Visible
  *  whenever the active session has at least one comment and supports
- *  the feature (acp-only). The send button is disabled while the
- *  structured view worker is not running so the prompt doesn't sink. */
+ *  the feature (acp-only). The send button is disabled only for a
+ *  trashed session, which never resumes a worker to drain into. */
 export function CommentsBanner({ count, sendEnabled, sendDisabledReason, onSend, onDiscardAll }: Props) {
   if (count === 0) return null;
   return (
@@ -30,15 +34,20 @@ export function CommentsBanner({ count, sendEnabled, sendDisabledReason, onSend,
         >
           Discard all
         </button>
-        <button
-          type="button"
-          onClick={onSend}
-          disabled={!sendEnabled}
-          title={sendEnabled ? "Send comments to agent" : sendDisabledReason}
-          className="px-2 py-0.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
-        >
-          Send
-        </button>
+        {/* Tooltip, not the native `title`: a `disabled` button receives no
+            pointer events, so the browser never shows its `title` and the
+            reason the send is blocked stays invisible. The Tooltip's hover
+            handlers live on the wrapper span, which is not disabled. */}
+        <Tooltip text={sendEnabled ? "Send comments to agent" : sendDisabledReason} multiline>
+          <button
+            type="button"
+            onClick={onSend}
+            disabled={!sendEnabled}
+            className="px-2 py-0.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
+          >
+            Send
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/web/src/components/diff/comments/SendCommentsDialog.tsx
+++ b/web/src/components/diff/comments/SendCommentsDialog.tsx
@@ -58,6 +58,7 @@ export function SendCommentsDialog({
 
   const preview = useMemo(() => buildCommentsMarkdown(comments, { isMultiRepo }), [comments, isMultiRepo]);
 
+  const sendBlocked = busy || comments.length === 0 || !sendEnabled;
   // One tooltip covering every reason Send can be disabled, so it never
   // explains the wrong one.
   const sendTooltip = !sendEnabled
@@ -198,15 +199,21 @@ export function SendCommentsDialog({
             >
               Cancel
             </button>
-            {/* Same reason as the banner: a `disabled` button never shows its
-                native `title`, so the blocked-send explanation needs a hover
-                target that isn't disabled. */}
+            {/* Tooltip + `aria-disabled` rather than `title` + `disabled`, for
+                the reasons spelled out in `CommentsBanner`: the browser renders
+                neither a `title` nor a focus ring on a natively disabled
+                button, so both pointer and keyboard users were left without the
+                explanation. `send()` re-checks every condition itself. */}
             <Tooltip text={sendTooltip} multiline>
               <button
                 type="button"
                 onClick={() => void send()}
-                disabled={busy || comments.length === 0 || !sendEnabled}
-                className="text-[12px] px-3 py-1.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
+                aria-disabled={sendBlocked}
+                className={`text-[12px] px-3 py-1.5 rounded-md transition-colors ${
+                  sendBlocked
+                    ? "bg-surface-700 text-text-dim cursor-not-allowed"
+                    : "bg-brand-600 text-white hover:bg-brand-500 cursor-pointer"
+                }`}
               >
                 {busy ? "Sending..." : "Send"}
               </button>

--- a/web/src/components/diff/comments/SendCommentsDialog.tsx
+++ b/web/src/components/diff/comments/SendCommentsDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Tooltip } from "../../Tooltip";
 import { CommentMarkdown } from "./CommentMarkdown";
 import { buildCommentsMarkdown, buildDiffCommentsPrompt } from "./buildPrompt";
 import type { DiffComment } from "./types";
@@ -9,11 +10,11 @@ interface Props {
   comments: DiffComment[];
   isMultiRepo: boolean;
   /** Same gate as the banner Send button. Reflects
-   *  `structured_view && acp_worker_state === "running"`. False
-   *  disables the Send button so prompts don't sink when the worker
-   *  isn't ready. */
+   *  `structured_view && !trashed`. False disables the Send button so
+   *  prompts don't sink into a session the reconciler never resumes. */
   sendEnabled: boolean;
-  sendDisabledReason?: string;
+  /** Required, and phrased as cause + remedy. See `CommentsBanner`. */
+  sendDisabledReason: string;
   introDraft: string;
   outroDraft: string;
   clearAfterSend: boolean;
@@ -56,6 +57,16 @@ export function SendCommentsDialog({
   }, []);
 
   const preview = useMemo(() => buildCommentsMarkdown(comments, { isMultiRepo }), [comments, isMultiRepo]);
+
+  // One tooltip covering every reason Send can be disabled, so it never
+  // explains the wrong one.
+  const sendTooltip = !sendEnabled
+    ? sendDisabledReason
+    : comments.length === 0
+      ? "Add at least one diff comment to send."
+      : busy
+        ? "Sending your comments to the agent..."
+        : "Send comments to agent";
 
   const send = useCallback(async () => {
     if (busy || comments.length === 0 || !sendEnabled) return;
@@ -187,15 +198,19 @@ export function SendCommentsDialog({
             >
               Cancel
             </button>
-            <button
-              type="button"
-              onClick={() => void send()}
-              disabled={busy || comments.length === 0 || !sendEnabled}
-              title={sendEnabled ? undefined : sendDisabledReason}
-              className="text-[12px] px-3 py-1.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
-            >
-              {busy ? "Sending..." : "Send"}
-            </button>
+            {/* Same reason as the banner: a `disabled` button never shows its
+                native `title`, so the blocked-send explanation needs a hover
+                target that isn't disabled. */}
+            <Tooltip text={sendTooltip} multiline>
+              <button
+                type="button"
+                onClick={() => void send()}
+                disabled={busy || comments.length === 0 || !sendEnabled}
+                className="text-[12px] px-3 py-1.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
+              >
+                {busy ? "Sending..." : "Send"}
+              </button>
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/web/src/components/diff/comments/__tests__/SendCommentsDialog.test.tsx
+++ b/web/src/components/diff/comments/__tests__/SendCommentsDialog.test.tsx
@@ -101,19 +101,34 @@ describe("SendCommentsDialog", () => {
   it("shows the empty-state preview and disables Send when there are no comments", () => {
     const { container } = setup({ comments: [] });
     expect(container.textContent).toContain("No comments.");
-    expect(sendButton(container).disabled).toBe(true);
+    expect(sendButton(container).getAttribute("aria-disabled")).toBe("true");
   });
 
-  it("disables Send and exposes the reason on hover when sendEnabled is false", async () => {
+  it("disables Send and exposes the reason to pointer and keyboard when sendEnabled is false", async () => {
     const { container } = setup({ sendEnabled: false, sendDisabledReason: "session is trashed" });
     const btn = sendButton(container);
-    expect(btn.disabled).toBe(true);
-    // The reason lives on the Tooltip wrapper, not the button's native
-    // `title`: a disabled button gets no pointer events, so a `title` on it
-    // would never render. Hovering the wrapper is what a user can actually do.
+    // `aria-disabled`, not `disabled`: a natively disabled button is not
+    // focusable and gets no pointer events, so neither a hover nor a keyboard
+    // user could ever reach the explanation.
+    expect(btn.getAttribute("aria-disabled")).toBe("true");
+    expect(btn.disabled).toBe(false);
+
     const wrapper = btn.parentElement as HTMLElement;
     fireEvent.mouseEnter(wrapper);
     await waitFor(() => expect(document.body.textContent).toContain("session is trashed"));
+    fireEvent.mouseLeave(wrapper);
+    await waitFor(() => expect(document.body.textContent).not.toContain("session is trashed"));
+
+    // Tabbing to the button surfaces the same reason.
+    btn.focus();
+    fireEvent.focus(btn);
+    await waitFor(() => expect(document.body.textContent).toContain("session is trashed"));
+  });
+
+  it("does not send when the button is aria-disabled", () => {
+    const { container } = setup({ sendEnabled: false });
+    fireEvent.click(sendButton(container));
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("submits the assembled prompt payload to the diff-comments endpoint and fires onSent", async () => {

--- a/web/src/components/diff/comments/__tests__/SendCommentsDialog.test.tsx
+++ b/web/src/components/diff/comments/__tests__/SendCommentsDialog.test.tsx
@@ -52,7 +52,7 @@ function setup(overrides?: {
       comments={overrides?.comments ?? [comment()]}
       isMultiRepo={overrides?.isMultiRepo ?? false}
       sendEnabled={overrides?.sendEnabled ?? true}
-      sendDisabledReason={overrides?.sendDisabledReason}
+      sendDisabledReason={overrides?.sendDisabledReason ?? "session is trashed"}
       introDraft={overrides?.introDraft ?? ""}
       outroDraft={overrides?.outroDraft ?? ""}
       clearAfterSend={overrides?.clearAfterSend ?? false}
@@ -104,11 +104,16 @@ describe("SendCommentsDialog", () => {
     expect(sendButton(container).disabled).toBe(true);
   });
 
-  it("disables Send and exposes the reason when sendEnabled is false", () => {
-    const { container } = setup({ sendEnabled: false, sendDisabledReason: "worker not running" });
+  it("disables Send and exposes the reason on hover when sendEnabled is false", async () => {
+    const { container } = setup({ sendEnabled: false, sendDisabledReason: "session is trashed" });
     const btn = sendButton(container);
     expect(btn.disabled).toBe(true);
-    expect(btn.getAttribute("title")).toBe("worker not running");
+    // The reason lives on the Tooltip wrapper, not the button's native
+    // `title`: a disabled button gets no pointer events, so a `title` on it
+    // would never render. Hovering the wrapper is what a user can actually do.
+    const wrapper = btn.parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    await waitFor(() => expect(document.body.textContent).toContain("session is trashed"));
   });
 
   it("submits the assembled prompt payload to the diff-comments endpoint and fires onSent", async () => {

--- a/web/tests/diff-comments.spec.ts
+++ b/web/tests/diff-comments.spec.ts
@@ -284,13 +284,31 @@ test.describe("Diff comments (#928)", () => {
     await expect(page.getByPlaceholder(/Leave a comment \(markdown supported\)/)).toHaveCount(0);
   });
 
-  test("send button disabled when worker not running", async ({ page }) => {
+  // A dormant session (worker auto-stopped for inactivity, `acp_worker_state:
+  // "absent"`) is still sendable: the diff-comments handler runs the same
+  // auto-wake as a plain composer prompt, so the send respawns the worker
+  // instead of sinking. The old gate blocked this, leaving a dead Send button
+  // on every idle session.
+  test("send still works when the worker is absent (dormant session auto-wakes)", async ({ page }) => {
     await setup(page, { structuredView: true, acpWorkerState: "absent" });
+    let posted = false;
+    await page.route("**/api/sessions/*/acp/prompt/diff-comments", (r) => {
+      posted = true;
+      return r.fulfill({ json: {} });
+    });
     await openSessionAndFile(page);
     await startSingleLineComment(page, 3);
     await page.getByPlaceholder(/Leave a comment \(markdown supported\)/).fill("nit");
     await page.getByRole("button", { name: "Save" }).click();
-    const send = page.getByRole("button", { name: /^Send$/ }).first();
-    await expect(send).toBeDisabled();
+    await page
+      .getByRole("button", { name: /^Send$/ })
+      .first()
+      .click();
+    await expect(page.getByText("Send diff comments")).toBeVisible();
+    await page
+      .getByRole("button", { name: /^Send$/ })
+      .last()
+      .click();
+    await expect.poll(() => posted).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

Writing a diff comment in the web view on an idle session produced a dead Send button: the comment saved, the banner counted it, the card was editable, and nothing could dispatch it.

The gate in `web/src/App.tsx` required `acp_worker_state === "running"`. A session whose structured-view worker has been auto-stopped for inactivity reports `acp_worker_state: "absent"` with `dormant: true`, so the gate was false for every idle session.

That gate outlived the backend it was protecting. `POST /api/sessions/{id}/acp/prompt/diff-comments` (`src/server/api/acp.rs:1437`) runs the same auto-wake as a plain composer prompt, `touch_and_wake_if_sunk` plus `trigger_resume_background` (#1748), so an archived, snoozed, or idle-dormant session respawns its worker on send instead of sinking the prompt. The plain composer already relies on that and stays enabled on exactly the sessions the diff banner refused: same session, composer live, Send dead.

Changes:

- Gate on `!trashed_at` instead of the worker state. A trashed session is the one case the reconciler never resumes, so it is the only one with nothing to drain into.
- Move the disabled reason off the button's native `title` and onto the shared `Tooltip`. A `disabled` button receives no pointer events, so the browser never rendered that `title`: the user saw a dead control and no cause at all. The Tooltip's hover handlers live on a wrapper span, which is not disabled.
- Make `sendDisabledReason` a required prop and phrase every reason as cause plus remedy ("This session is in the trash. Restore it to send comments to the agent.") rather than a bare state description.
- The dialog's tooltip also covers its other two disabled cases, no comments yet and send in flight, so it never explains the wrong one.

Found while debugging a real session (`view: "structured"`, `dormant: true`, `acp_worker_state: "absent"`) whose comment could not be sent.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs cover this gate; the reasoning lives in code comments next to the gate)
- [x] For UI changes: included screenshot or recording (see below)

### How I tested

- `cd web && npx tsc -b` clean, `npm run format:check` clean, `npm run lint` clean.
- `npm run test:unit -- --run`: 3678 passed, 351 files.
- `npx playwright test --config=playwright.config.ts tests/diff-comments.spec.ts`: 6 passed, including the new dormant-session case.
- Full mocked Playwright suite: 4 failures, all pre-existing and unrelated (`desktop-live-input` bracketed paste, `command-palette` cheat code, `acp-history-window`). Verified by stashing this diff, rebuilding `dist`, and rerunning those three specs on a clean tree: same failures.
- Manual: reproduced the dead button in the running dashboard against a real dormant session, and confirmed via the API that the session reported `view: "structured"`, `dormant: true`, `acp_worker_state: "absent"` while its composer stayed enabled. Live re-verification through a proxied dev server was not possible (the dev origin fails the passphrase login), so the fix itself is covered by the mocked spec, which drives the identical session payload through `App.tsx`.

### Screenshots

Captured from the mocked Playwright environment on a session with `acp_worker_state: "absent"`:

- Send button live (brand-orange) on a dormant session with one pending comment, where it was previously greyed out and unclickable.
- Hovering Send shows the tooltip pill; on a blocked session the same pill carries the cause-plus-remedy reason instead of the native `title` that never rendered.

I could not attach the PNGs through the API from a terminal session. To regenerate: add a `page.screenshot()` call to the dormant-session test in `web/tests/diff-comments.spec.ts`.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The old spec asserted the bug ("send button disabled when worker not running"). It is replaced by "send still works when the worker is absent (dormant session auto-wakes)", which selects a line, saves a comment, opens the dialog, sends, and asserts the POST reaches `/acp/prompt/diff-comments`. The Vitest case for the disabled state now hovers the Tooltip wrapper and asserts the reason text renders, instead of reading a `title` attribute that a user could never see. `web/tests/coverage-matrix.json` needed no new entry: the `diff-comments.send-flow` entry already lists both the spec and the two components, and `node tests/validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

The bug was reported by a human against a live session; the diagnosis, fix, tests, and this description were produced by the agent and reviewed by the author.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Allow diff comments to be sent from dormant sessions.
- Keep Send disabled only for trashed sessions.
- Use shared tooltips to explain blocked, empty, and in-progress send states.
- Keep blocked Send buttons keyboard-focusable with `aria-disabled`.
- Update unit and Playwright tests for dormant-session sending and tooltip behavior.

## Benefits

Users can resume work in archived, snoozed, or idle-dormant sessions without manually restarting them. Disabled Send states now provide clear guidance and remain accessible to keyboard users.

## Technical notes

- Make disabled-send reasons required across related components.
- Use guarded click handlers and conditional styling instead of native button disabling.
- Validate dormant-session auto-wake behavior with updated unit and end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->