### PR TITLE
fix(tmux): rekey sessions after title persistence

### DIFF
--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1693,6 +1693,18 @@ async fn capture_session(profile: &str, args: CaptureArgs) -> Result<()> {
     Ok(())
 }
 
+fn rename_success_message(
+    persisted_old_title: &str,
+    committed_title: &str,
+    title_requested: bool,
+) -> String {
+    if title_requested && persisted_old_title != committed_title {
+        format!("✓ Renamed session: {persisted_old_title} → {committed_title}")
+    } else {
+        format!("✓ Updated session: {committed_title}")
+    }
+}
+
 async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     if args.title.is_none() && args.group.is_none() {
         bail!("At least one of --title or --group must be specified");
@@ -1705,7 +1717,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     // tmux rename outside the storage flock.
     let (instances, _groups) = storage.load_with_groups()?;
     let inst = if let Some(id) = &args.identifier {
-        super::resolve_session(id, &instances)?
+        super::resolve_session(id, &instances)?.clone()
     } else {
         let current_session = std::env::var("TMUX_PANE")
             .ok()
@@ -1715,6 +1727,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
             instances
                 .iter()
                 .find(|i| crate::tmux::agent_session_belongs_to(&session_name, &i.id))
+                .cloned()
                 .ok_or_else(|| {
                     anyhow::anyhow!("Current tmux session is not an Agent of Empires session")
                 })?
@@ -1724,11 +1737,31 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     };
 
     let id = inst.id.clone();
+    let title_requested = args.title.is_some();
+    let session_lock_required = title_requested || args.rename_branch;
 
     // The initial load only resolves the requested row. Serialize every
-    // identity-changing rename from the fresh duplicate check through git/tmux
-    // effects and the durable commit.
+    // identity-changing rename from the fresh duplicate check through external
+    // effects and the durable commit. Existing-session mutations nest the
+    // per-session title and source lifecycle guards beneath the identity lock.
     let _identity_lock = acquire_session_identity_lock()?;
+    let _session_title_lock = if session_lock_required {
+        Some(
+            crate::session::acquire_session_title_lock(&id)
+                .context("failed to acquire session title lock")?,
+        )
+    } else {
+        None
+    };
+    let _lifecycle_lock = if session_lock_required {
+        Some(
+            storage
+                .acquire_instance_lifecycle_lock(&id)
+                .context("failed to acquire session lifecycle lock")?,
+        )
+    } else {
+        None
+    };
     let (authoritative_instances, _groups) = storage.load_with_groups()?;
     let inst = authoritative_instances
         .iter()
@@ -1839,28 +1872,20 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         bail!("--rename-branch only applies to a tied aoe-managed worktree session (session.tie_workdir_to_name)");
     }
 
-    // External effects deliberately remain under the app-wide title lock but
-    // outside the short profile Storage lock.
-    if title_changed {
-        let tmux_session = crate::tmux::Session::new(&id, &old_title)?;
-        if tmux_session.exists() {
-            let new_tmux_name = crate::tmux::Session::generate_name(&id, &effective_title);
-            if let Err(e) = tmux_session.rename(&new_tmux_name) {
-                eprintln!("Warning: failed to rename tmux session: {}", e);
-            } else {
-                crate::tmux::refresh_session_cache();
-            }
-        }
-    }
-
-    // Persist by id under the profile lock while retaining the title lock.
-    // Concurrent mutations to unrelated fields and groups are preserved.
+    // Persist before rekeying the live tmux session. Re-resolve by id under
+    // the profile lock so concurrent mutations to other sessions are
+    // preserved. `create_group` is idempotent and only runs when the closure
+    // actually mutated `group_path`, so `groups.json` is rewritten only on
+    // real group changes (cf. `update`'s diff check).
     let persist = storage.update(|instances, groups| {
         let inst = instances
             .iter_mut()
             .find(|i| i.id == id)
             .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
-        inst.title = effective_title.clone();
+        let persisted_old_title = inst.title.clone();
+        if title_requested {
+            inst.title = effective_title.clone();
+        }
         if let Some(path) = &new_path {
             inst.project_path = path.clone();
         }
@@ -1872,37 +1897,213 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         if let Some(group) = &new_group {
             inst.group_path = group.clone();
         }
+        let committed_title = inst.title.clone();
         let group_path = inst.group_path.clone();
         if !group_path.is_empty() {
             let mut group_tree = GroupTree::new_with_groups(instances, groups);
             group_tree.create_group(&group_path);
             *groups = group_tree.get_all_groups();
         }
-        Ok(())
+        Ok((persisted_old_title, committed_title))
     });
-    if let Err(e) = persist {
-        // When the git move already landed, surface that the disk and metadata
-        // are out of sync rather than a bare persist error.
-        if let Some(path) = &new_path {
-            bail!("Worktree was moved on disk to {path}, but persisting the new session metadata failed: {e}. Re-run to retry.");
+    let (persisted_old_title, committed_title) = match persist {
+        Ok(titles) => titles,
+        Err(error) => {
+            // When the git move already landed, surface that the disk and
+            // metadata are out of sync rather than a bare persist error.
+            if let Some(path) = &new_path {
+                bail!("Worktree was moved on disk to {path}, but persisting the new session metadata failed: {error}. Re-run to retry.");
+            }
+            return Err(error);
         }
-        return Err(e);
+    };
+    // Storage::update durably commits the identity and publishes its file-watch
+    // notification. Rekey needs only the per-session title/lifecycle guards.
+    drop(_identity_lock);
+
+    let committed_title_changed = title_requested && persisted_old_title != committed_title;
+    if committed_title_changed {
+        let rekey_id = id.clone();
+        let rekey_old_title = persisted_old_title.clone();
+        let rekey_new_title = committed_title.clone();
+        match tokio::task::spawn_blocking(move || {
+            crate::tmux::rekey_session(&rekey_id, &rekey_old_title, &rekey_new_title)
+        })
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => eprintln!("Warning: failed to rename tmux session: {error}"),
+            Err(error) => eprintln!("Warning: tmux rename task failed: {error}"),
+        }
     }
 
-    drop(_identity_lock);
     if let Some(path) = &new_path {
         println!("✓ Worktree moved to: {}", path);
         if let Some(branch) = &new_branch {
             println!("  Branch renamed to: {}", branch);
         }
     }
-    if title_changed {
-        println!("✓ Renamed session: {} → {}", old_title, effective_title);
-    } else {
-        println!("✓ Updated session: {}", effective_title);
-    }
+    println!(
+        "{}",
+        rename_success_message(&persisted_old_title, &committed_title, title_requested,)
+    );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod rename_tests {
+    use super::{rename_session, rename_success_message, RenameArgs};
+    use crate::session::{Instance, Status, Storage};
+    use serial_test::serial;
+
+    // Three duplicate-identity behaviors kept in one test on purpose: they
+    // share the costly setup that forces `#[serial]` (an isolated app dir plus
+    // a process-global `tie_workdir_to_name` config flip), so splitting them
+    // into three serial tests would triple that setup and the critical-path
+    // serial time for no added coverage. Each behavior asserts independently.
+    #[tokio::test]
+    #[serial]
+    async fn rename_rejects_duplicate_pair_but_allows_group_only_change() {
+        let _guard = crate::session::test_support::isolate_app_dir();
+        let storage = Storage::new_unwatched("rename-duplicate").unwrap();
+        let existing = Instance::new("main branch", "/tmp/repo/");
+        let target = Instance::new("throwaway", "/tmp/repo");
+        let target_id = target.id.clone();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![existing, target];
+                Ok(())
+            })
+            .unwrap();
+
+        let error = rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(target_id.clone()),
+                title: Some("main branch".to_string()),
+                group: None,
+                rename_branch: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Session already exists with same title and path"));
+
+        rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(target_id.clone()),
+                title: None,
+                group: Some("work".to_string()),
+                rename_branch: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let instances = storage.load().unwrap();
+        let target = instances
+            .iter()
+            .find(|instance| instance.id == target_id)
+            .unwrap();
+        assert_eq!(target.title, "throwaway");
+        assert_eq!(target.group_path, "work");
+        // In tied mode the duplicate identity uses the derived destination
+        // path, not the row's current worktree path. The collision must reject
+        // before any git side effect is attempted.
+        let _tie_guard = crate::session::test_support::TieWorkdirToNameGuard::set(true);
+        let existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
+        let mut tied = Instance::new("main branch", "/tmp/worktrees/drifted");
+        tied.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "drifted".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+        let tied_id = tied.id.clone();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![existing, tied];
+                Ok(())
+            })
+            .unwrap();
+
+        let error = rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(tied_id.clone()),
+                title: Some("main branch".to_string()),
+                group: None,
+                rename_branch: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Session already exists with same title and path"));
+        let tied = storage
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|instance| instance.id == tied_id)
+            .unwrap();
+        assert_eq!(tied.title, "main branch");
+        assert_eq!(tied.project_path, "/tmp/worktrees/drifted");
+
+        // An explicit unchanged title still enters tied mode so a drifted
+        // directory can be repaired. When the directory and branch are already
+        // stable, however, it is a true no-op and must remain valid even if the
+        // persisted session is active.
+        let mut active = Instance::new("Main Branch", "/tmp/worktrees/main-branch");
+        active.status = Status::Running;
+        active.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "main-branch".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+        let active_id = active.id.clone();
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![active];
+                Ok(())
+            })
+            .unwrap();
+
+        rename_session(
+            "rename-duplicate",
+            RenameArgs {
+                identifier: Some(active_id.clone()),
+                title: Some("Main Branch".to_string()),
+                group: None,
+                rename_branch: false,
+            },
+        )
+        .await
+        .expect("active cwd-stable title no-op must succeed");
+        let active = storage
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|instance| instance.id == active_id)
+            .unwrap();
+        assert_eq!(active.title, "Main Branch");
+        assert_eq!(active.project_path, "/tmp/worktrees/main-branch");
+    }
+
+    #[test]
+    fn group_only_success_uses_authoritative_committed_title() {
+        assert_eq!(
+            rename_success_message("stale resolver title", "peer committed title", false),
+            "✓ Updated session: peer committed title"
+        );
+    }
 }
 
 async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<()> {
@@ -1927,6 +2128,15 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     };
 
     let id = inst.id.clone();
+    let _identity_lock = acquire_session_identity_lock()?;
+    let _lifecycle_lock = storage
+        .acquire_instance_lifecycle_lock(&id)
+        .context("failed to acquire worktree rename lifecycle lock")?;
+    let authoritative_instances = storage.load()?;
+    let inst = authoritative_instances
+        .iter()
+        .find(|instance| instance.id == id)
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
     let current_path = inst.project_path.clone();
     let Some(worktree_info) = inst.worktree_info.clone() else {
         bail!("Session does not use a worktree");
@@ -1939,6 +2149,23 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
             .tie_workdir_to_name,
     ) {
         bail!("Renaming is unified while session.tie_workdir_to_name is on; use 'aoe session rename --title <name>' instead, and the worktree directory follows. Disable the setting to edit the directory independently.");
+    }
+    let duplicate_path = crate::session::worktree_edit::target_worktree_path(
+        std::path::Path::new(&current_path),
+        args.name.trim(),
+    )
+    .unwrap_or_else(|| std::path::PathBuf::from(&current_path))
+    .to_string_lossy()
+    .into_owned();
+    if duplicate_path.trim_end_matches('/') != current_path.trim_end_matches('/')
+        && is_duplicate_session(
+            authoritative_instances.iter(),
+            &inst.title,
+            &duplicate_path,
+            Some(&id),
+        )
+    {
+        return Err(duplicate_session_error(&inst.title));
     }
     // Persisted status can lag the real tmux pane, and moving the worktree of
     // a still-running session is unsafe. Recompute from live tmux state before
@@ -2005,6 +2232,7 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
                 "Worktree was moved on disk to {new_path}, but persisting the new session metadata failed: {e}. Re-run to retry."
             )
         })?;
+    drop(_identity_lock);
 
     println!("✓ Worktree moved to: {}", new_path);
     if let Some(branch) = &new_branch {
@@ -2743,153 +2971,6 @@ mod set_color_tests {
         // The rejected write must not have touched disk.
         let loaded = storage.load().unwrap();
         assert_eq!(loaded.iter().find(|i| i.id == id).unwrap().color, None);
-    }
-}
-
-#[cfg(test)]
-mod rename_tests {
-    use super::{rename_session, RenameArgs};
-    use crate::session::{Instance, Status, Storage};
-    use serial_test::serial;
-
-    // Three duplicate-identity behaviors kept in one test on purpose: they
-    // share the costly setup that forces `#[serial]` (an isolated app dir plus
-    // a process-global `tie_workdir_to_name` config flip), so splitting them
-    // into three serial tests would triple that setup and the critical-path
-    // serial time for no added coverage. Each behavior asserts independently.
-    #[tokio::test]
-    #[serial]
-    async fn rename_rejects_duplicate_pair_but_allows_group_only_change() {
-        let _guard = crate::session::test_support::isolate_app_dir();
-        let storage = Storage::new_unwatched("rename-duplicate").unwrap();
-        let existing = Instance::new("main branch", "/tmp/repo/");
-        let target = Instance::new("throwaway", "/tmp/repo");
-        let target_id = target.id.clone();
-        storage
-            .update(|instances, _groups| {
-                *instances = vec![existing, target];
-                Ok(())
-            })
-            .unwrap();
-
-        let error = rename_session(
-            "rename-duplicate",
-            RenameArgs {
-                identifier: Some(target_id.clone()),
-                title: Some("main branch".to_string()),
-                group: None,
-                rename_branch: false,
-            },
-        )
-        .await
-        .unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("Session already exists with same title and path"));
-
-        rename_session(
-            "rename-duplicate",
-            RenameArgs {
-                identifier: Some(target_id.clone()),
-                title: None,
-                group: Some("work".to_string()),
-                rename_branch: false,
-            },
-        )
-        .await
-        .unwrap();
-
-        let instances = storage.load().unwrap();
-        let target = instances
-            .iter()
-            .find(|instance| instance.id == target_id)
-            .unwrap();
-        assert_eq!(target.title, "throwaway");
-        assert_eq!(target.group_path, "work");
-        // In tied mode the duplicate identity uses the derived destination
-        // path, not the row's current worktree path. The collision must reject
-        // before any git side effect is attempted.
-        let _tie_guard = crate::session::test_support::TieWorkdirToNameGuard::set(true);
-        let existing = Instance::new("main branch", "/tmp/worktrees/main-branch");
-        let mut tied = Instance::new("main branch", "/tmp/worktrees/drifted");
-        tied.worktree_info = Some(crate::session::WorktreeInfo {
-            branch: "drifted".to_string(),
-            main_repo_path: "/tmp/repo".to_string(),
-            managed_by_aoe: true,
-            created_at: chrono::Utc::now(),
-            base_branch: None,
-        });
-        let tied_id = tied.id.clone();
-        storage
-            .update(|instances, _groups| {
-                *instances = vec![existing, tied];
-                Ok(())
-            })
-            .unwrap();
-
-        let error = rename_session(
-            "rename-duplicate",
-            RenameArgs {
-                identifier: Some(tied_id.clone()),
-                title: Some("main branch".to_string()),
-                group: None,
-                rename_branch: false,
-            },
-        )
-        .await
-        .unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("Session already exists with same title and path"));
-        let tied = storage
-            .load()
-            .unwrap()
-            .into_iter()
-            .find(|instance| instance.id == tied_id)
-            .unwrap();
-        assert_eq!(tied.title, "main branch");
-        assert_eq!(tied.project_path, "/tmp/worktrees/drifted");
-
-        // An explicit unchanged title still enters tied mode so a drifted
-        // directory can be repaired. When the directory and branch are already
-        // stable, however, it is a true no-op and must remain valid even if the
-        // persisted session is active.
-        let mut active = Instance::new("Main Branch", "/tmp/worktrees/main-branch");
-        active.status = Status::Running;
-        active.worktree_info = Some(crate::session::WorktreeInfo {
-            branch: "main-branch".to_string(),
-            main_repo_path: "/tmp/repo".to_string(),
-            managed_by_aoe: true,
-            created_at: chrono::Utc::now(),
-            base_branch: None,
-        });
-        let active_id = active.id.clone();
-        storage
-            .update(|instances, _groups| {
-                *instances = vec![active];
-                Ok(())
-            })
-            .unwrap();
-
-        rename_session(
-            "rename-duplicate",
-            RenameArgs {
-                identifier: Some(active_id.clone()),
-                title: Some("Main Branch".to_string()),
-                group: None,
-                rename_branch: false,
-            },
-        )
-        .await
-        .expect("active cwd-stable title no-op must succeed");
-        let active = storage
-            .load()
-            .unwrap()
-            .into_iter()
-            .find(|instance| instance.id == active_id)
-            .unwrap();
-        assert_eq!(active.title, "Main Branch");
-        assert_eq!(active.project_path, "/tmp/worktrees/main-branch");
     }
 }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1226,6 +1226,32 @@ async fn ensure_sandbox_container_released_blocking(id: &str, is_sandboxed: bool
     })
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum RenamePersistOutcome {
+    Updated { old_title: String },
+    Missing,
+}
+
+fn persist_rename_metadata(
+    storage: &Storage,
+    id: &str,
+    title: &str,
+    new_path: Option<&str>,
+    new_branch: Option<&str>,
+) -> anyhow::Result<RenamePersistOutcome> {
+    storage.update(|instances, _groups| {
+        let Some(inst) = instances.iter_mut().find(|instance| instance.id == id) else {
+            return Ok(RenamePersistOutcome::Missing);
+        };
+        let old_title = inst.title.clone();
+        if let Some(path) = new_path {
+            apply_worktree_name_edit(inst, path, new_branch);
+        }
+        apply_session_title_rename(inst, title.to_string());
+        Ok(RenamePersistOutcome::Updated { old_title })
+    })
+}
+
 /// Rename a session's title (and, when tied, its worktree directory).
 ///
 /// The sandbox container probe runs on the blocking pool via
@@ -1280,11 +1306,9 @@ pub async fn rename_session(
         inst.clone()
     };
     let profile = live.source_profile.clone();
-    let profile_for_load = profile.clone();
-    let file_watch = state.file_watch.clone();
-    // Acquiring an app-wide flock may wait on another process, so never do it
-    // on a Tokio worker. Keep the guard through external effects, persistence,
-    // and cache publication; profile Storage locks are always nested beneath it.
+    // App-wide and per-session flocks may wait on another process, so never
+    // acquire them on a Tokio worker. Identity nests outside session title,
+    // source lifecycle, and profile Storage.
     let _identity_lock = match tokio::task::spawn_blocking(
         crate::session::acquire_session_identity_lock,
     )
@@ -1300,21 +1324,44 @@ pub async fn rename_session(
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
     };
-    let disk_instances = match tokio::task::spawn_blocking(move || {
-        Storage::new(&profile_for_load, file_watch)?.load()
-    })
-    .await
-    {
-        Ok(Ok(instances)) => instances,
-        Ok(Err(error)) => {
-            tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to load authoritative session state before rename");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-        Err(error) => {
-            tracing::error!(target: "http.api.sessions", session = %id, %error, "Session reload task failed before rename");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
+    let lock_id = id.clone();
+    let lock_profile = profile.clone();
+    let lock_file_watch = state.file_watch.clone();
+    let (_session_title_lock, _lifecycle_lock, storage, disk_instances) =
+        match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let session_title_lock =
+                crate::session::acquire_session_title_lock(&lock_id)?;
+            let storage = Storage::new(&lock_profile, lock_file_watch)?;
+            let lifecycle_lock = storage.acquire_instance_lifecycle_lock(&lock_id)?;
+            let instances = storage.load()?;
+            Ok((session_title_lock, lifecycle_lock, storage, instances))
+        })
+        .await
+        {
+            Ok(Ok(locks)) => locks,
+            Ok(Err(error)) => {
+                tracing::error!(target: "http.api.sessions", session = %id, "failed to acquire rename locks or load authoritative state: {error}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": "title_lock_failed",
+                        "message": "Could not serialize the session rename"
+                    })),
+                )
+                    .into_response();
+            }
+            Err(error) => {
+                tracing::error!(target: "http.api.sessions", session = %id, "rename lock task failed: {error}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": "title_lock_failed",
+                        "message": "Could not serialize the session rename"
+                    })),
+                )
+                    .into_response();
+            }
+        };
     let Some(mut fresh) = disk_instances
         .iter()
         .find(|instance| instance.id == id)
@@ -1483,46 +1530,31 @@ pub async fn rename_session(
     // silent persist failure would otherwise leave metadata pointing at the
     // old path after a daemon restart, so it returns 500 rather than a
     // misleading 200.
-    let persisted = {
-        let storage = Storage::new(&profile, state.file_watch.clone());
-        let title_clone = title.clone();
-        let id_clone = id.clone();
-        let new_path_clone = new_path.clone();
-        let new_branch_clone = new_branch.clone();
-        match storage {
-            Ok(storage) => tokio::task::spawn_blocking(move || {
-                storage.update(|instances, _groups| {
-                    let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) else {
-                        return Ok(false);
-                    };
-                    if let Some(path) = new_path_clone.as_deref() {
-                        apply_worktree_name_edit(inst, path, new_branch_clone.as_deref());
-                    }
-                    apply_session_title_rename(inst, title_clone);
-                    Ok(true)
-                })
-            })
-            .await
-            .map_err(|e| e.to_string())
-            .and_then(|r| r.map_err(|e| e.to_string())),
-            Err(e) => Err(e.to_string()),
-        }
-    };
-    match persisted {
-        Ok(true) => {}
-        Ok(false) => {
-            if let Some(path) = new_path.as_deref() {
-                tracing::warn!(
-                    target: "http.api.sessions",
-                    session = %id,
-                    moved_to = %path,
-                    "session row was removed by a peer after the worktree move landed; the moved directory is unreferenced"
-                );
-            }
+    let title_clone = title.clone();
+    let id_clone = id.clone();
+    let new_path_clone = new_path.clone();
+    let new_branch_clone = new_branch.clone();
+    let persisted = tokio::task::spawn_blocking(move || {
+        persist_rename_metadata(
+            &storage,
+            &id_clone,
+            &title_clone,
+            new_path_clone.as_deref(),
+            new_branch_clone.as_deref(),
+        )
+    })
+    .await
+    .map_err(|error| error.to_string())
+    .and_then(|result| result.map_err(|error| error.to_string()));
+    let persisted_old_title = match persisted {
+        Ok(RenamePersistOutcome::Updated { old_title }) => old_title,
+        Ok(RenamePersistOutcome::Missing) => {
+            // AppState can lag an external delete. A missing authoritative row
+            // is not a successful rename and must not trigger tmux/cache work.
             return super::session_not_found();
         }
-        Err(e) => {
-            tracing::error!(target: "http.api.sessions", session = %id, "Failed to save after rename: {e}");
+        Err(error) => {
+            tracing::error!(target: "http.api.sessions", session = %id, "Failed to save after rename: {error}");
             // Persist-first: never fall through to mutate in-memory state on a
             // failed write, or the rename silently reverts on restart. When a
             // dir move already landed, say so; otherwise it is a plain title
@@ -1538,7 +1570,8 @@ pub async fn rename_session(
             )
                 .into_response();
         }
-    }
+    };
+
 
     let published_path = new_path.as_deref().unwrap_or(&current_path);
     let renamed_path = new_path
@@ -1577,6 +1610,36 @@ pub async fn rename_session(
     // untied until the next list refresh.
     response.tie_workdir_to_name = tied;
     drop(_identity_lock);
+
+    let tmux_warning = if persisted_old_title != title && !is_structured {
+        let rekey_id = id.clone();
+        let rekey_old_title = persisted_old_title.clone();
+        let rekey_new_title = title.clone();
+        match tokio::task::spawn_blocking(move || {
+            crate::tmux::rekey_session(&rekey_id, &rekey_old_title, &rekey_new_title)
+        })
+        .await
+        {
+            Ok(Ok(_)) => None,
+            Ok(Err(error)) => {
+                tracing::warn!(target: "http.api.sessions", session = %id, "tmux rename failed after persistence: {error}");
+                Some(format!(
+                    "Session metadata was renamed, but its live tmux session could not be rekeyed: {error}"
+                ))
+            }
+            Err(error) => {
+                tracing::warn!(target: "http.api.sessions", session = %id, "tmux rename task failed after persistence: {error}");
+                Some(format!(
+                    "Session metadata was renamed, but its live tmux session could not be rekeyed: {error}"
+                ))
+            }
+        }
+    } else {
+        None
+    };
+    if let Some(warning) = tmux_warning {
+        response.warnings.push(warning);
+    }
 
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
@@ -1683,20 +1746,65 @@ pub async fn set_worktree_name(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let (worktree_info, current_path, status, profile, is_sandboxed, is_structured) = {
+    let live = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return super::session_not_found();
         };
-        (
-            inst.worktree_info.clone(),
-            inst.project_path.clone(),
-            inst.status,
-            inst.source_profile.clone(),
-            inst.is_sandboxed(),
-            inst.is_structured(),
-        )
+        inst.clone()
     };
+    let profile = live.source_profile.clone();
+    let _identity_lock = match tokio::task::spawn_blocking(
+        crate::session::acquire_session_identity_lock,
+    )
+    .await
+    {
+        Ok(Ok(lock)) => lock,
+        Ok(Err(error)) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to acquire worktree identity lock");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+        Err(error) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Worktree identity lock task failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    let lock_id = id.clone();
+    let lock_profile = profile.clone();
+    let lock_file_watch = state.file_watch.clone();
+    let (_lifecycle_lock, storage, authoritative_instances) =
+        match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let storage = Storage::new(&lock_profile, lock_file_watch)?;
+            let lifecycle = storage.acquire_instance_lifecycle_lock(&lock_id)?;
+            let instances = storage.load()?;
+            Ok((lifecycle, storage, instances))
+        })
+        .await
+        {
+            Ok(Ok(locked)) => locked,
+            Ok(Err(error)) => {
+                tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to lock or load worktree rename");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+            Err(error) => {
+                tracing::error!(target: "http.api.sessions", session = %id, %error, "Worktree rename lock task failed");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+    let Some(mut fresh) = authoritative_instances
+        .iter()
+        .find(|instance| instance.id == id)
+        .cloned()
+    else {
+        return super::session_not_found();
+    };
+    fresh.source_profile.clone_from(&profile);
+    fresh.merge_runtime_from_reload(&live);
+    let worktree_info = fresh.worktree_info.clone();
+    let current_path = fresh.project_path.clone();
+    let status = fresh.status;
+    let is_sandboxed = fresh.is_sandboxed();
+    let is_structured = fresh.is_structured();
 
     let Some(worktree_info) = worktree_info else {
         return (
@@ -1718,6 +1826,31 @@ pub async fn set_worktree_name(
             Json(serde_json::json!({
                 "error": "tied",
                 "message": "Renaming is unified while \"Tie Worktree Directory to Session Name\" is on; rename the session instead, and its directory follows."
+            })),
+        )
+            .into_response();
+    }
+    let duplicate_path = crate::session::worktree_edit::target_worktree_path(
+        std::path::Path::new(&current_path),
+        &name,
+    )
+    .unwrap_or_else(|| std::path::PathBuf::from(&current_path))
+    .to_string_lossy()
+    .into_owned();
+    if duplicate_path.trim_end_matches('/') != current_path.trim_end_matches('/')
+        && is_duplicate_session(
+            authoritative_instances.iter(),
+            &fresh.title,
+            &duplicate_path,
+            Some(&id),
+        )
+    {
+        let message = duplicate_session_error(&fresh.title).to_string();
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "duplicate_session",
+                "message": message,
             })),
         )
             .into_response();
@@ -1828,27 +1961,22 @@ pub async fn set_worktree_name(
             .into_response()
     };
 
-    let storage = match Storage::new(&profile, state.file_watch.clone()) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!(target: "http.api.sessions", session = %id, "Storage::new failed after worktree edit: {e}");
-            return persist_failed();
-        }
-    };
     let id_clone = id.clone();
     let new_path_clone = new_path.clone();
     let new_branch_clone = new_branch.clone();
     match tokio::task::spawn_blocking(move || {
         storage.update(|instances, _groups| {
-            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
-                apply_worktree_name_edit(inst, &new_path_clone, new_branch_clone.as_deref());
-            }
-            Ok(())
+            let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) else {
+                return Ok(false);
+            };
+            apply_worktree_name_edit(inst, &new_path_clone, new_branch_clone.as_deref());
+            Ok(true)
         })
     })
     .await
     {
-        Ok(Ok(())) => {}
+        Ok(Ok(true)) => {}
+        Ok(Ok(false)) => return super::session_not_found(),
         Ok(Err(e)) => {
             tracing::error!(target: "http.api.sessions", "Failed to save after worktree edit: {e}");
             return persist_failed();
@@ -1867,6 +1995,7 @@ pub async fn set_worktree_name(
         apply_worktree_name_edit(inst, &new_path, new_branch.as_deref());
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen())
     };
+    drop(_identity_lock);
 
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
@@ -10377,6 +10506,23 @@ mod tests {
     // impractical (AppState has no test constructor), so these lock the
     // helper's two guarantees directly: a success durably writes, and every
     // storage failure surfaces as `Err`.
+
+    #[test]
+    #[serial_test::serial]
+    fn rename_persistence_reports_missing_authoritative_row() {
+        let temp_home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        let _ = isolated_app_dir(temp_home.path());
+        let storage = Storage::new_unwatched("rename-missing").unwrap();
+
+        let outcome =
+            persist_rename_metadata(&storage, "missing-id", "New title", None, None).unwrap();
+        assert_eq!(outcome, RenamePersistOutcome::Missing);
+        assert!(
+            storage.load().unwrap().is_empty(),
+            "a missing row must not be synthesized by rename persistence"
+        );
+    }
 
     #[tokio::test]
     #[serial_test::serial]

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -264,11 +264,13 @@ pub struct SessionResponse {
     /// Each entry mirrors `WorkspaceRepo` minus paths the dashboard does
     /// not need to display.
     pub workspace_repos: Vec<WorkspaceRepoSummary>,
-    /// Non-fatal warnings emitted during worktree creation (e.g.
-    /// post-checkout hook failures where the worktree was created
-    /// successfully). Only populated on the create-session response;
-    /// omitted from subsequent fetches because it lives on `BuildResult`
-    /// and is not persisted to the instance.
+    /// Non-fatal warnings surfaced by a mutation response. On create these are
+    /// worktree-creation warnings (e.g. post-checkout hook failures where the
+    /// worktree was still created successfully). On rename these carry the
+    /// tmux rekey warning emitted when the title was persisted durably but the
+    /// live tmux session could not be renamed afterwards. Both live on the
+    /// response only: the field is not persisted to the instance, so it is
+    /// omitted from list/fetch responses.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
     /// Latest plan snapshot summarised for the sidebar. Present only on
@@ -1329,8 +1331,7 @@ pub async fn rename_session(
     let lock_file_watch = state.file_watch.clone();
     let (_session_title_lock, _lifecycle_lock, storage, disk_instances) =
         match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-            let session_title_lock =
-                crate::session::acquire_session_title_lock(&lock_id)?;
+            let session_title_lock = crate::session::acquire_session_title_lock(&lock_id)?;
             let storage = Storage::new(&lock_profile, lock_file_watch)?;
             let lifecycle_lock = storage.acquire_instance_lifecycle_lock(&lock_id)?;
             let instances = storage.load()?;
@@ -1551,6 +1552,14 @@ pub async fn rename_session(
         Ok(RenamePersistOutcome::Missing) => {
             // AppState can lag an external delete. A missing authoritative row
             // is not a successful rename and must not trigger tmux/cache work.
+            if let Some(path) = new_path.as_deref() {
+                tracing::warn!(
+                    target: "http.api.sessions",
+                    session = %id,
+                    new_path = %path,
+                    "authoritative row vanished after the worktree move; the moved directory is unreferenced"
+                );
+            }
             return super::session_not_found();
         }
         Err(error) => {
@@ -1571,7 +1580,6 @@ pub async fn rename_session(
                 .into_response();
         }
     };
-
 
     let published_path = new_path.as_deref().unwrap_or(&current_path);
     let renamed_path = new_path
@@ -1772,25 +1780,26 @@ pub async fn set_worktree_name(
     let lock_id = id.clone();
     let lock_profile = profile.clone();
     let lock_file_watch = state.file_watch.clone();
-    let (_lifecycle_lock, storage, authoritative_instances) =
-        match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+    let (_lifecycle_lock, storage, authoritative_instances) = match tokio::task::spawn_blocking(
+        move || -> anyhow::Result<_> {
             let storage = Storage::new(&lock_profile, lock_file_watch)?;
             let lifecycle = storage.acquire_instance_lifecycle_lock(&lock_id)?;
             let instances = storage.load()?;
             Ok((lifecycle, storage, instances))
-        })
-        .await
-        {
-            Ok(Ok(locked)) => locked,
-            Ok(Err(error)) => {
-                tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to lock or load worktree rename");
-                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-            }
-            Err(error) => {
-                tracing::error!(target: "http.api.sessions", session = %id, %error, "Worktree rename lock task failed");
-                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-            }
-        };
+        },
+    )
+    .await
+    {
+        Ok(Ok(locked)) => locked,
+        Ok(Err(error)) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Failed to lock or load worktree rename");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+        Err(error) => {
+            tracing::error!(target: "http.api.sessions", session = %id, %error, "Worktree rename lock task failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
     let Some(mut fresh) = authoritative_instances
         .iter()
         .find(|instance| instance.id == id)
@@ -1976,7 +1985,15 @@ pub async fn set_worktree_name(
     .await
     {
         Ok(Ok(true)) => {}
-        Ok(Ok(false)) => return super::session_not_found(),
+        Ok(Ok(false)) => {
+            tracing::warn!(
+                target: "http.api.sessions",
+                session = %id,
+                new_path = %new_path,
+                "authoritative row vanished after the worktree move; the moved directory is unreferenced"
+            );
+            return super::session_not_found();
+        }
         Ok(Err(e)) => {
             tracing::error!(target: "http.api.sessions", "Failed to save after worktree edit: {e}");
             return persist_failed();
@@ -9628,6 +9645,13 @@ mod tests {
                 base_branch: None,
             });
 
+            let storage = Storage::new_unwatched("test").unwrap();
+            storage
+                .update(|instances, _groups| {
+                    *instances = vec![inst.clone()];
+                    Ok(())
+                })
+                .unwrap();
             let state = crate::server::test_support::build_test_app_state(vec![inst]);
             state.acp_supervisor.test_insert_worker(case.id).await;
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -597,11 +597,13 @@ pub enum SessionBucket {
 
 /// One durable ownership protocol for every session lifecycle transition.
 ///
-/// A transition first acquires the per-instance lifecycle flock, then records
-/// a fresh generation under `Storage::update`. The durable reservation stays
-/// held through hooks, external side effects, and the exact-generation commit;
-/// callers may release the flock while running reentrant hooks. `status` is
-/// presentation state and never proves ownership.
+/// A transition acquires the per-instance lifecycle flock, then records a
+/// fresh generation under `Storage::update`. Terminal launch is the ordered
+/// exception: it first takes the app-global per-session title flock so title
+/// writers and launch cannot derive different tmux names. The durable
+/// reservation stays held through hooks, external side effects, and the
+/// exact-generation commit; callers may release outer flocks for reentrant hooks.
+/// `status` is presentation state and never proves ownership.
 ///
 /// A crashed owner loses both the flock and, after the TTL, its reservation.
 /// Recovery may then acquire a newer generation; exact-generation commits
@@ -4011,6 +4013,8 @@ impl Instance {
         let storage = super::storage::Storage::new(&profile, self.resolve_file_watch())
             .context("failed to open lifecycle lock storage")?;
 
+        let title_lock = super::storage::acquire_session_title_lock(&self.id)
+            .context("failed to acquire instance launch title lock")?;
         let lifecycle_lock = storage
             .acquire_instance_lifecycle_lock(&self.id)
             .context("failed to acquire instance launch lock")?;
@@ -4038,10 +4042,14 @@ impl Instance {
         )?;
 
         // The durable reservation excludes peer launches while user hooks run.
-        // The flock itself must be absent because a hook may invoke aoe for
-        // this same session.
+        // Both flocks must be absent because a hook may invoke aoe for this
+        // same session. Reacquire in the global order afterward and reload the
+        // authoritative title before deriving the tmux launch name.
         drop(lifecycle_lock);
+        drop(title_lock);
         let hook_result = self.run_pre_launch_hooks(skip_on_launch, &profile);
+        let _title_lock = super::storage::acquire_session_title_lock(&self.id)
+            .context("failed to reacquire instance launch title lock after hooks")?;
         let _lifecycle_lock = storage
             .acquire_instance_lifecycle_lock(&self.id)
             .context("failed to reacquire instance launch lock after hooks")?;
@@ -6124,6 +6132,8 @@ impl Instance {
         let storage = super::storage::Storage::new(&profile, self.resolve_file_watch())
             .context("failed to open lifecycle lock storage")?;
 
+        let title_lock = super::storage::acquire_session_title_lock(&self.id)
+            .context("failed to acquire instance start title lock")?;
         let lifecycle_lock = storage
             .acquire_instance_lifecycle_lock(&self.id)
             .context("failed to acquire instance start lock")?;
@@ -6150,9 +6160,13 @@ impl Instance {
         }
 
         // Keep the generation reservation durable, but allow hooks to invoke
-        // aoe against this session without waiting on our flock.
+        // aoe against this session without waiting on either flock. Reacquire
+        // title before lifecycle and reload before deriving the launch name.
         drop(lifecycle_lock);
+        drop(title_lock);
         let hook_result = self.run_pre_launch_hooks(skip_on_launch, &profile);
+        let _title_lock = super::storage::acquire_session_title_lock(&self.id)
+            .context("failed to reacquire instance start title lock after hooks")?;
         let _lifecycle_lock = storage
             .acquire_instance_lifecycle_lock(&self.id)
             .context("failed to reacquire instance start lock after hooks")?;

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3993,6 +3993,41 @@ impl Instance {
         Ok(())
     }
 
+    /// Reacquire launch locks after user hooks, preserving the global
+    /// title-before-lifecycle order and failing the reservation consistently.
+    fn reacquire_launch_locks_after_hooks(
+        &mut self,
+        storage: &super::storage::Storage,
+        hook_result: Result<()>,
+    ) -> Result<(super::storage::StorageFlock, super::storage::StorageFlock)> {
+        let title_lock = match super::storage::acquire_session_title_lock(&self.id)
+            .context("failed to reacquire instance title lock after hooks")
+        {
+            Ok(lock) => lock,
+            Err(error) => {
+                self.fail_reserved_launch(storage, &error, false);
+                return Err(error);
+            }
+        };
+        let lifecycle_lock = match storage
+            .acquire_instance_lifecycle_lock(&self.id)
+            .context("failed to reacquire instance lifecycle lock after hooks")
+        {
+            Ok(lock) => lock,
+            Err(error) => {
+                self.fail_reserved_launch(storage, &error, false);
+                return Err(error);
+            }
+        };
+        self.reconcile_from_disk();
+        if let Err(error) = hook_result {
+            self.fail_reserved_launch(storage, &error, false);
+            return Err(error);
+        }
+        self.ensure_reservation_current_or_fail(storage)?;
+        Ok((title_lock, lifecycle_lock))
+    }
+
     pub fn start_with_size(&mut self, size: Option<(u16, u16)>) -> Result<()> {
         self.start_with_size_opts(size, false).map(|_| ())
     }
@@ -4044,21 +4079,16 @@ impl Instance {
         // The durable reservation excludes peer launches while user hooks run.
         // Both flocks must be absent because a hook may invoke aoe for this
         // same session. Reacquire in the global order afterward and reload the
-        // authoritative title before deriving the tmux launch name.
+        // authoritative title (via `reconcile_from_disk`) before deriving the
+        // tmux launch name: `spawn_prepared_launch`'s `tmux_session()` reads
+        // `self.title`, so the reload guarantees the name comes from the
+        // committed title a concurrent rename may have written during hooks,
+        // never the pre-hook value.
         drop(lifecycle_lock);
         drop(title_lock);
         let hook_result = self.run_pre_launch_hooks(skip_on_launch, &profile);
-        let _title_lock = super::storage::acquire_session_title_lock(&self.id)
-            .context("failed to reacquire instance launch title lock after hooks")?;
-        let _lifecycle_lock = storage
-            .acquire_instance_lifecycle_lock(&self.id)
-            .context("failed to reacquire instance launch lock after hooks")?;
-        self.reconcile_from_disk();
-        if let Err(error) = hook_result {
-            self.fail_reserved_launch(&storage, &error, false);
-            return Err(error);
-        }
-        self.ensure_reservation_current_or_fail(&storage)?;
+        let (_title_lock, _lifecycle_lock) =
+            self.reacquire_launch_locks_after_hooks(&storage, hook_result)?;
         self.apply_fresh_launch_intent();
 
         let prepared = match self.prepare_launch_command() {
@@ -6161,21 +6191,15 @@ impl Instance {
 
         // Keep the generation reservation durable, but allow hooks to invoke
         // aoe against this session without waiting on either flock. Reacquire
-        // title before lifecycle and reload before deriving the launch name.
+        // title before lifecycle and reload (`reconcile_from_disk`) before
+        // deriving the launch name: `spawn_prepared_launch`'s `tmux_session()`
+        // reads `self.title`, so the reload guarantees the tmux name comes
+        // from the authoritative committed title, not a pre-hook value.
         drop(lifecycle_lock);
         drop(title_lock);
         let hook_result = self.run_pre_launch_hooks(skip_on_launch, &profile);
-        let _title_lock = super::storage::acquire_session_title_lock(&self.id)
-            .context("failed to reacquire instance start title lock after hooks")?;
-        let _lifecycle_lock = storage
-            .acquire_instance_lifecycle_lock(&self.id)
-            .context("failed to reacquire instance start lock after hooks")?;
-        self.reconcile_from_disk();
-        if let Err(error) = hook_result {
-            self.fail_reserved_launch(&storage, &error, false);
-            return Err(error);
-        }
-        self.ensure_reservation_current_or_fail(&storage)?;
+        let (_title_lock, _lifecycle_lock) =
+            self.reacquire_launch_locks_after_hooks(&storage, hook_result)?;
         let skipped_failed_resume_sid = self.apply_resume_policy(resume_policy);
         self.apply_fresh_launch_intent();
 
@@ -8646,7 +8670,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn launch_hooks_run_without_the_instance_lifecycle_flock() {
+    fn launch_hooks_run_without_title_or_lifecycle_flocks() {
         if !crate::tmux::tmux_command()
             .arg("-V")
             .output()
@@ -8709,17 +8733,25 @@ mod tests {
             let lock_storage = crate::session::storage::Storage::new_unwatched(&profile).unwrap();
             let id = storage.load().unwrap()[0].id.clone();
             let release_for_lock = release.clone();
+            let (title_tx, title_rx) = std::sync::mpsc::channel();
             let (lock_tx, lock_rx) = std::sync::mpsc::channel();
             let lock = std::thread::spawn(move || {
-                let guard = lock_storage.acquire_instance_lifecycle_lock(&id).unwrap();
-                drop(guard);
+                let title_guard = crate::session::storage::acquire_session_title_lock(&id).unwrap();
+                title_tx.send(()).unwrap();
+                let lifecycle_guard = lock_storage.acquire_instance_lifecycle_lock(&id).unwrap();
+                drop(lifecycle_guard);
+                drop(title_guard);
                 std::fs::write(release_for_lock, b"release").unwrap();
                 lock_tx.send(()).unwrap();
             });
-            let acquired = lock_rx
+            let title_acquired = title_rx
                 .recv_timeout(std::time::Duration::from_secs(2))
                 .is_ok();
-            if !acquired {
+            let both_acquired = title_acquired
+                && lock_rx
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .is_ok();
+            if !both_acquired {
                 std::fs::write(&release, b"release").unwrap();
             }
 
@@ -8730,7 +8762,11 @@ mod tests {
             lock.join().unwrap();
             let _ = instance.tmux_session().unwrap().kill();
             assert!(
-                acquired,
+                title_acquired,
+                "{label} hook ran while the title mutation flock was held"
+            );
+            assert!(
+                both_acquired,
                 "{label} hook ran while the lifecycle flock was held"
             );
             result.unwrap();

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -137,7 +137,9 @@ pub use repo_config::{
     RepoConfig, RepoTrust, TrustSurface,
 };
 pub use scope::SessionScope;
-pub(crate) use storage::{atomic_write, resolve_symlink_chain};
+pub(crate) use storage::{
+    acquire_session_title_lock, atomic_write, resolve_symlink_chain, StorageFlock,
+};
 pub use storage::{
     load_recent_projects, load_workspace_ordering, recent_project_entry_for, record_recent_project,
     update_workspace_ordering, RecentProjectEntry, Storage, WorkspaceOrdering,

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -929,7 +929,10 @@ fn apply_terminal_title(
 ) -> anyhow::Result<()> {
     let id = id.to_string();
     let new_title = new_title.map(str::to_string);
-    storage.update(|instances, _groups| {
+    let _session_title_lock = crate::session::storage::acquire_session_title_lock(&id)?;
+    let _lifecycle_lock = storage.acquire_instance_lifecycle_lock(&id)?;
+    let rekey = storage.update(|instances, _groups| {
+        let mut rekey = None;
         if let Some(index) = instances.iter().position(|instance| instance.id == id) {
             instances[index].smart_rename_attempted = true;
             if let Some(title) = &new_title {
@@ -950,42 +953,21 @@ fn apply_terminal_title(
                     tracing::warn!(target: "smart_rename", session = %id, title = %title, "skipped duplicate auto-title");
                 } else if should_write {
                     let instance = &mut instances[index];
-                    // The tmux session name embeds the title
-                    // (Session::generate_name), and both status pollers derive
-                    // the name from the current title. Rekey the live session
-                    // to match, else attach/stop/poll would target a name the
-                    // running pane no longer has. Best-effort, mirroring the
-                    // manual TUI rename (src/tui/home/operations.rs).
-                    rekey_tmux_session(&id, &instance.title, title);
+                    rekey = Some((instance.title.clone(), title.clone()));
                     tracing::info!(target: "smart_rename", session = %id, old = %instance.title, new = %title, "auto-renamed terminal session");
                     instance.title = title.clone();
                     instance.last_auto_title = Some(title.clone());
                 }
             }
         }
-        Ok(())
+        Ok(rekey)
     })?;
-    Ok(())
-}
-
-/// Rename the live tmux session from its old title-derived name to the new one,
-/// keeping the pane reachable after the stored title changes. Best-effort: a
-/// missing session or a failed rename is logged, not fatal (matches the manual
-/// rename path).
-fn rekey_tmux_session(id: &str, old_title: &str, new_title: &str) {
-    let Ok(session) = crate::tmux::Session::new(id, old_title) else {
-        return;
-    };
-    if !session.exists() {
-        return;
-    }
-    let new_name = crate::tmux::Session::generate_name(id, new_title);
-    match session.rename(&new_name) {
-        Ok(()) => crate::tmux::refresh_session_cache(),
-        Err(e) => {
-            tracing::warn!(target: "smart_rename", session = %id, "tmux rename failed: {e}")
+    if let Some((old_title, new_title)) = rekey {
+        if let Err(error) = crate::tmux::rekey_session(&id, &old_title, &new_title) {
+            tracing::warn!(target: "smart_rename", session = %id, "tmux rename failed: {error}");
         }
     }
+    Ok(())
 }
 
 /// Entry point for the detached `aoe __smart-rename [--force] <profile> <id>`
@@ -1416,11 +1398,13 @@ mod serve {
     /// is still a default civ name or still equals the last auto title we wrote
     /// (`title_is_auto_overwritable`), so a manual rename is never clobbered.
     /// Serializes against manual renames / worktree edits on this session via
-    /// the per-session instance lock, and mirrors memory only when the storage
-    /// write actually happened so the two never diverge. Two further cases skip
-    /// the write silently: the generated title already equalling the current
-    /// one (a no-op, new here relative to the pre-fix unconditional write), and
-    /// another session in this profile already owning the (title, path) pair.
+    /// both the process-local instance lock and the cross-process per-session
+    /// title lock. The latter is retained from the authoritative storage commit
+    /// through the AppState mirror so an external title writer cannot land in
+    /// the gap and then be overwritten in memory. The mirror changes only when
+    /// the storage write actually happened. Two further cases skip the write
+    /// silently: the generated title already equals the current one, and another
+    /// session in this profile already owns the (title, path) pair.
     pub(crate) async fn apply_auto_title(
         state: &Arc<AppState>,
         id: &str,
@@ -1444,8 +1428,10 @@ mod serve {
         // mirror after the join reuses the borrowed `new_title` directly.
         let id_owned = id.to_string();
         let title_owned = new_title.to_string();
-        let persisted = tokio::task::spawn_blocking(move || {
-            storage.update(|instances, _groups| {
+        let persisted = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let session_title_lock =
+                crate::session::storage::acquire_session_title_lock(&id_owned)?;
+            let wrote = storage.update(|instances, _groups| {
                 let Some(index) = instances
                     .iter()
                     .position(|instance| instance.id == id_owned)
@@ -1477,11 +1463,12 @@ mod serve {
                 } else {
                     Ok(false)
                 }
-            })
+            })?;
+            Ok((wrote, session_title_lock))
         })
         .await;
-        let wrote = match persisted {
-            Ok(Ok(wrote)) => wrote,
+        let (wrote, _session_title_lock) = match persisted {
+            Ok(Ok(result)) => result,
             Ok(Err(e)) => {
                 tracing::warn!(target: "smart_rename", session = %id, "persist failed: {e}");
                 return;
@@ -2730,20 +2717,46 @@ claude = "repo-wrapper"
 
     #[test]
     #[serial_test::serial]
-    fn apply_terminal_title_marks_attempted_and_respects_manual_rename() {
+    fn terminal_title_commit_controls_tmux_rekey_and_warning_contracts() {
         use crate::session::instance::Instance;
         use crate::session::storage::Storage;
+        use crate::tmux::test_helpers::TmuxTestSession;
+
         let home = tempfile::tempdir().expect("tempdir HOME");
-        // SAFETY: serialized by `#[serial]`; matches the sibling config test.
-        unsafe {
-            std::env::set_var("HOME", home.path());
-            std::env::set_var("XDG_CONFIG_HOME", home.path().join(".config"));
-        }
-        let storage = Storage::new_unwatched("default").expect("storage");
+        let _home_guard = crate::session::test_support::isolate_home(home.path());
+        let mut storage = Storage::new_unwatched("default").expect("storage");
 
         // Story 1: a still-civ-named session gets renamed and marked attempted.
         let civ = Instance::new("Vikings", "/tmp/x");
         let civ_id = civ.id.clone();
+        let old_tmux_name = crate::tmux::Session::generate_name(&civ_id, &civ.title);
+        let new_tmux_name = crate::tmux::Session::generate_name(&civ_id, "Fix login bug");
+
+        // The title lock is keyed only by validated session id at the app
+        // root, so a second writer cannot enter while the first is between
+        // commit and rekey, regardless of which profile Storage it will use.
+        assert!(crate::session::storage::acquire_session_title_lock("../unsafe").is_err());
+        let first_title_lock =
+            crate::session::storage::acquire_session_title_lock(&civ_id).unwrap();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let competing_id = civ_id.clone();
+        let competing_writer = std::thread::spawn(move || {
+            let _lock =
+                crate::session::storage::acquire_session_title_lock(&competing_id).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+        assert!(
+            acquired_rx
+                .recv_timeout(std::time::Duration::from_millis(150))
+                .is_err(),
+            "a competing title writer entered before the current writer released the lock"
+        );
+        drop(first_title_lock);
+        acquired_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("competing writer should enter after release");
+        competing_writer.join().unwrap();
+
         // Story 2: a manually-named session must never be overwritten.
         let mut manual = Instance::new("Britons", "/tmp/y");
         manual.title = "Hand-picked".to_string();
@@ -2754,19 +2767,91 @@ claude = "repo-wrapper"
         let duplicate_id = duplicate_candidate.id.clone();
         let mut duplicate_owner = Instance::new("Saxons", "/tmp/z");
         duplicate_owner.title = "Already owned".to_string();
+
+        // Story 4: a deterministic sessions write failure must leave both
+        // durable metadata and the live tmux destination untouched.
+        let failed = Instance::new("Franks", "/tmp/write-failure");
+        let failed_id = failed.id.clone();
+        let failed_tmux_name = crate::tmux::Session::generate_name(&failed_id, &failed.title);
         storage
             .update(|instances, _groups| {
                 instances.push(civ);
                 instances.push(manual);
                 instances.push(duplicate_candidate);
                 instances.push(duplicate_owner);
+                instances.push(failed);
                 Ok(())
             })
             .unwrap();
 
+        let tmux_available = crate::tmux::tmux_command()
+            .arg("-V")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false);
+        let _tmux_guards = if tmux_available {
+            let civ_guard = TmuxTestSession::from_name(old_tmux_name.clone());
+            let failed_guard = TmuxTestSession::from_name(failed_tmux_name.clone());
+            for name in [civ_guard.name(), failed_guard.name()] {
+                let output = crate::tmux::tmux_command()
+                    .args(["new-session", "-d", "-s", name, "sleep 60"])
+                    .output()
+                    .expect("tmux new-session");
+                assert!(
+                    output.status.success(),
+                    "failed to create tmux session {name}: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            crate::tmux::refresh_session_cache();
+            Some((civ_guard, failed_guard))
+        } else {
+            None
+        };
+
         apply_terminal_title(&storage, &civ_id, Some("Fix login bug")).unwrap();
         apply_terminal_title(&storage, &manual_id, Some("Should Not Apply")).unwrap();
         apply_terminal_title(&storage, &duplicate_id, Some("Already owned")).unwrap();
+
+        if tmux_available {
+            assert!(!crate::tmux::Session::from_name(&old_tmux_name).exists());
+            assert!(
+                crate::tmux::Session::from_name(&new_tmux_name).exists(),
+                "the committed title must determine the tmux destination"
+            );
+
+            // Simulate a sibling process rekeying the live pane without
+            // refreshing this process's cache. `rekey_session` must scan
+            // before resolving Session::new, adopt the id-matching peer name,
+            // and move that same pane to the requested destination.
+            let peer_tmux_name = crate::tmux::Session::generate_name(&civ_id, "Peer rename");
+            let final_tmux_name = crate::tmux::Session::generate_name(&civ_id, "Final rename");
+            let peer_rename = crate::tmux::tmux_command()
+                .args(["rename-session", "-t", &new_tmux_name, &peer_tmux_name])
+                .output()
+                .expect("peer tmux rename");
+            assert!(peer_rename.status.success());
+            assert!(crate::tmux::rekey_session(&civ_id, "Fix login bug", "Final rename").unwrap());
+            assert!(crate::tmux::Session::from_name(&final_tmux_name).exists());
+
+            // Populate a positive cache entry, remove the target without
+            // refreshing it, then exercise the absence path. The authoritative
+            // refresh must classify the vanished pane as `Ok(false)`, which
+            // keeps API/TUI callers from showing a warning.
+            let killed = crate::tmux::tmux_command()
+                .args(["kill-session", "-t", &final_tmux_name])
+                .output()
+                .expect("tmux kill-session");
+            assert!(killed.status.success());
+            assert!(!crate::tmux::rekey_session(&civ_id, "Final rename", "No live pane").unwrap());
+        }
+
+        storage.set_fail_writes_for_test(true);
+        let error = apply_terminal_title(&storage, &failed_id, Some("Must Not Land"))
+            .expect_err("injected persistence failure must abort the title mutation");
+        assert!(error
+            .to_string()
+            .contains("injected sessions write failure"));
 
         let (instances, _) = storage.load_with_groups().unwrap();
         let civ = instances.iter().find(|i| i.id == civ_id).unwrap();
@@ -2785,5 +2870,15 @@ claude = "repo-wrapper"
         assert_eq!(duplicate.title, "Franks");
         assert_eq!(duplicate.last_auto_title, None);
         assert!(duplicate.smart_rename_attempted);
+
+        let failed = instances.iter().find(|i| i.id == failed_id).unwrap();
+        assert_eq!(failed.title, "Franks");
+        assert!(!failed.smart_rename_attempted);
+        if tmux_available {
+            assert!(
+                crate::tmux::Session::from_name(&failed_tmux_name).exists(),
+                "tmux must not rekey when the title commit fails"
+            );
+        }
     }
 }

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -2715,34 +2715,41 @@ claude = "repo-wrapper"
         assert_eq!(extract_echo_baseline(""), "");
     }
 
+    /// Explicit named skip for tests that need a live tmux server. Returns
+    /// `true` when tmux is usable; otherwise prints a per-test skip line and
+    /// the caller early-returns, so a tmux-less environment reports the skip
+    /// instead of silently asserting nothing.
+    fn require_tmux(test: &str) -> bool {
+        let available = crate::tmux::tmux_command()
+            .arg("-V")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false);
+        if !available {
+            eprintln!("Skipping {test}: tmux not available");
+        }
+        available
+    }
+
     #[test]
     #[serial_test::serial]
-    fn terminal_title_commit_controls_tmux_rekey_and_warning_contracts() {
+    fn title_mutation_lock_validates_id_and_serializes_writers() {
         use crate::session::instance::Instance;
-        use crate::session::storage::Storage;
-        use crate::tmux::test_helpers::TmuxTestSession;
-
         let home = tempfile::tempdir().expect("tempdir HOME");
         let _home_guard = crate::session::test_support::isolate_home(home.path());
-        let mut storage = Storage::new_unwatched("default").expect("storage");
 
-        // Story 1: a still-civ-named session gets renamed and marked attempted.
-        let civ = Instance::new("Vikings", "/tmp/x");
-        let civ_id = civ.id.clone();
-        let old_tmux_name = crate::tmux::Session::generate_name(&civ_id, &civ.title);
-        let new_tmux_name = crate::tmux::Session::generate_name(&civ_id, "Fix login bug");
-
-        // The title lock is keyed only by validated session id at the app
-        // root, so a second writer cannot enter while the first is between
-        // commit and rekey, regardless of which profile Storage it will use.
+        // The lock is keyed only by validated session id at the app root, so a
+        // path-traversal id is rejected before any file is touched.
         assert!(crate::session::storage::acquire_session_title_lock("../unsafe").is_err());
-        let first_title_lock =
-            crate::session::storage::acquire_session_title_lock(&civ_id).unwrap();
+
+        // A second writer cannot enter while the first holds the lock between
+        // commit and rekey, regardless of which profile Storage it would use.
+        let id = Instance::new("Vikings", "/tmp/x").id;
+        let first_title_lock = crate::session::storage::acquire_session_title_lock(&id).unwrap();
         let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
-        let competing_id = civ_id.clone();
+        let competing_id = id.clone();
         let competing_writer = std::thread::spawn(move || {
-            let _lock =
-                crate::session::storage::acquire_session_title_lock(&competing_id).unwrap();
+            let _lock = crate::session::storage::acquire_session_title_lock(&competing_id).unwrap();
             acquired_tx.send(()).unwrap();
         });
         assert!(
@@ -2756,95 +2763,110 @@ claude = "repo-wrapper"
             .recv_timeout(std::time::Duration::from_secs(2))
             .expect("competing writer should enter after release");
         competing_writer.join().unwrap();
+    }
 
-        // Story 2: a manually-named session must never be overwritten.
+    #[test]
+    #[serial_test::serial]
+    fn apply_terminal_title_renames_auto_named_session_and_marks_attempted() {
+        use crate::session::instance::Instance;
+        use crate::session::storage::Storage;
+        let home = tempfile::tempdir().expect("tempdir HOME");
+        let _home_guard = crate::session::test_support::isolate_home(home.path());
+        let storage = Storage::new_unwatched("default").expect("storage");
+        let civ = Instance::new("Vikings", "/tmp/x");
+        let civ_id = civ.id.clone();
+        storage
+            .update(|instances, _groups| {
+                instances.push(civ);
+                Ok(())
+            })
+            .unwrap();
+
+        apply_terminal_title(&storage, &civ_id, Some("Fix login bug")).unwrap();
+
+        let inst = storage
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|i| i.id == civ_id)
+            .unwrap();
+        assert_eq!(inst.title, "Fix login bug");
+        assert_eq!(inst.last_auto_title.as_deref(), Some("Fix login bug"));
+        assert!(inst.smart_rename_attempted);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_terminal_title_never_overwrites_a_manual_title() {
+        use crate::session::instance::Instance;
+        use crate::session::storage::Storage;
+        let home = tempfile::tempdir().expect("tempdir HOME");
+        let _home_guard = crate::session::test_support::isolate_home(home.path());
+        let storage = Storage::new_unwatched("default").expect("storage");
         let mut manual = Instance::new("Britons", "/tmp/y");
         manual.title = "Hand-picked".to_string();
         let manual_id = manual.id.clone();
-        // Story 3: a generated title already owned at the same normalized path
-        // is skipped, but the one-shot remains marked attempted.
         let duplicate_candidate = Instance::new("Franks", "/tmp/z/");
         let duplicate_id = duplicate_candidate.id.clone();
         let mut duplicate_owner = Instance::new("Saxons", "/tmp/z");
         duplicate_owner.title = "Already owned".to_string();
+        storage
+            .update(|instances, _groups| {
+                instances.extend([manual, duplicate_candidate, duplicate_owner]);
+                Ok(())
+            })
+            .unwrap();
 
-        // Story 4: a deterministic sessions write failure must leave both
-        // durable metadata and the live tmux destination untouched.
+        apply_terminal_title(&storage, &manual_id, Some("Should Not Apply")).unwrap();
+        apply_terminal_title(&storage, &duplicate_id, Some("Already owned")).unwrap();
+
+        let instances = storage.load().unwrap();
+        let manual = instances.iter().find(|i| i.id == manual_id).unwrap();
+        assert_eq!(manual.title, "Hand-picked");
+        assert!(manual.smart_rename_attempted);
+        let duplicate = instances.iter().find(|i| i.id == duplicate_id).unwrap();
+        assert_eq!(duplicate.title, "Franks");
+        assert_eq!(duplicate.last_auto_title, None);
+        assert!(duplicate.smart_rename_attempted);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_terminal_title_write_failure_preserves_metadata_and_tmux() {
+        use crate::session::instance::Instance;
+        use crate::session::storage::Storage;
+        use crate::tmux::test_helpers::TmuxTestSession;
+        let home = tempfile::tempdir().expect("tempdir HOME");
+        let _home_guard = crate::session::test_support::isolate_home(home.path());
+        let mut storage = Storage::new_unwatched("default").expect("storage");
         let failed = Instance::new("Franks", "/tmp/write-failure");
         let failed_id = failed.id.clone();
         let failed_tmux_name = crate::tmux::Session::generate_name(&failed_id, &failed.title);
         storage
             .update(|instances, _groups| {
-                instances.push(civ);
-                instances.push(manual);
-                instances.push(duplicate_candidate);
-                instances.push(duplicate_owner);
                 instances.push(failed);
                 Ok(())
             })
             .unwrap();
 
-        let tmux_available = crate::tmux::tmux_command()
-            .arg("-V")
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false);
-        let _tmux_guards = if tmux_available {
-            let civ_guard = TmuxTestSession::from_name(old_tmux_name.clone());
-            let failed_guard = TmuxTestSession::from_name(failed_tmux_name.clone());
-            for name in [civ_guard.name(), failed_guard.name()] {
-                let output = crate::tmux::tmux_command()
-                    .args(["new-session", "-d", "-s", name, "sleep 60"])
-                    .output()
-                    .expect("tmux new-session");
-                assert!(
-                    output.status.success(),
-                    "failed to create tmux session {name}: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
-            }
+        let tmux = require_tmux("apply_terminal_title_write_failure_preserves_metadata_and_tmux");
+        let _tmux_guard = if tmux {
+            let guard = TmuxTestSession::from_name(failed_tmux_name.clone());
+            let output = crate::tmux::tmux_command()
+                .args(["new-session", "-d", "-s", guard.name(), "sleep 60"])
+                .output()
+                .expect("tmux new-session");
+            assert!(
+                output.status.success(),
+                "failed to create tmux session {}: {}",
+                guard.name(),
+                String::from_utf8_lossy(&output.stderr)
+            );
             crate::tmux::refresh_session_cache();
-            Some((civ_guard, failed_guard))
+            Some(guard)
         } else {
             None
         };
-
-        apply_terminal_title(&storage, &civ_id, Some("Fix login bug")).unwrap();
-        apply_terminal_title(&storage, &manual_id, Some("Should Not Apply")).unwrap();
-        apply_terminal_title(&storage, &duplicate_id, Some("Already owned")).unwrap();
-
-        if tmux_available {
-            assert!(!crate::tmux::Session::from_name(&old_tmux_name).exists());
-            assert!(
-                crate::tmux::Session::from_name(&new_tmux_name).exists(),
-                "the committed title must determine the tmux destination"
-            );
-
-            // Simulate a sibling process rekeying the live pane without
-            // refreshing this process's cache. `rekey_session` must scan
-            // before resolving Session::new, adopt the id-matching peer name,
-            // and move that same pane to the requested destination.
-            let peer_tmux_name = crate::tmux::Session::generate_name(&civ_id, "Peer rename");
-            let final_tmux_name = crate::tmux::Session::generate_name(&civ_id, "Final rename");
-            let peer_rename = crate::tmux::tmux_command()
-                .args(["rename-session", "-t", &new_tmux_name, &peer_tmux_name])
-                .output()
-                .expect("peer tmux rename");
-            assert!(peer_rename.status.success());
-            assert!(crate::tmux::rekey_session(&civ_id, "Fix login bug", "Final rename").unwrap());
-            assert!(crate::tmux::Session::from_name(&final_tmux_name).exists());
-
-            // Populate a positive cache entry, remove the target without
-            // refreshing it, then exercise the absence path. The authoritative
-            // refresh must classify the vanished pane as `Ok(false)`, which
-            // keeps API/TUI callers from showing a warning.
-            let killed = crate::tmux::tmux_command()
-                .args(["kill-session", "-t", &final_tmux_name])
-                .output()
-                .expect("tmux kill-session");
-            assert!(killed.status.success());
-            assert!(!crate::tmux::rekey_session(&civ_id, "Final rename", "No live pane").unwrap());
-        }
 
         storage.set_fail_writes_for_test(true);
         let error = apply_terminal_title(&storage, &failed_id, Some("Must Not Land"))
@@ -2853,32 +2875,67 @@ claude = "repo-wrapper"
             .to_string()
             .contains("injected sessions write failure"));
 
-        let (instances, _) = storage.load_with_groups().unwrap();
-        let civ = instances.iter().find(|i| i.id == civ_id).unwrap();
-        assert_eq!(civ.title, "Fix login bug");
-        assert_eq!(civ.last_auto_title.as_deref(), Some("Fix login bug"));
-        assert!(civ.smart_rename_attempted);
-
-        let manual = instances.iter().find(|i| i.id == manual_id).unwrap();
-        assert_eq!(manual.title, "Hand-picked");
-        // Still marked attempted so the poller does not respawn on every turn.
-        assert!(manual.smart_rename_attempted);
-        let duplicate = instances
-            .iter()
-            .find(|instance| instance.id == duplicate_id)
+        let failed = storage
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|i| i.id == failed_id)
             .unwrap();
-        assert_eq!(duplicate.title, "Franks");
-        assert_eq!(duplicate.last_auto_title, None);
-        assert!(duplicate.smart_rename_attempted);
-
-        let failed = instances.iter().find(|i| i.id == failed_id).unwrap();
         assert_eq!(failed.title, "Franks");
         assert!(!failed.smart_rename_attempted);
-        if tmux_available {
+        if tmux {
+            crate::tmux::refresh_session_cache();
             assert!(
                 crate::tmux::Session::from_name(&failed_tmux_name).exists(),
                 "tmux must not rekey when the title commit fails"
             );
         }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_terminal_title_rekeys_live_tmux_to_committed_title() {
+        if !require_tmux("apply_terminal_title_rekeys_live_tmux_to_committed_title") {
+            return;
+        }
+        use crate::session::instance::Instance;
+        use crate::session::storage::Storage;
+        use crate::tmux::test_helpers::TmuxTestSession;
+        let home = tempfile::tempdir().expect("tempdir HOME");
+        let _home_guard = crate::session::test_support::isolate_home(home.path());
+        let storage = Storage::new_unwatched("default").expect("storage");
+        let civ = Instance::new("Vikings", "/tmp/x");
+        let civ_id = civ.id.clone();
+        let old_tmux_name = crate::tmux::Session::generate_name(&civ_id, &civ.title);
+        let new_tmux_name = crate::tmux::Session::generate_name(&civ_id, "Fix login bug");
+        storage
+            .update(|instances, _groups| {
+                instances.push(civ);
+                Ok(())
+            })
+            .unwrap();
+
+        let old_guard = TmuxTestSession::from_name(old_tmux_name.clone());
+        let new_guard = TmuxTestSession::from_name(new_tmux_name.clone());
+        let output = crate::tmux::tmux_command()
+            .args(["new-session", "-d", "-s", old_guard.name(), "sleep 60"])
+            .output()
+            .expect("tmux new-session");
+        assert!(
+            output.status.success(),
+            "failed to create tmux session {}: {}",
+            old_guard.name(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        crate::tmux::refresh_session_cache();
+
+        apply_terminal_title(&storage, &civ_id, Some("Fix login bug")).unwrap();
+
+        assert!(!crate::tmux::Session::from_name(&old_tmux_name).exists());
+        assert!(
+            crate::tmux::Session::from_name(&new_tmux_name).exists(),
+            "the committed title must determine the tmux destination"
+        );
+        drop((old_guard, new_guard));
     }
 }

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -929,6 +929,7 @@ fn apply_terminal_title(
 ) -> anyhow::Result<()> {
     let id = id.to_string();
     let new_title = new_title.map(str::to_string);
+    let identity_lock = crate::session::acquire_session_identity_lock()?;
     let _session_title_lock = crate::session::storage::acquire_session_title_lock(&id)?;
     let _lifecycle_lock = storage.acquire_instance_lifecycle_lock(&id)?;
     let rekey = storage.update(|instances, _groups| {
@@ -962,6 +963,7 @@ fn apply_terminal_title(
         }
         Ok(rekey)
     })?;
+    drop(identity_lock);
     if let Some((old_title, new_title)) = rekey {
         if let Err(error) = crate::tmux::rekey_session(&id, &old_title, &new_title) {
             tracing::warn!(target: "smart_rename", session = %id, "tmux rename failed: {error}");
@@ -1392,19 +1394,13 @@ mod serve {
         apply_auto_title(&state, &session_id, &profile, &new_title).await;
     }
 
-    /// Apply an automatically-generated title to a session, persisting to
-    /// storage and mirroring the in-memory instance list so connected clients
-    /// see it without a reload. The write happens only while the current title
-    /// is still a default civ name or still equals the last auto title we wrote
-    /// (`title_is_auto_overwritable`), so a manual rename is never clobbered.
-    /// Serializes against manual renames / worktree edits on this session via
-    /// both the process-local instance lock and the cross-process per-session
-    /// title lock. The latter is retained from the authoritative storage commit
-    /// through the AppState mirror so an external title writer cannot land in
-    /// the gap and then be overwritten in memory. The mirror changes only when
-    /// the storage write actually happened. Two further cases skip the write
-    /// silently: the generated title already equals the current one, and another
-    /// session in this profile already owns the (title, path) pair.
+    /// Persist an automatically generated title and mirror it into AppState.
+    /// The title changes only while it remains auto-overwritable. The
+    /// process-local instance lock, global identity lock, and per-session title
+    /// lock serialize the write with manual renames. Identity covers duplicate
+    /// validation through the durable write. The title lock remains held
+    /// through the AppState mirror so a later writer cannot be overwritten in
+    /// memory. Unchanged and duplicate titles are skipped.
     pub(crate) async fn apply_auto_title(
         state: &Arc<AppState>,
         id: &str,
@@ -1429,6 +1425,7 @@ mod serve {
         let id_owned = id.to_string();
         let title_owned = new_title.to_string();
         let persisted = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let identity_lock = crate::session::acquire_session_identity_lock()?;
             let session_title_lock =
                 crate::session::storage::acquire_session_title_lock(&id_owned)?;
             let wrote = storage.update(|instances, _groups| {
@@ -1464,6 +1461,7 @@ mod serve {
                     Ok(false)
                 }
             })?;
+            drop(identity_lock);
             Ok((wrote, session_title_lock))
         })
         .await;
@@ -2733,18 +2731,16 @@ claude = "repo-wrapper"
 
     #[test]
     #[serial_test::serial]
-    fn title_mutation_lock_validates_id_and_serializes_writers() {
+    fn title_mutation_locks_validate_and_serialize_writers() {
         use crate::session::instance::Instance;
+        use crate::session::storage::Storage;
         let home = tempfile::tempdir().expect("tempdir HOME");
         let _home_guard = crate::session::test_support::isolate_home(home.path());
 
-        // The lock is keyed only by validated session id at the app root, so a
-        // path-traversal id is rejected before any file is touched.
         assert!(crate::session::storage::acquire_session_title_lock("../unsafe").is_err());
 
-        // A second writer cannot enter while the first holds the lock between
-        // commit and rekey, regardless of which profile Storage it would use.
-        let id = Instance::new("Vikings", "/tmp/x").id;
+        let instance = Instance::new("Vikings", "/tmp/x");
+        let id = instance.id.clone();
         let first_title_lock = crate::session::storage::acquire_session_title_lock(&id).unwrap();
         let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
         let competing_id = id.clone();
@@ -2756,13 +2752,45 @@ claude = "repo-wrapper"
             acquired_rx
                 .recv_timeout(std::time::Duration::from_millis(150))
                 .is_err(),
-            "a competing title writer entered before the current writer released the lock"
+            "a competing title writer entered before release"
         );
         drop(first_title_lock);
         acquired_rx
             .recv_timeout(std::time::Duration::from_secs(2))
             .expect("competing writer should enter after release");
         competing_writer.join().unwrap();
+
+        let storage = Storage::new_unwatched("identity-lock").unwrap();
+        storage
+            .update(|instances, _groups| {
+                instances.push(instance);
+                Ok(())
+            })
+            .unwrap();
+        let identity_lock = crate::session::acquire_session_identity_lock().unwrap();
+        let (finished_tx, finished_rx) = std::sync::mpsc::channel();
+        let writer_id = id.clone();
+        let identity_writer = std::thread::spawn(move || {
+            let storage = Storage::new_unwatched("identity-lock").unwrap();
+            apply_terminal_title(&storage, &writer_id, Some("Shared title")).unwrap();
+            finished_tx.send(()).unwrap();
+        });
+        assert!(
+            finished_rx
+                .recv_timeout(std::time::Duration::from_millis(150))
+                .is_err(),
+            "smart rename bypassed the identity transaction"
+        );
+        drop(identity_lock);
+        finished_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("smart rename should finish after identity release");
+        identity_writer.join().unwrap();
+        assert_eq!(
+            storage.load().unwrap()[0].title,
+            "Shared title",
+            "smart rename should commit after entering the transaction"
+        );
     }
 
     #[test]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -59,9 +59,12 @@
 //! identity lock is retained through the durable commit and cache publication,
 //! then released before post-commit tmux rekey; the session-title and lifecycle
 //! locks remain held through rekey. `aoe add` has no existing session id, so it
-//! takes identity directly before Storage. Launch and restart do not take
-//! identity: their order is session title, lifecycle, then Storage. Code must
-//! never acquire identity or session title while holding lifecycle or Storage.
+//! takes identity directly before Storage. Launch and same-profile restart do
+//! not take identity: their order is session title, lifecycle, then Storage.
+//! A `restart_selected_session` profile move is the exception: it acquires
+//! identity before the session-title and lifecycle locks even when the
+//! `(title, project_path)` pair is unchanged. Code must never acquire identity
+//! or session title while holding lifecycle or Storage.
 //!
 //! Server callers MUST drop `AppState.instances` (tokio RwLock) before
 //! acquiring any flock via `tokio::task::spawn_blocking`. A flock can park on

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -401,26 +401,16 @@ pub(crate) fn acquire_storage_flock(dir: &Path, name: &str) -> Result<StorageFlo
 /// writes, and any in-memory cache publication. See the module lock order.
 ///
 /// Held across slow external effects. The tied worktree rename path
-/// (`session::worktree_edit::edit_worktree_workdir`) runs `git branch -m` and
-/// `git worktree move`, and the callers refresh tmux state, all while this
-/// cross-process `flock` is held so duplicate validation and durable commit
-/// are one transaction with no TOCTOU window. Those git effects are therefore
-/// bounded (`WORKTREE_MUTATION_TIMEOUT` in `git::worktree`): a stalled
-/// filesystem turns into a surfaced error instead of pinning the lock, and
-/// thus every peer `aoe` process, indefinitely. The `flock` itself is released
-/// by the kernel on process exit, so a crashed holder cannot wedge peers
-/// either.
+/// (`session::worktree_edit::edit_worktree_workdir`) may run `git branch -m`
+/// and `git worktree move` while this lock is held. Both mutations are bounded
+/// by `WORKTREE_MUTATION_TIMEOUT`, so a stalled filesystem returns an error
+/// instead of blocking every identity writer indefinitely. Title writers
+/// release this lock after the durable commit and retain their per-session
+/// title and lifecycle locks through the bounded tmux rekey.
 ///
-/// Scope deliberately left OUTSIDE this lock, so `(title, project_path)`
-/// uniqueness is NOT a global invariant:
-///   - `session::smart_rename` rewrites a structured session's title from a
-///     detached one-shot without taking this lock (it only ever touches the
-///     title, never the worktree directory), so it can land a title that
-///     collides with another row.
-///   - Session-creation surfaces other than the guarded `aoe add` / rename
-///     paths (imports, restores, ACP-driven creation) do not serialize through
-///     here. The lock guarantees the add/rename endpoints cannot *introduce* a
-///     duplicate; it does not retroactively dedup rows created elsewhere.
+/// Imports, restores, and other creation surfaces that do not use guarded add
+/// or rename paths remain outside this lock. The lock prevents participating
+/// writers from introducing a duplicate; it does not repair existing rows.
 pub(crate) fn acquire_session_identity_lock() -> Result<StorageFlock> {
     acquire_storage_flock(&get_app_dir()?, SESSION_IDENTITY_LOCK_FILENAME)
 }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -37,6 +37,13 @@
 //!    crashed peer cannot wedge other aoe processes. Mirrors the pattern
 //!    already used by `recovery.rs` and `logging.rs`.
 //!
+//! Title writers additionally hold an app-global, per-session title flock
+//! across persistence and the post-commit tmux rekey. It is independent of
+//! profile so a cross-profile move and writers using either profile still
+//! serialize. Terminal title writers and launch callers then acquire the
+//! source profile's per-instance lifecycle flock before any profile Storage
+//! mutex/flock: session title -> lifecycle -> Storage.
+//!
 //! All mutation goes through `update` (load -> mutate -> save under both
 //! locks). `save_workspace_ordering` is private and only consumed by
 //! `update_workspace_ordering` internally; the per-profile `save` /
@@ -44,27 +51,28 @@
 //! impossible to bypass the locks.
 //!
 //! Lock-ordering rule across the process: a mutation that can change or create
-//! a `(title, project_path)` pair MUST first acquire the app-wide session
-//! identity flock via `acquire_session_identity_lock`, then acquire any profile
-//! `Storage` lock. The identity lock is global so a profile-changing rename
-//! never needs to hold two profile locks at once. It stays held through the
-//! authoritative duplicate check, external rename effects, persistence, and
-//! cache publication. `aoe add` acquires it only after hooks, around its final
-//! check and insert. Code must never acquire the identity lock while holding a
-//! profile `Storage` lock.
+//! a `(title, project_path)` pair first acquires the app-global session identity
+//! flock. A title-changing mutation of an existing session then acquires that
+//! session's app-dir title flock, followed by the source profile's lifecycle
+//! flock, before any profile `Storage` lock. A path-only manual edit skips the
+//! title flock but still nests lifecycle and Storage beneath identity. The
+//! identity lock is retained through the durable commit and cache publication,
+//! then released before post-commit tmux rekey; the session-title and lifecycle
+//! locks remain held through rekey. `aoe add` has no existing session id, so it
+//! takes identity directly before Storage. Launch and restart do not take
+//! identity: their order is session title, lifecycle, then Storage. Code must
+//! never acquire identity or session title while holding lifecycle or Storage.
 //!
 //! Server callers MUST drop `AppState.instances` (tokio RwLock) before
-//! acquiring either flock via `tokio::task::spawn_blocking`. A flock can park
-//! on a wedged peer for arbitrary time; holding the tokio RwLock across the
-//! wait would block every other reader/writer and park the worker thread. The
+//! acquiring any flock via `tokio::task::spawn_blocking`. A flock can park on
+//! a wedged peer for arbitrary time; holding the tokio RwLock across the wait
+//! would block every other reader/writer and park the worker thread. The
 //! cross-process storage flock is acquired AFTER the in-process mutex and
 //! released BEFORE it (RAII drop order). The closure passed to `update` is
 //! `FnOnce(...) -> Result<R>` and cannot await, so `std::sync::Mutex` is safe
-//! across the body even on the tokio runtime.
-//! Session launch callers additionally hold a per-instance lifecycle flock.
-//! The only permitted order is lifecycle flock, then the short-lived storage
-//! mutex/flock taken by `update`; a caller that already holds a lifecycle lock
-//! must use the internal locked launch path rather than reacquiring it.
+//! across the body even on the tokio runtime. A caller already holding the
+//! outer session-title and lifecycle locks must use the internal locked launch
+//! path rather than reacquiring them.
 //!
 //! Closures must remain CPU/memory only (no network, no user input, no tmux
 //! work). A closure that hangs holds both layers indefinitely and blocks
@@ -109,6 +117,9 @@ const INSTANCE_LIFECYCLE_LOCK_PREFIX: &str = ".instance-lifecycle-";
 /// The historical filename is retained so mixed-version processes still
 /// coordinate during an upgrade.
 const SESSION_IDENTITY_LOCK_FILENAME: &str = ".title-mutation.lock";
+/// Sidecar lock prefix for one session's title persistence plus tmux rekey.
+/// Lives at the app-data root so it remains stable across profile moves.
+const SESSION_TITLE_LOCK_PREFIX: &str = ".session-title-";
 
 /// Emit a tracing warn if the cross-process `flock` is held by a peer for
 /// longer than this. Surfaces a wedged peer in `aoe logs` instead of a
@@ -411,6 +422,21 @@ pub(crate) fn acquire_session_identity_lock() -> Result<StorageFlock> {
     acquire_storage_flock(&get_app_dir()?, SESSION_IDENTITY_LOCK_FILENAME)
 }
 
+/// Serialize one session's title commit and post-commit tmux rekey across
+/// profiles and processes.
+/// Callers must acquire this app-dir lock before a source per-instance
+/// lifecycle flock and before any profile [`Storage`] lock, then hold it until
+/// rekeying finishes. Keeping it separate from lifecycle locks limits its
+/// scope to title writers while still covering cross-profile moves.
+pub(crate) fn acquire_session_title_lock(instance_id: &str) -> Result<StorageFlock> {
+    super::validate_instance_id(instance_id)
+        .context("refusing session title lock for invalid instance id")?;
+    acquire_storage_flock(
+        &get_app_dir()?,
+        &format!("{SESSION_TITLE_LOCK_PREFIX}{instance_id}.lock"),
+    )
+}
+
 pub struct Storage {
     profile: String,
     sessions_path: PathBuf,
@@ -419,6 +445,8 @@ pub struct Storage {
     /// kernel-event-equivalent dispatcher path; see
     /// `FileWatchService::notify_local_change`. Cheap to clone (`Arc`).
     file_watch: Arc<FileWatchService>,
+    #[cfg(test)]
+    fail_writes_for_test: bool,
 }
 
 // Cross-device-syncable sidebar ordering. Workspaces are a client
@@ -451,6 +479,8 @@ impl Storage {
             sessions_path,
             save_lock,
             file_watch,
+            #[cfg(test)]
+            fail_writes_for_test: false,
         })
     }
 
@@ -473,6 +503,7 @@ impl Storage {
             sessions_path,
             save_lock: save_lock_for(profile),
             file_watch: FileWatchService::noop(),
+            fail_writes_for_test: false,
         }
     }
 
@@ -495,6 +526,8 @@ impl Storage {
             sessions_path,
             save_lock,
             file_watch,
+            #[cfg(test)]
+            fail_writes_for_test: false,
         })
     }
 
@@ -526,6 +559,11 @@ impl Storage {
             profile_dir,
             &format!("{INSTANCE_LIFECYCLE_LOCK_PREFIX}{instance_id}.lock"),
         )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_fail_writes_for_test(&mut self, fail: bool) {
+        self.fail_writes_for_test = fail;
     }
 
     pub fn profile(&self) -> &str {
@@ -738,6 +776,11 @@ impl Storage {
             // notify is guaranteed to read the post-rename file.
             self.file_watch.notify_local_change(&groups_path);
         }
+        #[cfg(test)]
+        if self.fail_writes_for_test {
+            anyhow::bail!("injected sessions write failure");
+        }
+
         atomic_write(&self.sessions_path, &instances_buf)?;
         self.file_watch.notify_local_change(&self.sessions_path);
         Ok(result)

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -37,7 +37,7 @@ pub mod test_support {
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
 use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
@@ -252,6 +252,25 @@ struct SessionCache {
     data: Option<HashMap<String, i64>>,
     time: Option<Instant>,
 }
+const TMUX_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn run_tmux_command_with_timeout_inner(
+    cmd: &mut Command,
+    timeout: Duration,
+) -> std::io::Result<Output> {
+    cmd.stdin(Stdio::null());
+    match crate::process::run_with_timeout(cmd, timeout)? {
+        Some(output) => Ok(output),
+        None => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!("tmux command timed out after {}s", timeout.as_secs_f64()),
+        )),
+    }
+}
+
+pub(crate) fn run_tmux_command_with_timeout(cmd: &mut Command) -> std::io::Result<Output> {
+    run_tmux_command_with_timeout_inner(cmd, TMUX_COMMAND_TIMEOUT)
+}
 
 /// Result of the authoritative `list-sessions` scan performed by
 /// [`refresh_session_cache`]. The shared cache intentionally keeps both
@@ -306,10 +325,9 @@ fn tmux_no_server_running(stderr: &[u8]) -> bool {
 
 pub fn refresh_session_cache() -> SessionCacheRefresh {
     let start = Instant::now();
-    let output = tmux_query_command()
-        .args(["list-sessions", "-F", "#{session_name}|#{session_activity}"])
-        .output();
-
+    let mut command = tmux_query_command();
+    command.args(["list-sessions", "-F", "#{session_name}|#{session_activity}"]);
+    let output = run_tmux_command_with_timeout(&mut command);
     let (new_data, outcome) = match output {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
@@ -1320,6 +1338,16 @@ mod tests {
         assert_eq!(args.first().map(|a| a.to_str().unwrap()), Some("-S"));
         assert!(args.get(1).is_some(), "socket path arg present");
         assert_eq!(cmd.get_program().to_str(), Some("tmux"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tmux_command_timeout_kills_a_stalled_client() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 5"]);
+        let error = run_tmux_command_with_timeout_inner(&mut command, Duration::from_millis(10))
+            .expect_err("stalled client must time out");
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -253,6 +253,18 @@ struct SessionCache {
     time: Option<Instant>,
 }
 
+/// Result of the authoritative `list-sessions` scan performed by
+/// [`refresh_session_cache`]. The shared cache intentionally keeps both
+/// no-server and unexpected failures as `data: None` so status pollers retain
+/// their existing conservative `Unknown` behavior; rekeying uses this outcome
+/// to suppress a warning only for the recognized no-server case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionCacheRefresh {
+    Populated,
+    NoServer,
+    Unknown,
+}
+
 // Field separator for multi-field tmux `-F` format strings. Must be a
 // printable ASCII byte that does not appear in `sanitize_session_name` output
 // (which preserves `[A-Za-z0-9_-]` and replaces everything else with `_`).
@@ -292,13 +304,13 @@ fn tmux_no_server_running(stderr: &[u8]) -> bool {
     })
 }
 
-pub fn refresh_session_cache() {
+pub fn refresh_session_cache() -> SessionCacheRefresh {
     let start = Instant::now();
     let output = tmux_query_command()
         .args(["list-sessions", "-F", "#{session_name}|#{session_activity}"])
         .output();
 
-    let new_data = match output {
+    let (new_data, outcome) = match output {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
             let mut map = HashMap::new();
@@ -308,24 +320,24 @@ pub fn refresh_session_cache() {
                     map.insert(name.to_string(), activity);
                 }
             }
-            Some(map)
+            (Some(map), SessionCacheRefresh::Populated)
+        }
+        Ok(out) if tmux_no_server_running(&out.stderr) => {
+            tracing::trace!(target: "tmux.cache", "no tmux server running; cache cleared");
+            (None, SessionCacheRefresh::NoServer)
         }
         Ok(out) => {
-            if tmux_no_server_running(&out.stderr) {
-                tracing::trace!(target: "tmux.cache", "no tmux server running; cache cleared");
-            } else {
-                tracing::warn!(
-                    target: "tmux.cache",
-                    status = ?out.status,
-                    stderr_bytes = out.stderr.len(),
-                    "list-sessions returned non-zero; cache cleared",
-                );
-            }
-            None
+            tracing::warn!(
+                target: "tmux.cache",
+                status = ?out.status,
+                stderr_bytes = out.stderr.len(),
+                "list-sessions returned non-zero; cache state unknown",
+            );
+            (None, SessionCacheRefresh::Unknown)
         }
         Err(e) => {
-            tracing::warn!(target: "tmux.cache", error = %e, "list-sessions spawn failed; cache cleared");
-            None
+            tracing::warn!(target: "tmux.cache", error = %e, "list-sessions spawn failed; cache state unknown");
+            (None, SessionCacheRefresh::Unknown)
         }
     };
 
@@ -342,6 +354,107 @@ pub fn refresh_session_cache() {
     if let Ok(mut cache) = SESSION_CACHE.write() {
         cache.data = new_data;
         cache.time = Some(Instant::now());
+    }
+    outcome
+}
+
+/// Classify the currently selected agent session without letting an
+/// ambiguous title-derived resolution turn "another live name carries this
+/// id" into confirmed absence.
+fn resolved_agent_existence(
+    id: &str,
+    session: &Session,
+    refresh: SessionCacheRefresh,
+) -> SessionExistence {
+    match refresh {
+        SessionCacheRefresh::NoServer => return SessionExistence::Absent,
+        SessionCacheRefresh::Unknown => return SessionExistence::Unknown,
+        SessionCacheRefresh::Populated => {}
+    }
+    let cache = match SESSION_CACHE.read() {
+        Ok(cache) if cache.time.is_some_and(|time| time.elapsed() <= CACHE_TTL) => cache,
+        _ => return SessionExistence::Unknown,
+    };
+    let Some(names) = cache.data.as_ref() else {
+        return SessionExistence::Unknown;
+    };
+    let suffix = id_suffix(id);
+    let shape = NameShape::agent(&suffix);
+    if !names.keys().any(|name| shape.matches(name)) {
+        return SessionExistence::Absent;
+    }
+    if names.contains_key(session.name()) {
+        SessionExistence::Present
+    } else {
+        // Multiple id-shaped candidates make `Session::new` deliberately
+        // retain the derived name. That is unresolved, not absence.
+        SessionExistence::Unknown
+    }
+}
+
+/// Rekey a live title-derived tmux session after its new title is durable.
+///
+/// Returns `Ok(false)` only when tmux authoritatively confirms that no live
+/// session exists. Title writers must persist first while holding the
+/// per-session title and lifecycle locks through this call; rekeying before
+/// commit can strand the pane when persistence fails.
+pub(crate) fn rekey_session(id: &str, old_title: &str, new_title: &str) -> anyhow::Result<bool> {
+    // Name resolution is cache-backed. Force an authoritative scan first so a
+    // process-local snapshot from before another writer's rename cannot point
+    // this mutation at the old title-derived name.
+    let initial_refresh = refresh_session_cache();
+    let session = Session::new(id, old_title)?;
+    match resolved_agent_existence(id, &session, initial_refresh) {
+        SessionExistence::Present => {}
+        SessionExistence::Absent => return Ok(false),
+        SessionExistence::Unknown => {
+            anyhow::bail!("Could not determine whether the tmux session exists")
+        }
+    }
+
+    let new_name = Session::generate_name(id, new_title);
+    let original_name = session.name().to_string();
+    let original_error = match session.rename(&new_name) {
+        Ok(()) => {
+            refresh_session_cache();
+            return Ok(true);
+        }
+        Err(error) => error,
+    };
+
+    // Another process may have rekeyed this id between our scan and
+    // rename-session. Refresh and resolve by the immutable id suffix, then
+    // retry once only when that same live session is confirmed under a newer
+    // name. A transient query failure is not evidence the pane disappeared,
+    // so preserve the original rename error in that case.
+    let retry_refresh = refresh_session_cache();
+    let refreshed = Session::new(id, old_title)?;
+    match resolved_agent_existence(id, &refreshed, retry_refresh) {
+        SessionExistence::Absent => return Ok(false),
+        SessionExistence::Unknown => return Err(original_error),
+        SessionExistence::Present => {}
+    }
+    if refreshed.name() == new_name {
+        return Ok(true);
+    }
+    if refreshed.name() == original_name {
+        return Err(original_error);
+    }
+
+    let retry_error = match refreshed.rename(&new_name) {
+        Ok(()) => {
+            refresh_session_cache();
+            return Ok(true);
+        }
+        Err(error) => error,
+    };
+    let final_refresh = refresh_session_cache();
+    let final_session = Session::new(id, old_title)?;
+    match resolved_agent_existence(id, &final_session, final_refresh) {
+        SessionExistence::Absent => Ok(false),
+        SessionExistence::Unknown => Err(original_error),
+        SessionExistence::Present if final_session.name() == new_name => Ok(true),
+        SessionExistence::Present => Err(retry_error),
     }
 }
 
@@ -570,11 +683,11 @@ fn session_name_from_cache(derived: &str, shape: &NameShape) -> Option<String> {
     if !fresh {
         return None;
     }
-    // A fresh snapshot with no data means the last `list-sessions` itself
-    // failed (no server running, unreachable socket). That is not evidence
-    // about any name, and it is an answer, not a stale snapshot: returning
-    // `None` here would make every caller re-refresh into the same failure,
-    // one subprocess per call from render loops that never had a session.
+    // A fresh snapshot with no data means the last `list-sessions` produced
+    // either no-server or an unexpected failure. Neither selects a live name,
+    // and this is an answer rather than a stale snapshot: returning `None`
+    // would make every caller re-refresh into the same result, one subprocess
+    // per call from render loops.
     let Some(names) = cache.data.as_ref() else {
         return Some(derived.to_string());
     };
@@ -897,8 +1010,9 @@ pub enum SessionExistence {
     Present,
     /// The tmux server answered and the session is not in its list.
     Absent,
-    /// The tmux server could not be reached (refused connection, stale
-    /// socket, spawn failure). This is NOT evidence the session is gone.
+    /// The shared cache cannot establish liveness (including a recognized
+    /// no-server response or an unexpected query failure). This is NOT
+    /// evidence the session is gone.
     Unknown,
 }
 
@@ -920,24 +1034,18 @@ fn session_existence_from_cache(name: &str) -> Option<SessionExistence> {
     Some(match &cache.data {
         Some(map) if map.contains_key(name) => SessionExistence::Present,
         Some(_) => SessionExistence::Absent,
-        // The last refresh's `list-sessions` call itself failed (non-zero
-        // exit or spawn error): a definitive "can't tell", not "absent".
-        // Do not fall back to a fresh `has-session` probe here; during a
-        // real outage that call fails the same way and just burns a
-        // subprocess per session per poll for no new information.
+        // The last refresh could not produce a session list (recognized
+        // no-server response or unexpected query failure): a definitive
+        // "can't tell" for status polling, not "absent". Do not fall back to a
+        // fresh `has-session` probe here; during an outage that call fails the
+        // same way and just burns a subprocess per session per poll for no new
+        // information.
         //
-        // This is also why a fully-down server can never resolve to
-        // `Absent` here: aoe's tmux sessions run with `remain-on-exit on`,
-        // so a dying agent leaves its pane dead but the session itself
-        // `Present` in `list-sessions`. The only way `list-sessions` fails
-        // is the server process itself being gone (crash, `kill-server`,
-        // or the last session in it being killed), and that case is
-        // indistinguishable from a transient connectivity blip from here.
-        // Resolving it to `Unknown` freezes every polled instance at its
+        // Resolving this arm to `Unknown` freezes every polled instance at its
         // prior status until the bounded-window escalation in
-        // `update_status_with_metadata_inner` kicks in; do not "fix" this
-        // arm back to `Absent`, that is the false-Error-latch bug this
-        // tri-state exists to prevent.
+        // `update_status_with_metadata_inner` kicks in; do not collapse it to
+        // `Absent`. Rekeying separately consumes `SessionCacheRefresh` so it
+        // can treat a recognized no-server result as an absent rename target.
         None => SessionExistence::Unknown,
     })
 }
@@ -1280,13 +1388,44 @@ mod tests {
     fn probe_session_existence_returns_unknown_when_server_unreachable() {
         let guard = SessionCacheGuard::capture();
         let name = format!("{P}probe_unknown_abc12345");
-        // Simulates the last `list-sessions` call failing (stale socket,
-        // refused connection): the cache is fresh but has no data. This must
-        // resolve straight from the cache, without falling back to a fresh
-        // `has-session` subprocess call (which would just fail the same way
-        // during a real outage).
+        // Simulates `list-sessions` failing unexpectedly (permission denied,
+        // malformed socket, or spawn failure): the cache is fresh but has no
+        // data. This must resolve straight from the cache, without falling
+        // back to a fresh `has-session` subprocess call.
         guard.force_unreachable();
         assert_eq!(probe_session_existence(&name), SessionExistence::Unknown);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn rekey_classification_treats_confirmed_no_server_as_absent() {
+        let guard = SessionCacheGuard::capture();
+        let id = "noserverdeadbeef";
+        guard.force_unreachable();
+        let session = Session::new(id, "derived").unwrap();
+        assert_eq!(
+            resolved_agent_existence(id, &session, SessionCacheRefresh::NoServer),
+            SessionExistence::Absent
+        );
+        assert_eq!(
+            resolved_agent_existence(id, &session, SessionCacheRefresh::Unknown),
+            SessionExistence::Unknown
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ambiguous_live_names_are_unknown_not_confirmed_absence() {
+        let guard = SessionCacheGuard::capture();
+        let id = "ambig123deadbeef";
+        let first = format!("{P}first_ambig123");
+        let second = format!("{P}second_ambig123");
+        guard.force_present(&[&first, &second]);
+        let session = Session::new(id, "derived").unwrap();
+        assert_eq!(
+            resolved_agent_existence(id, &session, SessionCacheRefresh::Populated),
+            SessionExistence::Unknown
+        );
     }
 
     /// A session id long enough that `truncate_id(.., 8)` actually truncates,

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -378,18 +378,17 @@ fn resolved_agent_existence(
     let Some(names) = cache.data.as_ref() else {
         return SessionExistence::Unknown;
     };
+    if names.contains_key(session.name()) {
+        return SessionExistence::Present;
+    }
     let suffix = id_suffix(id);
     let shape = NameShape::agent(&suffix);
     if !names.keys().any(|name| shape.matches(name)) {
         return SessionExistence::Absent;
     }
-    if names.contains_key(session.name()) {
-        SessionExistence::Present
-    } else {
-        // Multiple id-shaped candidates make `Session::new` deliberately
-        // retain the derived name. That is unresolved, not absence.
-        SessionExistence::Unknown
-    }
+    // Multiple id-shaped candidates make `Session::new` deliberately retain
+    // the derived name. That is unresolved, not absence.
+    SessionExistence::Unknown
 }
 
 /// Rekey a live title-derived tmux session after its new title is durable.
@@ -1428,6 +1427,19 @@ mod tests {
         );
     }
 
+    #[test]
+    #[serial_test::serial]
+    fn aux_shaped_live_derived_name_is_present_not_absent() {
+        let guard = SessionCacheGuard::capture();
+        let id = "auxshapedeadbeef";
+        let session = Session::new(id, "term rewriting").unwrap();
+        guard.force_present(&[session.name()]);
+        assert_eq!(
+            resolved_agent_existence(id, &session, SessionCacheRefresh::Populated),
+            SessionExistence::Present
+        );
+    }
+
     /// A session id long enough that `truncate_id(.., 8)` actually truncates,
     /// so the tests exercise the real `_<id8>` tail.
     const ID: &str = "abc12345deadbeef";
@@ -1857,6 +1869,75 @@ mod tests {
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn rekey_session_adopts_peer_renamed_pane() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let start_name = Session::generate_name(ID, "Fix login bug");
+        let peer_name = Session::generate_name(ID, "Peer rename");
+        let final_name = Session::generate_name(ID, "Final rename");
+        let start_guard = TmuxTestSession::from_name(start_name.clone());
+        let peer_guard = TmuxTestSession::from_name(peer_name.clone());
+        let final_guard = TmuxTestSession::from_name(final_name.clone());
+        let created = tmux_command()
+            .args(["new-session", "-d", "-s", start_guard.name(), "sleep 60"])
+            .output()
+            .expect("tmux new-session");
+        assert!(created.status.success());
+        refresh_session_cache();
+
+        // A sibling process renames the live pane without refreshing this
+        // process's cache. `rekey_session` must scan first, adopt the
+        // id-matching peer name, and move that same pane to the destination.
+        let peer_rename = tmux_command()
+            .args(["rename-session", "-t", &start_name, &peer_name])
+            .output()
+            .expect("peer tmux rename");
+        assert!(peer_rename.status.success());
+        assert!(rekey_session(ID, "Fix login bug", "Final rename").unwrap());
+        assert!(Session::from_name(&final_name).exists());
+        drop((start_guard, peer_guard, final_guard));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn rekey_session_reports_false_for_vanished_pane() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        // Keep the isolated tmux server alive after the target is killed, so
+        // the assertion distinguishes an absent session from a vanished server.
+        let dummy_guard = TmuxTestSession::new("aoe_test_rekey_dummy");
+        let dummy_created = tmux_command()
+            .args(["new-session", "-d", "-s", dummy_guard.name(), "sleep 60"])
+            .output()
+            .expect("dummy tmux new-session");
+        assert!(dummy_created.status.success());
+        let name = Session::generate_name(ID, "Final rename");
+        let guard = TmuxTestSession::from_name(name.clone());
+        let created = tmux_command()
+            .args(["new-session", "-d", "-s", guard.name(), "sleep 60"])
+            .output()
+            .expect("tmux new-session");
+        assert!(created.status.success());
+        // Populate a positive cache entry, then remove the target without
+        // refreshing it. The authoritative refresh inside `rekey_session` must
+        // classify the vanished pane as `Ok(false)`, keeping API/TUI callers
+        // from showing a warning.
+        refresh_session_cache();
+        let killed = tmux_command()
+            .args(["kill-session", "-t", &name])
+            .output()
+            .expect("tmux kill-session");
+        assert!(killed.status.success());
+        assert!(!rekey_session(ID, "Final rename", "No live pane").unwrap());
+        drop((guard, dummy_guard));
     }
 
     /// Verify that the compound-command approach (export + exec) correctly

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -620,9 +620,9 @@ impl Session {
             return Ok(());
         }
 
-        let output = crate::tmux::tmux_command()
-            .args(["rename-session", "-t", &self.name, new_name])
-            .output()?;
+        let mut command = crate::tmux::tmux_command();
+        command.args(["rename-session", "-t", &self.name, new_name]);
+        let output = crate::tmux::run_tmux_command_with_timeout(&mut command)?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/tmux/test_helpers.rs
+++ b/src/tmux/test_helpers.rs
@@ -27,6 +27,12 @@ impl TmuxTestSession {
         }
     }
 
+    /// Guard an exact name derived by production naming code. The caller is
+    /// still responsible for choosing a unique name and creating the session.
+    pub(crate) fn from_name(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
     pub(crate) fn name(&self) -> &str {
         &self.name
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -6770,26 +6770,39 @@ impl HomeView {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Session not found: {id}"))?;
         let source_profile = snapshot.source_profile.clone();
-        let session_title = crate::session::acquire_session_title_lock(id).map_err(|error| {
-            anyhow::anyhow!("failed to acquire session title lock: {error}")
-        })?;
-        let storage = Storage::new(&source_profile, self.file_watch.clone())?;
+        let session_title = crate::session::acquire_session_title_lock(id)
+            .map_err(|error| anyhow::anyhow!("failed to acquire session title lock: {error}"))?;
+        if !self.storages.contains_key(&source_profile) {
+            self.storages.insert(
+                source_profile.clone(),
+                Storage::open(&source_profile, self.file_watch.clone())?,
+            );
+        }
+        let storage = self
+            .storages
+            .get(&source_profile)
+            .expect("source storage was registered above");
         let lifecycle = storage
             .acquire_instance_lifecycle_lock(id)
             .map_err(|error| {
                 anyhow::anyhow!("failed to acquire session lifecycle lock: {error}")
             })?;
-        let mut authoritative = storage.update(|instances, _groups| {
-            instances
-                .iter()
-                .find(|instance| instance.id == id)
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("Session not found in source profile: {id}"))
-        })?;
+        // Read-only: both flocks (title + lifecycle) are already held above, so
+        // a plain `load()` gives the authoritative on-disk row without going
+        // through `update()`, which would unconditionally rewrite sessions.json
+        // and fire a `notify_local_change` even when nothing changed. Callers
+        // like `move_group_to_profile` acquire these guards per member in a
+        // loop, so an update-per-read would be N identical rewrites.
+        let mut authoritative = storage
+            .load()?
+            .into_iter()
+            .find(|instance| instance.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found in source profile: {id}"))?;
         let authoritative_generation = authoritative.lifecycle_generation;
         let authoritative_status = authoritative.status;
         let authoritative_idle_entered_at = authoritative.idle_entered_at;
         let authoritative_last_accessed_at = authoritative.last_accessed_at;
+        authoritative.merge_runtime_from_reload(&snapshot);
         authoritative.merge_from_tui(&snapshot);
         authoritative.source_profile.clone_from(&source_profile);
         authoritative.lifecycle_generation = authoritative_generation;
@@ -6819,19 +6832,28 @@ impl HomeView {
         target: &str,
         new_group_path: String,
     ) -> anyhow::Result<()> {
-        let Some(old_profile) = self.instances.get(id).map(|i| i.source_profile.clone()) else {
+        let now = chrono::Utc::now();
+        let Some((old_profile, lifecycle_reserved)) = self.instances.get(id).map(|instance| {
+            (
+                instance.source_profile.clone(),
+                instance.has_fresh_lifecycle_reservation(now),
+            )
+        }) else {
             return Ok(());
         };
         if old_profile == target {
             self.mutate_instance(id, |inst| inst.group_path = new_group_path);
             return Ok(());
         }
-
+        anyhow::ensure!(
+            !lifecycle_reserved,
+            "Cannot move session {id} between profiles while a lifecycle operation is in progress"
+        );
 
         if !self.storages.contains_key(target) {
             self.storages.insert(
                 target.to_string(),
-                Storage::new(target, self.file_watch.clone())?,
+                Storage::open(target, self.file_watch.clone())?,
             );
         }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -72,6 +72,16 @@ enum CreationCommit {
     Duplicate(Box<Instance>),
 }
 
+/// Cross-process guards for a single-session title mutation or profile move.
+/// The source profile's lifecycle flock is intentionally nested inside the
+/// per-session title flock; callers retain this value through durable
+/// persistence and any tmux rekey so a terminal launch cannot observe the
+/// transition halfway through.
+pub(super) struct SessionMutationGuards {
+    _session_title: crate::session::StorageFlock,
+    _lifecycle: crate::session::StorageFlock,
+}
+
 /// The GroupTree identity key for a session in project mode. Worktree sessions
 /// key on `main_repo_path` (so all branches of a repo group together); other
 /// sessions key on the last segment of `project_path`. Scratch sessions key on
@@ -6745,12 +6755,64 @@ impl HomeView {
         }
     }
 
+    /// Acquire the per-session title flock followed by the source profile's
+    /// per-instance lifecycle flock, then replace the TUI snapshot with the
+    /// authoritative source row. Only TUI-owned launch configuration is merged
+    /// from the snapshot; lifecycle/runtime fields always remain the values
+    /// reloaded under the source lifecycle lock.
+    pub(super) fn lock_session_mutation_and_reload(
+        &mut self,
+        id: &str,
+    ) -> anyhow::Result<SessionMutationGuards> {
+        let snapshot = self
+            .instances
+            .get(id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {id}"))?;
+        let source_profile = snapshot.source_profile.clone();
+        let session_title = crate::session::acquire_session_title_lock(id).map_err(|error| {
+            anyhow::anyhow!("failed to acquire session title lock: {error}")
+        })?;
+        let storage = Storage::new(&source_profile, self.file_watch.clone())?;
+        let lifecycle = storage
+            .acquire_instance_lifecycle_lock(id)
+            .map_err(|error| {
+                anyhow::anyhow!("failed to acquire session lifecycle lock: {error}")
+            })?;
+        let mut authoritative = storage.update(|instances, _groups| {
+            instances
+                .iter()
+                .find(|instance| instance.id == id)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Session not found in source profile: {id}"))
+        })?;
+        let authoritative_generation = authoritative.lifecycle_generation;
+        let authoritative_status = authoritative.status;
+        let authoritative_idle_entered_at = authoritative.idle_entered_at;
+        let authoritative_last_accessed_at = authoritative.last_accessed_at;
+        authoritative.merge_from_tui(&snapshot);
+        authoritative.source_profile.clone_from(&source_profile);
+        authoritative.lifecycle_generation = authoritative_generation;
+        authoritative.status = authoritative_status;
+        authoritative.idle_entered_at = authoritative_idle_entered_at;
+        authoritative.last_accessed_at =
+            authoritative_last_accessed_at.max(snapshot.last_accessed_at);
+        self.instances.insert(id.to_string(), authoritative);
+        Ok(SessionMutationGuards {
+            _session_title: session_title,
+            _lifecycle: lifecycle,
+        })
+    }
+
     /// Cross-profile move: structurally distinct from `mutate_instance`
     /// because the row must be tombstoned in the old profile's disk file
     /// AND marked as TUI-new for the target profile. Without this, save()'s
     /// per-profile loop misclassifies the row as peer-deleted in the new
     /// profile and leaves the old profile's disk row, which next reload
     /// resurrects under the original profile.
+    ///
+    /// Callers that need cross-process title/lifecycle serialization retain
+    /// [`SessionMutationGuards`] around this mutation and its durable save.
     pub(super) fn move_to_profile(
         &mut self,
         id: &str,
@@ -6764,6 +6826,7 @@ impl HomeView {
             self.mutate_instance(id, |inst| inst.group_path = new_group_path);
             return Ok(());
         }
+
 
         if !self.storages.contains_key(target) {
             self.storages.insert(

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -28,6 +28,21 @@ fn group_membership<'a>(
     }
 }
 
+fn rekey_tmux_after_persist(id: &str, old_title: &str, new_title: &str) -> Option<String> {
+    if old_title == new_title {
+        return None;
+    }
+    match crate::tmux::rekey_session(id, old_title, new_title) {
+        Ok(_) => None,
+        Err(error) => {
+            tracing::warn!(target: "tui.home", session = %id, "tmux rename failed after persistence: {error}");
+            Some(format!(
+                "Session metadata was renamed, but its live tmux session could not be rekeyed: {error}"
+            ))
+        }
+    }
+}
+
 /// Compact human readable label for the snooze status line (`"30 min"`,
 /// `"1 hr"`, `"24 hr"`, `"2 hr 30 min"`). The picker only ever submits
 /// 30 / 60 / 1440, but formatting is kept general so arbitrary values
@@ -408,6 +423,29 @@ impl HomeView {
         }
         self.restart_cooldown_at.insert(id.clone(), now);
 
+        // A restart-dialog profile move owns the ordered title/source
+        // lifecycle guards before any tool/config persistence. This prevents
+        // the target seed and the eventual launch from straddling a newer
+        // source-profile mutation.
+        let source_profile = self
+            .get_instance(&id)
+            .map(|instance| instance.source_profile.clone())
+            .unwrap_or_else(|| self.config_profile());
+        let moving_profiles =
+            new_profile.is_some_and(|target_profile| target_profile != source_profile);
+        if moving_profiles {
+            let target_profile = new_profile.expect("moving_profiles requires a target");
+            let profiles = list_profiles()?;
+            if !profiles.contains(&target_profile.to_string()) {
+                anyhow::bail!("Profile '{}' does not exist", target_profile);
+            }
+        }
+        let profile_move_guards = if moving_profiles {
+            Some(self.lock_session_mutation_and_reload(&id)?)
+        } else {
+            None
+        };
+
         // Outside Attention sort, restart on a snoozed row clears the
         // snooze flag so the persisted state matches what the user sees
         // after the wake-up (a Running row, no snooze badge). Sequenced
@@ -464,10 +502,6 @@ impl HomeView {
                         .unwrap_or_else(|| "default".to_string())
                 });
             if target_profile != current_profile {
-                let profiles = list_profiles()?;
-                if !profiles.contains(&target_profile.to_string()) {
-                    anyhow::bail!("Profile '{}' does not exist", target_profile);
-                }
                 if !self.storages.contains_key(target_profile) {
                     self.storages.insert(
                         target_profile.to_string(),
@@ -506,6 +540,10 @@ impl HomeView {
         // state. The worker owns the Starting reservation; publishing that
         // status here would make it reject its own request as concurrent.
         self.save()?;
+        // A profile move retains title -> source lifecycle ordering through
+        // both profile writes. The restart worker acquires its own ordered
+        // guards when it later launches the terminal.
+        drop(profile_move_guards);
 
         // The start cascade shells out to docker (image pull, container
         // create/start) and runs the before_start host hook, any of which can
@@ -845,7 +883,7 @@ impl HomeView {
 
         let old_prefix = format!("{}/", ctx.old_path);
 
-        // Collect sessions belonging to this group and its descendants
+        // Collect sessions belonging to this group and its descendants.
         let is_member = group_membership(&ctx.old_path, &old_prefix, Some(&ctx.old_profile));
         let affected_ids: Vec<String> = self
             .instances
@@ -854,7 +892,8 @@ impl HomeView {
             .map(|i| i.id.clone())
             .collect();
 
-        // Update group_path (and optionally source_profile) for all affected sessions
+
+        // Update group_path (and optionally source_profile) for all affected sessions.
         for id in &affected_ids {
             let new_group_path = if new_path != ctx.old_path {
                 let inst = self.get_instance(id);
@@ -879,7 +918,7 @@ impl HomeView {
             }
         }
 
-        // Ensure target profile storage exists when moving across profiles
+        // Ensure target profile storage exists when moving across profiles.
         if let Some(tp) = new_profile {
             if tp != ctx.old_profile && !self.storages.contains_key(tp) {
                 self.storages
@@ -888,7 +927,7 @@ impl HomeView {
         }
 
         let path_changed = new_path != ctx.old_path;
-        let profile_changed = new_profile.is_some_and(|p| p != ctx.old_profile);
+        let profile_changed = new_profile.is_some_and(|profile| profile != ctx.old_profile);
 
         // Capture old_path and its descendants from the pre-rebuild tree:
         // rebuild_group_trees below derives groups from instance.group_path,
@@ -948,20 +987,51 @@ impl HomeView {
         let Some(id) = self.selected_session.clone() else {
             return Ok(());
         };
-        let snapshot = self.get_instance(&id).map(|i| {
-            (
-                i.worktree_info.clone(),
-                i.status,
-                i.project_path.clone(),
-                i.is_sandboxed(),
-            )
-        });
-        let Some((worktree_info, status, project_path, is_sandboxed)) = snapshot else {
-            anyhow::bail!("Session not found");
-        };
+        let live = self
+            .get_instance(&id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+        let source_profile = live.source_profile.clone();
+        let _identity_lock = acquire_session_identity_lock()?;
+        let storage = Storage::new(&source_profile, self.file_watch.clone())?;
+        let _lifecycle_lock = storage.acquire_instance_lifecycle_lock(&id)?;
+        let authoritative_instances = storage.load()?;
+        let mut authoritative = authoritative_instances
+            .iter()
+            .find(|instance| instance.id == id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+        authoritative.source_profile.clone_from(&source_profile);
+        authoritative.merge_runtime_from_reload(&live);
+        self.instances.insert(id.clone(), authoritative.clone());
+        let worktree_info = authoritative.worktree_info.clone();
+        let status = authoritative.status;
+        let project_path = authoritative.project_path.clone();
+        let is_sandboxed = authoritative.is_sandboxed();
         let Some(worktree_info) = worktree_info else {
             anyhow::bail!("Session does not use a worktree");
         };
+        let duplicate_path = crate::session::worktree_edit::target_worktree_path(
+            std::path::Path::new(&project_path),
+            new_name,
+        )
+        .unwrap_or_else(|| std::path::PathBuf::from(&project_path))
+        .to_string_lossy()
+        .into_owned();
+        if duplicate_path.trim_end_matches('/') != project_path.trim_end_matches('/')
+            && is_duplicate_session(
+                authoritative_instances.iter(),
+                &authoritative.title,
+                &duplicate_path,
+                Some(&id),
+            )
+        {
+            self.info_dialog = Some(crate::tui::dialogs::InfoDialog::new(
+                "Rename Failed",
+                &duplicate_session_error(&authoritative.title).to_string(),
+            ));
+            return Ok(());
+        }
         if status.blocks_worktree_edit() {
             anyhow::bail!("Stop the session before editing its workdir name");
         }
@@ -1016,6 +1086,7 @@ impl HomeView {
                 }
             }
         })?;
+        drop(_identity_lock);
 
         self.rebuild_group_trees();
         self.save()?;
@@ -1112,36 +1183,29 @@ impl HomeView {
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
             let current_profile = live.source_profile.clone();
-            // The app-wide guard covers profile-changing renames too, so the
-            // authoritative target-profile check and both profile writes are
-            // one identity transaction without nesting profile locks.
+            let title_changed_by_user = !new_title.is_empty() && new_title != live.title;
+            // The app-wide identity guard covers profile-changing renames too.
+            // Existing-session guards nest beneath it in the order session
+            // title -> source lifecycle -> profile Storage.
             let _identity_lock = acquire_session_identity_lock()?;
-            let stored = if let Some(storage) = self.storages.get(&current_profile) {
-                storage.load()?
-            } else {
-                Storage::new(&current_profile, self.file_watch.clone())?.load()?
-            };
-            let mut previous = stored
-                .into_iter()
-                .find(|instance| instance.id == id)
+            let _mutation_guards = self.lock_session_mutation_and_reload(&id)?;
+            let previous = self
+                .get_instance(&id)
+                .cloned()
                 .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
-            previous.source_profile.clone_from(&current_profile);
-            previous.merge_runtime_from_reload(&live);
-            self.instances.insert(id.clone(), previous.clone());
             let current_title = previous.title.clone();
             let current_group = previous.group_path.clone();
 
-            // Determine effective title (keep current if empty)
-            let effective_title = if new_title.is_empty() {
+            // Empty or dialog-unchanged text means preserve the authoritative
+            // source title, never the snapshot captured before the locks.
+            let effective_title = if !title_changed_by_user {
                 current_title.clone()
             } else {
                 new_title.to_string()
             };
-
-            // Determine effective group
             let effective_group = match new_group {
-                None => current_group.clone(), // Keep current
-                Some(g) => g.to_string(),      // Set new (empty string means ungroup)
+                None => current_group.clone(),
+                Some(group) => group.to_string(),
             };
 
             let target_profile = new_profile.unwrap_or(&current_profile);
@@ -1286,33 +1350,13 @@ impl HomeView {
             // Handle profile change (move session to different profile)
             if let Some(target_profile) = new_profile {
                 if target_profile != current_profile {
-                    // Get the instance to move
-                    let mut instance = self
-                        .get_instance(&id)
-                        .cloned()
-                        .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
-
-                    // Apply title and group changes to the instance
-                    instance.title = effective_title.clone();
-                    instance.group_path = effective_group.clone();
-
-                    // Handle tmux rename if title changed
-                    if let Some(orig_inst) = self.get_instance(&id) {
-                        if orig_inst.title != effective_title {
-                            let tmux_session = orig_inst.tmux_session()?;
-                            if tmux_session.exists() {
-                                let new_tmux_name =
-                                    crate::tmux::Session::generate_name(&id, &effective_title);
-                                if let Err(e) = tmux_session.rename(&new_tmux_name) {
-                                    tracing::warn!(target: "tui.home", "Failed to rename tmux session: {}", e);
-                                } else {
-                                    crate::tmux::refresh_session_cache();
-                                }
-                            }
-                        }
+                    // Validate target profile exists
+                    let profiles = list_profiles()?;
+                    if !profiles.contains(&target_profile.to_string()) {
+                        anyhow::bail!("Profile '{}' does not exist", target_profile);
                     }
 
-                    // Ensure target profile storage exists
+                    // Ensure target profile storage exists.
                     if !self.storages.contains_key(target_profile) {
                         self.storages.insert(
                             target_profile.to_string(),
@@ -1320,17 +1364,14 @@ impl HomeView {
                         );
                     }
 
-                    // Update source_profile and save (handles moving between profiles)
-                    instance.source_profile = target_profile.to_string();
-                    let new_title = instance.title.clone();
                     let moved_path = new_path.clone();
                     let moved_branch = new_branch.clone();
-                    self.move_to_profile(&id, target_profile, instance.group_path.clone())?;
+                    self.move_to_profile(&id, target_profile, effective_group.clone())?;
                     // apply_user_action (not mutate_instance + save) so a tied
                     // worktree's moved project_path actually persists; save()
                     // via merge_from_tui does not write project_path. (#1927)
                     self.apply_user_action(&id, |inst| {
-                        inst.title = new_title.clone();
+                        inst.title = effective_title.clone();
                         if let Some(path) = &moved_path {
                             inst.project_path = path.clone();
                         }
@@ -1362,22 +1403,15 @@ impl HomeView {
                         }
                     }
                     self.save()?;
+                    drop(_identity_lock);
+                    let tmux_warning =
+                        rekey_tmux_after_persist(&id, &current_title, &effective_title);
                     self.reload()?;
-                    return Ok(());
-                }
-            }
-
-            // Rename tmux session BEFORE mutating the instance, so we can
-            // look up the session by its current (old) name.
-            if current_title != effective_title {
-                let old_tmux_session = crate::tmux::Session::new(&id, &current_title)?;
-                if old_tmux_session.exists() {
-                    let new_tmux_name = crate::tmux::Session::generate_name(&id, &effective_title);
-                    if let Err(e) = old_tmux_session.rename(&new_tmux_name) {
-                        tracing::warn!(target: "tui.home", "Failed to rename tmux session: {}", e);
-                    } else {
-                        crate::tmux::refresh_session_cache();
+                    if let Some(warning) = tmux_warning {
+                        self.info_dialog =
+                            Some(InfoDialog::new("Rename Saved with Warning", &warning));
                     }
+                    return Ok(());
                 }
             }
 
@@ -1393,6 +1427,8 @@ impl HomeView {
                     }
                 }
             })?;
+            drop(_identity_lock);
+            let tmux_warning = rekey_tmux_after_persist(&id, &current_title, &effective_title);
 
             // Rebuild group trees and create group if needed
             self.rebuild_group_trees();
@@ -1406,8 +1442,10 @@ impl HomeView {
                 }
             }
             self.save()?;
-
             self.reload()?;
+            if let Some(warning) = tmux_warning {
+                self.info_dialog = Some(InfoDialog::new("Rename Saved with Warning", &warning));
+            }
         }
         Ok(())
     }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -421,7 +421,6 @@ impl HomeView {
                 return Ok(());
             }
         }
-        self.restart_cooldown_at.insert(id.clone(), now);
 
         // A restart-dialog profile move owns the ordered title/source
         // lifecycle guards before any tool/config persistence. This prevents
@@ -440,11 +439,31 @@ impl HomeView {
                 anyhow::bail!("Profile '{}' does not exist", target_profile);
             }
         }
+        let profile_identity_guard = if moving_profiles {
+            Some(acquire_session_identity_lock()?)
+        } else {
+            None
+        };
         let profile_move_guards = if moving_profiles {
             Some(self.lock_session_mutation_and_reload(&id)?)
         } else {
             None
         };
+        if let Some(target_profile) = new_profile.filter(|_| moving_profiles) {
+            let authoritative = self
+                .get_instance(&id)
+                .ok_or_else(|| anyhow::anyhow!("Session not found: {id}"))?;
+            let target_rows = Storage::open(target_profile, self.file_watch.clone())?.load()?;
+            if is_duplicate_session(
+                target_rows.iter(),
+                &authoritative.title,
+                &authoritative.project_path,
+                None,
+            ) {
+                return Err(duplicate_session_error(&authoritative.title));
+            }
+        }
+        self.restart_cooldown_at.insert(id.clone(), now);
 
         // Outside Attention sort, restart on a snoozed row clears the
         // snooze flag so the persisted state matches what the user sees
@@ -489,25 +508,11 @@ impl HomeView {
             });
         }
 
-        // Apply profile move. Validates the target exists, lazily creates
-        // its Storage, and rebuilds group trees so the row renders under
-        // the new profile immediately.
+        // Apply profile move. The target was validated above; `move_to_profile`
+        // opens its existing Storage and rebuilds group trees so the row renders
+        // under the new profile immediately.
         if let Some(target_profile) = new_profile {
-            let current_profile = self
-                .get_instance(&id)
-                .map(|i| i.source_profile.clone())
-                .unwrap_or_else(|| {
-                    self.active_profile
-                        .clone()
-                        .unwrap_or_else(|| "default".to_string())
-                });
-            if target_profile != current_profile {
-                if !self.storages.contains_key(target_profile) {
-                    self.storages.insert(
-                        target_profile.to_string(),
-                        Storage::new(target_profile, self.file_watch.clone())?,
-                    );
-                }
+            if target_profile != source_profile {
                 if !self.group_trees.contains_key(target_profile) {
                     self.group_trees.insert(
                         target_profile.to_string(),
@@ -525,7 +530,7 @@ impl HomeView {
                     .map(|i| i.group_path.clone())
                     .unwrap_or_default();
                 self.move_to_profile(&id, target_profile, old_group_path.clone())?;
-                self.prune_empty_group(&current_profile, &old_group_path);
+                self.prune_empty_group(&source_profile, &old_group_path);
                 self.rebuild_group_trees();
                 // Rebuild the visible row list too; otherwise the row still
                 // renders under the old profile until the next reload, and
@@ -540,9 +545,14 @@ impl HomeView {
         // state. The worker owns the Starting reservation; publishing that
         // status here would make it reject its own request as concurrent.
         self.save()?;
+        drop(profile_identity_guard);
         // A profile move retains title -> source lifecycle ordering through
-        // both profile writes. The restart worker acquires its own ordered
-        // guards when it later launches the terminal.
+        // both profile writes. These MUST be dropped before the restart is
+        // dispatched: the launch reacquires the very same title flock (see
+        // `Instance::orchestrate_resume_launch`), and flock is not reentrant
+        // across a second open of the file, so holding the guards into the
+        // cascade would self-deadlock. The restart worker acquires its own
+        // ordered guards when it later launches the terminal.
         drop(profile_move_guards);
 
         // The start cascade shells out to docker (image pull, container
@@ -859,6 +869,7 @@ impl HomeView {
 
         // Defense-in-depth: reject duplicate names (dialog validates inline, but guard here too)
         let target_profile = new_profile.unwrap_or(&ctx.old_profile);
+        let profile_changed = target_profile != ctx.old_profile;
         if new_path != ctx.old_path {
             if let Some(tree) = self.group_trees.get(target_profile) {
                 if tree.group_exists(new_path) {
@@ -871,63 +882,98 @@ impl HomeView {
             }
         }
 
-        // Validate target profile exists when moving across profiles
-        if let Some(target) = new_profile {
-            if target != ctx.old_profile {
-                let profiles = list_profiles()?;
-                if !profiles.contains(&target.to_string()) {
-                    anyhow::bail!("Profile '{}' does not exist", target);
-                }
+        if profile_changed {
+            let profiles = list_profiles()?;
+            if !profiles.contains(&target_profile.to_string()) {
+                anyhow::bail!("Profile '{}' does not exist", target_profile);
             }
         }
 
         let old_prefix = format!("{}/", ctx.old_path);
-
-        // Collect sessions belonging to this group and its descendants.
         let is_member = group_membership(&ctx.old_path, &old_prefix, Some(&ctx.old_profile));
-        let affected_ids: Vec<String> = self
+        let _identity_guard = if profile_changed {
+            Some(acquire_session_identity_lock()?)
+        } else {
+            None
+        };
+        let mut affected_ids: Vec<String> = self
             .instances
             .values()
-            .filter(|i| is_member(i))
-            .map(|i| i.id.clone())
+            .filter(|instance| is_member(instance))
+            .map(|instance| instance.id.clone())
             .collect();
+        if profile_changed {
+            affected_ids.sort();
+        }
 
+        let _mutation_guards = if profile_changed {
+            let mut guards = Vec::with_capacity(affected_ids.len());
+            for id in &affected_ids {
+                guards.push(self.lock_session_mutation_and_reload(id)?);
+            }
+            let now = chrono::Utc::now();
+            for id in &affected_ids {
+                let authoritative = self
+                    .get_instance(id)
+                    .ok_or_else(|| anyhow::anyhow!("Session not found: {id}"))?;
+                anyhow::ensure!(
+                    authoritative.source_profile == ctx.old_profile && is_member(authoritative),
+                    "Group membership changed while the cross-profile move was pending"
+                );
+                anyhow::ensure!(
+                    authoritative.status != Status::Creating
+                        && !authoritative.has_fresh_lifecycle_reservation(now),
+                    "Cannot move group while session {id} has a lifecycle operation in progress"
+                );
+            }
+            if !self.storages.contains_key(target_profile) {
+                self.storages.insert(
+                    target_profile.to_string(),
+                    Storage::open(target_profile, self.file_watch.clone())?,
+                );
+            }
+            Some(guards)
+        } else {
+            None
+        };
+
+        let mut changes = Vec::with_capacity(affected_ids.len());
+        for id in &affected_ids {
+            let instance = self
+                .get_instance(id)
+                .ok_or_else(|| anyhow::anyhow!("Session not found: {id}"))?;
+            let new_group_path = if new_path != ctx.old_path {
+                if instance.group_path == ctx.old_path {
+                    new_path.to_string()
+                } else {
+                    let rest = instance
+                        .group_path
+                        .strip_prefix(&old_prefix)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Group membership changed while the cross-profile move was pending"
+                            )
+                        })?;
+                    format!("{new_path}/{rest}")
+                }
+            } else {
+                instance.group_path.clone()
+            };
+            changes.push((id.clone(), new_group_path));
+        }
 
         // Update group_path (and optionally source_profile) for all affected sessions.
-        for id in &affected_ids {
-            let new_group_path = if new_path != ctx.old_path {
-                let inst = self.get_instance(id);
-                match inst {
-                    Some(i) if i.group_path == ctx.old_path => new_path.to_string(),
-                    Some(i) => format!("{}{}", new_path, &i.group_path[ctx.old_path.len()..]),
-                    None => continue,
-                }
-            } else {
-                match self.get_instance(id) {
-                    Some(i) => i.group_path.clone(),
-                    None => continue,
-                }
-            };
-
+        for (id, new_group_path) in changes {
             if let Some(tp) = new_profile {
-                self.move_to_profile(id, tp, new_group_path.clone())?;
+                self.move_to_profile(&id, tp, new_group_path)?;
             } else {
-                self.apply_user_action(id, |inst| {
+                self.apply_user_action(&id, |inst| {
                     inst.group_path = new_group_path.clone();
                 })?;
             }
         }
 
-        // Ensure target profile storage exists when moving across profiles.
-        if let Some(tp) = new_profile {
-            if tp != ctx.old_profile && !self.storages.contains_key(tp) {
-                self.storages
-                    .insert(tp.to_string(), Storage::new(tp, self.file_watch.clone())?);
-            }
-        }
-
         let path_changed = new_path != ctx.old_path;
-        let profile_changed = new_profile.is_some_and(|profile| profile != ctx.old_profile);
 
         // Capture old_path and its descendants from the pre-rebuild tree:
         // rebuild_group_trees below derives groups from instance.group_path,
@@ -1234,7 +1280,7 @@ impl HomeView {
                 let candidates = if let Some(storage) = self.storages.get(target_profile) {
                     storage.load()?
                 } else {
-                    Storage::new(target_profile, self.file_watch.clone())?.load()?
+                    Storage::open(target_profile, self.file_watch.clone())?.load()?
                 };
                 if is_duplicate_session(
                     candidates.iter(),
@@ -1354,14 +1400,6 @@ impl HomeView {
                     let profiles = list_profiles()?;
                     if !profiles.contains(&target_profile.to_string()) {
                         anyhow::bail!("Profile '{}' does not exist", target_profile);
-                    }
-
-                    // Ensure target profile storage exists.
-                    if !self.storages.contains_key(target_profile) {
-                        self.storages.insert(
-                            target_profile.to_string(),
-                            Storage::new(target_profile, self.file_watch.clone())?,
-                        );
                     }
 
                     let moved_path = new_path.clone();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7,7 +7,9 @@ use tempfile::TempDir;
 use tui_input::Input;
 
 use super::{ConfigRefreshOrigin, ConfigWatchKey, HomeView, PreviewSelection, ViewMode};
-use crate::session::{GroupTree, Instance, Item, Status, Storage};
+use crate::session::{
+    GroupTree, Instance, Item, LifecycleOperation, LifecycleReservation, Status, Storage,
+};
 use crate::tmux::AvailableTools;
 use crate::tui::app::Action;
 use crate::tui::dialogs::{InfoDialog, NewSessionData, NewSessionDialog};
@@ -18039,8 +18041,7 @@ mod save_field_merge {
             Storage::new_unwatched("target").unwrap(),
         );
 
-        view.move_to_profile(&id, "target", String::new())
-            .unwrap();
+        view.move_to_profile(&id, "target", String::new()).unwrap();
         view.save().expect("save must succeed across profiles");
 
         let old_disk = Storage::new_unwatched("test").unwrap().load().unwrap();
@@ -18057,6 +18058,57 @@ mod save_field_merge {
 
     #[test]
     #[serial]
+    fn group_profile_move_reloads_members_and_registers_fallback_source() {
+        let temp = TempDir::new().unwrap();
+        let _guard = setup_test_home(&temp);
+        let source = Storage::new_unwatched("alpha").unwrap();
+        let mut row = Instance::new("stale-title", "/tmp/group-profile-authority");
+        row.group_path = "work".to_string();
+        let id = row.id.clone();
+        source
+            .update(|instances, groups| {
+                instances.push(row);
+                groups.push(crate::session::Group::new("work", "work"));
+                Ok(())
+            })
+            .unwrap();
+        let target = Storage::new_unwatched("beta").unwrap();
+        let tools = AvailableTools::with_tools(&["claude"]);
+        let mut view =
+            HomeView::new(None, tools, crate::file_watch::FileWatchService::noop()).unwrap();
+        view.mutate_instance(&id, |instance| {
+            instance.title = "stale-memory-title".to_string();
+            instance.lifecycle_generation = 3;
+        });
+        source
+            .update(|instances, _groups| {
+                let authoritative = instances.iter_mut().find(|row| row.id == id).unwrap();
+                authoritative.title = "peer-title".to_string();
+                authoritative.lifecycle_generation = 7;
+                Ok(())
+            })
+            .unwrap();
+        view.storages.remove("alpha");
+        view.group_rename_context = Some(super::super::GroupRenameContext {
+            old_path: "work".to_string(),
+            old_profile: "alpha".to_string(),
+        });
+
+        view.rename_selected_group(None, Some("beta")).unwrap();
+
+        assert!(source.load().unwrap().is_empty());
+        let moved = target
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|row| row.id == id)
+            .expect("authoritative row must move to the target");
+        assert_eq!(moved.title, "peer-title");
+        assert_eq!(moved.lifecycle_generation, 7);
+    }
+
+    #[test]
+    #[serial]
     fn profile_only_move_seeds_target_from_authoritative_title_and_lifecycle() {
         let (_temp, _guard, mut view, id) =
             boot_view_with_one_session("stale-title", "/tmp/profile-authority");
@@ -18066,7 +18118,7 @@ mod save_field_merge {
         );
 
         view.mutate_instance(&id, |row| {
-            row.lifecycle_generation = 7;
+            row.lifecycle_generation = 3;
             row.status = Status::Idle;
         });
         let source = Storage::new_unwatched("test").unwrap();
@@ -18080,14 +18132,13 @@ mod save_field_merge {
             })
             .unwrap();
 
-        let guards = view.lock_session_mutation_and_reload(&id).unwrap();
+        let _guards = view.lock_session_mutation_and_reload(&id).unwrap();
         let authoritative = view.get_instance(&id).unwrap();
         assert_eq!(authoritative.title, "peer-new-title");
         assert_eq!(authoritative.lifecycle_generation, 7);
         assert_eq!(authoritative.status, Status::Running);
 
-        view.move_to_profile(&id, "target", String::new())
-            .unwrap();
+        view.move_to_profile(&id, "target", String::new()).unwrap();
         view.save().unwrap();
 
         let target = Storage::new_unwatched("target")
@@ -18100,6 +18151,131 @@ mod save_field_merge {
         assert_eq!(target.title, "peer-new-title");
         assert_eq!(target.lifecycle_generation, 7);
         assert_eq!(target.status, Status::Running);
+    }
+
+    #[test]
+    #[serial]
+    fn profile_move_blocks_fresh_but_allows_stale_lifecycle_reservation() {
+        let (_temp, _guard, mut view, id) =
+            boot_view_with_one_session("reserved", "/tmp/profile-reserved");
+        view.storages.insert(
+            "target".to_string(),
+            Storage::new_unwatched("target").unwrap(),
+        );
+        let reservation = LifecycleReservation {
+            op: LifecycleOperation::Launch,
+            generation: 1,
+            at: chrono::Utc::now(),
+        };
+        view.mutate_instance(&id, |row| {
+            row.lifecycle_generation = 1;
+            row.lifecycle_reservation = Some(reservation.clone());
+            row.status = Status::Starting;
+        });
+        let source = Storage::new_unwatched("test").unwrap();
+        source
+            .update(|instances, _groups| {
+                let row = instances.iter_mut().find(|row| row.id == id).unwrap();
+                row.lifecycle_generation = 1;
+                row.lifecycle_reservation = Some(reservation);
+                row.status = Status::Starting;
+                Ok(())
+            })
+            .unwrap();
+
+        let _guards = view.lock_session_mutation_and_reload(&id).unwrap();
+        let error = view
+            .move_to_profile(&id, "target", String::new())
+            .expect_err("reserved session must not move profiles");
+
+        assert!(error
+            .to_string()
+            .contains("lifecycle operation is in progress"));
+        assert_eq!(view.get_instance(&id).unwrap().source_profile, "test");
+        assert!(view
+            .pending_deletions
+            .get("test")
+            .is_none_or(|ids| !ids.contains(&id)));
+        assert!(Storage::new_unwatched("target")
+            .unwrap()
+            .load()
+            .unwrap()
+            .is_empty());
+        assert!(source.load().unwrap().iter().any(|row| row.id == id));
+
+        let stale_at =
+            chrono::Utc::now() - Instance::LIFECYCLE_RESERVATION_TTL - chrono::Duration::seconds(1);
+        view.mutate_instance(&id, |row| {
+            row.lifecycle_reservation.as_mut().unwrap().at = stale_at;
+        });
+        source
+            .update(|instances, _groups| {
+                instances
+                    .iter_mut()
+                    .find(|row| row.id == id)
+                    .unwrap()
+                    .lifecycle_reservation
+                    .as_mut()
+                    .unwrap()
+                    .at = stale_at;
+                Ok(())
+            })
+            .unwrap();
+
+        view.move_to_profile(&id, "target", String::new())
+            .expect("stale reservation must not block profile move");
+        view.save().unwrap();
+        assert!(source.load().unwrap().is_empty());
+        assert!(Storage::new_unwatched("target")
+            .unwrap()
+            .load()
+            .unwrap()
+            .iter()
+            .any(|row| row.id == id));
+    }
+
+    #[test]
+    #[serial]
+    fn restart_profile_move_rejects_target_identity_collision_before_mutation() {
+        let (_temp, _guard, mut view, id) =
+            boot_view_with_one_session("source", "/tmp/profile-restart-collision");
+        let target = Storage::new_unwatched("target").unwrap();
+        target
+            .update(|instances, _groups| {
+                let mut collision = Instance::new("source", "/tmp/profile-restart-collision/");
+                collision.source_profile = "target".to_string();
+                instances.push(collision);
+                Ok(())
+            })
+            .unwrap();
+        view.storages.insert("target".to_string(), target);
+        view.selected_session = Some(id.clone());
+
+        let error = view
+            .restart_selected_session(Some("target"), Some("claude"), None, None)
+            .expect_err("target identity collision must reject restart profile move");
+
+        assert!(error
+            .to_string()
+            .contains("Session already exists with same title and path"));
+        assert_eq!(view.get_instance(&id).unwrap().source_profile, "test");
+        assert!(!view.restart_cooldown_at.contains_key(&id));
+        assert_eq!(
+            Storage::new_unwatched("test")
+                .unwrap()
+                .load()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            Storage::new_unwatched("target")
+                .unwrap()
+                .load()
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7,7 +7,7 @@ use tempfile::TempDir;
 use tui_input::Input;
 
 use super::{ConfigRefreshOrigin, ConfigWatchKey, HomeView, PreviewSelection, ViewMode};
-use crate::session::{GroupTree, Instance, Item, Storage};
+use crate::session::{GroupTree, Instance, Item, Status, Storage};
 use crate::tmux::AvailableTools;
 use crate::tui::app::Action;
 use crate::tui::dialogs::{InfoDialog, NewSessionData, NewSessionDialog};
@@ -18039,7 +18039,8 @@ mod save_field_merge {
             Storage::new_unwatched("target").unwrap(),
         );
 
-        view.move_to_profile(&id, "target", String::new()).unwrap();
+        view.move_to_profile(&id, "target", String::new())
+            .unwrap();
         view.save().expect("save must succeed across profiles");
 
         let old_disk = Storage::new_unwatched("test").unwrap().load().unwrap();
@@ -18052,6 +18053,53 @@ mod save_field_merge {
             new_disk.iter().any(|i| i.id == id),
             "new profile disk MUST contain the moved row"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn profile_only_move_seeds_target_from_authoritative_title_and_lifecycle() {
+        let (_temp, _guard, mut view, id) =
+            boot_view_with_one_session("stale-title", "/tmp/profile-authority");
+        view.storages.insert(
+            "target".to_string(),
+            Storage::new_unwatched("target").unwrap(),
+        );
+
+        view.mutate_instance(&id, |row| {
+            row.lifecycle_generation = 7;
+            row.status = Status::Idle;
+        });
+        let source = Storage::new_unwatched("test").unwrap();
+        source
+            .update(|instances, _groups| {
+                let row = instances.iter_mut().find(|row| row.id == id).unwrap();
+                row.title = "peer-new-title".to_string();
+                row.lifecycle_generation = 7;
+                row.status = Status::Running;
+                Ok(())
+            })
+            .unwrap();
+
+        let guards = view.lock_session_mutation_and_reload(&id).unwrap();
+        let authoritative = view.get_instance(&id).unwrap();
+        assert_eq!(authoritative.title, "peer-new-title");
+        assert_eq!(authoritative.lifecycle_generation, 7);
+        assert_eq!(authoritative.status, Status::Running);
+
+        view.move_to_profile(&id, "target", String::new())
+            .unwrap();
+        view.save().unwrap();
+
+        let target = Storage::new_unwatched("target")
+            .unwrap()
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|row| row.id == id)
+            .unwrap();
+        assert_eq!(target.title, "peer-new-title");
+        assert_eq!(target.lifecycle_generation, 7);
+        assert_eq!(target.status, Status::Running);
     }
 
     #[test]

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1400,7 +1400,9 @@ export const SessionRow = memo(function SessionRow({
     // For a tied worktree session the rename also moves the directory and can
     // fail (e.g. 409 while running); surface the server message. See #1927.
     const result = await renameSession(sessionId, trimmed);
-    if (!result.ok && result.message) {
+    if (result.ok) {
+      result.warnings?.forEach((warning) => reportError(warning));
+    } else if (result.message) {
       reportError(result.message);
     }
   };

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1398,12 +1398,15 @@ export const SessionRow = memo(function SessionRow({
     // the prefilled value should still set the title.
     if (!trimmed || trimmed === sessionTitle || !sessionId) return;
     // For a tied worktree session the rename also moves the directory and can
-    // fail (e.g. 409 while running); surface the server message. See #1927.
+    // fail (e.g. 409 while running); surface that as an error toast. See #1927.
     const result = await renameSession(sessionId, trimmed);
     if (result.ok) {
-      result.warnings?.forEach((warning) => reportError(warning));
-    } else if (result.message) {
-      reportError(result.message);
+      // Non-fatal: the title persisted, but the live tmux session could not be
+      // rekeyed. Route to the info channel, not reportError, so it reads as a
+      // heads-up rather than a failed rename (the rename itself succeeded).
+      result.warnings?.forEach((warning) => reportInfo(warning));
+    } else {
+      reportError(result.message ?? "Could not rename this session. Please try again.");
     }
   };
 

--- a/web/src/components/__tests__/WorkdirNameEdit.test.tsx
+++ b/web/src/components/__tests__/WorkdirNameEdit.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useRef, type ReactNode } from "react";
 
-import { reportError } from "../../lib/toastBus";
+import { reportError, reportInfo } from "../../lib/toastBus";
 import { DragSuppressContext, SessionRow, type RowBulkApi } from "../WorkspaceSidebar";
 
 // Single-row stub for the bulk-triage bridge; this harness mounts one
@@ -86,6 +86,7 @@ const fetchSpy = vi.fn<typeof fetch>();
 beforeEach(() => {
   fetchSpy.mockReset();
   vi.mocked(reportError).mockClear();
+  vi.mocked(reportInfo).mockClear();
   vi.stubGlobal("fetch", fetchSpy);
   fetchSpy.mockImplementation(
     async () =>
@@ -200,8 +201,10 @@ describe("sidebar Edit workdir name", () => {
     });
 
     await vi.waitFor(() =>
-      expect(reportError).toHaveBeenCalledWith("Session was saved, but its live tmux session could not be rekeyed"),
+      expect(reportInfo).toHaveBeenCalledWith("Session was saved, but its live tmux session could not be rekeyed"),
     );
+    // Non-fatal: the rename itself succeeded, so it must not surface as an error.
+    expect(reportError).not.toHaveBeenCalled();
   });
 
   it("surfaces the server message when a tied rename is rejected (#1927)", async () => {
@@ -225,6 +228,22 @@ describe("sidebar Edit workdir name", () => {
     });
 
     await vi.waitFor(() => expect(reportError).toHaveBeenCalledWith("Stop the session before renaming it."));
+  });
+
+  it("surfaces a fallback when inline rename has no server message", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("network unavailable"));
+    openMenu(workspace("w", [session()]));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-rename"));
+    fireEvent.change(screen.getByTestId("sidebar-rename-input"), {
+      target: { value: "new title" },
+    });
+    fireEvent.keyDown(screen.getByTestId("sidebar-rename-input"), {
+      key: "Enter",
+    });
+
+    await vi.waitFor(() =>
+      expect(reportError).toHaveBeenCalledWith("Could not rename this session. Please try again."),
+    );
   });
 
   it("surfaces the server validation message on failure", async () => {

--- a/web/src/components/__tests__/WorkdirNameEdit.test.tsx
+++ b/web/src/components/__tests__/WorkdirNameEdit.test.tsx
@@ -85,6 +85,7 @@ const fetchSpy = vi.fn<typeof fetch>();
 
 beforeEach(() => {
   fetchSpy.mockReset();
+  vi.mocked(reportError).mockClear();
   vi.stubGlobal("fetch", fetchSpy);
   fetchSpy.mockImplementation(
     async () =>
@@ -177,6 +178,30 @@ describe("sidebar Edit workdir name", () => {
     expect(url).toBe("/api/sessions/s1");
     expect(init?.method).toBe("PATCH");
     expect(JSON.parse(init?.body as string)).toEqual({ title: "new title" });
+  });
+
+  it("surfaces warnings returned by a successful inline rename", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "s1",
+          warnings: ["Session was saved, but its live tmux session could not be rekeyed"],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    openMenu(workspace("w", [session()]));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-rename"));
+    fireEvent.change(screen.getByTestId("sidebar-rename-input"), {
+      target: { value: "new title" },
+    });
+    fireEvent.keyDown(screen.getByTestId("sidebar-rename-input"), {
+      key: "Enter",
+    });
+
+    await vi.waitFor(() =>
+      expect(reportError).toHaveBeenCalledWith("Session was saved, but its live tmux session could not be rekeyed"),
+    );
   });
 
   it("surfaces the server message when a tied rename is rejected (#1927)", async () => {

--- a/web/src/lib/api.coverage.test.ts
+++ b/web/src/lib/api.coverage.test.ts
@@ -1181,6 +1181,18 @@ describe("logout", () => {
 // Session mutations
 
 describe("renameSession", () => {
+  it("returns exactly { ok: true } on a 200 with no warnings", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 200 }));
+    const result = await renameSession("s1", "New Title");
+    // toEqual is exact: the warnings key must be absent when the response
+    // carries none, so callers never iterate an empty/undefined array.
+    expect(result).toEqual({ ok: true });
+    const [url, init] = lastCall();
+    expect(url).toBe("/api/sessions/s1");
+    expect(init?.method).toBe("PATCH");
+    expect(bodyOf(init)).toEqual({ title: "New Title" });
+  });
+
   it("PATCHes the title and returns successful response warnings", async () => {
     fetchSpy.mockResolvedValueOnce(
       jsonResponse({ warnings: ["Metadata was saved, but the live tmux session could not be rekeyed"] }),
@@ -1194,6 +1206,14 @@ describe("renameSession", () => {
     expect(url).toBe("/api/sessions/s1");
     expect(init?.method).toBe("PATCH");
     expect(bodyOf(init)).toEqual({ title: "New Title" });
+  });
+
+  it("drops non-string entries from successful warnings", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ warnings: ["kept", 3, null] }));
+    await expect(renameSession("s1", "New Title")).resolves.toEqual({
+      ok: true,
+      warnings: ["kept"],
+    });
   });
 
   it("surfaces the server message on a 409", async () => {

--- a/web/src/lib/api.coverage.test.ts
+++ b/web/src/lib/api.coverage.test.ts
@@ -1181,10 +1181,15 @@ describe("logout", () => {
 // Session mutations
 
 describe("renameSession", () => {
-  it("PATCHes the title and returns ok on 200", async () => {
-    fetchSpy.mockResolvedValueOnce(new Response("", { status: 200 }));
+  it("PATCHes the title and returns successful response warnings", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ warnings: ["Metadata was saved, but the live tmux session could not be rekeyed"] }),
+    );
     const result = await renameSession("s1", "New Title");
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: true,
+      warnings: ["Metadata was saved, but the live tmux session could not be rekeyed"],
+    });
     const [url, init] = lastCall();
     expect(url).toBe("/api/sessions/s1");
     expect(init?.method).toBe("PATCH");

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2162,14 +2162,23 @@ export async function logout(): Promise<void> {
  * to match and returns 409 if the session is running, so the message is
  * surfaced to the caller. See #1927.
  */
-export async function renameSession(id: string, title: string): Promise<{ ok: boolean; message?: string }> {
+export async function renameSession(
+  id: string,
+  title: string,
+): Promise<{ ok: boolean; message?: string; warnings?: string[] }> {
   try {
     const res = await fetch(`/api/sessions/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title }),
     });
-    if (res.ok) return { ok: true };
+    if (res.ok) {
+      const body = await res.json().catch(() => null);
+      const warnings = Array.isArray(body?.warnings)
+        ? body.warnings.filter((warning: unknown): warning is string => typeof warning === "string")
+        : [];
+      return warnings.length > 0 ? { ok: true, warnings } : { ok: true };
+    }
     let message: string | undefined;
     try {
       const body = await res.json();

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -3379,6 +3379,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/lib/api.ts"]
     },
     {
+      "id": "sidebar.rename-success-warning",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/api.coverage.test.ts", "src/components/__tests__/WorkdirNameEdit.test.tsx"],
+      "components": ["web/src/lib/api.ts", "web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.add-project",
       "kind": "vitest",
       "risk": "high",


### PR DESCRIPTION
## Description

Persists a session title before rekeying its title-derived tmux name. A shared `tmux::rekey_session` resolves the live session by immutable ID suffix, retries once after an authoritative refresh, and treats a confirmed missing session as absent.

Manual and smart title writers use the lock order `identity -> session title -> lifecycle -> Storage`. Identity covers duplicate validation through the durable write. Session title and lifecycle locks remain through rekey. Every tmux query and rename has a 10-second deadline, closed stdin, and a timed-out client is killed. API rekey failures are returned as non-fatal warnings and surfaced through the existing dashboard info toast.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No layout change; the existing toast surface displays post-commit warnings.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: Vitest covers response parsing and toast routing; `web/tests/coverage-matrix.json` contains `sidebar.rename-success-warning`.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: deterministic Rust tests cover lock ordering, timeout, vanished sessions, retry, and post-commit rekey behavior.

## Dependencies

Merge #3457, then #3411, before this PR. This branch contains both prerequisite heads.

## Validation

Head: `de5793a9`, based on `upstream/main` `91e33702`.

- `cargo test title_mutation_locks_validate_and_serialize_writers -- --nocapture`: 1 passed
- `cargo test tmux_command_timeout_kills_a_stalled_client -- --nocapture`: 1 passed
- `cargo test rekey_session_ -- --nocapture`: 2 passed
- Cumulative stack on #3427: `cargo test --features serve`, 6,645 passed and 8 ignored
- Cumulative stack on #3427: `cargo clippy --features serve --lib --bins -- -D warnings`
- `npm run format:check`, `npm run lint`, and `npx tsc -b`
- Targeted Vitest: 197 passed, no type errors

CI status was not checked in this update.

## Risks

The metadata commit is authoritative. Rekey failures remain successful mutations with explicit warnings; they do not roll metadata back.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you'd like to share:** Implementation, validation, concurrency analysis, and review assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
