### PR TITLE
fix(sv): adopt the daemon's turn_active so steered prompts stop wedging the composer

### DIFF
--- a/docs/development/server-owned-sv-state.md
+++ b/docs/development/server-owned-sv-state.md
@@ -4,7 +4,8 @@ Status: shipped 2026-08-17. The daemon owns the structured-view (SV) control
 state, the transcript, and the prompt-dispatch decision; both clients render
 them. What the web still folds from raw events is the state the daemon does not
 model: the worker-lifecycle latches, the monitor and wakeup badges, the usage
-cost baseline, rejected prompts, and the optimistic turn counters.
+cost baseline, rejected prompts, and the optimistic overlay for prompts this
+client has POSTed but not yet seen echoed.
 
 This doc is the record of why the arc happened and what was rejected along the
 way. For what the wire actually looks like today, read
@@ -85,14 +86,35 @@ of truth.
 
 ### The optimism decision
 
-The open question when this was planned was turn-active latency: the web bumps
-`pendingUserPromptSeq` optimistically before the server echoes, so the composer
-flips to "working" instantly. The answer was **server-authoritative with a thin
-client optimistic overlay**: the client keeps a local "I just sent a prompt"
-flag that OR's into the rendered turn-active until the next `reduced_state`
-frame arrives, then defers to the server. That preserves instant feedback
-without a second source of truth for the steady state. `turnActive` and its
-prompt / stop counters are the one carve-out that stayed client-side.
+The open question when this was planned was turn-active latency: the client
+wants the composer to flip to "working" the instant the user hits send, before
+the server echoes the prompt back. The answer was **server-authoritative with a
+thin client optimistic overlay**: the client keeps its own "I just sent a
+prompt" marker that OR's into the rendered turn-active, and defers to the
+server for the steady state.
+
+That is what shipped in the end, but only in #3417; the original migration left
+`turnActive` deriving from a client-side `pendingUserPromptSeq >
+lastStoppedSeq` counter pair, and never read the `turn_active` the daemon was
+already sending. The counters assumed one terminal `Stopped` per prompt, which
+mid-turn steering (#2805) does not honor: the daemon injects the prompt into
+the running turn and emits no extra terminal event, so N prompts closed with
+one `Stopped` and the composer showed Stop plus a spinner forever.
+
+Today `turnActive` is `serverTurnActive || inflightPromptIds.length > 0`.
+`serverTurnActive` is adopted from every `reduced_state` frame.
+`inflightPromptIds` holds the client-minted `prompt_id` of each POSTed prompt,
+correlated so one prompt settling cannot retire another's turn, and settled by
+the server's `UserPromptSent` echo or by whatever the POST returned instead. It
+is request-local and never persisted: after a reload there is no POST left to
+acknowledge it.
+
+`applyEvent` still mirrors the daemon's seven `turn_active` edges
+(`src/acp/state.rs`) rather than waiting for `reduced_state`. That is not
+belt-and-braces: `GET /acp/replay` serves raw events with no `reduced_state`
+alongside, so a cold open that folded only the opening edges would paint a
+spinner over a session that finished hours ago until the WS connect snapshot
+corrected it. `reduced_state` stays authoritative wherever both arrive.
 
 ## Alternatives considered
 

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -173,7 +173,7 @@ export function AcpRuntime({
   // lifecycle. See #2237.
   const onCancel = useCancelEscalation(
     sessionId,
-    acp.state.pendingUserPromptSeq,
+    acp.state.turnSeq,
     acp.state.cancelling,
     acp.cancelPrompt,
     acp.forceEndTurn,

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -173,7 +173,7 @@ export function AcpRuntime({
   // lifecycle. See #2237.
   const onCancel = useCancelEscalation(
     sessionId,
-    acp.state.turnSeq,
+    acp.state.promptSeq,
     acp.state.cancelling,
     acp.cancelPrompt,
     acp.forceEndTurn,

--- a/web/src/components/acp/useCancelEscalation.ts
+++ b/web/src/components/acp/useCancelEscalation.ts
@@ -28,8 +28,8 @@ export function nextCancelAction(cancelling: boolean, alreadyRequested: boolean)
  * The intent is captured as a `(sessionId, turnSeq)` token rather than reset
  * via an effect: a new turn bumps `turnSeq` and a session switch changes
  * `sessionId`, so either one is automatically a mismatch and the first Stop of
- * the next turn or session is graceful again. `turnSeq` is the monotonic
- * per-turn counter on `AcpState`, bumped on each turn-open edge.
+ * the next turn or session is graceful again. `turnSeq` is `AcpState`'s
+ * monotonic `promptSeq`, bumped once per dispatched user prompt.
  */
 export function useCancelEscalation(
   sessionId: string,

--- a/web/src/components/acp/useCancelEscalation.ts
+++ b/web/src/components/acp/useCancelEscalation.ts
@@ -29,7 +29,7 @@ export function nextCancelAction(cancelling: boolean, alreadyRequested: boolean)
  * via an effect: a new turn bumps `turnSeq` and a session switch changes
  * `sessionId`, so either one is automatically a mismatch and the first Stop of
  * the next turn or session is graceful again. `turnSeq` is the monotonic
- * per-turn prompt counter (`pendingUserPromptSeq`).
+ * per-turn counter on `AcpState`, bumped on each turn-open edge.
  */
 export function useCancelEscalation(
   sessionId: string,

--- a/web/src/hooks/useAcpSession.configOption.test.ts
+++ b/web/src/hooks/useAcpSession.configOption.test.ts
@@ -327,25 +327,25 @@ describe("useAcpSession / setConfigOption", () => {
   });
 });
 
-// ---- normaliseTurnCounters backfill -------------------------------------
+// ---- normaliseTurnState backfill -------------------------------------
 
-describe("normaliseTurnCounters / config-option backfill", () => {
+describe("normaliseTurnState / config-option backfill", () => {
   it("backfills empty configOptions when the persisted entry pre-dates #1403", async () => {
-    const { normaliseTurnCounters } = await import("../lib/acpTypes");
+    const { normaliseTurnState } = await import("../lib/acpTypes");
     const stale = {
       ...emptyAcpState(),
     } as Record<string, unknown>;
     delete stale.configOptions;
     delete stale.configOptionSwitchFailed;
     delete stale.pendingConfigOption;
-    const next = normaliseTurnCounters(stale as unknown as Parameters<typeof normaliseTurnCounters>[0]);
+    const next = normaliseTurnState(stale as unknown as Parameters<typeof normaliseTurnState>[0]);
     expect(next.configOptions).toEqual([]);
     expect(next.configOptionSwitchFailed).toBeNull();
     expect(next.pendingConfigOption).toBeNull();
   });
 
   it("preserves a populated configOptions list across hydration", async () => {
-    const { normaliseTurnCounters } = await import("../lib/acpTypes");
+    const { normaliseTurnState } = await import("../lib/acpTypes");
     const seeded = {
       ...emptyAcpState(),
       configOptions: [
@@ -358,7 +358,7 @@ describe("normaliseTurnCounters / config-option backfill", () => {
         },
       ],
     };
-    const next = normaliseTurnCounters(seeded);
+    const next = normaliseTurnState(seeded);
     expect(next.configOptions).toHaveLength(1);
     expect(next.configOptions[0]!.current_value).toBe("claude-opus-4-7");
   });

--- a/web/src/hooks/useAcpSession.inflight.test.ts
+++ b/web/src/hooks/useAcpSession.inflight.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// The client half of #3417: `turnActive` is the daemon's `turn_active` OR'd
+// with prompts this client has POSTed but not yet seen acknowledged. Every
+// POST outcome has to settle its own id, or that id latches the spinner for
+// the life of the session. Before this landed, a non-503 5xx and a network
+// exception settled nothing at all.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { applyEvent, emptyAcpState, type AcpState } from "../lib/acpTypes";
+import { acpHookReducer, clearAcpCache, useAcpSession } from "./useAcpSession";
+import { act, renderHook } from "@testing-library/react";
+
+describe("acpHookReducer / in-flight prompt settlement", () => {
+  function sent(id: string): AcpState {
+    return acpHookReducer(emptyAcpState(), { kind: "user_prompt", id, text: "hi" });
+  }
+
+  it("user_prompt records the id and shows the spinner immediately", () => {
+    const state = sent("p1");
+    expect(state.inflightPromptIds).toEqual(["p1"]);
+    expect(state.turnActive).toBe(true);
+    expect(state.serverTurnActive).toBe(false);
+    expect(state.promptSeq).toBe(1);
+  });
+
+  it("every failure action settles its own id and unlocks the composer", () => {
+    // One row per POST outcome that no `UserPromptSent` will follow. The
+    // rejection keeps its overlay row so the user still sees what they tried
+    // to send; the rollback drops it because the prompt moved to the queue.
+    const cases: Array<
+      [string, "prompt_send_rejected" | "settle_inflight_prompt" | "rollback_optimistic_prompt", boolean]
+    > = [
+      ["4xx rejection", "prompt_send_rejected", true],
+      ["5xx or network exception", "settle_inflight_prompt", true],
+      ["worker_not_ready 503 or queued disposition", "rollback_optimistic_prompt", false],
+    ];
+    for (const [label, kind, keepsRow] of cases) {
+      const next = acpHookReducer(sent("p1"), { kind, id: "p1" });
+      expect(next.inflightPromptIds, label).toEqual([]);
+      expect(next.turnActive, label).toBe(false);
+      expect(next.optimisticRows.length > 0, label).toBe(keepsRow);
+    }
+  });
+
+  it("settling one prompt does not retire another still in flight", () => {
+    let state = sent("p1");
+    state = acpHookReducer(state, { kind: "user_prompt", id: "p2", text: "second" });
+    state = acpHookReducer(state, { kind: "settle_inflight_prompt", id: "p1" });
+    expect(state.inflightPromptIds).toEqual(["p2"]);
+    expect(state.turnActive).toBe(true);
+  });
+
+  it("a settled prompt cannot close a turn the daemon reports as running", () => {
+    let state = sent("p1");
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "hi", prompt_id: "p1" } },
+    });
+    expect(state.serverTurnActive).toBe(true);
+    // A late ambiguous-failure settlement for the same id must not win over
+    // the daemon's acknowledgement.
+    state = acpHookReducer(state, { kind: "settle_inflight_prompt", id: "p1" });
+    expect(state.turnActive).toBe(true);
+  });
+});
+
+describe("useAcpSession / dispatchPromptNow settles on every POST outcome", () => {
+  beforeEach(() => {
+    clearAcpCache();
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function sendAndReadTurnActive(respond: () => Promise<Response> | never): Promise<boolean> {
+    vi.spyOn(globalThis, "fetch").mockImplementation((async (input: RequestInfo | URL) => {
+      const url = String(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+      if (url.includes("/acp/prompt")) return respond();
+      return new Response("[]", { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as typeof fetch);
+
+    const { result } = renderHook(() => useAcpSession("s-1"));
+    await act(async () => {
+      await result.current.sendPrompt("hello");
+    });
+    return result.current.state.turnActive;
+  }
+
+  it("a 500 does not leave the spinner latched", async () => {
+    expect(await sendAndReadTurnActive(async () => new Response("boom", { status: 500 }))).toBe(false);
+  });
+
+  it("a network exception does not leave the spinner latched", async () => {
+    expect(
+      await sendAndReadTurnActive(() => {
+        throw new TypeError("Failed to fetch");
+      }),
+    ).toBe(false);
+  });
+});

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -13,10 +13,11 @@ import {
   applyEvent,
   applyReducedState,
   emptyAcpState,
-  isTurnActive,
+  deriveTurnActive,
+  withTurnActive,
   mergePrependedActivity,
   mergeServerRows,
-  normaliseTurnCounters,
+  normaliseTurnState,
   patchServerRow,
   reduceFrames,
   summarizeAnswers,
@@ -100,7 +101,8 @@ export type Action =
   | { kind: "transcript_remove"; id: string }
   | { kind: "lagged"; skipped: number }
   | { kind: "user_prompt"; text: string; attachments?: AcpAttachment[]; id?: string }
-  | { kind: "prompt_send_rejected" }
+  | { kind: "prompt_send_rejected"; id: string }
+  | { kind: "settle_inflight_prompt"; id: string }
   | { kind: "rollback_optimistic_prompt"; id: string }
   | { kind: "error"; message: string }
   | { kind: "clear_error" }
@@ -218,8 +220,13 @@ function evictOldestPersistedAcpState(currentKey: string): boolean {
 function toPersistedState(state: AcpState): AcpState {
   // Optimistic overlay rows are ephemeral client presentation: a confirmed
   // prompt is already in the server-owned `activity` (re-fetched on reload),
-  // so persisting the overlay would risk a stale duplicate. Drop it.
-  const base = state.optimisticRows.length > 0 ? { ...state, optimisticRows: [] } : state;
+  // so persisting the overlay would risk a stale duplicate. Drop it, and
+  // with it the in-flight prompt ids: after a reload no POST is left to
+  // acknowledge them, so a persisted id would latch the spinner forever.
+  const base: AcpState =
+    state.optimisticRows.length > 0 || state.inflightPromptIds.length > 0
+      ? { ...state, optimisticRows: [], inflightPromptIds: [] }
+      : state;
   if (!base.queuedPrompts.some((q) => q.attachments?.length)) return base;
   return {
     ...base,
@@ -279,10 +286,10 @@ function loadPersistedState(sessionId: string): AcpState | undefined {
     // Merge over the current defaults so an entry persisted by an older
     // bundle gains any fields added since (e.g. `pendingElicitations`);
     // without this the new code reads `undefined` for a freshly-added
-    // array and crashes on `.map`. Then backfill the seq-counter pair
-    // introduced by #1170; see `normaliseTurnCounters` for the rules.
+    // array and crashes on `.map`. Then backfill the turn state; see
+    // `normaliseTurnState` for the rules.
     const merged: AcpState = { ...emptyAcpState(), ...(state as AcpState) };
-    return normaliseTurnCounters(merged);
+    return normaliseTurnState(merged);
   } catch {
     return undefined;
   }
@@ -546,6 +553,17 @@ export function classifyElicitationResolveResponse(
  *  `activity` (same deterministic id), so the overlay never double-renders a
  *  confirmed prompt / elicitation answer. Returns `state` unchanged when
  *  nothing was pruned. */
+/** Drop one in-flight prompt id and re-derive `turnActive`. Called for every
+ *  POST outcome that no `UserPromptSent` echo will follow. */
+function settleInflightPrompt(state: AcpState, id: string): AcpState {
+  const inflightPromptIds = state.inflightPromptIds.filter((p) => p !== id);
+  if (inflightPromptIds.length === state.inflightPromptIds.length) return state;
+  return withTurnActive(
+    { ...state, inflightPromptIds },
+    deriveTurnActive({ serverTurnActive: state.serverTurnActive, inflightPromptIds }),
+  );
+}
+
 function pruneOptimisticRows(state: AcpState): AcpState {
   if (state.optimisticRows.length === 0) return state;
   const serverIds = new Set(state.activity.map((r) => r.id));
@@ -692,13 +710,12 @@ export function reducer(state: AcpState, action: Action): AcpState {
     // echoes reconciles it (the overlay is dropped once that row lands in
     // `activity`). Never appended to `activity` (that is server-owned).
     //
-    // Bump `pendingUserPromptSeq` (the source of truth for `turnActive`,
-    // derived from `pendingUserPromptSeq > lastStoppedSeq`) so the spinner
-    // shows immediately; the server `UserPromptSent` control frame recognizes
-    // this optimistic id and does NOT double-bump. See #1170 / #3173.
-    const pendingUserPromptSeq = state.pendingUserPromptSeq + 1;
+    // Record the minted id as in flight so the spinner shows immediately;
+    // the server `UserPromptSent` echo settles it by the same id, and every
+    // POST failure path settles it too. See #3417 / #3173.
+    const id = action.id ?? `user-opt-${Date.now()}-${state.optimisticRows.length}`;
     const row: ActivityRow = {
-      id: action.id ?? `user-opt-${Date.now()}-${state.optimisticRows.length}`,
+      id,
       kind: "user_prompt",
       text: action.text,
       attachments: action.attachments && action.attachments.length > 0 ? action.attachments : undefined,
@@ -711,48 +728,44 @@ export function reducer(state: AcpState, action: Action): AcpState {
       // trying again, so don't keep nagging them.
       startupError: null,
       lastError: null,
-      pendingUserPromptSeq,
-      turnActive: isTurnActive({
-        pendingUserPromptSeq,
-        lastStoppedSeq: state.lastStoppedSeq,
-      }),
+      inflightPromptIds: state.inflightPromptIds.includes(id)
+        ? state.inflightPromptIds
+        : state.inflightPromptIds.concat(id),
+      ...withTurnActive({ turnActive: state.turnActive, turnSeq: state.turnSeq }, true),
     };
   }
   if (action.kind === "prompt_send_rejected") {
-    // Optimistic submit already bumped pendingUserPromptSeq. When the
-    // prompt POST is rejected client-side (for example unsupported
-    // attachments), retire exactly one pending turn so Stop unlocks and
-    // the composer returns to idle without waiting for a Stopped frame
-    // that will never arrive.
-    const lastStoppedSeq = Math.min(state.lastStoppedSeq + 1, state.pendingUserPromptSeq);
-    return {
-      ...state,
-      inFlightTool: null,
-      lastStoppedSeq,
-      turnActive: isTurnActive({
-        pendingUserPromptSeq: state.pendingUserPromptSeq,
-        lastStoppedSeq,
-      }),
-    };
+    // The prompt POST was rejected with a 4xx (for example unsupported
+    // attachments), so no `UserPromptSent` will ever acknowledge this id.
+    // Settle it so Stop unlocks. The overlay row deliberately stays so the
+    // user still sees what they tried to send.
+    return settleInflightPrompt({ ...state, inFlightTool: null }, action.id);
+  }
+  if (action.kind === "settle_inflight_prompt") {
+    // Every other POST outcome that no `UserPromptSent` will follow: a 5xx,
+    // a network exception, a daemon `queued` disposition. Without this the
+    // optimistic id latches the spinner forever, which is the same defect
+    // class as #3417 arriving by a different route.
+    return settleInflightPrompt(state, action.id);
   }
   if (action.kind === "rollback_optimistic_prompt") {
     // A transient send failure (worker_not_ready 503 while resuming) re-queues
     // the prompt, so its optimistic overlay row must be removed: otherwise the
     // drain's re-send would echo a second copy the server `UserPromptSent`
     // cannot reconcile. Remove exactly the overlay row we added; the prompt now
-    // lives only in `queuedPrompts` (the QUEUED strip).
-    //
-    // Deliberately DO NOT touch `pendingUserPromptSeq` / `turnActive`: leaving
-    // the turn pending keeps the drain effect braked on `if (state.turnActive)
-    // return` so it does not hot-loop re-POSTing the wake while the worker is
-    // still resuming. The phantom turn is retired instead on the next
-    // `AcpSessionAssigned` (the worker-online signal). See #3094 / #3087.
+    // lives only in `queuedPrompts` (the QUEUED strip), which is server-owned
+    // and drains on its own. Settle the id with it: a queued prompt is not a
+    // running turn, and leaving it in flight would hold Stop over an idle
+    // session. See #3094 / #3087.
     const idx = state.optimisticRows.findIndex((r) => r.id === action.id);
-    if (idx === -1) return state;
-    return {
-      ...state,
-      optimisticRows: state.optimisticRows.slice(0, idx).concat(state.optimisticRows.slice(idx + 1)),
-    };
+    if (idx === -1) return settleInflightPrompt(state, action.id);
+    return settleInflightPrompt(
+      {
+        ...state,
+        optimisticRows: state.optimisticRows.slice(0, idx).concat(state.optimisticRows.slice(idx + 1)),
+      },
+      action.id,
+    );
   }
   if (action.kind === "enqueue_prompt") {
     // Optimistic row: shown immediately, marked `pending` until the server
@@ -1826,12 +1839,17 @@ export function useAcpSession(
           // suppress the banner for attachment sends too. See #1833.
           const workerNotReady = res.status === 503 && detail.startsWith("worker_not_ready");
           if (rejected) {
-            dispatch({ kind: "prompt_send_rejected" });
+            dispatch({ kind: "prompt_send_rejected", id: promptId });
           } else if (workerNotReady) {
             // Undo the optimistic overlay row: the caller re-queues this
             // prompt, so it must live only in the queue until the drain
             // resends it once the worker is back online. See #3094 / #3087.
             dispatch({ kind: "rollback_optimistic_prompt", id: promptId });
+          } else {
+            // Any other 5xx. No `UserPromptSent` is coming, so settle the
+            // optimistic marker; the overlay row stays so the user can see
+            // what they tried to send. See #3417.
+            dispatch({ kind: "settle_inflight_prompt", id: promptId });
           }
           if (!workerNotReady) {
             dispatch({
@@ -1853,6 +1871,10 @@ export function useAcpSession(
         }
         return { kind: "dispatched" };
       } catch (e) {
+        // The POST never completed, so nothing will acknowledge this id.
+        // Settling it is the safe direction: a brief false idle converges on
+        // the next control frame, a false active never converges. See #3417.
+        dispatch({ kind: "settle_inflight_prompt", id: promptId });
         dispatch({
           kind: "error",
           message: `Network error sending prompt: ${describeError(e)}`,

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -14,7 +14,6 @@ import {
   applyReducedState,
   emptyAcpState,
   deriveTurnActive,
-  withTurnActive,
   mergePrependedActivity,
   mergeServerRows,
   normaliseTurnState,
@@ -558,10 +557,11 @@ export function classifyElicitationResolveResponse(
 function settleInflightPrompt(state: AcpState, id: string): AcpState {
   const inflightPromptIds = state.inflightPromptIds.filter((p) => p !== id);
   if (inflightPromptIds.length === state.inflightPromptIds.length) return state;
-  return withTurnActive(
-    { ...state, inflightPromptIds },
-    deriveTurnActive({ serverTurnActive: state.serverTurnActive, inflightPromptIds }),
-  );
+  return {
+    ...state,
+    inflightPromptIds,
+    turnActive: deriveTurnActive({ serverTurnActive: state.serverTurnActive, inflightPromptIds }),
+  };
 }
 
 function pruneOptimisticRows(state: AcpState): AcpState {
@@ -731,7 +731,8 @@ export function reducer(state: AcpState, action: Action): AcpState {
       inflightPromptIds: state.inflightPromptIds.includes(id)
         ? state.inflightPromptIds
         : state.inflightPromptIds.concat(id),
-      ...withTurnActive({ turnActive: state.turnActive, turnSeq: state.turnSeq }, true),
+      promptSeq: state.promptSeq + 1,
+      turnActive: true,
     };
   }
   if (action.kind === "prompt_send_rejected") {

--- a/web/src/lib/acpTypes.reducer.test.ts
+++ b/web/src/lib/acpTypes.reducer.test.ts
@@ -577,24 +577,25 @@ describe("patchServerRow (Tier 4 delta Patch)", () => {
   });
 });
 
-describe("applyEvent / UserPromptSent turn counter (Tier 4)", () => {
-  it("bumps pendingUserPromptSeq for a prompt with no matching optimistic overlay", () => {
+describe("applyEvent / UserPromptSent prompt counter (Tier 4)", () => {
+  it("bumps promptSeq for a prompt this client did not dispatch", () => {
     const next = applyEvent(emptyAcpState(), {
       session_id: "s-1",
       seq: 1,
       event: { UserPromptSent: { text: "hi", prompt_id: "cmp-1" } },
     });
-    expect(next.pendingUserPromptSeq).toBe(1);
+    expect(next.promptSeq).toBe(1);
     expect(next.turnActive).toBe(true);
     // The transcript row is server-owned; applyEvent adds none.
     expect(next.activity).toHaveLength(0);
   });
 
-  it("does NOT double-bump when the echoed prompt_id matches an optimistic overlay row", () => {
+  it("does NOT double-bump when the echoed prompt_id is one we have in flight", () => {
     const seeded: AcpState = {
       ...emptyAcpState(),
       optimisticRows: [{ id: "cmp-1", kind: "user_prompt", text: "hi", at: "t" }],
-      pendingUserPromptSeq: 1,
+      inflightPromptIds: ["cmp-1"],
+      promptSeq: 1,
       turnActive: true,
     };
     const next = applyEvent(seeded, {
@@ -602,6 +603,7 @@ describe("applyEvent / UserPromptSent turn counter (Tier 4)", () => {
       seq: 1,
       event: { UserPromptSent: { text: "hi", prompt_id: "cmp-1" } },
     });
-    expect(next.pendingUserPromptSeq).toBe(1);
+    expect(next.promptSeq).toBe(1);
+    expect(next.inflightPromptIds).toEqual([]);
   });
 });

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -1408,6 +1408,53 @@ describe("turnActive: daemon truth plus an optimistic overlay (#3417)", () => {
     expect(state.startupError).toBe("boom");
   });
 
+  it("an idle session's own first prompt is not a steered continuation", async () => {
+    // Regression: `turnActive` is true through the POST-to-echo gap of this
+    // client's own prompt, so gating the steered-continuation branch on it
+    // made the echo of an idle session's FIRST prompt look steered. The
+    // per-turn resets were then skipped and the worker banners survived a
+    // prompt that actually opened a fresh turn.
+    const { acpHookReducer } = await import("../hooks/useAcpSession");
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        PromptCapabilities: { image: false, audio: false, embedded_context: false, steering: true },
+      },
+    });
+    state = { ...state, workerStopped: true, workerRestarting: true };
+    state = acpHookReducer(state, { kind: "user_prompt", id: "cmp-first", text: "first" });
+    // Optimism alone must not read as "a turn was already running".
+    expect(state.turnActive).toBe(true);
+    expect(state.serverTurnActive).toBe(false);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { UserPromptSent: { text: "first", prompt_id: "cmp-first" } },
+    });
+    expect(state.workerStopped).toBe(false);
+    expect(state.workerRestarting).toBe(false);
+  });
+
+  it("a genuinely steered mid-turn prompt still skips the per-turn resets", () => {
+    // The other side of the same gate: the daemon's flag is true, so this
+    // prompt joined a running turn and must not reset its accumulated state.
+    const running: AcpState = {
+      ...emptyAcpState(),
+      promptCapabilities: { image: false, audio: false, embeddedContext: false, steering: true },
+      serverTurnActive: true,
+      turnActive: true,
+      cancelEscalatesAt: new Date(Date.now() + 10_000).toISOString(),
+    };
+    const next = applyEvent(running, {
+      session_id: "s-1",
+      seq: 2,
+      event: { UserPromptSent: { text: "steered" } },
+    });
+    expect(next.cancelEscalatesAt).not.toBeNull();
+  });
+
   it("optimistic-match UserPromptSent still applies the per-turn resets", () => {
     // A server echo whose prompt_id matches the outstanding optimistic overlay
     // applies the per-turn resets (worker banners, wakeup countdown) and
@@ -1473,7 +1520,7 @@ describe("normaliseTurnState (#3417 persisted-state backfill)", () => {
       ...emptyAcpState(),
       activity: [
         { id: "a", kind: "user_prompt", text: "one", at: "" },
-        { id: "b", kind: "agent_message", text: "hi", at: "" },
+        { id: "b", kind: "message", text: "hi", at: "" },
         { id: "c", kind: "user_prompt", text: "two", at: "" },
       ],
     } as AcpState & { promptSeq?: number };

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -13,11 +13,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   applyEvent,
+  applyReducedState,
+  deriveTurnActive,
   emptyAcpState,
-  isTurnActive,
-  normaliseTurnCounters,
+  normaliseTurnState,
   type AcpFrame,
   type AcpState,
+  type ReducedState,
 } from "./acpTypes";
 
 function frame(seq: number, text: string): AcpFrame {
@@ -31,9 +33,8 @@ function frame(seq: number, text: string): AcpFrame {
 function withOptimisticPrompt(state: AcpState, text: string, id = "cmp-1"): AcpState {
   // Mirrors the optimistic dispatch in useAcpSession.sendPrompt: an overlay
   // row keyed by the minted prompt_id (never appended to the server-owned
-  // `activity`), with `pendingUserPromptSeq` bumped so a subsequent server
-  // echo carrying the same prompt_id doesn't double-count. See #1170 / #3173.
-  const pendingUserPromptSeq = state.pendingUserPromptSeq + 1;
+  // `activity`), with the same id recorded in flight so the server echo
+  // carrying it settles this exact prompt. See #3417 / #3173.
   return {
     ...state,
     optimisticRows: state.optimisticRows.concat({
@@ -42,20 +43,22 @@ function withOptimisticPrompt(state: AcpState, text: string, id = "cmp-1"): AcpS
       text,
       at: new Date().toISOString(),
     }),
-    pendingUserPromptSeq,
-    turnActive: pendingUserPromptSeq > state.lastStoppedSeq,
+    inflightPromptIds: state.inflightPromptIds.concat(id),
+    promptSeq: state.promptSeq + 1,
+    turnActive: true,
   };
 }
 
 describe("applyEvent / UserPromptSent (control state)", () => {
-  // The transcript row is server-owned now (Tier 4); applyEvent only advances
-  // the turn counter and applies the per-turn resets. The optimistic overlay
+  // The transcript row is server-owned now (Tier 4); applyEvent only opens
+  // the turn and applies the per-turn resets. The optimistic overlay
   // reconcile-by-prompt_id lives in the hook + acpTypes.reducer.test.ts.
-  it("bumps the turn counter and marks the turn active, adding no activity row", () => {
+  it("opens the turn and marks it active, adding no activity row", () => {
     const next = applyEvent(emptyAcpState(), frame(1, "hi"));
     expect(next.activity).toHaveLength(0);
-    expect(next.pendingUserPromptSeq).toBe(1);
+    expect(next.serverTurnActive).toBe(true);
     expect(next.turnActive).toBe(true);
+    expect(next.promptSeq).toBe(1);
     expect(next.lastSeq).toBe(1);
   });
 
@@ -96,11 +99,12 @@ describe("applyEvent / UserDiffCommentsPrompt (#1123) (control state)", () => {
     };
   }
 
-  it("bumps the turn counter (the typed row itself is server-owned)", () => {
+  it("opens the turn (the typed row itself is server-owned)", () => {
     const next = applyEvent(emptyAcpState(), diffCommentsFrame(1));
     expect(next.activity).toHaveLength(0);
-    expect(next.pendingUserPromptSeq).toBe(1);
+    expect(next.serverTurnActive).toBe(true);
     expect(next.turnActive).toBe(true);
+    expect(next.promptSeq).toBe(1);
   });
 
   it("applies the same per-turn resets as a plain prompt", () => {
@@ -153,7 +157,7 @@ describe("applyEvent / ACP session id lifecycle", () => {
   it("SessionContextReset clears stale usage and arms the primer after a prior prompt", () => {
     // The context_reset transcript row is server-owned (Tier 4); applyEvent
     // clears the usage/baseline and arms the one-shot primer affordance,
-    // gated on a prior user turn via pendingUserPromptSeq.
+    // gated on a prior user turn via turnSeq.
     let state = applyEvent(emptyAcpState(), {
       session_id: "s-1",
       seq: 1,
@@ -1211,91 +1215,142 @@ describe("applyEvent / AgentSwitched", () => {
   });
 });
 
-describe("turnActive derivation from prompt/stop counters (#1170)", () => {
-  // `turnActive` derives from `pendingUserPromptSeq > lastStoppedSeq`.
-  // The boolean field is kept on `AcpState` as a memoised alias so
-  // existing `state.turnActive` reads stay correct, but the counters
-  // are the source of truth a late `Stopped` cannot clobber.
+describe("turnActive: daemon truth plus an optimistic overlay (#3417)", () => {
+  // `turnActive` is `serverTurnActive || inflightPromptIds.length > 0`. The
+  // daemon owns the steady state (only it knows whether a mid-turn prompt was
+  // steered into the running turn or opened one of its own); the client owns
+  // only the gap between its own prompt POST and the server echo of it.
 
-  it("isTurnActive flips on / off when counters cross", () => {
-    expect(isTurnActive({ pendingUserPromptSeq: 2, lastStoppedSeq: 1 })).toBe(true);
-    expect(isTurnActive({ pendingUserPromptSeq: 1, lastStoppedSeq: 1 })).toBe(false);
-    expect(isTurnActive({ pendingUserPromptSeq: 0, lastStoppedSeq: 0 })).toBe(false);
+  function reduced(turn_active: boolean): ReducedState {
+    return {
+      agent: "claude",
+      model: null,
+      mode: "Default",
+      current_plan: null,
+      in_flight_tool: null,
+      pending_approvals: [],
+      pending_elicitations: [],
+      thinking: null,
+      rate_limit: null,
+      available_commands: [],
+      available_modes: [],
+      current_mode_id: null,
+      turn_active,
+      cancelling: false,
+      compacting: false,
+    };
+  }
+
+  it("deriveTurnActive ORs daemon truth with an unacknowledged prompt", () => {
+    const cases: Array<[boolean, string[], boolean]> = [
+      [true, [], true],
+      [false, [], false],
+      [false, ["p1"], true], // POST sent, echo not yet applied
+      [true, ["p1"], true],
+    ];
+    for (const [serverTurnActive, inflightPromptIds, expected] of cases) {
+      expect(deriveTurnActive({ serverTurnActive, inflightPromptIds })).toBe(expected);
+    }
   });
 
-  it("Stopped advances lastStoppedSeq by one and recomputes turnActive", () => {
-    // Single-prompt happy path: send → Stopped flips turnActive off.
+  it("N prompts steered into one turn are all closed by its single Stopped", async () => {
+    // The bug. A steering-capable agent gets follow-ups injected into the
+    // running turn, and the daemon deliberately emits no extra terminal event
+    // for them, so five prompts closed with one Stopped. The old counters
+    // ended 5 vs 1 and the composer showed Stop plus a spinner forever.
+    const { acpHookReducer } = await import("../hooks/useAcpSession");
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { PromptCapabilities: { image: false, audio: false, embedded_context: false, steering: true } },
+    });
+    let seq = 1;
+    for (const id of ["p1", "p2", "p3", "p4", "p5"]) {
+      state = acpHookReducer(state, { kind: "user_prompt", id, text: id });
+      expect(state.turnActive).toBe(true);
+      seq += 1;
+      state = applyEvent(state, {
+        session_id: "s-1",
+        seq,
+        event: { UserPromptSent: { text: id, prompt_id: id } },
+      });
+      state = applyReducedState(state, reduced(true));
+      expect(state.turnActive).toBe(true);
+    }
+    expect(state.inflightPromptIds).toEqual([]);
+    // Five prompts dispatched, each counted once despite the server echo.
+    expect(state.promptSeq).toBe(5);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: seq + 1,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    state = applyReducedState(state, reduced(false));
+    expect(state.turnActive).toBe(false);
+    expect(state.serverTurnActive).toBe(false);
+  });
+
+  it("a Stopped ends the turn on the happy single-prompt path", () => {
     let state = applyEvent(emptyAcpState(), {
       session_id: "s-1",
       seq: 1,
       event: { UserPromptSent: { text: "hi" } },
     });
-    expect(state.pendingUserPromptSeq).toBe(1);
-    expect(state.lastStoppedSeq).toBe(0);
     expect(state.turnActive).toBe(true);
-
     state = applyEvent(state, {
       session_id: "s-1",
       seq: 2,
       event: { Stopped: { reason: "prompt_complete" } },
     });
-    expect(state.pendingUserPromptSeq).toBe(1);
-    expect(state.lastStoppedSeq).toBe(1);
     expect(state.turnActive).toBe(false);
   });
 
-  it("late Stopped from prior turn does NOT clobber turnActive after a fresh follow-up", async () => {
-    // The bug. Prior turn: pendingUserPromptSeq=1, lastStoppedSeq=0
-    // (turnActive=true). User submits a follow-up before the prior
-    // turn's Stopped frame has been applied client-side; the
-    // optimistic `user_prompt` action bumps pending to 2. A beat
-    // later the Stopped frame for turn 1 lands. Under the old
-    // unconditional `turnActive=false`, the spinner died and the
-    // late agent chunks reordered visually below the new prompt.
-    // Under the counter model, lastStoppedSeq advances to 1
-    // (capped at pending) and `2 > 1` keeps turnActive true.
+  it("late Stopped from a prior turn does NOT clobber a fresh follow-up", async () => {
+    // #1170. The user taps Send the instant the prior turn ends, so the
+    // optimistic dispatch lands before that turn's Stopped frame. The
+    // unacknowledged id holds the spinner up through it.
     const { acpHookReducer } = await import("../hooks/useAcpSession");
-
     let state = applyEvent(emptyAcpState(), {
       session_id: "s-1",
       seq: 1,
       event: { UserPromptSent: { text: "first turn" } },
     });
     expect(state.turnActive).toBe(true);
-    // User taps Send the instant the turn ends; the optimistic
-    // dispatch lands BEFORE the Stopped frame for the prior turn.
-    state = acpHookReducer(state, {
-      kind: "user_prompt",
-      text: "follow-up",
-    });
-    expect(state.pendingUserPromptSeq).toBe(2);
-    expect(state.turnActive).toBe(true);
-    // Late Stopped (was for turn 1) now arrives. Must NOT kill the
-    // spinner because turn 2 is the active turn.
+    state = acpHookReducer(state, { kind: "user_prompt", id: "cmp-fu", text: "follow-up" });
+    expect(state.inflightPromptIds).toEqual(["cmp-fu"]);
+
     state = applyEvent(state, {
       session_id: "s-1",
       seq: 2,
       event: { Stopped: { reason: "prompt_complete" } },
     });
-    expect(state.pendingUserPromptSeq).toBe(2);
-    expect(state.lastStoppedSeq).toBe(1);
+    expect(state.serverTurnActive).toBe(false);
+    expect(state.turnActive).toBe(true);
+    // Even an authoritative idle frame cannot suppress it while the POST is
+    // still unacknowledged.
+    state = applyReducedState(state, reduced(false));
     expect(state.turnActive).toBe(true);
 
-    // Eventually turn 2's own Stopped lands and flips it off.
+    // The echo lands: the id settles and the daemon confirms the new turn.
     state = applyEvent(state, {
       session_id: "s-1",
       seq: 3,
+      event: { UserPromptSent: { text: "follow-up", prompt_id: "cmp-fu" } },
+    });
+    expect(state.inflightPromptIds).toEqual([]);
+    expect(state.turnActive).toBe(true);
+    expect(state.promptSeq).toBe(2);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
       event: { Stopped: { reason: "prompt_complete" } },
     });
-    expect(state.lastStoppedSeq).toBe(2);
     expect(state.turnActive).toBe(false);
   });
 
-  it("spurious Stopped on an idle session does not flip a future prompt off", () => {
-    // Defence-in-depth: a Stopped frame arriving with no outstanding
-    // turn must not advance `lastStoppedSeq` past `pendingUserPromptSeq`,
-    // otherwise the next prompt's increment wouldn't catch up and
-    // `turnActive` would stay false even with a real turn in flight.
+  it("a spurious Stopped on an idle session does not poison the next prompt", () => {
     let state = applyEvent(emptyAcpState(), {
       session_id: "s-1",
       seq: 1,
@@ -1307,46 +1362,38 @@ describe("turnActive derivation from prompt/stop counters (#1170)", () => {
       event: { Stopped: { reason: "prompt_complete" } },
     });
     expect(state.turnActive).toBe(false);
-    // Spurious extra Stopped (e.g. duplicate replay of the close).
+    // Duplicate replay of the close.
     state = applyEvent(state, {
       session_id: "s-1",
       seq: 3,
       event: { Stopped: { reason: "prompt_complete" } },
     });
-    expect(state.lastStoppedSeq).toBe(1);
-    expect(state.pendingUserPromptSeq).toBe(1);
-    // Next real prompt: turn must reactivate.
+    expect(state.turnActive).toBe(false);
     state = applyEvent(state, {
       session_id: "s-1",
       seq: 4,
       event: { UserPromptSent: { text: "second" } },
     });
-    expect(state.pendingUserPromptSeq).toBe(2);
-    expect(state.lastStoppedSeq).toBe(1);
     expect(state.turnActive).toBe(true);
+    expect(state.promptSeq).toBe(2);
   });
 
-  it("optimistic user_prompt + matching server echo (by prompt_id) only bump pending once", async () => {
-    // Avoids double-counting: the server's UserPromptSent whose prompt_id
-    // matches an outstanding optimistic overlay row must not bump
-    // `pendingUserPromptSeq` again. See #1170 / #3173.
+  it("optimistic user_prompt plus its matching echo settles exactly that id", async () => {
     const { acpHookReducer } = await import("../hooks/useAcpSession");
-    let state = acpHookReducer(emptyAcpState(), {
-      kind: "user_prompt",
-      id: "cmp-echo",
-      text: "echo me",
-    });
-    expect(state.pendingUserPromptSeq).toBe(1);
+    let state = acpHookReducer(emptyAcpState(), { kind: "user_prompt", id: "cmp-echo", text: "echo me" });
+    expect(state.inflightPromptIds).toEqual(["cmp-echo"]);
     state = applyEvent(state, {
       session_id: "s-1",
       seq: 5,
       event: { UserPromptSent: { text: "echo me", prompt_id: "cmp-echo" } },
     });
-    expect(state.pendingUserPromptSeq).toBe(1);
+    expect(state.inflightPromptIds).toEqual([]);
     expect(state.turnActive).toBe(true);
+    // One prompt, not two: the echo of our own dispatch does not double count.
+    expect(state.promptSeq).toBe(1);
   });
 
-  it("AgentStartupError advances lastStoppedSeq, preserving the race-safe semantics", () => {
+  it("AgentStartupError closes the turn", () => {
     let state = applyEvent(emptyAcpState(), {
       session_id: "s-1",
       seq: 1,
@@ -1357,15 +1404,14 @@ describe("turnActive derivation from prompt/stop counters (#1170)", () => {
       seq: 2,
       event: { AgentStartupError: { message: "boom" } },
     });
-    expect(state.lastStoppedSeq).toBe(1);
     expect(state.turnActive).toBe(false);
     expect(state.startupError).toBe("boom");
   });
 
-  it("optimistic-match UserPromptSent (by prompt_id) resets per-turn flags without double-counting", () => {
+  it("optimistic-match UserPromptSent still applies the per-turn resets", () => {
     // A server echo whose prompt_id matches the outstanding optimistic overlay
-    // still applies the per-turn resets (worker banners, wakeup countdown) but
-    // must NOT bump the counter again. See #1170 / #3173.
+    // applies the per-turn resets (worker banners, wakeup countdown) and
+    // settles that id. See #3173.
     const stale: AcpState = {
       ...withOptimisticPrompt(emptyAcpState(), "follow-up", "cmp-fu"),
       workerStopped: true,
@@ -1382,52 +1428,57 @@ describe("turnActive derivation from prompt/stop counters (#1170)", () => {
     expect(next.workerRestarting).toBe(false);
     expect(next.nextWakeupAt).toBeNull();
     expect(next.nextWakeupReason).toBeNull();
-    // withOptimisticPrompt bumped it to 1; the matching echo keeps it at 1.
-    expect(next.pendingUserPromptSeq).toBe(1);
+    expect(next.inflightPromptIds).toEqual([]);
     expect(next.turnActive).toBe(true);
   });
 });
 
-describe("normaliseTurnCounters (#1170 persisted-state backfill)", () => {
-  it("backfills counters from cached turnActive=true", () => {
+describe("normaliseTurnState (#3417 persisted-state backfill)", () => {
+  it("seeds serverTurnActive from a cached turnActive=true", () => {
     const cached = {
       ...emptyAcpState(),
       turnActive: true,
-    } as AcpState & { pendingUserPromptSeq?: number; lastStoppedSeq?: number };
-    delete cached.pendingUserPromptSeq;
-    delete cached.lastStoppedSeq;
-    const normalised = normaliseTurnCounters(cached);
-    expect(normalised.pendingUserPromptSeq).toBe(1);
-    expect(normalised.lastStoppedSeq).toBe(0);
+    } as AcpState & { serverTurnActive?: boolean };
+    delete cached.serverTurnActive;
+    const normalised = normaliseTurnState(cached);
+    expect(normalised.serverTurnActive).toBe(true);
     expect(normalised.turnActive).toBe(true);
   });
 
-  it("backfills counters from cached turnActive=false", () => {
+  it("seeds serverTurnActive from a cached turnActive=false", () => {
     const cached = {
       ...emptyAcpState(),
       turnActive: false,
-    } as AcpState & { pendingUserPromptSeq?: number; lastStoppedSeq?: number };
-    delete cached.pendingUserPromptSeq;
-    delete cached.lastStoppedSeq;
-    const normalised = normaliseTurnCounters(cached);
-    expect(normalised.pendingUserPromptSeq).toBe(0);
-    expect(normalised.lastStoppedSeq).toBe(0);
+    } as AcpState & { serverTurnActive?: boolean };
+    delete cached.serverTurnActive;
+    const normalised = normaliseTurnState(cached);
+    expect(normalised.serverTurnActive).toBe(false);
     expect(normalised.turnActive).toBe(false);
   });
 
-  it("passes through entries that already carry counters", () => {
-    const fresh: AcpState = {
+  it("never restores in-flight prompt ids: no POST survives a reload", () => {
+    const cached = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 5,
-      lastStoppedSeq: 3,
-      turnActive: false,
-    };
-    const normalised = normaliseTurnCounters(fresh);
-    expect(normalised.pendingUserPromptSeq).toBe(5);
-    expect(normalised.lastStoppedSeq).toBe(3);
-    // Even if the cached `turnActive` boolean was stale, the derived
-    // value wins so the spinner gate matches the counters.
-    expect(normalised.turnActive).toBe(true);
+      serverTurnActive: false,
+      turnActive: true,
+      inflightPromptIds: ["cmp-stale"],
+    } as AcpState;
+    const normalised = normaliseTurnState(cached);
+    expect(normalised.inflightPromptIds).toEqual([]);
+    expect(normalised.turnActive).toBe(false);
+  });
+
+  it("backfills promptSeq from the persisted prompt rows on a pre-#3417 entry", () => {
+    const cached = {
+      ...emptyAcpState(),
+      activity: [
+        { id: "a", kind: "user_prompt", text: "one", at: "" },
+        { id: "b", kind: "agent_message", text: "hi", at: "" },
+        { id: "c", kind: "user_prompt", text: "two", at: "" },
+      ],
+    } as AcpState & { promptSeq?: number };
+    delete cached.promptSeq;
+    expect(normaliseTurnState(cached).promptSeq).toBe(2);
   });
 });
 
@@ -1490,7 +1541,7 @@ describe("compaction reminder dismissal", () => {
       compactionReminderDismissed?: AcpState["compactionReminderDismissed"];
     };
     delete persisted.compactionReminderDismissed;
-    expect(normaliseTurnCounters(persisted).compactionReminderDismissed).toBeNull();
+    expect(normaliseTurnState(persisted).compactionReminderDismissed).toBeNull();
   });
 });
 
@@ -1586,8 +1637,9 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
   it("sets agentOrphaned and workerRestarting on prompt_orphaned", () => {
     let state: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 1,
-      lastStoppedSeq: 0,
+      serverTurnActive: true,
+      turnActive: true,
+      promptSeq: 1,
     };
     state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
     expect(state.agentOrphaned).toBe(true);
@@ -1599,8 +1651,9 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
   it("clears agentUnresponsive when prompt_orphaned arrives after it", () => {
     let state: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 2,
-      lastStoppedSeq: 0,
+      serverTurnActive: true,
+      turnActive: true,
+      promptSeq: 2,
     };
     state = applyEvent(state, stoppedFrame("agent_unresponsive", 1));
     expect(state.agentUnresponsive).toBe(true);
@@ -1613,8 +1666,9 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
   it("clears agentOrphaned on AcpSessionAssigned (respawn completed)", () => {
     let state: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 1,
-      lastStoppedSeq: 0,
+      serverTurnActive: true,
+      turnActive: true,
+      promptSeq: 1,
     };
     state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
     expect(state.agentOrphaned).toBe(true);
@@ -1630,8 +1684,9 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
   it("clears agentOrphaned on UserPromptSent (user moving on)", () => {
     let state: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 1,
-      lastStoppedSeq: 0,
+      serverTurnActive: true,
+      turnActive: true,
+      promptSeq: 1,
     };
     state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
     expect(state.agentOrphaned).toBe(true);
@@ -1646,8 +1701,9 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
   it("clears agentOrphaned on user_stopped", () => {
     let state: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 1,
-      lastStoppedSeq: 0,
+      serverTurnActive: true,
+      turnActive: true,
+      promptSeq: 1,
     };
     state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
     expect(state.agentOrphaned).toBe(true);
@@ -1657,44 +1713,41 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
 
   it("backfills agentOrphaned=false on pre-#1240 persisted state", () => {
     // Simulate a localStorage entry written before #1240: agentOrphaned
-    // absent. normaliseTurnCounters must default it to false so the
+    // absent. normaliseTurnState must default it to false so the
     // reducer and banner code see a well-typed value.
     const stale = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 0,
-      lastStoppedSeq: 0,
+      promptSeq: 0,
     } as AcpState & { agentOrphaned?: boolean };
     delete stale.agentOrphaned;
-    const normalised = normaliseTurnCounters(stale);
+    const normalised = normaliseTurnState(stale);
     expect(normalised.agentOrphaned).toBe(false);
   });
 
   it("backfills usageBaseline=null on pre-#1354 persisted state", () => {
     // Simulate a localStorage entry written before #1354: usageBaseline
-    // absent. normaliseTurnCounters must default it to null so the
+    // absent. normaliseTurnState must default it to null so the
     // UsageUpdated reducer arm's `next.usageBaseline && ...` check sees
     // a well-typed value rather than `undefined`.
     const stale = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 0,
-      lastStoppedSeq: 0,
+      promptSeq: 0,
     } as AcpState & { usageBaseline?: { cost: number } | null };
     delete stale.usageBaseline;
-    const normalised = normaliseTurnCounters(stale);
+    const normalised = normaliseTurnState(stale);
     expect(normalised.usageBaseline).toBeNull();
   });
 
-  it("preserves a non-null usageBaseline through normaliseTurnCounters", () => {
+  it("preserves a non-null usageBaseline through normaliseTurnState", () => {
     // A session that ran /clear before reload writes a baseline into
     // localStorage. Hydration must keep it so post-reload UsageUpdate
     // frames continue subtracting the boundary cumulative.
     const cached: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 3,
-      lastStoppedSeq: 3,
+      promptSeq: 3,
       usageBaseline: { cost: 0.42 },
     };
-    const normalised = normaliseTurnCounters(cached);
+    const normalised = normaliseTurnState(cached);
     expect(normalised.usageBaseline?.cost).toBeCloseTo(0.42, 6);
   });
 
@@ -1705,8 +1758,9 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
     // "Restarting…" copy. See CodeRabbit review on #1248.
     let state: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 1,
-      lastStoppedSeq: 0,
+      serverTurnActive: true,
+      turnActive: true,
+      promptSeq: 1,
     };
     state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
     expect(state.agentOrphaned).toBe(true);
@@ -1724,8 +1778,9 @@ describe("AcpState reducer / silent-orphan watchdog (#1240)", () => {
     // escalation copy that matches the active recovery phase.
     let state: AcpState = {
       ...emptyAcpState(),
-      pendingUserPromptSeq: 2,
-      lastStoppedSeq: 0,
+      serverTurnActive: true,
+      turnActive: true,
+      promptSeq: 2,
     };
     state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
     expect(state.agentOrphaned).toBe(true);

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -642,6 +642,7 @@ export interface ReducedState {
   available_commands: AvailableCommand[];
   available_modes: Array<{ id: string; name: string; description?: string | null }>;
   current_mode_id: string | null;
+  turn_active: boolean;
   cancelling: boolean;
   compacting: boolean;
 }
@@ -748,24 +749,33 @@ export interface AcpState {
    *  "working" spinner so the UI feels alive even when the agent
    *  isn't streaming text or running a tool yet.
    *
-   *  Derived from `pendingUserPromptSeq > lastStoppedSeq`; never
-   *  written directly. Keeping it on the state shape (instead of
+   *  Derived from `serverTurnActive || inflightPromptIds.length > 0`;
+   *  never written directly. Keeping it on the state shape (instead of
    *  exporting a selector) lets all the existing `state.turnActive`
-   *  reads stay unchanged. The counter pair is the source of truth so
-   *  a late `Stopped` from a prior turn can't clobber a fresh
-   *  follow-up that's already incremented `pendingUserPromptSeq`.
-   *  See #1170. */
+   *  reads stay unchanged. See {@link deriveTurnActive} and #3417. */
   turnActive: boolean;
-  /** Monotonic count of user prompts the client has dispatched (either
-   *  via the optimistic `user_prompt` action or via a server-confirmed
-   *  `UserPromptSent` echo that didn't match an outstanding optimistic
-   *  row). Source of truth for `turnActive`; never decremented. */
-  pendingUserPromptSeq: number;
-  /** Snapshot of `pendingUserPromptSeq` at the moment the most recent
-   *  `Stopped` (or `AgentStartupError`) arrived. `turnActive` derives
-   *  to false only when no further prompt has bumped
-   *  `pendingUserPromptSeq` past this snapshot. */
-  lastStoppedSeq: number;
+  /** The daemon's `AcpState.turn_active`, adopted verbatim from the
+   *  `reduced_state` frame. Authoritative for the steady state: the
+   *  daemon is the only party that knows whether a mid-turn prompt was
+   *  steered into the running turn (one terminal `Stopped` for many
+   *  prompts) or opened a turn of its own. See #3417 / #2805. */
+  serverTurnActive: boolean;
+  /** Client-minted prompt ids POSTed but not yet acknowledged, either by
+   *  the server's `UserPromptSent` echo or by the POST settling with a
+   *  failure. The thin optimistic overlay that covers the POST-to-echo
+   *  gap so the composer flips to "working" instantly; correlated by id
+   *  so one prompt settling cannot retire another's turn. Request-local,
+   *  never persisted. */
+  inflightPromptIds: string[];
+  /** Monotonic count of turns opened, bumped on every false to true edge of
+   *  {@link AcpState.turnActive} and never decremented. A steered prompt
+   *  joins the running turn without an edge, so it does not bump.
+   *
+   *  Two readers: `useCancelEscalation` tokenises "already pressed Stop this
+   *  turn" as `(sessionId, turnSeq)` so the next turn's first Stop is graceful
+   *  again (#2237), and the `SessionContextReset` arm treats zero as "this
+   *  session never had a prompt to lose" and suppresses the re-prime offer. */
+  turnSeq: number;
   /** Real ACP-advertised modes from the agent's NewSessionResponse,
    *  plus the agent's currently-active mode id. Empty until the
    *  agent reports them; the picker falls back to the hard-coded
@@ -1244,8 +1254,9 @@ export function emptyAcpState(): AcpState {
     incompatibleAgent: null,
     lastError: null,
     turnActive: false,
-    pendingUserPromptSeq: 0,
-    lastStoppedSeq: 0,
+    serverTurnActive: false,
+    inflightPromptIds: [],
+    turnSeq: 0,
     availableModes: [],
     currentModeId: null,
     availableCommands: [],
@@ -1274,10 +1285,6 @@ export function emptyAcpState(): AcpState {
   };
 }
 
-/** Per-turn state resets shared by every "a new user turn started"
- *  event (a plain `UserPromptSent` and a `UserDiffCommentsPrompt`).
- *  Mutates `next` in place; the caller has already appended the
- *  activity row and bumped `pendingUserPromptSeq`. */
 /** Whether a `UserPromptSent` is a message steered into the turn already
  *  running rather than the start of a new one (#2805).
  *
@@ -1288,17 +1295,19 @@ export function emptyAcpState(): AcpState {
  *  turn's single `Stopped` still has to see the output flag and the
  *  pending-cancel state the turn actually accumulated.
  *
- *  Takes the pre-event state, since the arms bump `pendingUserPromptSeq`
- *  (which feeds `isTurnActive`) before they reach the reset.
+ *  Takes the pre-event state, since the arms open the turn before they
+ *  reach the reset.
  */
 function isSteeredContinuation(state: AcpState): boolean {
   return state.turnActive && !!state.promptCapabilities?.steering;
 }
 
+/** Per-turn state resets shared by every "a new user turn started"
+ *  event (a plain `UserPromptSent` and a `UserDiffCommentsPrompt`).
+ *  Mutates `next` in place; the caller has already opened the turn. */
 function applyNewTurnResets(next: AcpState): void {
   next.startupError = null;
   next.lastError = null;
-  next.turnActive = isTurnActive(next);
   // The cancel phase itself is server-owned (a fresh non-steered turn clears
   // it there); only the escalation deadline is ours to drop. See #1727.
   next.cancelEscalatesAt = null;
@@ -1458,11 +1467,12 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
   }
   if ("Stopped" in event) {
     // Final marker. Every in-turn phase it used to clear (in-flight tool,
-    // thinking, cancelling, compacting) is server-owned since Tier 1.2; what
-    // remains is the client's own turn bookkeeping. See #1170.
+    // thinking, cancelling, compacting) is server-owned since Tier 1.2, and
+    // closing the turn joined them in #3417: whether this `Stopped` ends the
+    // turn or only one of several prompts steered into it is the daemon's
+    // call, and the `reduced_state` frame that always follows this event
+    // carries the answer. Only the escalation deadline is ours to drop.
     next.cancelEscalatesAt = null;
-    next.lastStoppedSeq = Math.min(next.lastStoppedSeq + 1, next.pendingUserPromptSeq);
-    next.turnActive = isTurnActive(next);
     // Clear the "monitoring" badge once the monitor has fired and that turn
     // ends. See #2325.
     if (next.monitorArmed && next.monitorWorkSeen) {
@@ -1512,17 +1522,12 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // powers the StartupErrorScreen.
     next.incompatibleAgent = event.IncompatibleAgent.detail;
     next.agentUnresponsive = false;
-    next.lastStoppedSeq = Math.min(next.lastStoppedSeq + 1, next.pendingUserPromptSeq);
-    next.turnActive = isTurnActive(next);
     return next;
   }
   if ("AgentStartupError" in event) {
     next.startupError = event.AgentStartupError.message;
     // A failed respawn supersedes any in-progress unresponsive escalation.
     next.agentUnresponsive = false;
-    // Same race-safe semantics as Stopped. See #1170.
-    next.lastStoppedSeq = Math.min(next.lastStoppedSeq + 1, next.pendingUserPromptSeq);
-    next.turnActive = isTurnActive(next);
     return next;
   }
   if ("PromptRuntimeError" in event) {
@@ -1540,17 +1545,19 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     return next;
   }
   if ("UserPromptSent" in event) {
-    // Control-only: the transcript row is server-owned. Reconcile the turn
-    // counter against the optimistic overlay by the minted prompt_id, so a
-    // server echo of a prompt this client dispatched optimistically does not
-    // double-bump the counter (the optimistic `user_prompt` action already
-    // bumped it). A prompt with no matching optimistic row (replay, another
-    // device, a drained queue entry) bumps here. See #1170 / #3173.
+    // Control-only: the transcript row is server-owned. This is the daemon
+    // acknowledging the prompt, so it settles the matching optimistic id by
+    // the minted `prompt_id` (#3173) and opens the turn. Opening it here
+    // rather than waiting for the `reduced_state` frame that follows is the
+    // one place the client mirrors a daemon turn edge: without it, settling
+    // the id would drop `turnActive` for the single frame between the two.
+    // The following `reduced_state` stays authoritative.
     const pid = event.UserPromptSent.prompt_id;
-    const isOptimistic = pid != null && pid.length > 0 && state.optimisticRows.some((o) => o.id === pid);
-    if (!isOptimistic) {
-      next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
+    if (pid != null && pid.length > 0) {
+      next.inflightPromptIds = next.inflightPromptIds.filter((id) => id !== pid);
     }
+    next.serverTurnActive = true;
+    openTurn(next);
     if (!isSteeredContinuation(state)) {
       applyNewTurnResets(next);
     }
@@ -1558,9 +1565,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
   }
   if ("UserDiffCommentsPrompt" in event) {
     // The "Send diff comments" dialog posts directly with no optimistic
-    // overlay, so always bump the turn counter. The typed row is
-    // server-owned.
-    next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
+    // overlay, so there is no id to settle. The typed row is server-owned.
+    next.serverTurnActive = true;
+    openTurn(next);
     if (!isSteeredContinuation(state)) {
       applyNewTurnResets(next);
     }
@@ -1578,14 +1585,6 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     next.workerIdleStopped = false;
     next.agentUnresponsive = false;
     next.agentOrphaned = false;
-    // A prompt sent to an idle-dormant worker left pendingUserPromptSeq
-    // bumped (turn pending) so the drain effect stays braked. The respawn
-    // handshake is the worker-online signal: retire that phantom turn so the
-    // drain fires. Scoped to a non-empty queue. See #3094 / #3087.
-    if (next.queuedPrompts.length > 0 && next.pendingUserPromptSeq > next.lastStoppedSeq) {
-      next.lastStoppedSeq = next.pendingUserPromptSeq;
-      next.turnActive = isTurnActive(next);
-    }
     return next;
   }
   if ("SessionContextReset" in event) {
@@ -1596,9 +1595,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // Suppress the primer offer on a session that never saw a user prompt
     // (a 0-prompt session's session/load failure is expected). The visible
     // reset row is server-owned; here we only gate the primer affordance.
-    // `pendingUserPromptSeq` counts prompts applied before this event (frames
-    // are applied in seq order), so it is the "had a prior prompt" signal.
-    if (state.pendingUserPromptSeq <= 0) {
+    // `turnSeq` counts turns opened before this event (frames are applied in
+    // seq order), so zero is the "never had a prompt" signal.
+    if (state.turnSeq <= 0) {
       return next;
     }
     // Offer the opt-in primer affordance; one-shot, cleared by the next
@@ -1669,10 +1668,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     };
     const REJECTED_PROMPTS_CAP = 5;
     next.rejectedPrompts = [...next.rejectedPrompts, entry].slice(-REJECTED_PROMPTS_CAP);
-    // Retire the spinner for this rejected submission so the composer
-    // unlocks. See #1170.
-    next.lastStoppedSeq = Math.min(next.lastStoppedSeq + 1, next.pendingUserPromptSeq);
-    next.turnActive = isTurnActive(next);
+    // The turn this rejection leaves running (or not) is the daemon's call
+    // and arrives on the following `reduced_state`; the composer's own
+    // optimistic marker is settled by the POST that got the rejection.
     return next;
   }
   if ("BackgroundAgentLaunched" in event) {
@@ -1787,6 +1785,14 @@ export function applyReducedState(state: AcpState, reduced: ReducedState, unchan
     availableCommands: holds("available_commands") ? state.availableCommands : reduced.available_commands,
     availableModes: holds("available_modes") ? state.availableModes : reduced.available_modes,
     currentModeId: reduced.current_mode_id,
+    // Steady-state turn truth. A false frame cannot suppress a prompt whose
+    // POST is still unacknowledged, so an unrelated frame arriving in that
+    // window does not flicker the composer back to idle. See #3417.
+    serverTurnActive: reduced.turn_active,
+    ...withTurnActive(
+      { turnActive: state.turnActive, turnSeq: state.turnSeq },
+      deriveTurnActive({ serverTurnActive: reduced.turn_active, inflightPromptIds: state.inflightPromptIds }),
+    ),
     cancelling: reduced.cancelling,
     compacting: reduced.compacting,
     locallyResolved,
@@ -1883,19 +1889,34 @@ export function appendElicitationAnswerRow(
   });
 }
 
-/** Derived `turnActive` from the prompt / stop seq counters. Exported
- *  so any new consumer can compute it from the counters directly; the
- *  reducer also calls this to keep `state.turnActive` in lockstep so
- *  existing `state.turnActive` reads stay correct. See #1170.
+/** Rendered `turnActive`: the daemon's steady-state truth, OR'd with the
+ *  client's own unacknowledged prompt POSTs.
  *
- *  Invariant: `lastStoppedSeq <= pendingUserPromptSeq` always holds.
- *  Both counters start at 0; `pendingUserPromptSeq` increments by one
- *  on every dispatched user prompt, and `lastStoppedSeq` advances by
- *  one per `Stopped` / `AgentStartupError` but is capped at
- *  `pendingUserPromptSeq` so spurious extra Stopped frames cannot
- *  poison a future turn. */
-export function isTurnActive(state: Pick<AcpState, "pendingUserPromptSeq" | "lastStoppedSeq">): boolean {
-  return state.pendingUserPromptSeq > state.lastStoppedSeq;
+ *  This replaced a client-side `pendingUserPromptSeq > lastStoppedSeq`
+ *  counter pair, which assumed one terminal `Stopped` per prompt. Mid-turn
+ *  steering (#2805) breaks that cardinality: the daemon injects a prompt
+ *  into the running turn and deliberately emits no extra terminal event,
+ *  so N prompts closed with one `Stopped` left the counters permanently
+ *  apart and the composer stuck on Stop plus a spinner. The daemon already
+ *  models this correctly as a boolean and already ships it; the client now
+ *  adopts it. See #3417 and `docs/development/server-owned-sv-state.md`. */
+export function deriveTurnActive(state: Pick<AcpState, "serverTurnActive" | "inflightPromptIds">): boolean {
+  return state.serverTurnActive || state.inflightPromptIds.length > 0;
+}
+
+/** Set the rendered turn flag, bumping {@link AcpState.turnSeq} on each
+ *  false to true edge. Steered prompts arrive while the flag is already true,
+ *  so they extend the running turn rather than opening a new one. */
+export function withTurnActive<S extends Pick<AcpState, "turnActive" | "turnSeq">>(state: S, active: boolean): S {
+  if (active === state.turnActive) return state;
+  return { ...state, turnActive: active, turnSeq: active ? state.turnSeq + 1 : state.turnSeq };
+}
+
+/** In-place {@link withTurnActive}`(next, true)` for the `applyEvent` arms,
+ *  which mutate a pre-spread `next`. */
+function openTurn(next: AcpState): void {
+  if (!next.turnActive) next.turnSeq += 1;
+  next.turnActive = true;
 }
 
 /** Whether the structured view should show the compaction reminder.
@@ -1922,16 +1943,18 @@ export function isCompactionReminderDue(
   return (usage.used / usage.size) * 100 >= prefs.compactionReminderPercent;
 }
 
-/** Normalise a partial AcpState so the turn counters are populated.
- *  Used by the localStorage loader after the #1170 schema change: pre-
- *  schema persisted entries have no counters, so we backfill from the
- *  cached `turnActive` boolean (true → one outstanding prompt, false →
- *  fully retired) and re-derive `turnActive` from the counters. */
-export function normaliseTurnCounters(
+/** Normalise a partial AcpState so the turn state is populated. Used by
+ *  the localStorage loader: an entry persisted before #3417 carries the
+ *  retired `pendingUserPromptSeq` / `lastStoppedSeq` counters and no
+ *  `serverTurnActive`, so we seed the latter from the cached `turnActive`
+ *  boolean as a warm hint. The WS connect snapshot replaces it with daemon
+ *  truth a moment later. In-flight prompt ids are request-local and always
+ *  start empty: after a reload there is no POST left to acknowledge them. */
+export function normaliseTurnState(
   state: AcpState & {
     oldestSeq?: number;
-    pendingUserPromptSeq?: number;
-    lastStoppedSeq?: number;
+    serverTurnActive?: boolean;
+    turnSeq?: number;
     rejectedPrompts?: RejectedPrompt[];
     agentUnresponsive?: boolean;
     agentOrphaned?: boolean;
@@ -1942,10 +1965,14 @@ export function normaliseTurnCounters(
     compactionReminderDismissed?: SessionUsage | null;
   },
 ): AcpState {
-  const pendingUserPromptSeq =
-    typeof state.pendingUserPromptSeq === "number" ? state.pendingUserPromptSeq : state.turnActive ? 1 : 0;
-  const lastStoppedSeq =
-    typeof state.lastStoppedSeq === "number" ? state.lastStoppedSeq : state.turnActive ? 0 : pendingUserPromptSeq;
+  const serverTurnActive =
+    typeof state.serverTurnActive === "boolean" ? state.serverTurnActive : state.turnActive === true;
+  // A hydrate that already has prompt rows already had turns; a cold entry
+  // re-folds its history and counts them on the way through.
+  const turnSeq =
+    typeof state.turnSeq === "number" && Number.isFinite(state.turnSeq)
+      ? Math.max(0, Math.floor(state.turnSeq))
+      : (state.activity ?? []).filter((r) => r.kind === "user_prompt").length;
   // Pre-#1196 persisted entries lack rejectedPrompts / agentUnresponsive;
   // backfill so the reducer and renderers see well-typed values instead
   // of `undefined` (which crashes RejectedPromptsStrip's `.length` read).
@@ -1989,8 +2016,9 @@ export function normaliseTurnCounters(
     configOptionSwitchFailed,
     pendingConfigOption,
     compactionReminderDismissed,
-    pendingUserPromptSeq,
-    lastStoppedSeq,
-    turnActive: isTurnActive({ pendingUserPromptSeq, lastStoppedSeq }),
+    serverTurnActive,
+    turnSeq,
+    inflightPromptIds: [],
+    turnActive: serverTurnActive,
   };
 }

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -767,15 +767,17 @@ export interface AcpState {
    *  so one prompt settling cannot retire another's turn. Request-local,
    *  never persisted. */
   inflightPromptIds: string[];
-  /** Monotonic count of turns opened, bumped on every false to true edge of
-   *  {@link AcpState.turnActive} and never decremented. A steered prompt
-   *  joins the running turn without an edge, so it does not bump.
+  /** Monotonic count of user prompts dispatched, never decremented. Bumped
+   *  by the optimistic `user_prompt` action and by any `UserPromptSent` with
+   *  no matching outstanding optimistic id (a replay, another device, a
+   *  drained queue entry), so an echo of this client's own prompt counts once.
    *
-   *  Two readers: `useCancelEscalation` tokenises "already pressed Stop this
-   *  turn" as `(sessionId, turnSeq)` so the next turn's first Stop is graceful
-   *  again (#2237), and the `SessionContextReset` arm treats zero as "this
-   *  session never had a prompt to lose" and suppresses the re-prime offer. */
-  turnSeq: number;
+   *  Two readers: `useCancelEscalation` tokenises "already pressed Stop for
+   *  this prompt" as `(sessionId, promptSeq)` so the next prompt's first Stop
+   *  is graceful again (#2237), and the `SessionContextReset` arm treats zero
+   *  as "this session never had a prompt to lose" and suppresses the re-prime
+   *  offer. Deliberately not turn truth: see {@link deriveTurnActive}. */
+  promptSeq: number;
   /** Real ACP-advertised modes from the agent's NewSessionResponse,
    *  plus the agent's currently-active mode id. Empty until the
    *  agent reports them; the picker falls back to the hard-coded
@@ -1256,7 +1258,7 @@ export function emptyAcpState(): AcpState {
     turnActive: false,
     serverTurnActive: false,
     inflightPromptIds: [],
-    turnSeq: 0,
+    promptSeq: 0,
     availableModes: [],
     currentModeId: null,
     availableCommands: [],
@@ -1368,6 +1370,13 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // model: the agent reports session-lifetime cumulative cost, so each
     // boundary snapshots it to keep the footer reading "since the most recent
     // boundary". See #1354 / #1109.
+    if (event === "ThinkingStarted") {
+      // Agent-initiated work with no prompt behind it still opens a turn.
+      // Mirrors `AcpState::apply_event`; see closeTurn's note on why the raw
+      // fold tracks these edges at all.
+      next.serverTurnActive = true;
+      next.turnActive = true;
+    }
     if (event === "ConversationCompacted" || event === "SessionCleared") {
       const priorUsage = state.sessionUsage?.cost?.amount ?? 0;
       const priorBaseline = state.usageBaseline?.cost ?? 0;
@@ -1470,9 +1479,11 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // thinking, cancelling, compacting) is server-owned since Tier 1.2, and
     // closing the turn joined them in #3417: whether this `Stopped` ends the
     // turn or only one of several prompts steered into it is the daemon's
-    // call, and the `reduced_state` frame that always follows this event
-    // carries the answer. Only the escalation deadline is ours to drop.
+    // call, and the `reduced_state` frame that follows this event on the WS
+    // carries the answer. The raw edge is mirrored for the history fold; see
+    // closeTurn.
     next.cancelEscalatesAt = null;
+    closeTurn(next);
     // Clear the "monitoring" badge once the monitor has fired and that turn
     // ends. See #2325.
     if (next.monitorArmed && next.monitorWorkSeen) {
@@ -1528,10 +1539,12 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     next.startupError = event.AgentStartupError.message;
     // A failed respawn supersedes any in-progress unresponsive escalation.
     next.agentUnresponsive = false;
+    closeTurn(next);
     return next;
   }
   if ("PromptRuntimeError" in event) {
     next.lastError = event.PromptRuntimeError.message;
+    closeTurn(next);
     return next;
   }
   if ("PromptCapabilities" in event) {
@@ -1553,11 +1566,14 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // the id would drop `turnActive` for the single frame between the two.
     // The following `reduced_state` stays authoritative.
     const pid = event.UserPromptSent.prompt_id;
-    if (pid != null && pid.length > 0) {
+    const wasInflight = pid != null && pid.length > 0 && next.inflightPromptIds.includes(pid);
+    if (wasInflight) {
       next.inflightPromptIds = next.inflightPromptIds.filter((id) => id !== pid);
+    } else {
+      next.promptSeq += 1;
     }
     next.serverTurnActive = true;
-    openTurn(next);
+    next.turnActive = true;
     if (!isSteeredContinuation(state)) {
       applyNewTurnResets(next);
     }
@@ -1566,8 +1582,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
   if ("UserDiffCommentsPrompt" in event) {
     // The "Send diff comments" dialog posts directly with no optimistic
     // overlay, so there is no id to settle. The typed row is server-owned.
+    next.promptSeq += 1;
     next.serverTurnActive = true;
-    openTurn(next);
+    next.turnActive = true;
     if (!isSteeredContinuation(state)) {
       applyNewTurnResets(next);
     }
@@ -1595,9 +1612,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // Suppress the primer offer on a session that never saw a user prompt
     // (a 0-prompt session's session/load failure is expected). The visible
     // reset row is server-owned; here we only gate the primer affordance.
-    // `turnSeq` counts turns opened before this event (frames are applied in
-    // seq order), so zero is the "never had a prompt" signal.
-    if (state.turnSeq <= 0) {
+    // `promptSeq` counts prompts applied before this event (frames are applied
+    // in seq order), so zero is the "never had a prompt" signal.
+    if (state.promptSeq <= 0) {
       return next;
     }
     // Offer the opt-in primer affordance; one-shot, cleared by the next
@@ -1668,9 +1685,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     };
     const REJECTED_PROMPTS_CAP = 5;
     next.rejectedPrompts = [...next.rejectedPrompts, entry].slice(-REJECTED_PROMPTS_CAP);
-    // The turn this rejection leaves running (or not) is the daemon's call
-    // and arrives on the following `reduced_state`; the composer's own
-    // optimistic marker is settled by the POST that got the rejection.
+    // The composer's own optimistic marker is settled by the POST that got
+    // the rejection; this closes the turn the daemon closed. See closeTurn.
+    closeTurn(next);
     return next;
   }
   if ("BackgroundAgentLaunched" in event) {
@@ -1789,10 +1806,10 @@ export function applyReducedState(state: AcpState, reduced: ReducedState, unchan
     // POST is still unacknowledged, so an unrelated frame arriving in that
     // window does not flicker the composer back to idle. See #3417.
     serverTurnActive: reduced.turn_active,
-    ...withTurnActive(
-      { turnActive: state.turnActive, turnSeq: state.turnSeq },
-      deriveTurnActive({ serverTurnActive: reduced.turn_active, inflightPromptIds: state.inflightPromptIds }),
-    ),
+    turnActive: deriveTurnActive({
+      serverTurnActive: reduced.turn_active,
+      inflightPromptIds: state.inflightPromptIds,
+    }),
     cancelling: reduced.cancelling,
     compacting: reduced.compacting,
     locallyResolved,
@@ -1904,19 +1921,19 @@ export function deriveTurnActive(state: Pick<AcpState, "serverTurnActive" | "inf
   return state.serverTurnActive || state.inflightPromptIds.length > 0;
 }
 
-/** Set the rendered turn flag, bumping {@link AcpState.turnSeq} on each
- *  false to true edge. Steered prompts arrive while the flag is already true,
- *  so they extend the running turn rather than opening a new one. */
-export function withTurnActive<S extends Pick<AcpState, "turnActive" | "turnSeq">>(state: S, active: boolean): S {
-  if (active === state.turnActive) return state;
-  return { ...state, turnActive: active, turnSeq: active ? state.turnSeq + 1 : state.turnSeq };
-}
-
-/** In-place {@link withTurnActive}`(next, true)` for the `applyEvent` arms,
- *  which mutate a pre-spread `next`. */
-function openTurn(next: AcpState): void {
-  if (!next.turnActive) next.turnSeq += 1;
-  next.turnActive = true;
+/** Close the turn from a raw event, mirroring `AcpState::apply_event`'s own
+ *  `turn_active = false` edges (`src/acp/state.rs`).
+ *
+ *  The `reduced_state` frame the daemon pushes after every event is still
+ *  authoritative, so this looks redundant on the WS path. It is not on the
+ *  history path: `GET /acp/replay` serves raw events with no `reduced_state`
+ *  alongside, so a cold open that folded only the opening edges would paint a
+ *  spinner over a session that finished hours ago until the WS connect
+ *  snapshot corrected it. Mirroring the same seven edges the daemon uses
+ *  keeps the raw fold self-consistent. See #3417. */
+function closeTurn(next: AcpState): void {
+  next.serverTurnActive = false;
+  next.turnActive = deriveTurnActive(next);
 }
 
 /** Whether the structured view should show the compaction reminder.
@@ -1954,7 +1971,7 @@ export function normaliseTurnState(
   state: AcpState & {
     oldestSeq?: number;
     serverTurnActive?: boolean;
-    turnSeq?: number;
+    promptSeq?: number;
     rejectedPrompts?: RejectedPrompt[];
     agentUnresponsive?: boolean;
     agentOrphaned?: boolean;
@@ -1967,11 +1984,11 @@ export function normaliseTurnState(
 ): AcpState {
   const serverTurnActive =
     typeof state.serverTurnActive === "boolean" ? state.serverTurnActive : state.turnActive === true;
-  // A hydrate that already has prompt rows already had turns; a cold entry
+  // A hydrate that already has prompt rows already had prompts; a cold entry
   // re-folds its history and counts them on the way through.
-  const turnSeq =
-    typeof state.turnSeq === "number" && Number.isFinite(state.turnSeq)
-      ? Math.max(0, Math.floor(state.turnSeq))
+  const promptSeq =
+    typeof state.promptSeq === "number" && Number.isFinite(state.promptSeq)
+      ? Math.max(0, Math.floor(state.promptSeq))
       : (state.activity ?? []).filter((r) => r.kind === "user_prompt").length;
   // Pre-#1196 persisted entries lack rejectedPrompts / agentUnresponsive;
   // backfill so the reducer and renderers see well-typed values instead
@@ -2017,7 +2034,7 @@ export function normaliseTurnState(
     pendingConfigOption,
     compactionReminderDismissed,
     serverTurnActive,
-    turnSeq,
+    promptSeq,
     inflightPromptIds: [],
     turnActive: serverTurnActive,
   };

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1299,9 +1299,15 @@ export function emptyAcpState(): AcpState {
  *
  *  Takes the pre-event state, since the arms open the turn before they
  *  reach the reset.
+ *
+ *  Reads `serverTurnActive`, not the rendered `turnActive`: since #3417 the
+ *  latter is also true through the POST-to-echo gap of this client's own
+ *  prompt, so an idle session's very first prompt would look steered to its
+ *  own echo and skip the resets it needs. Only the daemon's flag means "a
+ *  turn was already running".
  */
 function isSteeredContinuation(state: AcpState): boolean {
-  return state.turnActive && !!state.promptCapabilities?.steering;
+  return state.serverTurnActive && !!state.promptCapabilities?.steering;
 }
 
 /** Per-turn state resets shared by every "a new user turn started"

--- a/web/tests/helpers/acpMock.ts
+++ b/web/tests/helpers/acpMock.ts
@@ -13,6 +13,15 @@
 
 import { expect, type Page, type WebSocketRoute } from "@playwright/test";
 
+/** Parsed `POST .../acp/prompt` request body. `prompt_id` is the
+ *  client-minted id the daemon echoes back on `UserPromptSent`, so a spec can
+ *  assert the optimistic-row correlation directly. Optional because a caller
+ *  that predates the id (or posts by hand) may omit it. */
+export interface AcpPromptBody {
+  text: string;
+  prompt_id?: string;
+}
+
 export interface AcpSessionMockOptions {
   sessionId?: string;
   title?: string;
@@ -21,7 +30,7 @@ export interface AcpSessionMockOptions {
   /** Maps a captured `POST .../acp/prompt` body to events replayed on
    *  the WS after the POST is fulfilled, standing in for the live
    *  fake-ACP agent's scripted turn. */
-  onPrompt?: (body: { text: string }) => unknown[];
+  onPrompt?: (body: AcpPromptBody) => unknown[];
   /** Same, for `POST .../acp/config-option`: the returned events play
    *  the adapter's confirming snapshot (or rejection). */
   onConfigOption?: (body: { config_id: string; value: string }) => unknown[];
@@ -36,7 +45,7 @@ export interface AcpSessionMock {
   sessionId: string;
   title: string;
   /** Parsed bodies of every `POST .../acp/prompt` the page sent. */
-  promptBodies: Array<{ text: string }>;
+  promptBodies: AcpPromptBody[];
   /** Parsed bodies of every `POST .../acp/config-option`. */
   configOptionBodies: Array<{ config_id: string; value: string }>;
   /** Parsed bodies of every `POST /api/telemetry/seen`. */
@@ -295,7 +304,7 @@ export async function mockAcpSession(page: Page, opts: AcpSessionMockOptions = {
     });
   });
   await page.route("**/api/sessions/*/acp/prompt", async (r) => {
-    const body = JSON.parse(r.request().postData() ?? "{}") as { text: string; prompt_id?: string };
+    const body = JSON.parse(r.request().postData() ?? "{}") as AcpPromptBody;
     handle.promptBodies.push(body);
     await r.fulfill({ json: {} });
     // The daemon publishes `UserPromptSent` carrying the client-minted

--- a/web/tests/helpers/acpMock.ts
+++ b/web/tests/helpers/acpMock.ts
@@ -295,9 +295,16 @@ export async function mockAcpSession(page: Page, opts: AcpSessionMockOptions = {
     });
   });
   await page.route("**/api/sessions/*/acp/prompt", async (r) => {
-    const body = JSON.parse(r.request().postData() ?? "{}") as { text: string };
+    const body = JSON.parse(r.request().postData() ?? "{}") as { text: string; prompt_id?: string };
     handle.promptBodies.push(body);
     await r.fulfill({ json: {} });
+    // The daemon publishes `UserPromptSent` carrying the client-minted
+    // `prompt_id` BEFORE it forwards the prompt to the agent
+    // (`send_turn` -> `publish_user_prompt_with_attachments`). That echo is
+    // what settles the client's optimistic in-flight marker and opens the
+    // turn, so a mock that jumps straight to the agent's reply leaves the
+    // composer wedged in its "working" state. See #3417.
+    pushEvents([{ UserPromptSent: { text: body.text, prompt_id: body.prompt_id ?? null } }]);
     pushEvents(opts.onPrompt?.(body) ?? []);
   });
   await page.route("**/api/sessions/*/acp/config-option", async (r) => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A finished structured-view session kept rendering the Stop button and a working spinner in the composer forever, while the sidebar correctly showed it as finished. Only a page reload cleared it.

The web reducer derived `turnActive` from a `pendingUserPromptSeq > lastStoppedSeq` counter pair, which assumes one terminal `Stopped` per prompt. Mid-turn steering (#2805) does not honor that: the daemon injects the prompt into the running turn and deliberately emits no extra terminal event, so N prompts close with a single `Stopped`. The affected session's event log shows 5 `UserPromptSent`, 2 `Stopped`, `PromptCapabilities.steering = true`, and nothing terminal in between; the counters ended 5 vs 2 and never converged.

The daemon already models this correctly as a plain `AcpState.turn_active` boolean, and already ships it on every `reduced_state` frame plus the whole-state snapshot on connect. The web's `ReducedState` interface simply never declared the field. So the fix is to finish the migration `docs/development/server-owned-sv-state.md` already specified: the daemon owns the steady state, and the client keeps only a thin optimistic overlay for the gap between its own prompt POST and the server echo of it. `turnActive` is now `serverTurnActive || inflightPromptIds.length > 0`, with in-flight ids correlated by the client-minted `prompt_id` so one prompt settling cannot retire another's turn.

Rejected along the way: the narrower fix of skipping the counter bump for a steered prompt. A steered prompt has three daemon outcomes the client cannot distinguish at `UserPromptSent` time (injected with no further event, raced the turn end and re-dispatched as its own turn, or failed to `PromptRejected`), and in the latter two the later retiring event would over-retire and kill the spinner of a genuinely running turn.

While closing this, two pre-existing paths of the same defect class turned up in `dispatchPromptNow`: a non-503 5xx and a network exception settled nothing at all, leaving an optimistic row no server row would ever prune. Both now settle their own id.

No Rust change. The daemon and the native TUI already read the boolean and never had this bug.

Closes #3417

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Open a structured-view session on a steering-capable agent (`claude`), send a prompt, then send two or three follow-ups while the agent is still working. When the turn ends, the composer shows Send with no spinner, and matches the sidebar.
- [ ] Send a single prompt and let it finish normally. The spinner appears immediately on send and clears on completion.
- [ ] Send a follow-up in the same instant the previous turn ends. The spinner stays up through the prior turn's `Stopped` rather than flickering off.
- [ ] Reload the page on a session that finished while you were away. It opens idle, with no spinner to dismiss.
- [ ] Press Stop twice during a turn. The first press cancels gracefully, the second force-ends. Start a new prompt and press Stop once: it is graceful again.
- [ ] Stop `aoe serve`, then send a prompt from the still-open tab. The composer unlocks with an error banner instead of spinning forever.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the defect is pure reducer logic over the WS event stream, with no browser-only surface (no focus, keyboard, drag-drop, or viewport dependency), so Vitest is the cheapest tier that can actually fail. `web/tests/coverage-matrix.json` already maps both changed modules (`web/src/lib/acpTypes.ts` and `web/src/hooks/useAcpSession.ts`) and `validate-coverage-matrix.mjs` passes. The regression test was proven red on the pre-fix tree in a detached worktree at the parent commit, failing with `turnActive` still `true` after the turn's terminal `Stopped`, and green after.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-investigate` and `/aoe-implement` skills)

**Any Additional AI Details you'd like to share:**
Investigation, the plan, and the implementation were drafted by Claude under my direction. I made the design call to reject the narrower steered-bump fix in favour of adopting the daemon's `turn_active`, reviewed each commit, and ran the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the structured-view client to use the daemon’s authoritative `turn_active` state.
- Added prompt ID tracking for prompts awaiting server confirmation.
- Fixed stuck Stop buttons and spinners when multiple prompts run in one turn.
- Cleared optimistic prompt state after acknowledgements, rejections, server errors, network errors, and rollbacks.
- Updated state hydration, sequencing, test mocks, and documentation.
- Added reducer and prompt-settlement tests for steering, duplicate events, delayed events, and request failures.

## Benefits

- The UI now reflects session activity more reliably.
- Multiple steered prompts no longer leave the composer active indefinitely.
- In-flight prompt failures settle independently.
- Server-owned state reduces reliance on client-side event counters.

## Further enhancement

- Add end-to-end coverage for server activity transitions and delayed acknowledgements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->