### PR TITLE
fix(sv): keep workers alive for cwd-stable renames

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -85,7 +85,8 @@ When tied:
 
 - Renaming a session (TUI rename, web inline rename, `aoe session rename`, or `PATCH /api/sessions/{id}`) moves the worktree directory to the title's path-safe slug first, then sets the title only if the move succeeds, so the two cannot drift on a partial failure.
 - The git branch is never swept in by a title rename by default. To rename it too, check "Also rename git branch" in the TUI rename dialog, pass `--rename-branch` to `aoe session rename`, or send `rename_branch: true` to the PATCH. It stays opt-in because a branch may carry an upstream or an open PR; the TUI toggle warns when the branch tracks a remote, since the remote branch (and any open PR) won't follow the local rename.
-- The session must be stopped first. Moving the directory of a running worktree is unsafe, so a tied rename of a running session is refused with a clear message. Stop the session, or disable the setting, to relabel it freely.
+- A tied rename that relocates the worktree directory, or renames its branch, needs a stopped session: moving or re-pointing a live checkout is unsafe, so it is refused with a clear message while the session is active. Stop the session, or disable the setting, to relabel it freely.
+- A rename whose title slugs to the directory the session already has moves nothing, so `PATCH /api/sessions/{id}` accepts it even while the session runs and leaves a live structured-view worker alone. The TUI rename and `aoe session rename` still ask you to stop the session first.
 - Naming collapses into the single rename action: the standalone "edit workdir name" affordance is hidden (TUI and web) and the standalone CLI / REST workdir-name edit is rejected, since the directory now follows the title.
 
 Toggle the setting off (TUI settings, web settings, or the toml above) to relabel sessions freely while running and to edit the directory name independently of the title.

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1256,8 +1256,13 @@ pub async fn rename_session(
             std::path::Path::new(&current_path),
             &leaf,
         );
-        let renames_branch =
-            body.rename_branch && worktree_info.as_ref().is_some_and(|wt| wt.branch != leaf);
+        let renames_branch = worktree_info.as_ref().is_some_and(|wt| {
+            crate::session::worktree_edit::worktree_branch_rename_required(
+                wt,
+                &leaf,
+                body.rename_branch,
+            )
+        });
         let container_holds = !status.blocks_worktree_edit()
             && moves_worktree
             && ensure_sandbox_container_released_blocking(&id, is_sandboxed).await;
@@ -1573,10 +1578,18 @@ pub async fn set_worktree_name(
 
     // Stop any live structured-view worker before the move so it can't crash on
     // the pulled-out cwd and respawn-loop at the stale path (#2260). Held under
-    // the instance_lock acquired at the top of this function.
-    if let Err(resp) = quiesce_structured_worker_for_worktree_move(&state, &id, is_structured).await
-    {
-        return resp;
+    // the instance_lock acquired at the top of this function. Gated on
+    // `moves_worktree` for the same reason as the tied `rename_session` path: a
+    // branch-only edit (name unchanged, `rename_branch` set) leaves the cwd
+    // valid, so interrupting the worker would be a needless respawn. When the
+    // name is unchanged and no branch rename is requested, `edit_worktree_workdir`
+    // rejects with `Unchanged` below and nothing is touched either way.
+    if moves_worktree {
+        if let Err(resp) =
+            quiesce_structured_worker_for_worktree_move(&state, &id, is_structured).await
+        {
+            return resp;
+        }
     }
 
     let wt = worktree_info.clone();
@@ -8862,6 +8875,200 @@ mod tests {
             Some("existing-branch"),
             "the active branch-only request must be rejected before git mutation"
         );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rename_session_quiesces_structured_worker_only_when_its_cwd_moves() {
+        // Invariant #2260: a live structured-view worker is pinned to its cwd,
+        // so a tied rename that MOVES the worktree directory must stop the
+        // worker first (else it crash-loops at the pulled-out path), while a
+        // rename that leaves the cwd in place must NOT interrupt it. The
+        // quiesce runs before the git edit, so the cwd-moving assertion holds
+        // even though the edit itself then fails on a fixture with no real
+        // worktree to move: what #2260 pins is that the worker is gone by then.
+        let _app_dir = crate::session::test_support::isolate_app_dir();
+
+        struct Case {
+            id: &'static str,
+            leaf: &'static str,
+            new_title: &'static str,
+            // Whether the new title's slug relocates the worktree directory.
+            moves_cwd: bool,
+        }
+        // The cwd-stable row's slug ("my-session") equals the existing leaf, so
+        // the edit is a no-op move; the cwd-moving row's slug differs, forcing
+        // a relocation.
+        let cases = [
+            Case {
+                id: "quiesce-cwd-stable",
+                leaf: "my-session",
+                new_title: "My Session!",
+                moves_cwd: false,
+            },
+            Case {
+                id: "quiesce-cwd-moving",
+                leaf: "old-leaf",
+                new_title: "A Brand New Name",
+                moves_cwd: true,
+            },
+        ];
+
+        for case in cases {
+            let paths = tempfile::tempdir().unwrap();
+            let project_path = paths.path().join(case.leaf);
+            let mut inst = Instance::new(
+                "Original title",
+                project_path.to_str().expect("UTF-8 temp path"),
+            );
+            inst.id = case.id.to_string();
+            // Idle, not Running: a structured session the user "stopped" sits
+            // at Idle yet still owns a live worker, which is exactly the gap
+            // `blocks_worktree_edit` misses and quiesce closes.
+            inst.status = Status::Idle;
+            inst.view = crate::session::View::Structured;
+            inst.worktree_info = Some(crate::session::WorktreeInfo {
+                branch: case.leaf.to_string(),
+                main_repo_path: paths
+                    .path()
+                    .join("missing-repo")
+                    .to_string_lossy()
+                    .into_owned(),
+                managed_by_aoe: true,
+                created_at: chrono::Utc::now(),
+                base_branch: None,
+            });
+
+            let state = crate::server::test_support::build_test_app_state(vec![inst]);
+            state.acp_supervisor.test_insert_worker(case.id).await;
+
+            let _ = rename_session(
+                State(state.clone()),
+                Path(case.id.to_string()),
+                Ok(Json(RenameSessionBody {
+                    title: case.new_title.to_string(),
+                    rename_branch: false,
+                })),
+            )
+            .await
+            .into_response();
+
+            assert_eq!(
+                state.acp_supervisor.is_running(case.id).await,
+                !case.moves_cwd,
+                "{}: worker should be {} for moves_cwd={}",
+                case.id,
+                if case.moves_cwd {
+                    "stopped"
+                } else {
+                    "preserved"
+                },
+                case.moves_cwd
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn set_worktree_name_quiesces_structured_worker_only_when_its_cwd_moves() {
+        // The standalone-endpoint mirror of the rename_session gate above: both
+        // stop a live structured-view worker only when the edit actually moves
+        // the worktree cwd (#2260), never for a cwd-stable or branch-only edit.
+        // The quiesce precedes the git edit, so the cwd-moving assertion holds
+        // even though the edit itself then fails on a fixture with no real
+        // worktree to move: what #2260 pins is that the worker is gone by then.
+        let _app_dir = crate::session::test_support::isolate_app_dir();
+        // set_worktree_name refuses a tied managed worktree (tied callers must
+        // go through rename_session), so untie the profile to reach the worker
+        // gate that this test exercises.
+        let mut overrides = serde_json::Map::new();
+        overrides.insert(
+            "session".to_string(),
+            serde_json::json!({ "tie_workdir_to_name": false }),
+        );
+        crate::session::profile_config::save_profile_config(
+            "test",
+            &crate::session::profile_config::ProfileConfig {
+                description: None,
+                overrides,
+            },
+        )
+        .expect("write test profile override");
+
+        struct Case {
+            id: &'static str,
+            leaf: &'static str,
+            new_name: &'static str,
+            // Whether the requested name relocates the worktree directory.
+            moves_cwd: bool,
+        }
+        // The cwd-stable row's name equals the existing leaf (a no-op move); the
+        // cwd-moving row's name differs, forcing a relocation.
+        let cases = [
+            Case {
+                id: "sw-cwd-stable",
+                leaf: "my-session",
+                new_name: "my-session",
+                moves_cwd: false,
+            },
+            Case {
+                id: "sw-cwd-moving",
+                leaf: "old-leaf",
+                new_name: "new-leaf",
+                moves_cwd: true,
+            },
+        ];
+
+        for case in cases {
+            let paths = tempfile::tempdir().unwrap();
+            let project_path = paths.path().join(case.leaf);
+            let mut inst = Instance::new(
+                "Original title",
+                project_path.to_str().expect("UTF-8 temp path"),
+            );
+            inst.id = case.id.to_string();
+            inst.source_profile = "test".to_string();
+            inst.status = Status::Idle;
+            inst.view = crate::session::View::Structured;
+            inst.worktree_info = Some(crate::session::WorktreeInfo {
+                branch: case.leaf.to_string(),
+                main_repo_path: paths
+                    .path()
+                    .join("missing-repo")
+                    .to_string_lossy()
+                    .into_owned(),
+                managed_by_aoe: true,
+                created_at: chrono::Utc::now(),
+                base_branch: None,
+            });
+
+            let state = crate::server::test_support::build_test_app_state(vec![inst]);
+            state.acp_supervisor.test_insert_worker(case.id).await;
+
+            let _ = set_worktree_name(
+                State(state.clone()),
+                Path(case.id.to_string()),
+                Ok(Json(SetWorktreeNameBody {
+                    name: case.new_name.to_string(),
+                    rename_branch: false,
+                })),
+            )
+            .await
+            .into_response();
+
+            assert_eq!(
+                state.acp_supervisor.is_running(case.id).await,
+                !case.moves_cwd,
+                "{}: worker should be {} for moves_cwd={}",
+                case.id,
+                if case.moves_cwd {
+                    "stopped"
+                } else {
+                    "preserved"
+                },
+                case.moves_cwd
+            );
+        }
     }
 
     #[test]

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1236,51 +1236,56 @@ pub async fn rename_session(
     let mut new_branch: Option<String> = None;
 
     if tied {
-        // The dir move is gated on a quiescent worktree, exactly like the
-        // standalone worktree-name edit. A running session must be stopped
-        // first; the setting is the escape hatch for free-form relabeling.
+        // A directory move or branch rename is gated on a quiescent worktree,
+        // exactly like the standalone worktree-name edit. A running session
+        // must be stopped first; the setting is the escape hatch for
+        // free-form relabeling.
+        //
         // A sandbox session's container keeps the worktree dir mounted even
-        // while the agent is Idle, so the move would fail. The helper drops a
-        // merely-stopped container to free the mount and only reports held for
-        // a live one, which the user has to stop.
+        // while the agent is Idle, so a directory move would fail. The helper
+        // drops a merely-stopped container to free the mount and only reports
+        // held for a live one, which the user has to stop.
+        //
         // Short-circuited twice, because the helper removes a stopped
         // container: once on the status check, so a request about to be
         // rejected never discards, and once on whether the directory is
         // actually going to move, so a no-op or branch-only rename does not
-        // either. The tied leaf comes from the title, matching what is handed
-        // to `edit_worktree_workdir` below.
+        // either.
+        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&title);
         let moves_worktree = crate::session::worktree_edit::worktree_move_required(
             std::path::Path::new(&current_path),
-            &crate::session::worktree_edit::worktree_leaf_from_title(&title),
+            &leaf,
         );
+        let renames_branch =
+            body.rename_branch && worktree_info.as_ref().is_some_and(|wt| wt.branch != leaf);
         let container_holds = !status.blocks_worktree_edit()
             && moves_worktree
             && ensure_sandbox_container_released_blocking(&id, is_sandboxed).await;
-        if status.blocks_worktree_edit() || container_holds {
+        if (moves_worktree || renames_branch) && (status.blocks_worktree_edit() || container_holds)
+        {
             return (
                 StatusCode::CONFLICT,
                 Json(serde_json::json!({
                     "error": "session_running",
-                    "message": "Stop the session before renaming it: its worktree directory moves to match the new name. Disable \"Tie Worktree Directory to Session Name\" to relabel a running session."
+                    "message": "Stop the session before renaming its worktree directory or branch. Disable \"Tie Worktree Directory to Session Name\" to relabel a running session."
                 })),
             )
                 .into_response();
         }
 
-        // Stop any live structured-view worker before the move so it can't
-        // crash on the pulled-out cwd and respawn-loop at the stale path
-        // (#2260). Done under the instance_lock held since the top of this
-        // function. Preserves the agent transcript so the reconciler resumes
-        // context at the new path.
-        if let Err(resp) =
-            quiesce_structured_worker_for_worktree_move(&state, &id, is_structured).await
-        {
-            return resp;
+        // Stop a live structured-view worker only when its cwd will move. A
+        // title-only or branch-only edit leaves the cwd valid and must not
+        // interrupt the worker.
+        if moves_worktree {
+            if let Err(response) =
+                quiesce_structured_worker_for_worktree_move(&state, &id, is_structured).await
+            {
+                return response;
+            }
         }
 
         let wt = worktree_info.expect("tied implies worktree_info is Some");
         let cur = current_path.clone();
-        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&title);
         let rename_branch = body.rename_branch;
         let edit = tokio::task::spawn_blocking(move || {
             crate::session::worktree_edit::edit_worktree_workdir(
@@ -8739,6 +8744,123 @@ mod tests {
         assert_eq!(
             inst.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
             Some("feature/test")
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rename_session_distinguishes_cwd_stable_title_and_branch_changes() {
+        let _app_dir = crate::session::test_support::isolate_app_dir();
+        let paths = tempfile::tempdir().unwrap();
+        let title_path = paths.path().join("my-session");
+        let branch_path = paths.path().join("branch-only");
+        let title_id = "rename-title-only".to_string();
+        let branch_id = "rename-branch-only".to_string();
+
+        let mut title_only = Instance::new(
+            "Original title",
+            title_path.to_str().expect("UTF-8 temp path"),
+        );
+        title_only.id = title_id.clone();
+        title_only.status = Status::Running;
+        title_only.view = crate::session::View::Structured;
+        title_only.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "my-session".to_string(),
+            main_repo_path: paths
+                .path()
+                .join("missing-repo")
+                .to_string_lossy()
+                .into_owned(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+
+        let mut branch_only = Instance::new(
+            "Branch Only",
+            branch_path.to_str().expect("UTF-8 temp path"),
+        );
+        branch_only.id = branch_id.clone();
+        branch_only.status = Status::Running;
+        branch_only.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "existing-branch".to_string(),
+            main_repo_path: paths
+                .path()
+                .join("missing-repo")
+                .to_string_lossy()
+                .into_owned(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+
+        let state =
+            crate::server::test_support::build_test_app_state(vec![title_only, branch_only]);
+        state.acp_supervisor.test_insert_worker(&title_id).await;
+
+        // The title changes, but its slug already matches both the cwd leaf
+        // and branch. Even with the branch toggle armed, this is title-only.
+        let title_response = rename_session(
+            State(state.clone()),
+            Path(title_id.clone()),
+            Ok(Json(RenameSessionBody {
+                title: "My Session!".to_string(),
+                rename_branch: true,
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(title_response.status(), StatusCode::OK);
+        let title_json: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(title_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(title_json["tie_workdir_to_name"], true);
+        assert!(
+            state.acp_supervisor.is_running(&title_id).await,
+            "a cwd-stable title-only rename must not stop the structured worker"
+        );
+
+        {
+            let instances = state.instances.read().await;
+            let renamed = instances.iter().find(|inst| inst.id == title_id).unwrap();
+            assert_eq!(renamed.title, "My Session!");
+            assert_eq!(renamed.project_path, title_path.to_str().unwrap());
+            assert_eq!(
+                renamed.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
+                Some("my-session")
+            );
+        }
+
+        let branch_response = rename_session(
+            State(state.clone()),
+            Path(branch_id.clone()),
+            Ok(Json(RenameSessionBody {
+                title: "Branch Only".to_string(),
+                rename_branch: true,
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(branch_response.status(), StatusCode::CONFLICT);
+        let branch_json: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(branch_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(branch_json["error"], "session_running");
+
+        let instances = state.instances.read().await;
+        let rejected = instances.iter().find(|inst| inst.id == branch_id).unwrap();
+        assert_eq!(rejected.title, "Branch Only");
+        assert_eq!(rejected.project_path, branch_path.to_str().unwrap());
+        assert_eq!(
+            rejected.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
+            Some("existing-branch"),
+            "the active branch-only request must be rejected before git mutation"
         );
     }
 

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -83,6 +83,27 @@ pub fn worktree_move_required(current_path: &Path, new_name: &str) -> bool {
     target_worktree_path(current_path, new_name).is_some_and(|p| p != current_path)
 }
 
+/// Whether a workdir edit for `new_name` would actually rename the git branch.
+///
+/// The single source of truth for the branch-change predicate, mirroring
+/// [`worktree_move_required`] for the directory-move half. Callers that need to
+/// predict "will this edit rename the branch?" (to gate a running-session
+/// check, or to decide whether a structured-view worker must be quiesced) route
+/// through this so they cannot drift from [`edit_worktree_workdir`]'s own
+/// `branch_changes` decision.
+///
+/// Applies the same git-ref sanitizer (`git_sanitize_branch_name`) the edit
+/// applies to `new_name`, so a raw name that sanitizes to the branch the
+/// worktree already has is correctly reported as "no rename". A raw leaf
+/// comparison would miss that and over-report a rename.
+pub fn worktree_branch_rename_required(
+    worktree_info: &WorktreeInfo,
+    new_name: &str,
+    rename_branch: bool,
+) -> bool {
+    rename_branch && git_sanitize_branch_name(new_name) != worktree_info.branch
+}
+
 /// Release a sandbox session's hold on its worktree directory ahead of a
 /// `git worktree move`, and report whether the worktree is *still* held.
 ///
@@ -345,7 +366,8 @@ pub fn edit_worktree_workdir(
     let new_path = target_worktree_path(req.current_path, req.new_name)
         .ok_or_else(|| WorktreeEditError::NoParent(req.current_path.to_path_buf()))?;
 
-    let branch_changes = req.rename_branch && new_branch != req.worktree_info.branch;
+    let branch_changes =
+        worktree_branch_rename_required(req.worktree_info, req.new_name, req.rename_branch);
     let path_changes = new_path != req.current_path;
     if !branch_changes && !path_changes {
         return Err(WorktreeEditError::Unchanged);
@@ -478,6 +500,39 @@ mod tests {
                 target != cur,
                 "disagreement for {name:?}: target resolved to {}",
                 target.display()
+            );
+        }
+    }
+
+    /// `worktree_branch_rename_required` is the branch-half counterpart of
+    /// `worktree_move_required`, and must agree with the `branch_changes`
+    /// decision `edit_worktree_workdir` actually makes: `rename_branch` armed
+    /// AND the git-ref-sanitized name differing from the current branch. The
+    /// sanitizer step is the point a raw leaf comparison would get wrong.
+    #[test]
+    fn worktree_branch_rename_required_matches_the_sanitized_branch_change() {
+        let info = wt_info("feature/login", "/tmp/repo", true);
+        let cases = [
+            // rename_branch off: never a rename, whatever the name.
+            ("feature/logout", false, false),
+            // A genuinely different name with the toggle on renames the branch.
+            ("feature/logout", true, true),
+            // Sanitizes back to the current branch: git_sanitize_branch_name is
+            // idempotent on an already-valid ref, so this is NOT a rename even
+            // with the toggle on. A raw comparison would agree here.
+            ("feature/login", true, false),
+            // The case a raw string comparison gets WRONG: a forbidden ref
+            // char ('~') the git-ref sanitizer folds to '-' and then strips as
+            // a trailing dash lands back on the current branch, so the
+            // sanitized comparison must report no rename where a raw one would
+            // over-report one.
+            ("feature/login~", true, false),
+        ];
+        for (name, rename_branch, expected) in cases {
+            assert_eq!(
+                worktree_branch_rename_required(&info, name, rename_branch),
+                expected,
+                "name={name:?} rename_branch={rename_branch}"
             );
         }
     }


### PR DESCRIPTION
## Description

The tied-worktree rename endpoint stopped a live structured-view worker for every tied rename, even when the requested title mapped to the existing directory and the cwd would not move. Title-only spelling changes therefore interrupted valid workers. Branch-only git renames remain worktree mutations and must retain the active-session stop-first gate.

This PR computes path movement and branch mutation independently. Active sessions are rejected when either will change. Sandbox release and structured-worker quiesce remain gated only on path movement, so cwd-stable title-only edits preserve the worker while branch-only edits keep the existing stop-first contract.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No documentation or screenshot is needed; the endpoint contract and UI are unchanged.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: no dashboard rendering or interaction change
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR changes one server-side side-effect gate
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

- `cargo fmt --check`
- `cargo clippy --features serve --lib --bins -- -D warnings`
- `cargo test --features serve -- --skip tmux::session::tests::a_zoomed_pane_falls_back_to_the_plain_capture --skip tmux::session::tests::size_owner_lock_claims_rejects_steals_and_releases` (6,551 passed; 8 ignored; 2 filtered)

The filtered cases are unrelated tmux setup flakes independently verified on sibling scoped PR runs.

## Initial Review Cycle

Three independent reviewers confirmed cwd-stable title behavior and found one high-severity branch-only regression plus missing handler coverage. The single correction pass independently computes path and branch mutation: active sessions reject either mutation, while sandbox release and worker quiesce remain path-only. One handler-level test covers worker preservation and branch-only rejection. No second reviewer wave was run.

## Fresh Review Round 2

Three fresh reviewers found no defect in the path/branch mutation predicates or handler tests. Two lifecycle findings were rejected as pre-existing races unchanged by this gate-only PR. No correction, commit, or third reviewer wave was needed; head remains `7da7c3e2`.

## Risks

- Actual directory moves retain the existing running-session rejection and worker quiesce.
- Cwd-stable title-only edits keep the worker alive; active branch-only edits remain rejected because they mutate the checked-out ref.
- Sandbox container release remains gated on an actual path move.
- Worktree edit and persistence behavior are otherwise unchanged.

## GitHub Review Comments

No review threads or submitted review comments required code changes.

## Upstream Sync

Rebased onto `upstream/main` at `24226821`; ready for review. Final synchronized head: `7da7c3e2`. GitHub checks are green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you&#39;d like to share:** Finding isolation, implementation, and validation assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form




## Summary

- Updated worktree rename handling to distinguish directory moves, branch changes, and title-only edits.
- Rejects active sessions when the directory or branch changes.
- Preserves live workers for title-only and branch-only edits.
- Quiesces workers and releases sandboxes only when the worktree directory moves.
- Added a shared branch-rename predicate and expanded handler and unit test coverage.
- Formatting, Clippy, and 6,551 tests pass.

## Benefits

This prevents unnecessary worker shutdowns and preserves active sessions when their working directory and branch remain unchanged.

## Further enhancement

Consider adding higher-level integration tests for rename behavior across session lifecycle states.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Tied-worktree renames now distinguish directory moves, branch changes, and title-only edits.
- Active sessions reject directory or branch changes.
- Title-only edits preserve live workers when the worktree path stays unchanged.
- Sandbox release and structured-worker quiesce occur only when the worktree directory moves.
- Added a shared branch-rename predicate and focused unit tests.
- Updated worktree documentation to describe the refined rename behavior.

## Benefits

- Prevents unsafe changes to active sessions.
- Preserves workers when their working directory does not change.
- Keeps branch-only renames aligned with existing stop-first behavior.
- Improves coverage for worker state, metadata, conflicts, and rename decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->