### PR TITLE
fix(storage): preserve atomic write error contract

### DIFF
--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -102,7 +102,7 @@ const INSTANCE_LIFECYCLE_LOCK_PREFIX: &str = ".instance-lifecycle-";
 /// observability only, not a timeout.
 const FLOCK_WAIT_WARN_AFTER: Duration = Duration::from_secs(1);
 
-/// Write `content` to `path` atomically (temp file + data/metadata fsync + rename + dir fsync).
+/// Write `content` atomically (temp file + data/metadata fsync + rename + best-effort dir fsync).
 /// Existing perms are preserved; on a fresh file the result is tempfile's 0o600 default.
 /// All fallible file mutations complete before the final rename, so an error
 /// means the destination was not replaced.
@@ -235,6 +235,9 @@ where
     let result = mutate(&mut value);
     if result.is_ok() {
         atomic_write(path, serialize(&value)?.as_bytes())?;
+        // Best-effort here, unlike atomic_write's "every fallible mutation
+        // before the rename" contract: the content is already durably committed,
+        // so re-tightening a pre-existing file to 0o600 must not fail the write.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -996,6 +999,36 @@ mod tests {
             .unwrap()
             .file_type()
             .is_symlink());
+    }
+
+    /// A pre-existing file's non-default mode survives the write: `atomic_write`
+    /// copies the destination's permissions onto the temp file before the
+    /// rename, so a 0o644 file stays 0o644 rather than reverting to
+    /// `NamedTempFile`'s 0o600 default.
+    ///
+    /// The dual half of the contract, that a failure inside `set_permissions`
+    /// leaves the destination unreplaced, is deliberately not exercised here:
+    /// `set_permissions` on a freshly created temp file we own has no reachable
+    /// failure mode without a fault-injection seam, so that guarantee rests on
+    /// the ordering in the code (every fallible step precedes `persist`) rather
+    /// than on a test.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_preserves_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("perms.txt");
+        std::fs::write(&path, "old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        atomic_write(&path, b"new").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "a pre-existing non-default mode must survive the rename"
+        );
     }
 
     #[cfg(unix)]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -102,8 +102,10 @@ const INSTANCE_LIFECYCLE_LOCK_PREFIX: &str = ".instance-lifecycle-";
 /// observability only, not a timeout.
 const FLOCK_WAIT_WARN_AFTER: Duration = Duration::from_secs(1);
 
-/// Write `content` to `path` atomically (temp file + fsync + rename + dir fsync).
+/// Write `content` to `path` atomically (temp file + data/metadata fsync + rename + dir fsync).
 /// Existing perms are preserved; on a fresh file the result is tempfile's 0o600 default.
+/// All fallible file mutations complete before the final rename, so an error
+/// means the destination was not replaced.
 ///
 /// A symlink at `path` is resolved first and the write lands on the target, so
 /// a user who symlinks `config.toml` (or any other file we own) into a dotfiles
@@ -122,11 +124,11 @@ pub(crate) fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
     let existing_perms = fs::metadata(path).ok().map(|m| m.permissions());
     let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
     tmp.write_all(content)?;
-    tmp.as_file().sync_data()?;
-    let file = tmp.persist(path)?;
     if let Some(perms) = existing_perms {
-        file.set_permissions(perms)?;
+        tmp.as_file().set_permissions(perms)?;
     }
+    tmp.as_file().sync_all()?;
+    tmp.persist(path)?;
     // Best-effort dir fsync so the rename itself survives power loss.
     if let Ok(dir_file) = fs::File::open(dir) {
         let _ = dir_file.sync_all();


### PR DESCRIPTION
## Description

`atomic_write` restored existing permissions after persisting the temporary file over the destination. If that permission update failed, the function returned an error even though the new content was already committed. Callers could therefore execute failure cleanup or rollback against a successful write.

This change applies existing permissions to the temporary file before the `sync_all` (fsync) and the final rename. Every fallible mutation now completes before the commit point, so `Err` again means the destination was not replaced.

The flush was also lifted from a data-only `sync_data` (fdatasync) to a full `sync_all` (fsync): fdatasync only promises the file&#39;s data is durable and may skip the inode metadata, so the permission bits just written to the temp file could be lost on power loss. `sync_all` flushes data and metadata together, durably persisting the copied permissions before the rename commits the file.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No user documentation or screenshot is needed; this changes an internal storage guarantee.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Added a unit regression, `atomic_write_preserves_existing_permissions`, that writes a 0o644 file, calls `atomic_write`, and asserts the mode survives the rename. The dual half of the contract (a `set_permissions` failure leaves the destination unreplaced) has no reachable failure mode on a temp file we own without a fault-injection seam, so it rests on the code ordering rather than a test; this is called out in the test&#39;s doc comment.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --features serve --lib --bins -- -D warnings`
- `cargo test --features serve --lib session::storage` (58 passed)

## Initial Review Cycle

One initial cycle used three independent reviewers covering behavior, failure ordering, and scope/tests. All three returned zero actionable findings; no code correction or second reviewer wave was needed.

## Fresh Review Round 2

Fresh reviewers identified one metadata-durability gap: copied permissions were followed by data-only `sync_data`. The correction uses pre-commit `sync_all`, flushing data and permission metadata together while preserving the best-effort post-rename directory policy. Corrected head: `aee4c165`. No third reviewer wave was run.

## Risks

- Fresh files retain `NamedTempFile`&#39;s owner-only mode.
- Existing destination permissions are copied before persistence instead of after it.
- Directory fsync remains best-effort and occurs after the commit; it cannot turn a committed write into an error.

## GitHub Review Comments

The single actionable review comment was valid. The `atomic_write` documentation now explicitly calls the post-rename directory fsync best-effort while retaining the pre-commit data/metadata guarantee. Review fix: `aee4c165`.

## Upstream Sync

Rebased onto `upstream/main` at `24226821`; ready for review. Final synchronized head: `aee4c165`. GitHub checks are green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you&#39;d like to share:** Finding isolation, implementation, and validation assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form




## Summary

- Updated `atomic_write` to apply existing permissions before syncing and renaming the temporary file.
- Replaced `sync_data` with `sync_all` to persist file data and permissions.
- Documented best-effort permission tightening in `locked_update`.
- Added a Unix regression test for preserving `0o644` permissions.

## Benefits

- Failed writes leave the destination unchanged.
- Atomic replacements preserve existing permissions.
- The test suite now protects this behavior.

