### PR TITLE
fix(session): reject duplicate smart rename titles

### DIFF
--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -935,14 +935,21 @@ fn apply_terminal_title(
             if let Some(title) = &new_title {
                 let should_write = title_is_auto_overwritable(&instances[index])
                     && instances[index].title != *title;
+                // `is_duplicate_session` scans every instance and does not skip
+                // this session by id, so the `title != current` half of
+                // `should_write` is what keeps a session from reading its own
+                // row as the collision. Self-exclusion by id lives in the manual
+                // rename predicate (#3411), which owns the shared surfaces.
                 let duplicate = should_write
                     && crate::cli::add::is_duplicate_session(
                         instances,
                         title,
                         &instances[index].project_path,
                     );
-                let instance = &mut instances[index];
-                if should_write && !duplicate {
+                if duplicate {
+                    tracing::warn!(target: "smart_rename", session = %id, title = %title, "skipped duplicate auto-title");
+                } else if should_write {
+                    let instance = &mut instances[index];
                     // The tmux session name embeds the title
                     // (Session::generate_name), and both status pollers derive
                     // the name from the current title. Rekey the live session
@@ -953,8 +960,6 @@ fn apply_terminal_title(
                     tracing::info!(target: "smart_rename", session = %id, old = %instance.title, new = %title, "auto-renamed terminal session");
                     instance.title = title.clone();
                     instance.last_auto_title = Some(title.clone());
-                } else if duplicate {
-                    tracing::warn!(target: "smart_rename", session = %id, title = %title, "skipped duplicate auto-title");
                 }
             }
         }
@@ -1412,7 +1417,10 @@ mod serve {
     /// (`title_is_auto_overwritable`), so a manual rename is never clobbered.
     /// Serializes against manual renames / worktree edits on this session via
     /// the per-session instance lock, and mirrors memory only when the storage
-    /// write actually happened so the two never diverge.
+    /// write actually happened so the two never diverge. Two further cases skip
+    /// the write silently: the generated title already equalling the current
+    /// one (a no-op, new here relative to the pre-fix unconditional write), and
+    /// another session in this profile already owning the (title, path) pair.
     pub(crate) async fn apply_auto_title(
         state: &Arc<AppState>,
         id: &str,
@@ -1430,6 +1438,10 @@ mod serve {
                 return;
             }
         };
+        // Own copies for the closure below: `storage.update` runs inside
+        // `spawn_blocking`, whose body must be `'static + Send`, so the borrowed
+        // `id`/`new_title` cannot cross the thread boundary. The in-memory
+        // mirror after the join reuses the borrowed `new_title` directly.
         let id_owned = id.to_string();
         let title_owned = new_title.to_string();
         let persisted = tokio::task::spawn_blocking(move || {
@@ -1440,6 +1452,12 @@ mod serve {
                 else {
                     return Ok(false);
                 };
+                // Skip a no-op rename: when the generated title already equals
+                // the current one there is nothing to write, and this same
+                // `title != current` guard is what excludes this session from
+                // its own duplicate scan below, since `is_duplicate_session`
+                // matches by (title, path) with no id filter. Id-based
+                // self-exclusion lives in the manual rename predicate (#3411).
                 let should_write = title_is_auto_overwritable(&instances[index])
                     && instances[index].title != title_owned;
                 let duplicate = should_write
@@ -1450,14 +1468,16 @@ mod serve {
                     );
                 if duplicate {
                     tracing::warn!(target: "smart_rename", session = %id_owned, title = %title_owned, "skipped duplicate auto-title");
-                    return Ok(false);
-                }
-                if should_write {
+                    Ok(false)
+                } else if should_write {
                     instances[index].title = title_owned.clone();
-                    instances[index].last_auto_title = Some(title_owned.clone());
-                    return Ok(true);
+                    // Last owned use of `title_owned`: move it into the field
+                    // rather than cloning a second time.
+                    instances[index].last_auto_title = Some(title_owned);
+                    Ok(true)
+                } else {
+                    Ok(false)
                 }
-                Ok(false)
             })
         })
         .await;
@@ -1528,6 +1548,35 @@ mod serve {
                     .title,
                 "Franks"
             );
+        }
+
+        #[test]
+        fn is_duplicate_session_normalizes_trailing_slash() {
+            // The skip in `apply_auto_title` / `apply_terminal_title` reuses the
+            // creation predicate, which trims trailing '/' on both sides before
+            // comparing paths. Pin that normalization explicitly: an existing
+            // session at "/tmp/shared" collides with a candidate whose path
+            // differs only by a trailing slash.
+            let mut existing = crate::session::Instance::new("Already owned", "/tmp/shared");
+            existing.source_profile = "default".to_string();
+            let instances = vec![existing];
+            let cases = [
+                ("Already owned", "/tmp/shared", true),
+                // "/tmp/shared/" and "/tmp/shared" are equal after trim_end_matches('/').
+                ("Already owned", "/tmp/shared/", true),
+                // trim_end_matches removes every trailing slash, not just one.
+                ("Already owned", "/tmp/shared//", true),
+                ("Already owned", "/tmp/other", false),
+                // Same path, different title: not a duplicate.
+                ("Different", "/tmp/shared", false),
+            ];
+            for (title, path, expected) in cases {
+                assert_eq!(
+                    crate::cli::add::is_duplicate_session(&instances, title, path),
+                    expected,
+                    "title {title:?} path {path:?}"
+                );
+            }
         }
 
         #[tokio::test]

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -930,20 +930,31 @@ fn apply_terminal_title(
     let id = id.to_string();
     let new_title = new_title.map(str::to_string);
     storage.update(|instances, _groups| {
-        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-            inst.smart_rename_attempted = true;
-            if let Some(t) = &new_title {
-                if title_is_auto_overwritable(inst) && &inst.title != t {
+        if let Some(index) = instances.iter().position(|instance| instance.id == id) {
+            instances[index].smart_rename_attempted = true;
+            if let Some(title) = &new_title {
+                let should_write = title_is_auto_overwritable(&instances[index])
+                    && instances[index].title != *title;
+                let duplicate = should_write
+                    && crate::cli::add::is_duplicate_session(
+                        instances,
+                        title,
+                        &instances[index].project_path,
+                    );
+                let instance = &mut instances[index];
+                if should_write && !duplicate {
                     // The tmux session name embeds the title
                     // (Session::generate_name), and both status pollers derive
                     // the name from the current title. Rekey the live session
                     // to match, else attach/stop/poll would target a name the
                     // running pane no longer has. Best-effort, mirroring the
                     // manual TUI rename (src/tui/home/operations.rs).
-                    rekey_tmux_session(&id, &inst.title, t);
-                    tracing::info!(target: "smart_rename", session = %id, old = %inst.title, new = %t, "auto-renamed terminal session");
-                    inst.title = t.clone();
-                    inst.last_auto_title = Some(t.clone());
+                    rekey_tmux_session(&id, &instance.title, title);
+                    tracing::info!(target: "smart_rename", session = %id, old = %instance.title, new = %title, "auto-renamed terminal session");
+                    instance.title = title.clone();
+                    instance.last_auto_title = Some(title.clone());
+                } else if duplicate {
+                    tracing::warn!(target: "smart_rename", session = %id, title = %title, "skipped duplicate auto-title");
                 }
             }
         }
@@ -1423,12 +1434,27 @@ mod serve {
         let title_owned = new_title.to_string();
         let persisted = tokio::task::spawn_blocking(move || {
             storage.update(|instances, _groups| {
-                let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) else {
+                let Some(index) = instances
+                    .iter()
+                    .position(|instance| instance.id == id_owned)
+                else {
                     return Ok(false);
                 };
-                if title_is_auto_overwritable(inst) {
-                    inst.title = title_owned.clone();
-                    inst.last_auto_title = Some(title_owned.clone());
+                let should_write = title_is_auto_overwritable(&instances[index])
+                    && instances[index].title != title_owned;
+                let duplicate = should_write
+                    && crate::cli::add::is_duplicate_session(
+                        instances,
+                        &title_owned,
+                        &instances[index].project_path,
+                    );
+                if duplicate {
+                    tracing::warn!(target: "smart_rename", session = %id_owned, title = %title_owned, "skipped duplicate auto-title");
+                    return Ok(false);
+                }
+                if should_write {
+                    instances[index].title = title_owned.clone();
+                    instances[index].last_auto_title = Some(title_owned.clone());
                     return Ok(true);
                 }
                 Ok(false)
@@ -1462,6 +1488,47 @@ mod serve {
     mod tests {
         use super::*;
         use std::time::Duration;
+
+        #[tokio::test]
+        #[serial_test::serial]
+        async fn apply_auto_title_skips_duplicate_title_and_path() {
+            let _guard = crate::session::test_support::isolate_app_dir();
+            let storage =
+                crate::session::storage::Storage::new_unwatched("default").expect("storage");
+            let mut target = crate::session::Instance::new("Franks", "/tmp/shared/");
+            target.source_profile = "default".to_string();
+            let target_id = target.id.clone();
+            let mut owner = crate::session::Instance::new("Already owned", "/tmp/shared");
+            owner.source_profile = "default".to_string();
+            storage
+                .update(|instances, _groups| {
+                    *instances = vec![target.clone(), owner.clone()];
+                    Ok(())
+                })
+                .unwrap();
+            let state = crate::server::test_support::build_test_app_state(vec![target, owner]);
+
+            apply_auto_title(&state, &target_id, "default", "Already owned").await;
+
+            let persisted = storage.load().unwrap();
+            assert_eq!(
+                persisted
+                    .iter()
+                    .find(|instance| instance.id == target_id)
+                    .unwrap()
+                    .title,
+                "Franks"
+            );
+            let in_memory = state.instances.read().await;
+            assert_eq!(
+                in_memory
+                    .iter()
+                    .find(|instance| instance.id == target_id)
+                    .unwrap()
+                    .title,
+                "Franks"
+            );
+        }
 
         #[tokio::test]
         async fn run_oneshot_returns_none_on_spawn_failure() {
@@ -2633,16 +2700,25 @@ claude = "repo-wrapper"
         let mut manual = Instance::new("Britons", "/tmp/y");
         manual.title = "Hand-picked".to_string();
         let manual_id = manual.id.clone();
+        // Story 3: a generated title already owned at the same normalized path
+        // is skipped, but the one-shot remains marked attempted.
+        let duplicate_candidate = Instance::new("Franks", "/tmp/z/");
+        let duplicate_id = duplicate_candidate.id.clone();
+        let mut duplicate_owner = Instance::new("Saxons", "/tmp/z");
+        duplicate_owner.title = "Already owned".to_string();
         storage
             .update(|instances, _groups| {
                 instances.push(civ);
                 instances.push(manual);
+                instances.push(duplicate_candidate);
+                instances.push(duplicate_owner);
                 Ok(())
             })
             .unwrap();
 
         apply_terminal_title(&storage, &civ_id, Some("Fix login bug")).unwrap();
         apply_terminal_title(&storage, &manual_id, Some("Should Not Apply")).unwrap();
+        apply_terminal_title(&storage, &duplicate_id, Some("Already owned")).unwrap();
 
         let (instances, _) = storage.load_with_groups().unwrap();
         let civ = instances.iter().find(|i| i.id == civ_id).unwrap();
@@ -2654,5 +2730,12 @@ claude = "repo-wrapper"
         assert_eq!(manual.title, "Hand-picked");
         // Still marked attempted so the poller does not respawn on every turn.
         assert!(manual.smart_rename_attempted);
+        let duplicate = instances
+            .iter()
+            .find(|instance| instance.id == duplicate_id)
+            .unwrap();
+        assert_eq!(duplicate.title, "Franks");
+        assert_eq!(duplicate.last_auto_title, None);
+        assert!(duplicate.smart_rename_attempted);
     }
 }


### PR DESCRIPTION
## Description

Automatic smart rename writes generated titles through two paths: terminal one-shot persistence and structured-session daemon persistence. Neither path checked whether another session in the same profile already owned the generated `(title, project_path)` pair, so auto rename could recreate the collision that session creation rejects.

This PR applies the existing creation predicate inside each path&#39;s `Storage::update` closure. The check and write are therefore one profile-local serialized decision. A colliding generated title is skipped. Terminal smart rename still marks the one-shot attempted, preventing repeated model calls; structured smart rename leaves both persisted and in-memory titles unchanged. Manual-title protection remains unchanged.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No documentation or screenshot is needed; this preserves the existing uniqueness invariant in a background operation.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a dashboard user flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: no TUI rendering or CLI contract changes
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

- `cargo fmt --check`
- `cargo clippy --features serve --lib --bins -- -D warnings`
- `cargo test --features serve apply_auto_title_skips_duplicate_title_and_path -- --nocapture` (1 passed)
- `cargo test apply_terminal_title_marks_attempted_and_respects_manual_rename -- --nocapture` (1 passed, including collision and attempted-state assertions)
- `cargo test --features serve -- --skip tmux::session::tests::a_zoomed_pane_falls_back_to_the_plain_capture --skip tmux::session::tests::size_owner_lock_claims_rejects_steals_and_releases` (6,551 passed; 8 ignored; 2 filtered)

The filtered cases are unrelated tmux setup flakes independently verified on sibling scoped PR runs.

## Initial Review Cycle

One initial cycle used three independent reviewers covering behavior, failure ordering, and scope/tests. All three returned zero actionable findings; no code correction or second reviewer wave was needed.

## Fresh Review Round 2

Three fresh independent reviewers returned zero actionable findings. No correction, commit, or third reviewer wave was needed; head remains `608e37b8`.

## Risks

- Duplicate comparison remains identical to creation: exact title and path equality after trimming trailing slashes.
- The check is profile-local because each smart-rename worker writes one profile storage.
- Collision is intentionally a logged skip rather than a user-facing error because smart rename is best-effort and fire-and-forget.
- Manual titles and the `smart_rename_attempted` retry contract are unchanged.

## GitHub Review Comments

No review threads or submitted review comments required code changes.

## Upstream Sync

Rebased onto `upstream/main` at `24226821`; ready for review. Final synchronized head: `608e37b8`. GitHub checks are green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you&#39;d like to share:** Finding isolation, implementation, and validation assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form




## Summary

- Prevent duplicate smart-rename titles in terminal and structured-session persistence paths.
- Skip generated titles that match an existing `(title, project_path)` pair.
- Preserve terminal attempt tracking while leaving duplicate titles unchanged.
- Keep structured-session titles unchanged in both storage and memory when a duplicate is found.
- Skip unnecessary writes when the generated title already matches the current title.
- Normalize trailing slashes during duplicate checks.
- Add focused tests for duplicate handling and path normalization.
- Validate the changes with formatting, Clippy, focused tests, and the full test suite.

## Benefits

These changes prevent duplicate session titles and keep persisted and in-memory session state consistent. Manual-title behavior remains unchanged.

