### PR TITLE
fix(tui): finalize session creation atomically

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1417,15 +1417,22 @@ fn cleanup_partial_session(
     }
 }
 
-pub fn is_duplicate_session(instances: &[Instance], title: &str, path: &str) -> bool {
+pub(crate) fn find_duplicate_session<'a>(
+    instances: &'a [Instance],
+    title: &str,
+    path: &str,
+) -> Option<&'a Instance> {
     let normalized_path = path.trim_end_matches('/');
-    instances.iter().any(|inst| {
-        let existing_path = inst.project_path.trim_end_matches('/');
-        existing_path == normalized_path && inst.title == title
+    instances.iter().find(|instance| {
+        instance.title == title && instance.project_path.trim_end_matches('/') == normalized_path
     })
 }
 
-fn duplicate_session_error(title: &str) -> anyhow::Error {
+pub fn is_duplicate_session(instances: &[Instance], title: &str, path: &str) -> bool {
+    find_duplicate_session(instances, title, path).is_some()
+}
+
+pub(crate) fn duplicate_session_error(title: &str) -> anyhow::Error {
     anyhow::anyhow!(
         "Session already exists with same title and path: {}\n\
          Tip: use a different --title or remove the existing session first",

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -394,6 +394,7 @@ pub(crate) async fn spawn_structured_session(
                 &instance,
                 created_worktree.as_ref(),
                 &created_workspace_worktrees,
+                None,
             );
             return Err(anyhow::anyhow!("on_create hook failed: {e:#}"));
         }

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -872,6 +872,8 @@ impl CleanupProtection<'_> {
                 .is_some_and(|(left, right)| left == right)
     }
 
+    /// Exact matches protect a winner-owned worktree; containment protects a
+    /// winner path nested under a workspace root from recursive root cleanup.
     fn path_references_target(reference: &Path, target: &Path) -> bool {
         if reference == target || reference.starts_with(target) {
             return true;
@@ -961,6 +963,12 @@ pub fn cleanup_instance(
 ) {
     // The loser may never have reached storage, so lifecycle-coordinated stop
     // cannot reserve its row. Tear down only tmux resources named by its id.
+    // There is no per-build poller/monitor thread to stop here: the build
+    // path's only extra threads are the scoped worktree-creation threads that
+    // join before `build_instance` returns, and the async creation poller's
+    // build thread has already finished delivering its result before a rollback
+    // reaches this helper. So the tmux (below) and container (further down)
+    // teardown reclaim every runtime resource with no thread left running.
     instance.kill_all_tmux_sessions_without_lifecycle_row();
 
     if let Some(sandbox) = &instance.sandbox_info {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -3,7 +3,10 @@
 //! This module provides shared logic for building new session instances,
 //! used by both synchronous (TUI operations) and asynchronous (background poller) code paths.
 
-use std::{collections::HashSet, path::PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{bail, Result};
 use chrono::Utc;
@@ -71,10 +74,12 @@ pub struct BuildResult {
     pub warnings: Vec<String>,
 }
 
-/// Info about a worktree created during instance building.
+/// A worktree provisioned during instance building and owned by this build.
 pub struct CreatedWorktree {
     pub path: PathBuf,
     pub main_repo_path: PathBuf,
+    /// Branch created by this build. `None` when attaching an existing branch.
+    pub owned_branch: Option<String>,
 }
 
 /// Result of creating a multi-repo workspace.
@@ -273,10 +278,9 @@ pub fn create_workspace(
     }
 
     let cleanup = |created: &[CreatedWorktree], ws_path: &std::path::Path| {
-        for wt in created {
-            if let Ok(git_wt) = GitWorktree::new(wt.main_repo_path.clone()) {
-                let _ = git_wt.remove_worktree(&wt.path, false);
-            }
+        let protection = CleanupProtection::default();
+        for worktree in created {
+            cleanup_created_worktree(worktree, "workspace worktree", &protection);
         }
         let _ = std::fs::remove_dir_all(ws_path);
     };
@@ -389,6 +393,7 @@ pub fn create_workspace(
                 created_worktrees.push(CreatedWorktree {
                     path: plan.worktree_subdir.clone(),
                     main_repo_path: plan.main_repo_path.clone(),
+                    owned_branch: create_new_branch.then(|| branch.to_string()),
                 });
                 repos.push(WorkspaceRepo {
                     name: plan.repo_name.clone(),
@@ -661,6 +666,7 @@ pub fn build_instance(
                     created_worktree = Some(CreatedWorktree {
                         path: worktree_path,
                         main_repo_path: main_repo_path.clone(),
+                        owned_branch: None,
                     });
                     worktree_info = Some(WorktreeInfo {
                         branch: branch.clone(),
@@ -706,6 +712,7 @@ pub fn build_instance(
                 created_worktree = Some(CreatedWorktree {
                     path: worktree_path,
                     main_repo_path: main_repo_path.clone(),
+                    owned_branch: Some(branch.clone()),
                 });
                 worktree_info = Some(WorktreeInfo {
                     branch: branch.clone(),
@@ -850,17 +857,128 @@ pub fn build_instance(
     })
 }
 
+#[derive(Default)]
+struct CleanupProtection<'a> {
+    owner: Option<&'a Instance>,
+}
+
+impl CleanupProtection<'_> {
+    fn paths_equal(left: &Path, right: &Path) -> bool {
+        left == right
+            || left
+                .canonicalize()
+                .ok()
+                .zip(right.canonicalize().ok())
+                .is_some_and(|(left, right)| left == right)
+    }
+
+    fn path_references_target(reference: &Path, target: &Path) -> bool {
+        if reference == target || reference.starts_with(target) {
+            return true;
+        }
+        reference
+            .canonicalize()
+            .ok()
+            .zip(target.canonicalize().ok())
+            .is_some_and(|(reference, target)| reference == target || reference.starts_with(target))
+    }
+
+    fn references_path(&self, target: &Path) -> bool {
+        let Some(owner) = self.owner else {
+            return false;
+        };
+        if Self::path_references_target(Path::new(&owner.project_path), target) {
+            return true;
+        }
+        owner.workspace_info.as_ref().is_some_and(|workspace| {
+            Self::path_references_target(Path::new(&workspace.workspace_dir), target)
+                || workspace.repos.iter().any(|repo| {
+                    Self::path_references_target(Path::new(&repo.worktree_path), target)
+                })
+        })
+    }
+
+    fn references_branch(&self, main_repo_path: &Path, branch: &str) -> bool {
+        let Some(owner) = self.owner else {
+            return false;
+        };
+        owner.worktree_info.as_ref().is_some_and(|worktree| {
+            Self::paths_equal(Path::new(&worktree.main_repo_path), main_repo_path)
+                && worktree.branch == branch
+        }) || owner.workspace_info.as_ref().is_some_and(|workspace| {
+            workspace.repos.iter().any(|repo| {
+                Self::paths_equal(Path::new(&repo.main_repo_path), main_repo_path)
+                    && repo.branch == branch
+            })
+        })
+    }
+}
+
+/// Remove a worktree and then its build-owned branch. The branch stays intact
+/// when worktree removal fails because Git still considers it checked out.
+fn cleanup_created_worktree(
+    created: &CreatedWorktree,
+    label: &str,
+    protection: &CleanupProtection<'_>,
+) {
+    if protection.references_path(&created.path) {
+        tracing::debug!(
+            target: "session.create",
+            path = %created.path.display(),
+            "Preserving {label} referenced by the persisted uniqueness winner"
+        );
+        return;
+    }
+    let Ok(worktree) = GitWorktree::new(created.main_repo_path.clone()) else {
+        return;
+    };
+    if let Err(error) = worktree.remove_worktree(&created.path, false) {
+        tracing::warn!(target: "session.create", "Failed to clean up {label}: {error}");
+        return;
+    }
+    if let Some(branch) = created
+        .owned_branch
+        .as_deref()
+        .filter(|branch| !protection.references_branch(&created.main_repo_path, branch))
+    {
+        if let Err(error) = worktree.delete_branch(branch) {
+            tracing::warn!(target: "session.create", branch, "Failed to clean up branch: {error}");
+        }
+    }
+}
+
 /// Clean up resources created during a failed or cancelled instance build.
 ///
-/// This handles:
-/// - Removing worktrees created by aoe
-/// - Removing Docker containers
-/// - Killing tmux sessions
+/// Runtime resources always belong to the losing build and are stopped first,
+/// so a sandbox bind mount cannot block worktree removal. `protected_owner`
+/// is the persisted row that won a final uniqueness race; filesystem and Git
+/// resources referenced by that row are retained.
 pub fn cleanup_instance(
     instance: &Instance,
     created_worktree: Option<&CreatedWorktree>,
     created_workspace_worktrees: &[CreatedWorktree],
+    protected_owner: Option<&Instance>,
 ) {
+    // The loser may never have reached storage, so lifecycle-coordinated stop
+    // cannot reserve its row. Tear down only tmux resources named by its id.
+    instance.kill_all_tmux_sessions_without_lifecycle_row();
+
+    if let Some(sandbox) = &instance.sandbox_info {
+        if sandbox.enabled {
+            // Direct idempotent teardown, never gated on a separate existence
+            // probe. This must precede filesystem cleanup because the
+            // container bind-mounts the worktree.
+            let container = containers::DockerContainer::from_session_id(&instance.id);
+            if let containers::Teardown::Failed(e) = container.teardown(&instance.id) {
+                tracing::warn!(target: "session.create", "Failed to clean up container: {}", e);
+            }
+        }
+    }
+
+    let protection = CleanupProtection {
+        owner: protected_owner,
+    };
+
     // Scratch dirs are provisioned eagerly inside `build_instance`
     // (well before this helper's other cleanup targets exist), so an
     // abort between provisioning and the caller finishing the session
@@ -869,7 +987,9 @@ pub fn cleanup_instance(
     // wipe unrelated app data.
     if instance.scratch {
         let scratch_path = PathBuf::from(&instance.project_path);
-        if super::scratch::is_scratch_path(&scratch_path) {
+        if !protection.references_path(&scratch_path)
+            && super::scratch::is_scratch_path(&scratch_path)
+        {
             if let Err(e) = std::fs::remove_dir_all(&scratch_path) {
                 tracing::warn!(
                     target: "session.create",
@@ -880,40 +1000,19 @@ pub fn cleanup_instance(
         }
     }
 
-    if let Some(wt) = created_worktree {
-        if let Ok(git_wt) = GitWorktree::new(wt.main_repo_path.clone()) {
-            if let Err(e) = git_wt.remove_worktree(&wt.path, false) {
-                tracing::warn!(target: "session.create", "Failed to clean up worktree: {}", e);
-            }
-        }
+    if let Some(worktree) = created_worktree {
+        cleanup_created_worktree(worktree, "worktree", &protection);
     }
 
-    // Workspace worktree cleanup
-    for wt in created_workspace_worktrees {
-        if let Ok(git_wt) = GitWorktree::new(wt.main_repo_path.clone()) {
-            if let Err(e) = git_wt.remove_worktree(&wt.path, false) {
-                tracing::warn!(target: "session.create", "Failed to clean up workspace worktree: {}", e);
-            }
+    for worktree in created_workspace_worktrees {
+        cleanup_created_worktree(worktree, "workspace worktree", &protection);
+    }
+    if let Some(workspace) = &instance.workspace_info {
+        let workspace_dir = Path::new(&workspace.workspace_dir);
+        if !protection.references_path(workspace_dir) {
+            let _ = std::fs::remove_dir_all(workspace_dir);
         }
     }
-    // Clean up workspace directory if workspace was created
-    if let Some(ws_info) = &instance.workspace_info {
-        let _ = std::fs::remove_dir_all(&ws_info.workspace_dir);
-    }
-
-    if let Some(sandbox) = &instance.sandbox_info {
-        if sandbox.enabled {
-            // Direct idempotent teardown, never gated on a separate existence
-            // probe: a transient `inspect` failure must not skip removal and
-            // orphan a live container. Volumes are swept inside `teardown`.
-            let container = containers::DockerContainer::from_session_id(&instance.id);
-            if let containers::Teardown::Failed(e) = container.teardown(&instance.id) {
-                tracing::warn!(target: "session.create", "Failed to clean up container: {}", e);
-            }
-        }
-    }
-
-    let _ = instance.kill();
 }
 
 /// Structured-view (ACP) helpers for the TUI create paths. The web create
@@ -1864,6 +1963,17 @@ mod tests {
             None,
             "a repo with no configured base records none, so the diff falls through to detection"
         );
+        assert!(result
+            .created_worktrees
+            .iter()
+            .all(|worktree| worktree.owned_branch.as_deref() == Some("feature-x")));
+        for worktree in &result.created_worktrees {
+            cleanup_created_worktree(worktree, "test worktree", &CleanupProtection::default());
+            let repo = git2::Repository::open(&worktree.main_repo_path).unwrap();
+            assert!(repo
+                .find_branch("feature-x", git2::BranchType::Local)
+                .is_err());
+        }
     }
 
     /// A repo whose branch aoe did not create has no base of its own: the base
@@ -1895,6 +2005,42 @@ mod tests {
         .expect("workspace creation should succeed");
 
         assert_eq!(result.workspace_info.repos[0].base_branch, None);
+        assert_eq!(result.created_worktrees[0].owned_branch, None);
+        let worktree = &result.created_worktrees[0];
+        cleanup_created_worktree(worktree, "test worktree", &CleanupProtection::default());
+        let repo = git2::Repository::open(&worktree.main_repo_path).unwrap();
+        assert!(repo
+            .find_branch("feature-x", git2::BranchType::Local)
+            .is_ok());
+    }
+
+    #[test]
+    fn cleanup_keeps_owned_branch_when_worktree_removal_fails() {
+        let (parent, _) = init_repo_with_branch("cleanup", "release");
+        let main_repo_path = parent.path().join("cleanup");
+        let worktree_path = parent.path().join("dirty-worktree");
+        let git = GitWorktree::new(main_repo_path.clone()).unwrap();
+        git.create_worktree("rollback-branch", &worktree_path, true, None)
+            .unwrap();
+        std::fs::write(worktree_path.join("README.md"), "dirty\n").unwrap();
+
+        let created = CreatedWorktree {
+            path: worktree_path.clone(),
+            main_repo_path: main_repo_path.clone(),
+            owned_branch: Some("rollback-branch".to_string()),
+        };
+        cleanup_created_worktree(&created, "test worktree", &CleanupProtection::default());
+
+        assert!(worktree_path.exists(), "dirty worktree must survive");
+        let repo = git2::Repository::open(&main_repo_path).unwrap();
+        assert!(
+            repo.find_branch("rollback-branch", git2::BranchType::Local)
+                .is_ok(),
+            "owned branch must not be deleted while its worktree remains"
+        );
+
+        git.remove_worktree(&worktree_path, true).unwrap();
+        git.delete_branch("rollback-branch").unwrap();
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -7570,80 +7570,62 @@ mod tests {
     use tracing_test::traced_test;
 
     #[test]
-    fn summarize_omp_banner_uses_message_above_anchor() {
-        // #3377: the omp error banner's dismissal footer anchors the reason
-        // extraction; the message line above it (glyph stripped) is returned.
-        let pane = "────\n\
-                     ✘ 401 Incorrect API key provided: sk-dummy.\n\
-                     Dismissed when you send your next message.\n\
-                     ────\n\
-                     ╭── π  > GPT-5.6 Sol ─╮\n\
-                     ╰─                   ─╯";
-        assert_eq!(
-            summarize_error_from_pane(pane),
-            "401 Incorrect API key provided: sk-dummy."
-        );
-    }
+    fn summarize_error_from_pane_handles_banner_shapes() {
+        let cases = [
+            (
+                "message above anchor",
+                "────\n\
+                 ✘ 401 Incorrect API key provided: sk-dummy.\n\
+                 Dismissed when you send your next message.\n\
+                 ────\n\
+                 ╭── π  > GPT-5.6 Sol ─╮\n\
+                 ╰─                   ─╯",
+                "401 Incorrect API key provided: sk-dummy.",
+            ),
+            (
+                "multiline message",
+                "────\n\
+                 ✖ 429 Too Many Requests (rate limited). Retry after 30s.\n\
+                    This is a continuation with more detail.\n\
+                    And a third line.\n\
+                 Dismissed when you send your next message.\n\
+                 ────\n\
+                 ╭── π  > GPT-5.6 Sol ─╮\n\
+                 ╰─                   ─╯",
+                "429 Too Many Requests (rate limited). Retry after 30s. This is a continuation with more detail. And a third line.",
+            ),
+            (
+                "terminal lines below stale banner",
+                "────\n\
+                 ✖ 429 Too Many Requests (rate limited). Retry after 30s.\n\
+                 Dismissed when you send your next message.\n\
+                 ────\n\
+                 Error: Retry budget exhausted after 10 retries: Unable to connect. Is the computer able to access the url?\n\
+                 Error: Retry failed after 10 attempts: Unable to connect. Is the computer able to access the url?\n\
+                 ╭── π  > GPT-5.6 Sol ─╮\n\
+                 ╰─                   ─╯",
+                "Error: Retry failed after 10 attempts: Unable to connect. Is the computer able to access the url?",
+            ),
+            (
+                "no banner",
+                "building failed: no such file\n╭── π  > GPT-5.6 Sol ─╮\n╰─   ─╯",
+                "building failed: no such file",
+            ),
+            (
+                "anchor without message",
+                "────\n\
+                 Dismissed when you send your next message.\n\
+                 ────\n\
+                 building failed: no such file\n\
+                 ╭── π  > GPT-5.6 Sol ─╮\n\
+                 ╰─                   ─╯",
+                "building failed: no such file",
+            ),
+        ];
 
-    #[test]
-    fn summarize_omp_banner_joins_multiline_message() {
-        // A wrapped banner message (continuation lines indented) is joined
-        // with single spaces, borders and the anchor excluded.
-        let pane = "────\n\
-                     ✖ 429 Too Many Requests (rate limited). Retry after 30s.\n\
-                        This is a continuation with more detail.\n\
-                        And a third line.\n\
-                     Dismissed when you send your next message.\n\
-                     ────\n\
-                     ╭── π  > GPT-5.6 Sol ─╮\n\
-                     ╰─                   ─╯";
-        assert_eq!(
-            summarize_error_from_pane(pane),
-            "429 Too Many Requests (rate limited). Retry after 30s. This is a continuation with more detail. And a third line."
-        );
-    }
-
-    #[test]
-    fn summarize_prefers_terminal_lines_below_a_stale_banner() {
-        // When the terminal retry lines sit below the anchor, the word list
-        // picks them instead of the stale banner (lowest signal wins).
-        let pane = "────\n\
-                     ✖ 429 Too Many Requests (rate limited). Retry after 30s.\n\
-                     Dismissed when you send your next message.\n\
-                     ────\n\
-                     Error: Retry budget exhausted after 10 retries: Unable to connect. Is the computer able to access the url?\n\
-                     Error: Retry failed after 10 attempts: Unable to connect. Is the computer able to access the url?\n\
-                     ╭── π  > GPT-5.6 Sol ─╮\n\
-                     ╰─                   ─╯";
-        assert_eq!(
-            summarize_error_from_pane(pane),
-            "Error: Retry failed after 10 attempts: Unable to connect. Is the computer able to access the url?"
-        );
-    }
-
-    #[test]
-    fn summarize_without_banner_keeps_word_list_behavior() {
-        let pane = "building failed: no such file\n╭── π  > GPT-5.6 Sol ─╮\n╰─   ─╯";
-        assert_eq!(
-            summarize_error_from_pane(pane),
-            "building failed: no such file"
-        );
-    }
-
-    #[test]
-    fn summarize_falls_back_when_anchor_has_no_message_lines() {
-        // A banner whose dismissal footer is immediately under the top border
-        // has no collectable message lines: fall through to the word list.
-        let pane = "────\n\
-                     Dismissed when you send your next message.\n\
-                     ────\n\
-                     building failed: no such file\n\
-                     ╭── π  > GPT-5.6 Sol ─╮\n\
-                     ╰─                   ─╯";
-        assert_eq!(
-            summarize_error_from_pane(pane),
-            "building failed: no such file"
-        );
+        for (name, pane, expected) in cases {
+            assert_eq!(summarize_error_from_pane(pane), expected, "{name}");
+        }
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -6555,12 +6555,12 @@ impl Instance {
         self.kill_all_tmux_sessions_uncoordinated();
     }
 
-    /// Break-glass teardown after force-removal has durably deleted the row.
+    /// Tear down tmux resources when no durable lifecycle row exists.
     ///
-    /// A lifecycle reservation cannot be acquired once the row is absent.
-    /// Force-removal is limited to an already-Deleting row, so no launch can
-    /// race this idempotent cleanup.
-    pub(crate) fn kill_all_tmux_sessions_after_forced_removal(&self) {
+    /// Used after force-removal and when rolling back an instance that failed
+    /// before its row was committed. With no row, lifecycle reservation is
+    /// impossible; callers must already know the id cannot race a launch.
+    pub(crate) fn kill_all_tmux_sessions_without_lifecycle_row(&self) {
         self.kill_all_tmux_sessions_uncoordinated();
     }
 

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -26,6 +26,8 @@ pub enum CreationResult {
         instance: Box<Instance>,
         /// Worktree created during build, needed for cleanup if cancelled
         created_worktree: Option<CreatedWorktreeInfo>,
+        /// Workspace worktrees created during build, needed for rollback.
+        created_workspace_worktrees: Vec<CreatedWorktreeInfo>,
         /// Whether on_launch hooks were already executed in the background
         on_launch_hooks_ran: bool,
         /// Non-fatal warnings from worktree creation (e.g. post-checkout hook
@@ -40,6 +42,7 @@ pub enum CreationResult {
 pub struct CreatedWorktreeInfo {
     pub path: String,
     pub main_repo_path: String,
+    pub owned_branch: Option<String>,
 }
 
 impl From<&CreatedWorktree> for CreatedWorktreeInfo {
@@ -47,6 +50,17 @@ impl From<&CreatedWorktree> for CreatedWorktreeInfo {
         Self {
             path: wt.path.to_string_lossy().to_string(),
             main_repo_path: wt.main_repo_path.to_string_lossy().to_string(),
+            owned_branch: wt.owned_branch.clone(),
+        }
+    }
+}
+
+impl From<&CreatedWorktreeInfo> for CreatedWorktree {
+    fn from(worktree: &CreatedWorktreeInfo) -> Self {
+        Self {
+            path: worktree.path.as_str().into(),
+            main_repo_path: worktree.main_repo_path.as_str().into(),
+            owned_branch: worktree.owned_branch.clone(),
         }
     }
 }
@@ -154,6 +168,7 @@ impl CreationPoller {
                         &instance,
                         created_worktree.as_ref(),
                         &created_workspace_worktrees,
+                        None,
                     );
                     return CreationResult::Error(format!("{:#}", e));
                 }
@@ -172,6 +187,7 @@ impl CreationPoller {
                             &instance,
                             created_worktree.as_ref(),
                             &created_workspace_worktrees,
+                            None,
                         );
                         return CreationResult::Error(format!("on_create hook failed: {:#}", e));
                     }
@@ -186,6 +202,7 @@ impl CreationPoller {
                     &instance,
                     created_worktree.as_ref(),
                     &created_workspace_worktrees,
+                    None,
                 );
                 return CreationResult::Error(format!("on_create hook failed: {:#}", e));
             }
@@ -238,17 +255,23 @@ impl CreationPoller {
                     &instance,
                     created_worktree.as_ref(),
                     &created_workspace_worktrees,
+                    None,
                 );
                 return CreationResult::Error(format!("{:#}", e));
             }
         }
 
         let created_worktree_info = created_worktree.as_ref().map(CreatedWorktreeInfo::from);
+        let created_workspace_worktree_info = created_workspace_worktrees
+            .iter()
+            .map(CreatedWorktreeInfo::from)
+            .collect();
 
         CreationResult::Success {
             session_id: instance.id.clone(),
             instance: Box::new(instance),
             created_worktree: created_worktree_info,
+            created_workspace_worktrees: created_workspace_worktree_info,
             on_launch_hooks_ran: has_on_launch,
             warnings,
         }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -31,6 +31,22 @@ use crate::session::{
 use crate::tmux::AvailableTools;
 
 use super::creation_poller::{CreatedWorktreeInfo, CreationPoller, CreationRequest};
+use super::deletion_poller::DeletionPoller;
+#[cfg(feature = "serve")]
+use super::dialogs::ServeView;
+use super::dialogs::{
+    AttachProjectDialog, ChangelogDialog, CommandPaletteDialog, ConfirmDialog, ContextMenuDialog,
+    GroupDeleteOptionsDialog, GroupPickerDialog, HooksInstallDialog, InfoDialog, IntroDialog,
+    NewSessionData, NewSessionDialog, NoAgentsDialog, ProfilePickerDialog,
+    ProjectSessionPickerDialog, ProjectsDialog, RenameDialog, RepoTrustDialog, RestartDialog,
+    SnoozeDurationDialog, SortPickerDialog, UnifiedDeleteDialog, UpdateConfirmDialog,
+    WorktreeNameDialog,
+};
+use super::diff::DiffView;
+use super::restart_poller::RestartPoller;
+use super::settings::SettingsView;
+use super::status_poller::{StatusPoller, StatusUpdate};
+use super::stop_poller::StopPoller;
 
 fn cleanup_creation_resources(
     instance: &Instance,
@@ -55,22 +71,6 @@ enum CreationCommit {
     Inserted,
     Duplicate(Box<Instance>),
 }
-use super::deletion_poller::DeletionPoller;
-#[cfg(feature = "serve")]
-use super::dialogs::ServeView;
-use super::dialogs::{
-    AttachProjectDialog, ChangelogDialog, CommandPaletteDialog, ConfirmDialog, ContextMenuDialog,
-    GroupDeleteOptionsDialog, GroupPickerDialog, HooksInstallDialog, InfoDialog, IntroDialog,
-    NewSessionData, NewSessionDialog, NoAgentsDialog, ProfilePickerDialog,
-    ProjectSessionPickerDialog, ProjectsDialog, RenameDialog, RepoTrustDialog, RestartDialog,
-    SnoozeDurationDialog, SortPickerDialog, UnifiedDeleteDialog, UpdateConfirmDialog,
-    WorktreeNameDialog,
-};
-use super::diff::DiffView;
-use super::restart_poller::RestartPoller;
-use super::settings::SettingsView;
-use super::status_poller::{StatusPoller, StatusUpdate};
-use super::stop_poller::StopPoller;
 
 /// The GroupTree identity key for a session in project mode. Worktree sessions
 /// key on `main_repo_path` (so all branches of a repo group together); other

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -30,7 +30,31 @@ use crate::session::{
 };
 use crate::tmux::AvailableTools;
 
-use super::creation_poller::{CreationPoller, CreationRequest};
+use super::creation_poller::{CreatedWorktreeInfo, CreationPoller, CreationRequest};
+
+fn cleanup_creation_resources(
+    instance: &Instance,
+    created_worktree: Option<&CreatedWorktreeInfo>,
+    created_workspace_worktrees: &[CreatedWorktreeInfo],
+    protected_owner: Option<&Instance>,
+) {
+    let worktree = created_worktree.map(crate::session::builder::CreatedWorktree::from);
+    let workspace_worktrees: Vec<_> = created_workspace_worktrees
+        .iter()
+        .map(crate::session::builder::CreatedWorktree::from)
+        .collect();
+    crate::session::builder::cleanup_instance(
+        instance,
+        worktree.as_ref(),
+        &workspace_worktrees,
+        protected_owner,
+    );
+}
+
+enum CreationCommit {
+    Inserted,
+    Duplicate(Box<Instance>),
+}
 use super::deletion_poller::DeletionPoller;
 #[cfg(feature = "serve")]
 use super::dialogs::ServeView;
@@ -804,6 +828,10 @@ pub struct HomeView {
     pub(super) creating_hook_progress: HashMap<String, CreatingHookProgress>,
     /// The stub instance ID for the current background creation
     pub(super) creating_stub_id: Option<String>,
+    /// Group paths introduced only to display the current Creating stub.
+    /// Finalization removes these from persisted metadata before replacing the
+    /// stub, while preserving groups that were already present when requested.
+    creating_provisional_group_paths: HashSet<String>,
 
     // Performance: preview caching
     pub(super) preview_cache: PreviewCache,
@@ -2320,6 +2348,7 @@ impl HomeView {
             on_launch_hooks_ran: HashSet::new(),
             creating_hook_progress: HashMap::new(),
             creating_stub_id: None,
+            creating_provisional_group_paths: HashSet::new(),
             preview_cache: PreviewCache::default(),
             preview_timings: PreviewTimings::default(),
             terminal_preview_cache: PreviewCache::default(),
@@ -2616,9 +2645,8 @@ impl HomeView {
         self.group_trees.retain(|k, _| storage_keys.contains(k));
 
         // Snapshot the in-flight Creating stub before `self.instances` is
-        // overwritten. The stub isn't on disk (added via `add_instance` from
-        // `create_session` before the async worker starts) and would
-        // otherwise vanish across reload.
+        // overwritten. An intervening save may have persisted it, but while it
+        // is still memory-only it would otherwise vanish across reload.
         let creating_stub_snapshot: Option<Instance> = self
             .creating_stub_id
             .as_ref()
@@ -4156,6 +4184,16 @@ impl HomeView {
 
         let stub_id = stub.id.clone();
         let target_profile = data.profile.clone();
+        let existing_group_paths: HashSet<String> = self
+            .group_trees
+            .get(&target_profile)
+            .map(|tree| {
+                tree.get_all_groups()
+                    .into_iter()
+                    .map(|group| group.path)
+                    .collect()
+            })
+            .unwrap_or_default();
 
         // Add stub to instance list
         self.add_instance(stub);
@@ -4165,6 +4203,17 @@ impl HomeView {
                 tree.create_group(&data.group);
             }
         }
+        self.creating_provisional_group_paths = self
+            .group_trees
+            .get(&target_profile)
+            .map(|tree| {
+                tree.get_all_groups()
+                    .into_iter()
+                    .map(|group| group.path)
+                    .filter(|path| !existing_group_paths.contains(path))
+                    .collect()
+            })
+            .unwrap_or_default();
 
         // Initialize progress tracking and select the stub
         self.creating_hook_progress.insert(
@@ -4214,6 +4263,7 @@ impl HomeView {
         }
         // Remove the stub instance
         if let Some(stub_id) = self.creating_stub_id.take() {
+            self.creating_provisional_group_paths.clear();
             self.remove_instance(&stub_id);
             self.creating_hook_progress.remove(&stub_id);
             self.rebuild_group_trees();
@@ -4227,13 +4277,12 @@ impl HomeView {
     /// Returns Some(session_id) if creation succeeded and we should attach.
     pub fn apply_creation_results(&mut self) -> Option<String> {
         use super::creation_poller::CreationResult;
-        use crate::session::builder::{self, CreatedWorktree};
-        use std::path::PathBuf;
 
         let result = self.creation_poller.try_recv_result()?;
 
         // Clean up the stub and progress tracking
         let stub_id = self.creating_stub_id.take();
+        let provisional_group_paths = std::mem::take(&mut self.creating_provisional_group_paths);
         if let Some(ref id) = stub_id {
             self.creating_hook_progress.remove(id);
         }
@@ -4247,14 +4296,16 @@ impl HomeView {
             if let CreationResult::Success {
                 ref instance,
                 ref created_worktree,
+                ref created_workspace_worktrees,
                 ..
             } = result
             {
-                let worktree = created_worktree.as_ref().map(|wt| CreatedWorktree {
-                    path: PathBuf::from(&wt.path),
-                    main_repo_path: PathBuf::from(&wt.main_repo_path),
-                });
-                builder::cleanup_instance(instance, worktree.as_ref(), &[]);
+                cleanup_creation_resources(
+                    instance,
+                    created_worktree.as_ref(),
+                    created_workspace_worktrees,
+                    None,
+                );
             }
             self.rebuild_group_trees();
             self.rebuild_flat_items();
@@ -4266,9 +4317,10 @@ impl HomeView {
             CreationResult::Success {
                 session_id,
                 instance,
+                created_worktree,
+                created_workspace_worktrees,
                 on_launch_hooks_ran,
-                warnings,
-                ..
+                mut warnings,
             } => {
                 // Remove the stub instance
                 if let Some(id) = &stub_id {
@@ -4283,24 +4335,141 @@ impl HomeView {
                 });
                 instance.source_profile = target_profile.clone();
 
-                // Ensure target profile storage exists
                 if !self.storages.contains_key(&target_profile) {
-                    if let Ok(s) = Storage::new(&target_profile, self.file_watch.clone()) {
-                        self.storages.insert(target_profile.clone(), s);
+                    match Storage::new(&target_profile, self.file_watch.clone()) {
+                        Ok(storage) => {
+                            self.storages.insert(target_profile.clone(), storage);
+                        }
+                        Err(error) => {
+                            cleanup_creation_resources(
+                                &instance,
+                                created_worktree.as_ref(),
+                                &created_workspace_worktrees,
+                                None,
+                            );
+                            self.info_dialog = Some(InfoDialog::sized_to_fit(
+                                "Creation Failed",
+                                &format!("Failed to open profile storage: {error}"),
+                            ));
+                            self.new_dialog = None;
+                            self.rebuild_group_trees();
+                            self.rebuild_flat_items();
+                            self.update_selected();
+                            return None;
+                        }
                     }
                 }
 
-                self.add_instance(instance.clone());
-                self.rebuild_group_trees();
-                if !instance.group_path.is_empty() {
-                    if let Some(tree) = self.group_trees.get_mut(&target_profile) {
+                let storage = self
+                    .storages
+                    .get(&target_profile)
+                    .expect("target profile storage was just ensured");
+                let persist_result = storage.update(|instances, groups| {
+                    // `save()` can run while the builder is working and persist
+                    // the placeholder. Remove that exact row under the same
+                    // storage lock used for collision detection and insertion,
+                    // otherwise the placeholder collides with its own result.
+                    let removed_persisted_stub = stub_id.as_deref().is_some_and(|stub_id| {
+                        let before = instances.len();
+                        instances.retain(|row| row.id != stub_id);
+                        instances.len() != before
+                    });
+                    if removed_persisted_stub && !provisional_group_paths.is_empty() {
+                        groups.retain(|group| !provisional_group_paths.contains(&group.path));
+                        // A peer may have committed another row into one of
+                        // these paths. Rebuild from the remaining rows so its
+                        // group survives even though the stub-created metadata
+                        // was provisional.
+                        *groups = GroupTree::new_with_groups(instances, groups).get_all_groups();
+                    }
+                    if let Some(owner) = crate::cli::add::find_duplicate_session(
+                        instances,
+                        &instance.title,
+                        &instance.project_path,
+                    ) {
+                        return Ok(CreationCommit::Duplicate(Box::new(owner.clone())));
+                    }
+                    instances.push(instance.clone());
+                    if !instance.group_path.is_empty() {
+                        let mut tree = GroupTree::new_with_groups(instances, groups);
                         tree.create_group(&instance.group_path);
+                        *groups = tree.get_all_groups();
                     }
+                    Ok(CreationCommit::Inserted)
+                });
+                match persist_result {
+                    Ok(CreationCommit::Inserted) => {}
+                    Ok(CreationCommit::Duplicate(owner)) => {
+                        cleanup_creation_resources(
+                            &instance,
+                            created_worktree.as_ref(),
+                            &created_workspace_worktrees,
+                            Some(&owner),
+                        );
+                        self.info_dialog = Some(InfoDialog::sized_to_fit(
+                            "Creation Failed",
+                            &crate::cli::add::duplicate_session_error(&instance.title).to_string(),
+                        ));
+                        self.new_dialog = None;
+                        if let Err(error) = self.reload() {
+                            tracing::warn!(
+                                target: "tui.home",
+                                "Failed to reload authoritative state after creation collision: {error}"
+                            );
+                        }
+                        return None;
+                    }
+                    Err(error) => match storage.load() {
+                        Ok(instances) if instances.iter().any(|row| row.id == instance.id) => {
+                            warnings.push(format!(
+                                "Session metadata was written, but finalizing profile storage reported an error: {error}"
+                            ));
+                        }
+                        Ok(instances) => {
+                            let owner = crate::cli::add::find_duplicate_session(
+                                &instances,
+                                &instance.title,
+                                &instance.project_path,
+                            )
+                            .cloned();
+                            cleanup_creation_resources(
+                                &instance,
+                                created_worktree.as_ref(),
+                                &created_workspace_worktrees,
+                                owner.as_ref(),
+                            );
+                            self.info_dialog = Some(InfoDialog::sized_to_fit(
+                                "Creation Failed",
+                                &format!("Failed to save session: {error}"),
+                            ));
+                            self.new_dialog = None;
+                            if let Err(reload_error) = self.reload() {
+                                tracing::warn!(
+                                    target: "tui.home",
+                                    "Failed to reload authoritative state after creation rollback: {reload_error}"
+                                );
+                            }
+                            return None;
+                        }
+                        Err(verify_error) => {
+                            self.info_dialog = Some(InfoDialog::sized_to_fit(
+                                "Creation Failed",
+                                &format!(
+                                    "Failed to save session and could not verify the result: {error}\n\
+                                     Created resources were retained to avoid deleting a persisted session: {verify_error}"
+                                ),
+                            ));
+                            self.new_dialog = None;
+                            self.rebuild_group_trees();
+                            self.rebuild_flat_items();
+                            self.update_selected();
+                            return None;
+                        }
+                    },
                 }
 
-                if let Err(e) = self.save() {
-                    tracing::error!(target: "tui.home", "Failed to save after creation: {}", e);
-                }
+                self.publish_persisted_instance(instance.clone());
+                self.rebuild_group_trees();
 
                 if on_launch_hooks_ran {
                     self.on_launch_hooks_ran.insert(session_id.clone());
@@ -4468,17 +4637,16 @@ impl HomeView {
         if let Some(crate::tui::creation_poller::CreationResult::Success {
             ref instance,
             ref created_worktree,
+            ref created_workspace_worktrees,
             ..
         }) = result
         {
-            let worktree =
-                created_worktree
-                    .as_ref()
-                    .map(|wt| crate::session::builder::CreatedWorktree {
-                        path: std::path::PathBuf::from(&wt.path),
-                        main_repo_path: std::path::PathBuf::from(&wt.main_repo_path),
-                    });
-            crate::session::builder::cleanup_instance(instance, worktree.as_ref(), &[]);
+            cleanup_creation_resources(
+                instance,
+                created_worktree.as_ref(),
+                created_workspace_worktrees,
+                None,
+            );
             tracing::info!(target: "tui.home", "Cleaned up cancelled session on exit");
         }
     }
@@ -6492,6 +6660,22 @@ impl HomeView {
             .or_default()
             .insert(instance.id.clone());
         self.instances.insert(instance.id.clone(), instance);
+    }
+
+    /// Publish a row that this process already committed through
+    /// `Storage::update`. Unlike a provisional TUI add, a later missing disk row
+    /// is a peer deletion and must not be recreated by `save()`.
+    fn publish_persisted_instance(&mut self, instance: Instance) {
+        let profile = instance.source_profile.clone();
+        let id = instance.id.clone();
+        self.add_instance(instance);
+        let remove_profile_entry = self.pending_added.get_mut(&profile).is_some_and(|pending| {
+            pending.remove(&id);
+            pending.is_empty()
+        });
+        if remove_profile_entry {
+            self.pending_added.remove(&profile);
+        }
     }
 
     /// Centralized instance removal: shift-removes from the ordered map

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4282,6 +4282,10 @@ impl HomeView {
 
         // Clean up the stub and progress tracking
         let stub_id = self.creating_stub_id.take();
+        // Taken (not borrowed) so every early return below leaves the field
+        // empty: the provisional group paths belong to this stub alone, and a
+        // rolled-back or failed finalize must not carry them into the next
+        // creation.
         let provisional_group_paths = std::mem::take(&mut self.creating_provisional_group_paths);
         if let Some(ref id) = stub_id {
             self.creating_hook_progress.remove(id);
@@ -4360,10 +4364,12 @@ impl HomeView {
                     }
                 }
 
-                let storage = self
-                    .storages
-                    .get(&target_profile)
-                    .expect("target profile storage was just ensured");
+                let Some(storage) = self.storages.get(&target_profile) else {
+                    // The block above either found or inserted this profile's
+                    // storage, so this is unreachable; bail without attaching
+                    // rather than panicking on a production path.
+                    return None;
+                };
                 let persist_result = storage.update(|instances, groups| {
                     // `save()` can run while the builder is working and persist
                     // the placeholder. Remove that exact row under the same
@@ -4468,6 +4474,11 @@ impl HomeView {
                     },
                 }
 
+                // `publish_persisted_instance` records the create-count and
+                // clears the id from `pending_added` (the row is authoritative
+                // now, not a provisional add). Its in-memory insert is
+                // superseded by the `reload()` below on success, but is the
+                // fallback that keeps the row visible if that reload fails.
                 self.publish_persisted_instance(instance.clone());
                 self.rebuild_group_trees();
 

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -753,7 +753,7 @@ impl HomeView {
         if let Some(inst) = instance {
             std::thread::spawn(move || {
                 if let Err(panic) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    inst.kill_all_tmux_sessions_after_forced_removal()
+                    inst.kill_all_tmux_sessions_without_lifecycle_row()
                 })) {
                     tracing::error!(
                         target: "session.delete",

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7131,10 +7131,9 @@ fn test_has_dialog_true_when_search_active() {
     assert!(view.has_dialog());
 }
 
-/// Verify that the async CreationPoller path returns a session ID from
-/// `apply_creation_results` once the background thread finishes. This is
-/// the code path that was previously starved by continuous input events
-/// in the tokio::select! event loop (see #633).
+/// Verify the async CreationPoller result replaces a Creating stub even when
+/// an intervening TUI save persisted it. Also covers the peer-collision path
+/// and ownership-safe cleanup of group metadata introduced by the stub.
 #[test]
 #[serial]
 fn test_apply_creation_results_returns_session_id() {
@@ -7145,6 +7144,19 @@ fn test_apply_creation_results_returns_session_id() {
 
     let project_dir = temp.path().join("project");
     std::fs::create_dir_all(&project_dir).unwrap();
+    {
+        let repo = git2::Repository::init(&project_dir).unwrap();
+        let signature = git2::Signature::now("Test", "test@example.com").unwrap();
+        std::fs::write(project_dir.join("README.md"), "test\n").unwrap();
+        let tree_id = {
+            let mut index = repo.index().unwrap();
+            index.add_path(std::path::Path::new("README.md")).unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &signature, &signature, "init", &tree, &[])
+            .unwrap();
+    }
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(
@@ -7161,7 +7173,7 @@ fn test_apply_creation_results_returns_session_id() {
         profile: "default".to_string(),
         title: "Async Test".to_string(),
         path: project_dir.to_str().unwrap().to_string(),
-        group: String::new(),
+        group: "async-success".to_string(),
         tool: "claude".to_string(),
         worktree_enabled: false,
         worktree_branch: None,
@@ -7179,13 +7191,28 @@ fn test_apply_creation_results_returns_session_id() {
         structured: false,
     };
 
-    // Use the async CreationPoller path (pass None hooks, non-sandbox,
-    // but call request_creation directly to force the async path)
-    view.request_creation(data, None);
+    let storage = Storage::new_unwatched("default").unwrap();
+    view.request_creation(data.clone(), None);
     assert!(view.is_creation_pending());
+    let stub_id = view
+        .creating_stub_id
+        .clone()
+        .expect("request should install a Creating stub");
+    view.save().unwrap();
+    let (persisted_while_creating, groups_while_creating) = storage.load_with_groups().unwrap();
+    assert_eq!(persisted_while_creating.len(), 1);
+    assert_eq!(persisted_while_creating[0].id, stub_id);
+    assert_eq!(
+        persisted_while_creating[0].status,
+        crate::session::Status::Creating
+    );
+    assert!(
+        groups_while_creating
+            .iter()
+            .any(|group| group.path == "async-success"),
+        "the intervening save should persist the stub's provisional group"
+    );
 
-    // Wait for the background thread to finish (should be near-instant
-    // for non-sandbox, non-hook creation)
     let start = std::time::Instant::now();
     let mut session_id = None;
     while start.elapsed() < std::time::Duration::from_secs(5) {
@@ -7201,6 +7228,223 @@ fn test_apply_creation_results_returns_session_id() {
         view.get_instance(&session_id).is_some(),
         "created session should be findable after apply_creation_results"
     );
+    assert!(
+        !view
+            .pending_added
+            .get("default")
+            .is_some_and(|pending| pending.contains(&session_id)),
+        "a row committed by finalization is not a provisional pending add"
+    );
+    let (persisted_after_finalization, groups_after_finalization) =
+        storage.load_with_groups().unwrap();
+    assert_eq!(
+        persisted_after_finalization.len(),
+        1,
+        "finalization should replace the persisted stub with one real row"
+    );
+    assert_eq!(persisted_after_finalization[0].id, session_id);
+    assert!(
+        persisted_after_finalization
+            .iter()
+            .all(|instance| instance.id != stub_id
+                && instance.status != crate::session::Status::Creating),
+        "the persisted Creating stub must not survive finalization"
+    );
+    assert!(
+        groups_after_finalization
+            .iter()
+            .any(|group| group.path == "async-success"),
+        "the finalized row's group should remain persisted"
+    );
+    assert!(
+        view.get_instance(&stub_id).is_none(),
+        "the in-memory Creating stub must be replaced too"
+    );
+
+    storage
+        .update(|instances, _groups| {
+            instances.retain(|instance| instance.id != session_id);
+            Ok(())
+        })
+        .unwrap();
+    view.save().unwrap();
+    assert!(
+        view.get_instance(&session_id).is_none(),
+        "save must evict the peer-deleted finalized row from memory"
+    );
+    assert!(
+        !storage
+            .load()
+            .unwrap()
+            .iter()
+            .any(|instance| instance.id == session_id),
+        "a peer-deleted finalized row must not be resurrected by save"
+    );
+
+    // A peer can commit the same title/path while the background builder is
+    // waiting for finalization. Use a real created branch/worktree so rollback
+    // proves it preserves resources referenced by the persisted winner.
+    let preexisting_group = "existing-empty";
+    let transient_group = "existing-empty/collision";
+    view.group_trees
+        .get_mut("default")
+        .expect("default profile should have a group tree")
+        .create_group(preexisting_group);
+    view.save().unwrap();
+    assert!(
+        storage
+            .load_with_groups()
+            .unwrap()
+            .1
+            .iter()
+            .any(|group| group.path == preexisting_group),
+        "the parent group must be intentionally persisted before the request"
+    );
+    let branch = "raced-worktree";
+    let mut raced = data;
+    raced.title = "Raced title".to_string();
+    raced.group = transient_group.to_string();
+    raced.worktree_enabled = true;
+    raced.worktree_branch = Some(branch.to_string());
+    raced.create_new_branch = true;
+    view.request_creation(raced, None);
+    let raced_stub_id = view
+        .creating_stub_id
+        .clone()
+        .expect("raced request should install a Creating stub");
+    view.save().unwrap();
+    let (raced_rows, raced_groups) = storage.load_with_groups().unwrap();
+    assert!(raced_rows.iter().any(|instance| {
+        instance.id == raced_stub_id && instance.status == crate::session::Status::Creating
+    }));
+    assert!(
+        raced_groups
+            .iter()
+            .any(|group| group.path == transient_group),
+        "the intervening save should persist the raced stub's child group"
+    );
+
+    let main_repo_path = project_dir.canonicalize().unwrap();
+    let git = crate::git::GitWorktree::new(main_repo_path.clone()).unwrap();
+    let start = std::time::Instant::now();
+    let winner_path = loop {
+        if let Some(path) = git
+            .list_worktrees()
+            .unwrap()
+            .into_iter()
+            .find(|worktree| worktree.branch.as_deref() == Some(branch))
+            .map(|worktree| worktree.path)
+        {
+            break path;
+        }
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "background worktree creation timed out"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    };
+
+    let mut owner = Instance::new("Raced title", winner_path.to_str().unwrap());
+    owner.source_profile = "default".to_string();
+    owner.worktree_info = Some(crate::session::WorktreeInfo {
+        branch: branch.to_string(),
+        main_repo_path: main_repo_path.to_string_lossy().into_owned(),
+        managed_by_aoe: false,
+        created_at: chrono::Utc::now(),
+        base_branch: None,
+    });
+    let owner_id = owner.id.clone();
+    storage
+        .update(|instances, _groups| {
+            instances.push(owner);
+            Ok(())
+        })
+        .unwrap();
+
+    let start = std::time::Instant::now();
+    let mut unexpected_id = None;
+    while start.elapsed() < std::time::Duration::from_secs(5) {
+        unexpected_id = view.apply_creation_results();
+        if unexpected_id.is_some() || !view.is_creation_pending() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(!view.is_creation_pending(), "background creation timed out");
+    assert_eq!(unexpected_id, None);
+    assert!(view.info_dialog.is_some());
+    assert!(
+        winner_path.is_dir(),
+        "rollback must preserve the winner's worktree"
+    );
+    assert!(
+        git.list_worktrees()
+            .unwrap()
+            .iter()
+            .any(|worktree| worktree.path == winner_path),
+        "winner worktree must remain registered"
+    );
+    assert!(
+        git2::Repository::open(&main_repo_path)
+            .unwrap()
+            .find_branch(branch, git2::BranchType::Local)
+            .is_ok(),
+        "rollback must preserve the winner's branch"
+    );
+    assert!(
+        view.group_trees.get("default").is_none_or(|tree| tree
+            .get_all_groups()
+            .iter()
+            .all(|group| group.path != transient_group)),
+        "duplicate rejection must discard the stub's provisional group"
+    );
+    assert!(
+        view.group_trees
+            .get("default")
+            .is_some_and(|tree| tree.group_exists(preexisting_group)),
+        "duplicate rejection must preserve an intentionally pre-existing empty group"
+    );
+
+    view.save().unwrap();
+    let (persisted, groups) = storage.load_with_groups().unwrap();
+    assert_eq!(
+        persisted
+            .iter()
+            .filter(|instance| {
+                instance.title == "Raced title"
+                    && std::path::Path::new(&instance.project_path) == winner_path
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        persisted.len(),
+        1,
+        "duplicate rejection should leave only the authoritative peer row"
+    );
+    assert!(
+        persisted.iter().all(|instance| {
+            instance.id != raced_stub_id && instance.status != crate::session::Status::Creating
+        }),
+        "duplicate rejection must remove the persisted Creating stub"
+    );
+    assert!(
+        groups.iter().all(|group| group.path != transient_group),
+        "a later save must not persist the rejected stub's group"
+    );
+    assert!(
+        groups.iter().any(|group| group.path == preexisting_group),
+        "a later save must preserve the pre-existing empty parent group"
+    );
+
+    storage
+        .update(|instances, _groups| {
+            instances.retain(|instance| instance.id != owner_id);
+            Ok(())
+        })
+        .unwrap();
+    git.remove_worktree(&winner_path, true).unwrap();
+    git.delete_branch(branch).unwrap();
 }
 
 #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10,7 +10,7 @@ use super::{ConfigRefreshOrigin, ConfigWatchKey, HomeView, PreviewSelection, Vie
 use crate::session::{GroupTree, Instance, Item, Storage};
 use crate::tmux::AvailableTools;
 use crate::tui::app::Action;
-use crate::tui::dialogs::{InfoDialog, NewSessionDialog};
+use crate::tui::dialogs::{InfoDialog, NewSessionData, NewSessionDialog};
 
 fn key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)
@@ -7131,14 +7131,20 @@ fn test_has_dialog_true_when_search_active() {
     assert!(view.has_dialog());
 }
 
-/// Verify the async CreationPoller result replaces a Creating stub even when
-/// an intervening TUI save persisted it. Also covers the peer-collision path
-/// and ownership-safe cleanup of group metadata introduced by the stub.
-#[test]
-#[serial]
-fn test_apply_creation_results_returns_session_id() {
-    use crate::tui::dialogs::NewSessionData;
+/// Shared fixture for the async-creation finalization tests: a fresh
+/// single-commit git repo under a temp `$HOME`, a `HomeView` bound to the
+/// `default` profile in manual-group mode, and an unwatched `Storage` handle
+/// onto the same profile. Each test spawns a real background builder against
+/// this repo, so the setup is factored out rather than duplicated.
+struct CreationTestEnv {
+    view: HomeView,
+    storage: Storage,
+    project_dir: std::path::PathBuf,
+    _guard: AppDirGuard,
+    _temp: TempDir,
+}
 
+fn setup_creation_test_env() -> CreationTestEnv {
     let temp = TempDir::new().unwrap();
     let _guard = setup_test_home(&temp);
 
@@ -7169,11 +7175,24 @@ fn test_apply_creation_results_returns_session_id() {
     view.flat_items = view.build_flat_items();
     view.update_selected();
 
-    let data = NewSessionData {
+    let storage = Storage::new_unwatched("default").unwrap();
+    CreationTestEnv {
+        view,
+        storage,
+        project_dir,
+        _guard,
+        _temp: temp,
+    }
+}
+
+/// Base new-session data targeting the shared repo. Callers tweak the
+/// title/group and worktree fields per scenario.
+fn creation_data(project_dir: &std::path::Path, title: &str, group: &str) -> NewSessionData {
+    NewSessionData {
         profile: "default".to_string(),
-        title: "Async Test".to_string(),
+        title: title.to_string(),
         path: project_dir.to_str().unwrap().to_string(),
-        group: "async-success".to_string(),
+        group: group.to_string(),
         tool: "claude".to_string(),
         worktree_enabled: false,
         worktree_branch: None,
@@ -7189,10 +7208,51 @@ fn test_apply_creation_results_returns_session_id() {
         scratch: false,
         fork_seed: None,
         structured: false,
-    };
+    }
+}
 
-    let storage = Storage::new_unwatched("default").unwrap();
-    view.request_creation(data.clone(), None);
+/// Pump `apply_creation_results` until the background builder delivers a
+/// result, returning the finalized session id (`Some`) or the rollback outcome
+/// (`None`). Consuming the result clears `is_creation_pending`, so this
+/// terminates once a result lands; it fails the test on timeout rather than
+/// looping forever. Centralizes the poll so the tests carry no bespoke timing
+/// loops of their own.
+fn drain_creation_result(view: &mut HomeView) -> Option<String> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(id) = view.apply_creation_results() {
+            return Some(id);
+        }
+        if !view.is_creation_pending() {
+            return None;
+        }
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(10),
+            "background creation timed out"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+/// The async CreationPoller result must replace a `Creating` stub even when an
+/// intervening TUI save already persisted it, keep the finalized row's group,
+/// and treat the committed row as authoritative: it is not a provisional
+/// pending add, and a later peer deletion is not resurrected by `save`.
+#[test]
+#[serial]
+fn apply_creation_results_finalizes_persisted_stub() {
+    let CreationTestEnv {
+        mut view,
+        storage,
+        project_dir,
+        _guard,
+        _temp,
+    } = setup_creation_test_env();
+
+    view.request_creation(
+        creation_data(&project_dir, "Async Test", "async-success"),
+        None,
+    );
     assert!(view.is_creation_pending());
     let stub_id = view
         .creating_stub_id
@@ -7213,17 +7273,12 @@ fn test_apply_creation_results_returns_session_id() {
         "the intervening save should persist the stub's provisional group"
     );
 
-    let start = std::time::Instant::now();
-    let mut session_id = None;
-    while start.elapsed() < std::time::Duration::from_secs(5) {
-        if let Some(id) = view.apply_creation_results() {
-            session_id = Some(id);
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-
-    let session_id = session_id.expect("apply_creation_results should return Some(session_id)");
+    let session_id = drain_creation_result(&mut view)
+        .expect("apply_creation_results should return Some(session_id)");
+    assert!(
+        view.creating_provisional_group_paths.is_empty(),
+        "finalization must leave no provisional group paths behind"
+    );
     assert!(
         view.get_instance(&session_id).is_some(),
         "created session should be findable after apply_creation_results"
@@ -7280,10 +7335,26 @@ fn test_apply_creation_results_returns_session_id() {
             .any(|instance| instance.id == session_id),
         "a peer-deleted finalized row must not be resurrected by save"
     );
+}
 
-    // A peer can commit the same title/path while the background builder is
-    // waiting for finalization. Use a real created branch/worktree so rollback
-    // proves it preserves resources referenced by the persisted winner.
+/// A peer can commit the same title/path while the background builder waits for
+/// finalization. The duplicate rollback must preserve every resource the
+/// persisted winner references (worktree, branch) and its own pre-existing
+/// empty group, while discarding the losing stub's provisional group, both in
+/// memory and across a later save.
+#[test]
+#[serial]
+fn apply_creation_results_rolls_back_on_peer_collision() {
+    let CreationTestEnv {
+        mut view,
+        storage,
+        project_dir,
+        _guard,
+        _temp,
+    } = setup_creation_test_env();
+
+    // Use a real created branch/worktree so rollback proves it preserves
+    // resources referenced by the persisted winner.
     let preexisting_group = "existing-empty";
     let transient_group = "existing-empty/collision";
     view.group_trees
@@ -7301,9 +7372,7 @@ fn test_apply_creation_results_returns_session_id() {
         "the parent group must be intentionally persisted before the request"
     );
     let branch = "raced-worktree";
-    let mut raced = data;
-    raced.title = "Raced title".to_string();
-    raced.group = transient_group.to_string();
+    let mut raced = creation_data(&project_dir, "Raced title", transient_group);
     raced.worktree_enabled = true;
     raced.worktree_branch = Some(branch.to_string());
     raced.create_new_branch = true;
@@ -7361,17 +7430,12 @@ fn test_apply_creation_results_returns_session_id() {
         })
         .unwrap();
 
-    let start = std::time::Instant::now();
-    let mut unexpected_id = None;
-    while start.elapsed() < std::time::Duration::from_secs(5) {
-        unexpected_id = view.apply_creation_results();
-        if unexpected_id.is_some() || !view.is_creation_pending() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-    assert!(!view.is_creation_pending(), "background creation timed out");
+    let unexpected_id = drain_creation_result(&mut view);
     assert_eq!(unexpected_id, None);
+    assert!(
+        view.creating_provisional_group_paths.is_empty(),
+        "rollback must leave no provisional group paths behind"
+    );
     assert!(view.info_dialog.is_some());
     assert!(
         winner_path.is_dir(),
@@ -16494,85 +16558,40 @@ mod live_send_mode {
         }
 
         #[test]
-        fn printable_paste_stays_one_literal() {
-            assert_eq!(
-                split_paste_for_live_send("hello world"),
-                vec![lit("hello world")],
-            );
-        }
+        fn paste_shapes_are_normalized_and_dispatched() {
+            let cases = [
+                ("printable", "hello world", vec![lit("hello world")]),
+                ("multiline", "first\nsecond", paste("first\nsecond")),
+                ("trailing newline", "only line\n", paste("only line\n")),
+                ("leading newline", "\nbody", paste("\nbody")),
+                // Windows and legacy-Mac line endings normalize to LF in the
+                // payload; tmux translates LF to CR while performing the paste.
+                ("crlf to lf", "a\r\nb", paste("a\nb")),
+                ("bare cr to lf", "a\rb", paste("a\nb")),
+                (
+                    "single-line tab",
+                    "a\tb",
+                    vec![lit("a"), named("Tab"), lit("b")],
+                ),
+                ("multiline tab", "a\tb\nc", paste("a\tb\nc")),
+                // BEL and ESC have no safe mapping and are dropped.
+                (
+                    "single-line control bytes",
+                    "a\x07b\x1bc",
+                    vec![lit("a"), lit("b"), lit("c")],
+                ),
+                ("multiline control bytes", "a\x07b\x1bc\nd", paste("abc\nd")),
+                (
+                    "drag-select multiline",
+                    "alpha beta\nsecond line\nthird",
+                    paste("alpha beta\nsecond line\nthird"),
+                ),
+                ("multiline utf8", "café\n🚀", paste("café\n🚀")),
+            ];
 
-        #[test]
-        fn newline_wraps_in_bracketed_paste() {
-            // Two-line paste travels as one tmux paste. Without it the
-            // agent treats the `\n` as Enter -> submit and posts each
-            // line as its own user message (#1546).
-            assert_eq!(
-                split_paste_for_live_send("first\nsecond"),
-                paste("first\nsecond"),
-            );
-        }
-
-        #[test]
-        fn trailing_newline_stays_inside_bracketed_paste() {
-            // A single line plus a trailing newline still wraps: the
-            // user gets a paste with a trailing CR in the agent's input
-            // buffer rather than a paste-then-submit. Lets the user
-            // review before sending.
-            assert_eq!(
-                split_paste_for_live_send("only line\n"),
-                paste("only line\n"),
-            );
-        }
-
-        #[test]
-        fn leading_newline_stays_inside_bracketed_paste() {
-            assert_eq!(split_paste_for_live_send("\nbody"), paste("\nbody"));
-        }
-
-        #[test]
-        fn crlf_coalesces_to_single_cr() {
-            // Windows-style line endings collapse to one newline so the
-            // agent doesn't see a double newline.
-            assert_eq!(split_paste_for_live_send("a\r\nb"), paste("a\nb"));
-        }
-
-        #[test]
-        fn bare_cr_becomes_cr_inside_bracketed_paste() {
-            assert_eq!(split_paste_for_live_send("a\rb"), paste("a\nb"));
-        }
-
-        #[test]
-        fn tab_in_single_line_paste_emits_named_tab() {
-            // Single-line tab pastes stay on the historical path.
-            assert_eq!(
-                split_paste_for_live_send("a\tb"),
-                vec![lit("a"), named("Tab"), lit("b")],
-            );
-        }
-
-        #[test]
-        fn tab_in_multiline_paste_rides_as_raw_byte() {
-            // Inside a paste, tab is a literal character of the paste
-            // content, not a key event, so it rides in the payload.
-            assert_eq!(split_paste_for_live_send("a\tb\nc"), paste("a\tb\nc"),);
-        }
-
-        #[test]
-        fn other_control_bytes_are_dropped_in_single_line_path() {
-            // BEL (0x07) and ESC (0x1b) have no safe paste mapping;
-            // they're dropped to avoid surprising agent input cancels.
-            assert_eq!(
-                split_paste_for_live_send("a\x07b\x1bc"),
-                vec![lit("a"), lit("b"), lit("c")],
-            );
-        }
-
-        #[test]
-        fn other_control_bytes_are_dropped_inside_bracketed_paste() {
-            // Same drop policy applies inside the paste: an embedded
-            // ESC could prematurely close the paste sequence on the
-            // agent's side, so we strip it rather than forward.
-            assert_eq!(split_paste_for_live_send("a\x07b\x1bc\nd"), paste("abc\nd"),);
+            for (name, input, expected) in cases {
+                assert_eq!(split_paste_for_live_send(input), expected, "{name}");
+            }
         }
 
         /// The bug: we used to hand-roll `\e[200~` / `\e[201~` into the
@@ -16598,18 +16617,6 @@ mod live_send_mode {
         }
 
         #[test]
-        fn multiline_drag_select_paste_round_trip() {
-            // Exact shape that comes back from drag-select copy: lines
-            // joined with `\n` and no trailing newline. After the fix
-            // for #1546 this travels as one paste so the agent sees one
-            // paste instead of three Enter keypresses.
-            assert_eq!(
-                split_paste_for_live_send("alpha beta\nsecond line\nthird"),
-                paste("alpha beta\nsecond line\nthird"),
-            );
-        }
-
-        #[test]
         fn multiline_paste_dispatches_as_one_payload() {
             // Single-dispatch: the entire paste is one `Paste` action, so
             // the worker fires exactly one `load-buffer` + `paste-buffer`
@@ -16621,15 +16628,6 @@ mod live_send_mode {
                 TmuxKey::Paste(_) => {}
                 other => panic!("expected Paste, got {other:?}"),
             }
-        }
-
-        #[test]
-        fn multiline_paste_with_utf8_preserves_bytes() {
-            // Non-ASCII chars (emoji, accented letters) ride as their
-            // UTF-8 byte sequences so the agent receives the same text
-            // the user copied. Regression guard for any future "ASCII
-            // only" filter.
-            assert_eq!(split_paste_for_live_send("café\n🚀"), paste("café\n🚀"),);
         }
 
         #[test]


### PR DESCRIPTION
## Description

Background TUI creation built worktrees and ran hooks off-thread, then merged the completed row into the in-memory model and called the broad `save()` path. A peer could persist the same `(title, path)` pair while the builder was running, so the final apply created a duplicate without the storage-locked recheck used by `aoe add`. Cancellation also carried only the primary worktree across the thread boundary, losing workspace cleanup ownership, and cleanup removed worktrees without removing branches created by that build.

This PR makes finalization one profile-local storage transaction:

- rechecks `(title, path)` uniqueness inside `Storage::update` immediately before insertion;
- persists the row and group before publishing it in memory;
- reconciles ambiguous write errors before deciding whether cleanup is safe;
- carries every created workspace worktree and branch-ownership marker through the poller result;
- removes only branches created by the failed build, and only after their worktree was removed successfully;
- cleans the same owned resources on cancellation, shutdown, or a lost final uniqueness race.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No screenshot is needed: the only user-visible change is an existing `InfoDialog` on a creation conflict. No guide change is needed for an invariant and rollback correction.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR changes the native TUI creation finalizer only
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is the storage commit interleaving inside `HomeView::apply_creation_results`; the in-module test deterministically inserts the peer row between request and result application, which a full-binary e2e cannot schedule reliably.

## Validation

- `cargo fmt --check`
- `cargo clippy --lib --bins -- -D warnings`
- `cargo test create_workspace_ -- --nocapture` (4 passed)
- `cargo test test_apply_creation_results_returns_session_id -- --nocapture` (1 passed, including the final-commit race)
- `cargo test -- --skip tmux::session::tests::a_zoomed_pane_falls_back_to_the_plain_capture --skip tmux::session::tests::size_owner_lock_claims_rejects_steals_and_releases` (4,805 passed; 8 ignored; 4 filtered; two additional tmux flakes passed independently)
- `cargo test tmux::session::tests::size_owner_lock_claims_rejects_steals_and_releases -- --nocapture` (1 passed)

The two filtered cases are unrelated tmux setup flakes previously verified independently.

## Initial Review Cycle

Three independent reviewers found four accepted issues: cleanup could remove a winner-claimed worktree, sandbox teardown occurred after worktree removal, committed rows remained in `pending_added`, and duplicate rollback retained a provisional group. The single correction pass protects winner-owned paths, tears containers down first, clears pending bookkeeping, reloads authoritative groups, and adds real Git/non-resurrection regressions. No second reviewer wave was run.

## Fresh Review Round 2

Fresh reviewers accepted one defect: an intervening TUI save could persist the provisional `Creating` stub, causing finalization to self-collide or leave a stale stub. Finalization now removes that exact stub inside the authoritative transaction and reconciles only stub-owned provisional groups; tests cover successful replacement and genuine peer collision. Three general cancellation/workspace/runtime-cleanup findings were rejected as pre-existing behavior outside this PR. Corrected head: `a318410b`. No third reviewer wave was run.

## Risks

- Duplicate rollback preserves every path/worktree/branch referenced by the persisted winner and cleans only loser-owned resources.
- If a write fails and the persisted result cannot be read back, resources are deliberately retained instead of risking deletion of a committed session.
- Sandbox/container teardown precedes worktree removal; existing branches are never deleted, and owned branches are deleted only after successful worktree removal.
- The storage transaction is profile-local, matching creation&#39;s existing uniqueness scope.

## GitHub Review Comments

No actionable inline defect was posted. The optional cleanup review was checked: the persisted-owner branch is already exercised by the real Git winner regression. Added the requested concise comment explaining exact-match versus containment path protection. Review fix: `a318410b`.

## Upstream Sync

Rebased onto `upstream/main` at `24226821`; ready for review. Final synchronized head: `a318410b`. GitHub checks are green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you&#39;d like to share:** Race analysis, transaction design, implementation, and validation assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form




## Summary

- Finalizes TUI session creation atomically through profile storage.
- Rechecks duplicate sessions before insertion and handles storage races safely.
- Publishes sessions and groups in memory only after persistence succeeds.
- Tracks created worktrees and owned branches through background creation.
- Improves cleanup for cancellation, failed builds, shutdown, and uniqueness races.
- Protects resources belonging to the winning session during rollback.
- Adds coverage for persistence races, cleanup, rollback, and provisional groups.

## Benefits

- Prevents partial or duplicate session state.
- Avoids deleting resources owned by another build.
- Improves recovery from ambiguous write failures.
- Keeps provisional creation state consistent across success and failure paths.





## Summary

This PR makes TUI session creation atomic and safer.

- Stores the session and group before publishing them in memory.
- Rechecks duplicate sessions before insertion.
- Rolls back failed or conflicting creations without removing resources owned by the winning session.
- Tracks created worktrees and branches through background creation.
- Removes owned branches only after successful worktree cleanup.
- Cleans up containers before removing worktrees.
- Handles cancellation, shutdown, failed builds, and ambiguous storage errors.
- Preserves provisional groups and creation stubs during concurrent updates.
- Renames tmux cleanup APIs to clarify their use for sessions without lifecycle records.
- Adds regression tests for storage races, Git cleanup, rollback, provisional groups, and paste handling.

## Benefits

These changes reduce partial session state, prevent accidental deletion of shared Git resources, and make failed session creation easier to recover from.

## Further enhancement

Future work could add more targeted coverage for path-protection edge cases and document the cleanup ownership rules near the related APIs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Finalizes TUI session creation through an atomic profile-local storage transaction.
- Prevents duplicate sessions by checking title and path again before insertion.
- Publishes sessions and groups in memory only after persistence succeeds.
- Tracks provisional groups, worktrees, and build-owned branches during creation.
- Improves cleanup after cancellation, shutdown, build failure, and duplicate-session races.
- Preserves resources owned by the winning session.
- Removes sandbox containers before worktrees and deletes only build-owned branches.
- Simplifies duplicate detection and lifecycle-independent tmux cleanup.
- Adds regression coverage for storage races, rollback, Git cleanup, provisional groups, paste handling, and resource preservation.

## Benefits

These changes reduce duplicate sessions and resource leaks. Failed or cancelled creation now leaves fewer stale resources and does not remove resources owned by a successful session.

## Further Consideration

Future changes could continue to centralize creation and cleanup paths as new resource types are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->