### PR TITLE
docs: fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ unchanged.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=agent-of-empires/agent-of-empires&type=date&legend=top-left)](https://www.star-history.com/#agent-of-empires/agent-of-empires&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=agent-of-empires/agent-of-empires&type=date&legend=top-left)](https://star-history.dera.page/#agent-of-empires/agent-of-empires&type=date&legend=top-left)
 
 ## Acknowledgments
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the data source it relied on is restricted by GitHub stargazer API limits, so the chart no longer renders for readers. This updates the chart to use a working alternative that needs no API token, so the chart displays again for everyone.

No other files are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Updated the README star history chart to use `star-history.dera.page`.
- Removed dependencies on the restricted `api.star-history.com` and `www.star-history.com` sources.
- Restored chart rendering for readers affected by GitHub API limits.

## Technical details
- Changed only `README.md`.
- No public entities or declarations changed.
- Further enhancement: Monitor the alternative data source to ensure continued availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->