### PR TITLE
test(session): stop assuming an FHS layout in the launch-path tests

### DIFF
--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -771,6 +771,7 @@ pub(crate) fn build_docker_env_args_with_managed_codex_home(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::test_support::EnvGuard;
 
     fn owned(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
         pairs
@@ -1919,72 +1920,43 @@ environment = ["GH_TOKEN=write_token"]
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_user_shell_reads_env() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/bin/zsh");
+        let _shell = EnvGuard::set(&[("SHELL", "/bin/zsh")]);
         assert_eq!(user_shell(), "/bin/zsh");
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_user_shell_fallback() {
-        let original = std::env::var("SHELL").ok();
-        std::env::remove_var("SHELL");
+        let _shell = EnvGuard::unset(&["SHELL"]);
         assert_eq!(user_shell(), "bash");
-        if let Some(v) = original {
-            std::env::set_var("SHELL", v);
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_user_shell_empty_falls_back() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "  ");
+        let _shell = EnvGuard::set(&[("SHELL", "  ")]);
         assert_eq!(user_shell(), "bash");
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_user_posix_shell_returns_posix() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/bin/zsh");
+        let _shell = EnvGuard::set(&[("SHELL", "/bin/zsh")]);
         assert_eq!(user_posix_shell(), "/bin/zsh");
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_user_posix_shell_falls_back_for_fish() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/usr/bin/fish");
+        let _shell = EnvGuard::set(&[("SHELL", "/usr/bin/fish")]);
         assert_eq!(user_posix_shell(), "bash");
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_user_posix_shell_falls_back_for_nu() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/usr/bin/nu");
+        let _shell = EnvGuard::set(&[("SHELL", "/usr/bin/nu")]);
         assert_eq!(user_posix_shell(), "bash");
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -11672,7 +11672,10 @@ mod tests {
             command
                 .args(["-c", &script])
                 .env_clear()
-                .env("PATH", "/usr/bin:/bin");
+                // Same reason as `test_path_with_shim`: `env_clear` is here to
+                // control the OMP_STORE_ENV_KEYS the fingerprint folds in, not
+                // to pin a filesystem layout, so inherit the caller's PATH.
+                .env("PATH", std::env::var_os("PATH").unwrap_or_default());
             // Pin the exact routing environment a host launch installs into the
             // pane for this HOME, so the check reproduces the fingerprint's env
             // instead of assuming the ambient OMP_STORE_ENV_KEYS are empty. They
@@ -11730,17 +11733,23 @@ mod tests {
         assert!(!command.contains("/dev/pts/*"));
         assert!(command.find("printf").unwrap() < command.rfind("exec sh -c").unwrap());
     }
+    /// The shim dir ahead of the caller's real `PATH`. Inheriting the caller's
+    /// value rather than forcing a literal `/usr/bin:/bin` is what lets these
+    /// run on a host whose coreutils live outside the FHS layout. The shim
+    /// stays first, so the fake `tmux` still wins over any real one.
+    ///
+    /// Built with `join_paths` over `OsString` rather than formatting: a
+    /// `PATH` entry need not be UTF-8, and `to_string_lossy` would corrupt it.
     #[cfg(unix)]
-    /// The shim dir ahead of the caller's real `PATH`. Appending the inherited
-    /// value rather than a literal `/usr/bin:/bin` is what lets these run on a
-    /// host whose coreutils live outside the FHS layout.
-    fn test_path_with_shim(bin: &std::path::Path) -> String {
-        match std::env::var_os("PATH") {
-            Some(path) => format!("{}:{}", bin.display(), path.to_string_lossy()),
-            None => bin.display().to_string(),
-        }
+    fn test_path_with_shim(bin: &std::path::Path) -> std::ffi::OsString {
+        let inherited = std::env::var_os("PATH").unwrap_or_default();
+        let entries = std::iter::once(bin.to_path_buf())
+            .chain(std::env::split_paths(&inherited))
+            .collect::<Vec<_>>();
+        std::env::join_paths(entries).expect("PATH entries contain no separator")
     }
 
+    #[cfg(unix)]
     #[test]
     fn omp_capture_gate_executes_nested_stdin_scripts() {
         use std::os::unix::fs::PermissionsExt;

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10603,9 +10603,12 @@ mod tests {
         // (NixOS, a minimal container) has no `/bin/bash` for it to reach.
         let bash = which::which("bash").expect("bash on PATH");
         // `EnvGuard` rather than a bare `set_var` plus a manual restore at the
-        // end: it holds the process-global env lock for the whole scope, so a
-        // concurrent test cannot observe the override, and it restores on the
-        // unwind if an assertion below fails.
+        // end: it restores on the unwind if an assertion below fails, and it
+        // serialises against other `EnvGuard` users. It does NOT hide the
+        // override from tests that take no guard - `ENV_LOCK` is only ever
+        // acquired by `EnvGuard` - which is why resolving a real `bash` above
+        // still matters: the concurrent readers of `$SHELL` see the override
+        // either way, and what they must not see is a path that cannot run.
         let _shell = EnvGuard::set(&[("SHELL", &bash)]);
         let temp = tempfile::tempdir().unwrap();
         let working_dir = temp.path().join("some project's dir");
@@ -11671,9 +11674,10 @@ mod tests {
             command
                 .args(["-c", &script])
                 .env_clear()
-                // Same reason as `test_path_with_shim`: `env_clear` is here to
-                // control the OMP_STORE_ENV_KEYS the fingerprint folds in, not
-                // to pin a filesystem layout, so inherit the caller's PATH.
+                // `env_clear` is here to control which OMP_STORE_ENV_KEYS the
+                // fingerprint folds in, not to pin a filesystem layout, so the
+                // PATH comes from the caller rather than a literal
+                // `/usr/bin:/bin`.
                 .env("PATH", std::env::var_os("PATH").unwrap_or_default());
             // Pin the exact routing environment a host launch installs into the
             // pane for this HOME, so the check reproduces the fingerprint's env
@@ -11741,7 +11745,13 @@ mod tests {
     /// `PATH` entry need not be UTF-8, and `to_string_lossy` would corrupt it.
     #[cfg(unix)]
     fn test_path_with_shim(bin: &std::path::Path) -> std::ffi::OsString {
-        let inherited = std::env::var_os("PATH").unwrap_or_default();
+        // An unset or empty PATH is handled separately: `split_paths("")`
+        // yields one EMPTY entry, and an empty PATH element means the current
+        // directory, so joining it would hand the child `<shim>:` and put cwd
+        // on its PATH.
+        let Some(inherited) = std::env::var_os("PATH").filter(|p| !p.is_empty()) else {
+            return bin.as_os_str().to_os_string();
+        };
         let entries = std::iter::once(bin.to_path_buf())
             .chain(std::env::split_paths(&inherited))
             .collect::<Vec<_>>();

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10598,12 +10598,15 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
-        let original = std::env::var("SHELL").ok();
         // Resolved rather than hardcoded to `/bin/bash`: the wrapper execs
         // `$SHELL`, and a host that keeps its shells outside the FHS layout
         // (NixOS, a minimal container) has no `/bin/bash` for it to reach.
         let bash = which::which("bash").expect("bash on PATH");
-        std::env::set_var("SHELL", &bash);
+        // `EnvGuard` rather than a bare `set_var` plus a manual restore at the
+        // end: it holds the process-global env lock for the whole scope, so a
+        // concurrent test cannot observe the override, and it restores on the
+        // unwind if an assertion below fails.
+        let _shell = EnvGuard::set(&[("SHELL", &bash)]);
         let temp = tempfile::tempdir().unwrap();
         let working_dir = temp.path().join("some project's dir");
         std::fs::create_dir(&working_dir).unwrap();
@@ -10631,10 +10634,6 @@ mod tests {
             String::from_utf8_lossy(&output.stdout).trim(),
             working_dir.to_string_lossy(),
         );
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     // Additional tests for is_sandboxed

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10578,21 +10578,15 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
-        // Resolved rather than hardcoded to `/bin/bash`: the wrapper execs
-        // `$SHELL`, and a host that keeps its shells outside the FHS layout
-        // (NixOS, a minimal container) has no `/bin/bash` for it to reach.
-        let bash = which::which("bash").expect("bash on PATH");
-        // `EnvGuard` rather than a bare `set_var` plus a manual restore at the
-        // end: it restores on the unwind if an assertion below fails, and it
-        // serialises against other `EnvGuard` users. It does NOT hide the
-        // override from tests that take no guard - `test_support::ENV_LOCK` is
-        // only ever acquired by `EnvGuard` (note `logging.rs` has a separate,
-        // unrelated `ENV_LOCK` that is locked directly) - which is why
-        // resolving a real `bash` above still matters: 12 of the 14
-        // `repo_config` hook tests take no guard, so they see the override
-        // either way, and what they must not see is a path that cannot run.
-        // The other two do hold the lock, and `EnvGuard` alone would have
-        // covered those.
+        // The wrapper execs `$SHELL`, so it has to be a shell that exists here.
+        let Ok(bash) = which::which("bash") else {
+            eprintln!("skipping: bash not found on PATH");
+            return;
+        };
+        // The guard restores on unwind; the resolved path matters separately,
+        // because `test_support::ENV_LOCK` is taken only by `EnvGuard` and 12
+        // of the 14 `repo_config` hook tests take none, so they read this
+        // override regardless and must not read a path that cannot run.
         let _shell = EnvGuard::set(&[("SHELL", &bash)]);
         let temp = tempfile::tempdir().unwrap();
         let working_dir = temp.path().join("some project's dir");
@@ -11720,13 +11714,10 @@ mod tests {
         assert!(!command.contains("/dev/pts/*"));
         assert!(command.find("printf").unwrap() < command.rfind("exec sh -c").unwrap());
     }
-    /// The shim dir ahead of the caller's real `PATH`. Inheriting the caller's
-    /// value rather than forcing a literal `/usr/bin:/bin` is what lets these
-    /// run on a host whose coreutils live outside the FHS layout. The shim
-    /// stays first, so the fake `tmux` still wins over any real one.
-    ///
-    /// Built with `join_paths` over `OsString` rather than formatting: a
-    /// `PATH` entry need not be UTF-8, and `to_string_lossy` would corrupt it.
+    /// The shim dir, then the caller's `PATH`. Shim first, so the fake `tmux`
+    /// wins over any real one; inherited rather than a literal `/usr/bin:/bin`,
+    /// so a host whose coreutils sit outside the FHS layout still resolves
+    /// them. `OsString` throughout: a `PATH` entry need not be UTF-8.
     #[cfg(unix)]
     fn test_path_with_shim(bin: &std::path::Path) -> std::ffi::OsString {
         // An unset or empty PATH is handled separately: `split_paths("")`
@@ -11742,20 +11733,16 @@ mod tests {
         std::env::join_paths(entries).expect("PATH entries contain no separator")
     }
 
+    /// `#[serial]` because this reads the inherited PATH, and the peers that
+    /// scrub PATH process-globally (`crate::acp::node`, `crate::acp::acp_client`)
+    /// carry that annotation. Not an `EnvGuard` lock: those three never take
+    /// `test_support::ENV_LOCK`, so it would exclude unrelated guard users and
+    /// leave this window open.
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn omp_capture_gate_executes_nested_stdin_scripts() {
         use std::os::unix::fs::PermissionsExt;
-
-        // Held purely as a lock, per the precedent in
-        // `src/server/api/plugins.rs`. Reading the inherited PATH means this
-        // test is no longer immune to the peers that scrub PATH
-        // process-globally (`crate::acp::node` removes it,
-        // `crate::acp::acp_client` points it at an empty tempdir). Those
-        // carry `#[serial]`, which excludes annotated peers but not this
-        // one, so take the same lock rather than add an annotation nothing
-        // else here needs.
-        let _env_lock = EnvGuard::unset(&[]);
 
         let temp = tempfile::tempdir().unwrap();
         let bin = temp.path().join("bin");

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -11733,11 +11733,12 @@ mod tests {
         std::env::join_paths(entries).expect("PATH entries contain no separator")
     }
 
-    /// `#[serial]` because this reads the inherited PATH, and the peers that
-    /// scrub PATH process-globally (`crate::acp::node`, `crate::acp::acp_client`)
-    /// carry that annotation. Not an `EnvGuard` lock: those three never take
-    /// `test_support::ENV_LOCK`, so it would exclude unrelated guard users and
-    /// leave this window open.
+    /// `#[serial]` because this reads the inherited PATH, and the tests that
+    /// scrub PATH process-globally carry that annotation: `crate::acp::node`,
+    /// `crate::acp::acp_client`, and four more in `crate::update::install`.
+    /// Not an `EnvGuard` lock: none of them takes `test_support::ENV_LOCK`, so
+    /// a guard would exclude unrelated guard users and leave this window open.
+    /// A future PATH mutator outside the default serial group would reopen it.
     #[cfg(unix)]
     #[test]
     #[serial_test::serial]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10522,9 +10522,8 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_wrap_command_uses_stdin_script() {
-        let original = std::env::var("SHELL").ok();
         for shell in &["/bin/bash", "/bin/zsh", "/usr/bin/fish", "/usr/bin/nu"] {
-            std::env::set_var("SHELL", shell);
+            let _shell = EnvGuard::set(&[("SHELL", shell)]);
             let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
             assert!(
                 wrapped.contains("/dev/fd/3 3<<'AOE_LAUNCH_BODY'"),
@@ -10533,33 +10532,23 @@ mod tests {
             assert!(wrapped.contains("\nstty susp undef\nexec env claude\n"));
             assert!(!wrapped.contains(" -c "));
         }
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_wrap_command_posix_shell_uses_login() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/bin/zsh");
+        let _shell = EnvGuard::set(&[("SHELL", "/bin/zsh")]);
         let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
         assert!(
             wrapped.starts_with("'/bin/zsh' -l /dev/fd/3 "),
             "POSIX shell should use a login descriptor script: {wrapped}",
         );
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_wrap_command_fish_skips_login() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/usr/bin/fish");
+        let _shell = EnvGuard::set(&[("SHELL", "/usr/bin/fish")]);
         let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
         // The bash fallback must not load bash login files because the user's
         // PATH setup belongs to fish.
@@ -10567,26 +10556,17 @@ mod tests {
             wrapped.starts_with("'bash' /dev/fd/3 "),
             "fish should use a non-login bash descriptor script: {wrapped}",
         );
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_wrap_command_nu_skips_login() {
-        let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/usr/bin/nu");
+        let _shell = EnvGuard::set(&[("SHELL", "/usr/bin/nu")]);
         let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
         assert!(
             wrapped.starts_with("'bash' /dev/fd/3 "),
             "nu should use a non-login bash descriptor script: {wrapped}",
         );
-        match original {
-            Some(v) => std::env::set_var("SHELL", v),
-            None => std::env::remove_var("SHELL"),
-        }
     }
 
     /// #3265: a login shell's own profile/rc files can `cd` elsewhere
@@ -11762,6 +11742,16 @@ mod tests {
     #[test]
     fn omp_capture_gate_executes_nested_stdin_scripts() {
         use std::os::unix::fs::PermissionsExt;
+
+        // Held purely as a lock, per the precedent in
+        // `src/server/api/plugins.rs`. Reading the inherited PATH means this
+        // test is no longer immune to the peers that scrub PATH
+        // process-globally (`crate::acp::node` removes it,
+        // `crate::acp::acp_client` points it at an empty tempdir). Those
+        // carry `#[serial]`, which excludes annotated peers but not this
+        // one, so take the same lock rather than add an annotation nothing
+        // else here needs.
+        let _env_lock = EnvGuard::unset(&[]);
 
         let temp = tempfile::tempdir().unwrap();
         let bin = temp.path().join("bin");

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -11735,7 +11735,8 @@ mod tests {
 
     /// `#[serial]` because this reads the inherited PATH, and the tests that
     /// scrub PATH process-globally carry that annotation: `crate::acp::node`,
-    /// `crate::acp::acp_client`, and four more in `crate::update::install`.
+    /// `crate::acp::acp_client`, and `crate::update::install` (eleven such
+    /// tests in total, across four PATH-setting helper sites).
     /// Not an `EnvGuard` lock: none of them takes `test_support::ENV_LOCK`, so
     /// a guard would exclude unrelated guard users and leave this window open.
     /// A future PATH mutator outside the default serial group would reopen it.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10585,10 +10585,14 @@ mod tests {
         // `EnvGuard` rather than a bare `set_var` plus a manual restore at the
         // end: it restores on the unwind if an assertion below fails, and it
         // serialises against other `EnvGuard` users. It does NOT hide the
-        // override from tests that take no guard - `ENV_LOCK` is only ever
-        // acquired by `EnvGuard` - which is why resolving a real `bash` above
-        // still matters: the concurrent readers of `$SHELL` see the override
+        // override from tests that take no guard - `test_support::ENV_LOCK` is
+        // only ever acquired by `EnvGuard` (note `logging.rs` has a separate,
+        // unrelated `ENV_LOCK` that is locked directly) - which is why
+        // resolving a real `bash` above still matters: 12 of the 14
+        // `repo_config` hook tests take no guard, so they see the override
         // either way, and what they must not see is a path that cannot run.
+        // The other two do hold the lock, and `EnvGuard` alone would have
+        // covered those.
         let _shell = EnvGuard::set(&[("SHELL", &bash)]);
         let temp = tempfile::tempdir().unwrap();
         let working_dir = temp.path().join("some project's dir");

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10599,7 +10599,11 @@ mod tests {
     #[serial_test::serial(shell_env)]
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
         let original = std::env::var("SHELL").ok();
-        std::env::set_var("SHELL", "/bin/bash");
+        // Resolved rather than hardcoded to `/bin/bash`: the wrapper execs
+        // `$SHELL`, and a host that keeps its shells outside the FHS layout
+        // (NixOS, a minimal container) has no `/bin/bash` for it to reach.
+        let bash = which::which("bash").expect("bash on PATH");
+        std::env::set_var("SHELL", &bash);
         let temp = tempfile::tempdir().unwrap();
         let working_dir = temp.path().join("some project's dir");
         std::fs::create_dir(&working_dir).unwrap();
@@ -11727,6 +11731,16 @@ mod tests {
         assert!(command.find("printf").unwrap() < command.rfind("exec sh -c").unwrap());
     }
     #[cfg(unix)]
+    /// The shim dir ahead of the caller's real `PATH`. Appending the inherited
+    /// value rather than a literal `/usr/bin:/bin` is what lets these run on a
+    /// host whose coreutils live outside the FHS layout.
+    fn test_path_with_shim(bin: &std::path::Path) -> String {
+        match std::env::var_os("PATH") {
+            Some(path) => format!("{}:{}", bin.display(), path.to_string_lossy()),
+            None => bin.display().to_string(),
+        }
+    }
+
     #[test]
     fn omp_capture_gate_executes_nested_stdin_scripts() {
         use std::os::unix::fs::PermissionsExt;
@@ -11754,7 +11768,7 @@ mod tests {
         std::fs::write(&script, outer).unwrap();
         let status = std::process::Command::new("sh")
             .arg(&script)
-            .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+            .env("PATH", test_path_with_shim(&bin))
             .env("TMUX_PANE", "%1")
             .status()
             .unwrap();
@@ -11776,7 +11790,7 @@ mod tests {
         std::fs::write(&script, large_outer).unwrap();
         let status = std::process::Command::new("sh")
             .arg(&script)
-            .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+            .env("PATH", test_path_with_shim(&bin))
             .env("TMUX_PANE", "%1")
             .status()
             .unwrap();

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -11653,9 +11653,9 @@ mod tests {
                 .args(["-c", &script])
                 .env_clear()
                 // `env_clear` is here to control which OMP_STORE_ENV_KEYS the
-                // fingerprint folds in, not to pin a filesystem layout, so the
-                // PATH comes from the caller rather than a literal
-                // `/usr/bin:/bin`.
+                // fingerprint folds in, not to pin a filesystem layout. The
+                // child still needs a PATH that resolves `sha256sum` / `tr`,
+                // so it inherits the caller's.
                 .env("PATH", std::env::var_os("PATH").unwrap_or_default());
             // Pin the exact routing environment a host launch installs into the
             // pane for this HOME, so the check reproduces the fingerprint's env
@@ -11715,9 +11715,9 @@ mod tests {
         assert!(command.find("printf").unwrap() < command.rfind("exec sh -c").unwrap());
     }
     /// The shim dir, then the caller's `PATH`. Shim first, so the fake `tmux`
-    /// wins over any real one; inherited rather than a literal `/usr/bin:/bin`,
-    /// so a host whose coreutils sit outside the FHS layout still resolves
-    /// them. `OsString` throughout: a `PATH` entry need not be UTF-8.
+    /// wins over any real one; inherited, so a host whose coreutils sit
+    /// outside the FHS layout still resolves them. `OsString` throughout: a
+    /// `PATH` entry need not be UTF-8.
     #[cfg(unix)]
     fn test_path_with_shim(bin: &std::path::Path) -> std::ffi::OsString {
         // An unset or empty PATH is handled separately: `split_paths("")`
@@ -11733,10 +11733,10 @@ mod tests {
         std::env::join_paths(entries).expect("PATH entries contain no separator")
     }
 
-    /// `#[serial]` because this reads the inherited PATH, and the tests that
-    /// scrub PATH process-globally carry that annotation: `crate::acp::node`,
-    /// `crate::acp::acp_client`, and `crate::update::install` (eleven such
-    /// tests in total, across four PATH-setting helper sites).
+    /// `#[serial]` because this reads the inherited PATH, and every test that
+    /// scrubs PATH process-globally carries that same default-key annotation:
+    /// `crate::acp::node`, `crate::acp::acp_client`, and
+    /// `crate::update::install`.
     /// Not an `EnvGuard` lock: none of them takes `test_support::ENV_LOCK`, so
     /// a guard would exclude unrelated guard users and leave this window open.
     /// A future PATH mutator outside the default serial group would reopen it.

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4019,14 +4019,13 @@ mod tests {
         file.disarm();
     }
 
+    /// `#[serial]` because the assertion reads the inherited PATH, and the
+    /// peers that scrub it process-globally (`crate::acp::node`,
+    /// `crate::acp::acp_client`) carry that annotation. Not an `EnvGuard` lock:
+    /// they never take `test_support::ENV_LOCK`.
     #[test]
+    #[serial_test::serial]
     fn test_container_env_file_does_not_mutate_host_process_environment() {
-        // Held purely as a lock (see `src/server/api/plugins.rs`): the
-        // assertion now reads the inherited PATH, so it has to be linearized
-        // against the peers that scrub PATH process-globally in
-        // `crate::acp::node` and `crate::acp::acp_client`.
-        let _env_lock = crate::session::test_support::EnvGuard::unset(&[]);
-
         let temp = tempfile::tempdir().unwrap();
         let host_output = temp.path().join("host-env");
         let payload_output = temp.path().join("container-env");

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4020,9 +4020,10 @@ mod tests {
     }
 
     /// `#[serial]` because the assertion reads the inherited PATH, and the
-    /// peers that scrub it process-globally (`crate::acp::node`,
-    /// `crate::acp::acp_client`) carry that annotation. Not an `EnvGuard` lock:
-    /// they never take `test_support::ENV_LOCK`.
+    /// tests that scrub it process-globally carry that annotation:
+    /// `crate::acp::node`, `crate::acp::acp_client`, and four more in
+    /// `crate::update::install`. Not an `EnvGuard` lock: none of them takes
+    /// `test_support::ENV_LOCK`.
     #[test]
     #[serial_test::serial]
     fn test_container_env_file_does_not_mutate_host_process_environment() {

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4021,9 +4021,9 @@ mod tests {
 
     /// `#[serial]` because the assertion reads the inherited PATH, and the
     /// tests that scrub it process-globally carry that annotation:
-    /// `crate::acp::node`, `crate::acp::acp_client`, and four more in
-    /// `crate::update::install`. Not an `EnvGuard` lock: none of them takes
-    /// `test_support::ENV_LOCK`.
+    /// `crate::acp::node`, `crate::acp::acp_client` and `crate::update::install`
+    /// — eleven tests across four PATH-setting helper sites. Not an `EnvGuard`
+    /// lock: none of them takes `test_support::ENV_LOCK`.
     #[test]
     #[serial_test::serial]
     fn test_container_env_file_does_not_mutate_host_process_environment() {
@@ -4070,9 +4070,10 @@ mod tests {
         // The PATH is asserted back below to prove the env file did not mutate
         // the host process environment, so it has to be a value this host can
         // actually resolve `cat` on rather than a hardcoded `/usr/bin:/bin`.
-        // `var_os`, not `var`: a PATH entry need not be UTF-8, and `var` would
-        // hand back an empty string for one that isn't, silently emptying the
-        // PATH instead of failing.
+        // `var_os`, not `var`: a PATH entry need not be UTF-8, and `var`
+        // returns `Err(VarError::NotUnicode)` for one that isn't — which the
+        // `unwrap_or_default` below would turn into an empty PATH rather than
+        // a failure.
         let host_path = std::env::var_os("PATH").unwrap_or_default();
         let status = std::process::Command::new("/bin/sh")
             .args(["-c", &wrapper])

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4019,11 +4019,11 @@ mod tests {
         file.disarm();
     }
 
-    /// `#[serial]` because the assertion reads the inherited PATH, and the
-    /// tests that scrub it process-globally carry that annotation:
-    /// `crate::acp::node`, `crate::acp::acp_client` and `crate::update::install`
-    /// — eleven tests across four PATH-setting helper sites. Not an `EnvGuard`
-    /// lock: none of them takes `test_support::ENV_LOCK`.
+    /// `#[serial]` because the assertion reads the inherited PATH, and every
+    /// test that scrubs PATH process-globally carries that same default-key
+    /// annotation: `crate::acp::node`, `crate::acp::acp_client`, and
+    /// `crate::update::install`. Not an `EnvGuard` lock: none of them takes
+    /// `test_support::ENV_LOCK`.
     #[test]
     #[serial_test::serial]
     fn test_container_env_file_does_not_mutate_host_process_environment() {
@@ -4069,9 +4069,9 @@ mod tests {
 
         // The PATH is asserted back below to prove the env file did not mutate
         // the host process environment, so it has to be a value this host can
-        // actually resolve `cat` on rather than a hardcoded `/usr/bin:/bin`.
+        // actually resolve `cat` on.
         // `var_os`, not `var`: a PATH entry need not be UTF-8, and `var`
-        // returns `Err(VarError::NotUnicode)` for one that isn't — which the
+        // returns `Err(VarError::NotUnicode)` for one that isn't, which the
         // `unwrap_or_default` below would turn into an empty PATH rather than
         // a failure.
         let host_path = std::env::var_os("PATH").unwrap_or_default();
@@ -4088,7 +4088,16 @@ mod tests {
         // round trip through the shell but not through `read_to_string`.
         let mut expected = host_path.as_encoded_bytes().to_vec();
         expected.extend_from_slice(b"\nunset");
-        assert_eq!(std::fs::read(host_output).unwrap(), expected);
+        // Rendered lossily in the message only: `assert_eq!` on `Vec<u8>`
+        // prints decimal byte arrays, which is unreadable for a whole PATH.
+        let actual = std::fs::read(host_output).unwrap();
+        assert_eq!(
+            actual,
+            expected,
+            "env file mutated the host environment: {:?} != {:?}",
+            String::from_utf8_lossy(&actual),
+            String::from_utf8_lossy(&expected),
+        );
         assert_eq!(
             std::fs::read_to_string(payload_output).unwrap(),
             "PATH=/repo-controlled/bin\n\

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4021,6 +4021,12 @@ mod tests {
 
     #[test]
     fn test_container_env_file_does_not_mutate_host_process_environment() {
+        // Held purely as a lock (see `src/server/api/plugins.rs`): the
+        // assertion now reads the inherited PATH, so it has to be linearized
+        // against the peers that scrub PATH process-globally in
+        // `crate::acp::node` and `crate::acp::acp_client`.
+        let _env_lock = crate::session::test_support::EnvGuard::unset(&[]);
+
         let temp = tempfile::tempdir().unwrap();
         let host_output = temp.path().join("host-env");
         let payload_output = temp.path().join("container-env");

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4064,7 +4064,10 @@ mod tests {
         // The PATH is asserted back below to prove the env file did not mutate
         // the host process environment, so it has to be a value this host can
         // actually resolve `cat` on rather than a hardcoded `/usr/bin:/bin`.
-        let host_path = std::env::var("PATH").unwrap_or_default();
+        // `var_os`, not `var`: a PATH entry need not be UTF-8, and `var` would
+        // hand back an empty string for one that isn't, silently emptying the
+        // PATH instead of failing.
+        let host_path = std::env::var_os("PATH").unwrap_or_default();
         let status = std::process::Command::new("/bin/sh")
             .args(["-c", &wrapper])
             .env("PATH", &host_path)
@@ -4074,10 +4077,11 @@ mod tests {
             .status()
             .unwrap();
         assert!(status.success());
-        assert_eq!(
-            std::fs::read_to_string(host_output).unwrap(),
-            format!("{host_path}\nunset")
-        );
+        // Compared as bytes for the same reason: a non-UTF-8 PATH survives the
+        // round trip through the shell but not through `read_to_string`.
+        let mut expected = host_path.as_encoded_bytes().to_vec();
+        expected.extend_from_slice(b"\nunset");
+        assert_eq!(std::fs::read(host_output).unwrap(), expected);
         assert_eq!(
             std::fs::read_to_string(payload_output).unwrap(),
             "PATH=/repo-controlled/bin\n\

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4037,7 +4037,7 @@ mod tests {
         let payload_path = file.container_env_path.as_ref().unwrap().clone();
         let command = format!(
             "printf '%s\\n%s' \"$PATH\" \"${{DOCKER_HOST-unset}}\" > {}; \
-             /bin/cat {} > {}",
+             cat {} > {}",
             script_shell_escape(&host_output.to_string_lossy()),
             crate::session::environment::CONTAINER_EXEC_ENV_PATH,
             script_shell_escape(&payload_output.to_string_lossy()),
@@ -4061,9 +4061,13 @@ mod tests {
             );
         }
 
+        // The PATH is asserted back below to prove the env file did not mutate
+        // the host process environment, so it has to be a value this host can
+        // actually resolve `cat` on rather than a hardcoded `/usr/bin:/bin`.
+        let host_path = std::env::var("PATH").unwrap_or_default();
         let status = std::process::Command::new("/bin/sh")
             .args(["-c", &wrapper])
-            .env("PATH", "/usr/bin:/bin")
+            .env("PATH", &host_path)
             .env_remove("DOCKER_HOST")
             .env_remove("BASH_ENV")
             .env_remove("ENV")
@@ -4072,7 +4076,7 @@ mod tests {
         assert!(status.success());
         assert_eq!(
             std::fs::read_to_string(host_output).unwrap(),
-            "/usr/bin:/bin\nunset"
+            format!("{host_path}\nunset")
         );
         assert_eq!(
             std::fs::read_to_string(payload_output).unwrap(),


### PR DESCRIPTION
## Description

Several unit tests hardcode paths that only exist under a Filesystem Hierarchy
Standard layout, so `cargo test` fails on hosts that do not have them (NixOS,
minimal containers). No production code changes; the diff is entirely inside
`#[cfg(test)]` modules.

Four sites, all the same class:

| Test | Assumed |
|---|---|
| `test_wrap_command_reasserts_working_dir_after_login_shell` | `SHELL=/bin/bash`, then execs it |
| `omp_capture_gate_executes_nested_stdin_scripts` | `PATH=<shim>:/usr/bin:/bin` |
| `omp_routing_fingerprint_accepts_matching_live_env_and_rejects_drift` | `env_clear()` + `PATH=/usr/bin:/bin` |
| `test_container_env_file_does_not_mutate_host_process_environment` | `PATH=/usr/bin:/bin`, runs `/bin/cat` |

On this host `/bin` contains only `sh`, so the first fails on itself:

```
wrapped command failed: bash: line 1: /bin/bash: No such file or directory
```

Each now resolves what it needs instead of assuming a location: `bash` via
`which` (already a regular dependency, 17 call sites before this PR), and the
shim `PATH` prepended to the caller's inherited one rather than replacing it. In
`test_container_env_file_...` the `PATH` is asserted back — that assertion is
the point of the test, proving the env file did not mutate the host
environment — so it is taken from the caller, passed in, and asserted against
the same value.

### The `SHELL` literal was also escaping its serial group

`std::env::set_var` is process-global, so the literal did not stay inside
`#[serial_test::serial(shell_env)]` — it leaked to every test running
concurrently. The `repo_config` hook tests spawn the user's shell
(`repo_config.rs:1019` → `user_shell()`, which reads `$SHELL`), so they
inherited a path that does not resolve and failed with `os error 2`. That is
why they pass under `--test-threads=1` and fail in parallel, which reads like
flakiness but is not.

The override now goes through `EnvGuard::set`, which restores on `Drop`
including on an unwind — the previous manual restore at the end of the test did
not run if an assertion failed first — and serialises against other `EnvGuard`
users.

Being precise about what that does **not** do, since an earlier revision of this
description overstated it: `ENV_LOCK` is acquired only by `EnvGuard`, so it does
not hide the override from tests that take no guard, and 12 of the 14
`repo_config` hook tests take none. They still observe the override. What makes
that harmless is resolving a real `bash`, so the value they see is one they can
actually run. The guard buys panic-safety and guard-mutual-exclusion; the
`which` lookup is what fixes the 14.

### Measured on a NixOS host

Totals move run to run, so a single before/after pair would be misleading.
Three full `cargo test --lib` runs each:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| `main` @ 26e5fe93, sweep A | 25 | 24 | 26 |
| `main` @ 26e5fe93, sweep B | 27 | 27 | 26 |
| this branch, sweep A | 3 | 5 | 5 |
| this branch, sweep B | 4 | 3 | 2 |

Two independent three-run sweeps, because a single sweep understated the
spread: `main` ranges 24-27 and the branch 2-5. The set difference below was
**identical** in both sweeps, which is why it is the figure to read.

The stable figure is the set difference, not a subtraction of noisy totals:
**22 tests fail in every `main` run and in no run of this branch**, 14 of them
the `repo_config` hook tests.

What still fails on this branch, by how many of the three runs it appeared in:

```
3/3  tui::dialogs::hooks_install::tests::test_content_shows_settings_path
1/3  tmux::session::tests::{a_stacked_split_composites_one_line_per_window_row,
     send_key_tokens_appends_no_implicit_enter, size_owner_lock_claims_...,
     test_capture_pane_targets_first_window_with_multiple_windows,
     test_is_attached_true_with_live_client, test_is_pane_dead_on_running_session,
     vt_owner_lock_claims_rejects_and_releases_independently}
1/3  tmux::terminal_session::tests::test_terminal_session_is_pane_dead_after_command_exits
1/3  tmux::test_helpers::tests::drop_kills_session
```

Neither group is an FHS problem, and neither is addressed here:

- The `tmux::*` ones are **not** thread-parallelism flakes, and an earlier
  revision of this description wrongly said they pass single-threaded. They do
  not: `cargo test --lib -- --test-threads=1` on this branch still fails
  `size_owner_lock_claims_rejects_steals_and_releases` and
  `test_is_attached_true_with_live_client`, and the same reproduces on `main`.
  Run individually they pass, so the cause is in-process state left behind by
  earlier tmux tests in the same process, not concurrency. tmux 3.6a is
  installed; a missing server is not the explanation either. Separate issue,
  not addressed here, and I am not claiming a diagnosis beyond "not this PR".
- `test_content_shows_settings_path` is the only stable remainder and is not
  environment-layout related at all. It renders through
  `agent_settings_path_display_for_host_environment`, which honours
  `$CLAUDE_CONFIG_DIR`; with that variable set the dialog shows that path
  instead of `~/.claude/settings.json`. Verified directly:

  ```
  $ cargo test --lib tui::dialogs::hooks_install::tests::test_content_shows_settings_path
  test result: FAILED. 0 passed; 1 failed
  $ env -u CLAUDE_CONFIG_DIR cargo test --lib ...same test...
  test result: ok. 1 passed; 0 failed
  ```

  It depends on the *value*, not merely on the variable being set:
  `CLAUDE_CONFIG_DIR=$HOME/.claude` makes it pass, since the rendered path then
  ends in `.claude/settings.json` anyway. So it fails wherever the variable
  points somewhere else, on any OS. Happy to fix it in a follow-up if you want
  it.

### Why CI does not see this

The workflows run `ubuntu-latest` and `macos-latest` only, both of which have
`/bin/bash` and FHS coreutils. Worth flagging a near miss: `flake.nix` defines
`checks.aoe-test = craneLib.cargoTest`, and no job runs `nix flake check` — the
Nix Build job runs `nix build` with `doCheck = false`. I ran that check on both
sides rather than guess at it: `main` 27 failed, this branch 8 failed. So it
catches 19 of the 22, not all of them (three want tmux, which the sandbox has
no `nativeBuildInputs` entry for), and it also surfaces 8 failures unrelated to
this PR that persist on the branch — sandboxed network and nosuid cases. The
check would not go green on this branch; it would go from 27 to 8.

I have not run the suite on an FHS host, so I am not claiming it is unchanged
there; the changes are all "resolve instead of assume", which should be a no-op
where the assumed paths exist.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (see the measured remainder above: 2-5 tests
  still fail on my host, all pre-existing and none introduced here)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The change is to the tests themselves; the existing tests are the coverage, and
the evidence is the 22-test stable set difference above.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Worth disclosing how the first revision of this PR was wrong, since it was
public for a while. As opened it claimed "26 → 5", "19 cleared", and described
the remainder as "tmux pane-liveness and dialog-path tests that want a live
tmux server". An adversarial review pass re-derived every number and found:
the totals are unstable so the pair was a best-case cherry-pick; 19 contradicted
the PR's own table (26 − 5 = 21); and the remainder description was simply
false — two of those remaining failures were further instances of the very
`/usr/bin:/bin` bug this PR is about, which the wording hid. Those two are now
fixed here, and the numbers above are the stable set difference across three
runs per side.

Review rounds since: Copilot's `EnvGuard` suggestion and CodeRabbit's
non-UTF-8 `PATH` point were both adopted in `6a30089e` — the first removes the
`SHELL` leak outright instead of neutralising it, the second keeps the
round-tripped `PATH` as bytes. The `to_string_lossy` comments from the first
round were against the original commit and were already fixed in `f92f364b`.

That pass also caught a real regression in the first commit: the new helper was
inserted between an existing `#[cfg(unix)]` and the `#[test]` it guarded,
dropping the gate from the test. Fixed in the follow-up commit.

Stated carefully, because an earlier revision of this description overstated it:
this restores a gate, it does not avert a Windows build break. `mod tests` in
that file carries no `cfg(unix)` and already contains ungated `std::os::unix`
uses on `main` (`instance.rs:13014` and `:16166`), so the Windows test build was
broken before this PR and still is. No workflow runs Windows.

- [x] I am an AI Agent filling out this form (check box if true)


---

**Revision note.** This description has been corrected twice after adversarial
review passes over my own commits. Claims that were published and are now known
to have been wrong: "26 → 5" and "19 cleared" (cherry-picked from unstable
totals; the stable set difference is 22), "the remaining 5 are tmux tests that
want a live tmux server" (two of them fail single-threaded; two more were
further instances of the bug this PR fixes), "would hit exactly these failures
in a nix sandbox" (19 of 22, and it adds 8 unrelated), "18 existing call sites"
(17), "would have broken the Windows test build" (already broken on `main`), and
that `EnvGuard` stops concurrent tests observing the override (it does not).
Flagging them rather than quietly editing, since the earlier text was public.
