### PR TITLE
fix(tui): let tmux decide bracketed paste on live-send multi-line pastes

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1280,7 +1280,7 @@ impl Session {
     /// receiving program actually set DECSET 2004. Hand-rolling the markers
     /// instead (as a raw `send-keys -H` payload) delivers them to raw shells
     /// and simple REPLs that never asked for them, which render the leftovers
-    /// as literal `00~` / `01~` text (#3364-adjacent, live-send paste).
+    /// as literal `00~` / `01~` text on the live-send paste path.
     ///
     /// See `send_via_paste_buffer` for the buffer-naming and cleanup
     /// contract. tmux translates LF to CR in the buffer by default, matching

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1275,6 +1275,21 @@ impl Session {
         Ok(())
     }
 
+    /// Paste `text` into the session's first pane through tmux's own paste
+    /// path, so the bracketed-paste markers are emitted only when the
+    /// receiving program actually set DECSET 2004. Hand-rolling the markers
+    /// instead (as a raw `send-keys -H` payload) delivers them to raw shells
+    /// and simple REPLs that never asked for them, which render the leftovers
+    /// as literal `00~` / `01~` text (#3364-adjacent, live-send paste).
+    ///
+    /// See [`Self::send_via_paste_buffer`] for the buffer-naming and cleanup
+    /// contract. tmux translates LF to CR in the buffer by default, matching
+    /// the raw-byte encoding this replaces.
+    pub fn paste_text(&self, text: &str) -> Result<()> {
+        let target = format!("{}:^.0", self.name);
+        Self::send_via_paste_buffer(&target, text)
+    }
+
     pub fn get_pane_pid(&self) -> Option<u32> {
         process::get_pane_pid(&self.name)
     }

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1282,7 +1282,7 @@ impl Session {
     /// and simple REPLs that never asked for them, which render the leftovers
     /// as literal `00~` / `01~` text (#3364-adjacent, live-send paste).
     ///
-    /// See [`Self::send_via_paste_buffer`] for the buffer-naming and cleanup
+    /// See `send_via_paste_buffer` for the buffer-naming and cleanup
     /// contract. tmux translates LF to CR in the buffer by default, matching
     /// the raw-byte encoding this replaces.
     pub fn paste_text(&self, text: &str) -> Result<()> {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -99,17 +99,6 @@ fn persist_telemetry_consent(opt_in: bool) {
     crate::telemetry::apply_opt_in_change(opt_in);
 }
 
-/// xterm bracketed-paste start sequence: `ESC [ 2 0 0 ~`. An agent that
-/// has enabled bracketed paste mode (`\e[?2004h`) treats everything
-/// between this marker and the matching end marker as one paste rather
-/// than as keystrokes, so interior newlines accumulate in the input
-/// buffer instead of firing `submit` per line.
-const BRACKETED_PASTE_START: &[u8] = &[0x1b, b'[', b'2', b'0', b'0', b'~'];
-
-/// xterm bracketed-paste end sequence: `ESC [ 2 0 1 ~`. Pairs with
-/// [`BRACKETED_PASTE_START`].
-const BRACKETED_PASTE_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
-
 /// Decompose pasted text into a series of `TmuxKey`s safe for the
 /// live-send worker to dispatch.
 ///
@@ -120,17 +109,17 @@ const BRACKETED_PASTE_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
 /// literal text. Tabs in single-line pastes still go through as
 /// `Named("Tab")` to mirror the historical path.
 ///
-/// Multi-line pastes get wrapped in xterm bracketed-paste markers
-/// (`\e[200~` / `\e[201~`) so the receiving agent sees the entire
-/// payload as one paste rather than as N independent Enter keypresses.
+/// Multi-line pastes are handed to tmux as a single paste
+/// (`load-buffer` + `paste-buffer -p`), so the receiving agent sees the
+/// entire payload as one paste rather than as N independent Enter
+/// keypresses, and tmux emits the bracketed-paste markers only for panes
+/// that actually set DECSET 2004.
 /// Without the wrapping, agents that submit on Enter (Claude Code,
 /// Codex, OpenCode, ...) post one user message per pasted line, which
-/// is the bug behind #1546. The whole payload (markers, printable
-/// runs, interior CRs, and tabs) goes through as a single `HexBytes`
-/// action, which the worker dispatches as one or more size-bounded
-/// `tmux send-keys -H` forks (a per-byte argv overflows `ARG_MAX` on a
-/// large paste, so it can't always be one fork). `\r\n` pairs coalesce
-/// to a single CR so
+/// is the bug behind #1546. The whole payload goes through as a single
+/// `Paste` action, which the worker delivers with one `load-buffer` +
+/// `paste-buffer` pair (no `ARG_MAX` chunking, unlike the per-byte hex
+/// encoding this replaced). `\r\n` pairs coalesce to a single newline so
 /// Windows-line-ending pastes don't double up; other control bytes
 /// (BEL, ESC, ...) are dropped rather than risk that an embedded
 /// escape closes the bracketed-paste sequence on the agent's side.
@@ -167,40 +156,38 @@ fn split_inline_paste(text: &str) -> Vec<live_send::TmuxKey> {
 }
 
 fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
-    // Build one contiguous byte payload: start marker, then the paste
-    // content with printables as their UTF-8 bytes / interior newlines
-    // as CR (0x0d) / tabs as 0x09, then the end marker. Sending it as
-    // one `HexBytes` means the worker fires exactly one `tmux send-keys
-    // -H` subprocess per paste rather than one per chunk.
-    let mut bytes = Vec::with_capacity(text.len() + BRACKETED_PASTE_START.len() * 2);
-    bytes.extend_from_slice(BRACKETED_PASTE_START);
-
+    // Hand the payload to tmux as one paste and let `paste-buffer -p` decide
+    // about the markers. Emitting `\e[200~` / `\e[201~` ourselves delivered
+    // them to every pane, including raw shells and SQL REPLs that never set
+    // DECSET 2004; those parse `\e[2` as a partial Insert-key sequence, drop
+    // it, and self-insert the leftover `00~` / `01~` into the user's text.
+    // tmux tracks the pane's paste mode and brackets only when the program
+    // asked for it, which keeps the #1546 fix for agents intact.
+    //
+    // tmux replaces LF with CR in the buffer by default, so interior newlines
+    // land exactly as the old raw-byte encoding delivered them. `\r\n` pairs
+    // still coalesce here so Windows-line-ending pastes don't double up, and
+    // other control bytes (BEL, ESC, ...) are still dropped rather than risk
+    // an embedded escape closing the bracketed-paste sequence on the agent's
+    // side.
+    let mut out = String::with_capacity(text.len());
     let mut chars = text.chars().peekable();
-    let mut utf8_buf = [0u8; 4];
     while let Some(ch) = chars.next() {
         match ch {
-            '\n' => bytes.push(0x0d),
+            '\n' => out.push('\n'),
             '\r' => {
                 if chars.peek() == Some(&'\n') {
                     chars.next();
                 }
-                bytes.push(0x0d);
+                out.push('\n');
             }
-            '\t' => bytes.push(0x09),
-            c if (c as u32) < 0x20 || c == '\x7f' => {
-                // Embedded ESC / BEL / etc. has no safe encoding
-                // inside the paste payload; drop rather than risk a
-                // bogus terminal escape closing the paste early.
-            }
-            c => {
-                let s = c.encode_utf8(&mut utf8_buf);
-                bytes.extend_from_slice(s.as_bytes());
-            }
+            '\t' => out.push('\t'),
+            c if (c as u32) < 0x20 || c == '\x7f' => {}
+            c => out.push(c),
         }
     }
 
-    bytes.extend_from_slice(BRACKETED_PASTE_END);
-    vec![live_send::TmuxKey::HexBytes(bytes)]
+    vec![live_send::TmuxKey::Paste(out)]
 }
 
 /// The rectangle mouse coordinates are mapped into, or `None` when the pointer

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1580,8 +1580,18 @@ impl LiveCaptureWorker {
 /// coalescing ordering via `coalesce` directly without needing a real
 /// session.
 fn dispatch_batch(tmux_name: &str, batch: Vec<WorkerMsg>) {
-    for action in coalesce(batch) {
-        if let Err(err) = dispatch_via_fork(tmux_name, &action) {
+    let actions = coalesce(batch);
+    // A `Paste` can only go through tmux (`paste-buffer -p` is what decides
+    // whether the pane gets bracketed-paste markers), so a batch holding one
+    // would otherwise split across two writers: the paste via tmux and its
+    // neighbouring keystrokes via the vt socket. The socket hands bytes to the
+    // `pipe-pane -I` forwarder, which writes to the pty independently, so the
+    // two can land out of order and scramble a type-then-paste sequence. Pin
+    // the whole batch to tmux instead, which serializes its own writes, and
+    // keep the single-writer invariant in `tmux::vt::input_mode` intact.
+    let force_tmux = actions.iter().any(|a| matches!(a, TmuxAction::Paste(_)));
+    for action in actions {
+        if let Err(err) = dispatch_via_fork(tmux_name, &action, force_tmux) {
             tracing::warn!(
                 target: "tui.live_send",
                 error = %err,
@@ -1595,7 +1605,7 @@ fn dispatch_batch(tmux_name: &str, batch: Vec<WorkerMsg>) {
 /// Execute one `TmuxAction` as a one-shot `tmux` subprocess. Module-
 /// level fn (rather than a method on the worker) so it stays callable
 /// from the spawned thread without holding a worker reference.
-fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()> {
+fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction, force_tmux: bool) -> anyhow::Result<()> {
     use std::process::Stdio;
 
     // Fast path (`[tmux] vt_live`): when a *live* input channel is armed for this
@@ -1622,7 +1632,7 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
     // failure to prove the writer is dead, so falling back here could race a
     // still-live socket writer.
     #[cfg(unix)]
-    if let Some(app_cursor) = crate::tmux::vt::input_mode(tmux_name) {
+    if let Some(app_cursor) = crate::tmux::vt::input_mode(tmux_name).filter(|_| !force_tmux) {
         if !matches!(action, TmuxAction::Resize { .. } | TmuxAction::Paste(_)) {
             let bytes = encode_action_bytes(action, app_cursor);
             if bytes.is_empty() {
@@ -2020,7 +2030,8 @@ pub(super) fn send_key_oneshot(tmux_name: &str, key: TmuxKey) {
         .name("aoe-wheel-forward".to_string())
         .spawn(move || {
             let _slot = OneshotSlot;
-            if let Err(err) = dispatch_via_fork(&tmux_name, &action) {
+            // A wheel notch is never a paste, so the vt fast path stays open.
+            if let Err(err) = dispatch_via_fork(&tmux_name, &action, false) {
                 tracing::warn!(
                     target: "tui.live_send",
                     error = %err,

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -351,6 +351,8 @@ pub(super) enum TmuxAction {
         count: usize,
     },
     HexBytes(Vec<u8>),
+    /// A multi-line paste routed through `paste-buffer -p`.
+    Paste(String),
     Resize {
         cols: u16,
         rows: u16,
@@ -395,6 +397,13 @@ pub(super) fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
                     Some(TmuxAction::HexBytes(prev)) => prev.extend_from_slice(&bytes),
                     _ => out.push(TmuxAction::HexBytes(bytes)),
                 }
+            }
+            WorkerMsg::Send(TmuxKey::Paste(text)) => {
+                // Never merged: a paste is one discrete tmux paste-buffer
+                // call, and folding it into a neighbouring run would put the
+                // payload back on the literal path the markers came from.
+                flush(&mut out, &mut run);
+                out.push(TmuxAction::Paste(text));
             }
             WorkerMsg::Resize { cols, rows } => {
                 flush(&mut out, &mut run);
@@ -1614,7 +1623,7 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
     // still-live socket writer.
     #[cfg(unix)]
     if let Some(app_cursor) = crate::tmux::vt::input_mode(tmux_name) {
-        if !matches!(action, TmuxAction::Resize { .. }) {
+        if !matches!(action, TmuxAction::Resize { .. } | TmuxAction::Paste(_)) {
             let bytes = encode_action_bytes(action, app_cursor);
             if bytes.is_empty() {
                 return Ok(());
@@ -1678,6 +1687,12 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
             // (the web live view's input path uses the same fn).
             return crate::tmux::Session::from_name(tmux_name).send_raw_bytes(bytes);
         }
+        TmuxAction::Paste(text) => {
+            // tmux emits the bracketed-paste markers only if the program in
+            // the pane set DECSET 2004, so a raw shell or a SQL REPL gets
+            // clean text instead of literal `00~` / `01~` leftovers.
+            return crate::tmux::Session::from_name(tmux_name).paste_text(text);
+        }
         TmuxAction::Resize { cols, rows } => {
             // Size the window through `Session::resize_window` so the pane lands
             // at exactly `rows` after tmux's status-bar chrome, the same math the
@@ -1716,6 +1731,9 @@ fn encode_action_bytes(action: &TmuxAction, app_cursor: bool) -> Vec<u8> {
             let one = encode_named_key(name, app_cursor);
             one.repeat(*count)
         }
+        // Paste never reaches here: the vt fast path is skipped for it so
+        // tmux can make the bracketed-paste decision.
+        TmuxAction::Paste(_) => Vec::new(),
         TmuxAction::Resize { .. } => Vec::new(),
     }
 }
@@ -1991,6 +2009,7 @@ pub(super) fn send_key_oneshot(tmux_name: &str, key: TmuxKey) {
         TmuxKey::Named(name) => TmuxAction::Named(name),
         TmuxKey::NamedRepeat { name, count } => TmuxAction::NamedRepeat { name, count },
         TmuxKey::HexBytes(bytes) => TmuxAction::HexBytes(bytes),
+        TmuxKey::Paste(text) => TmuxAction::Paste(text),
     };
     // `Builder::spawn` returns the OS error instead of panicking (`spawn`
     // panics if the OS refuses a new thread), so a thread-creation failure
@@ -2091,6 +2110,10 @@ pub(super) enum TmuxKey {
         count: usize,
     },
     HexBytes(Vec<u8>),
+    /// A multi-line paste, delivered through tmux's `paste-buffer -p` so
+    /// tmux decides whether the receiving program gets bracketed-paste
+    /// markers. Never merged with neighbours: it is one discrete paste.
+    Paste(String),
 }
 
 /// Map one crossterm `KeyEvent` onto a `LiveDispatch`.

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -2902,6 +2902,32 @@ mod tests {
     }
 
     #[test]
+    fn coalesce_paste_breaks_literal_run_and_never_merges() {
+        // A paste must stay its own action: folding it into a
+        // neighbouring literal run would put the payload back on the
+        // `send-keys` path, where tmux never gets to decide about the
+        // bracketed-paste markers (the `00~` / `01~` bug), and would
+        // also drop the #1546 one-paste framing for agents that DO set
+        // DECSET 2004. Ordering across the batch has to survive too.
+        let out = coalesce(vec![
+            snd_lit("a"),
+            snd_lit("b"),
+            WorkerMsg::Send(TmuxKey::Paste("x\ny".into())),
+            snd_lit("c"),
+            WorkerMsg::Send(TmuxKey::Paste("p\nq".into())),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::Literal("ab".into()),
+                TmuxAction::Paste("x\ny".into()),
+                TmuxAction::Literal("c".into()),
+                TmuxAction::Paste("p\nq".into()),
+            ]
+        );
+    }
+
+    #[test]
     fn unhandled_keys_are_ignored() {
         assert_eq!(translate(k(KeyCode::Null)), LiveDispatch::Ignore);
         assert_eq!(translate(k(KeyCode::CapsLock)), LiveDispatch::Ignore);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -16181,21 +16181,15 @@ mod live_send_mode {
             TmuxKey::Named(name.to_string())
         }
 
-        /// xterm bracketed-paste start: `ESC [ 2 0 0 ~`.
-        const BP_START: &[u8] = &[0x1b, b'[', b'2', b'0', b'0', b'~'];
-        /// xterm bracketed-paste end: `ESC [ 2 0 1 ~`.
-        const BP_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
-
-        /// Build the expected `HexBytes` payload for a multi-line
-        /// paste: start marker, then the per-line `body` bytes, then
-        /// end marker. Keeps each test focused on the *shape* of the
-        /// paste content rather than on hand-rolled byte arithmetic.
-        fn wrap(body: &[u8]) -> Vec<TmuxKey> {
-            let mut out = Vec::with_capacity(BP_START.len() + body.len() + BP_END.len());
-            out.extend_from_slice(BP_START);
-            out.extend_from_slice(body);
-            out.extend_from_slice(BP_END);
-            vec![TmuxKey::HexBytes(out)]
+        /// Expected shape for a multi-line paste: one `Paste` action
+        /// carrying the payload verbatim. No bracketed-paste markers
+        /// appear here on purpose. tmux adds them via `paste-buffer -p`
+        /// only for panes that set DECSET 2004, so a raw shell or SQL
+        /// REPL no longer receives markers it would render as literal
+        /// `00~` / `01~` text. Interior newlines stay `\n`; tmux
+        /// translates them to CR when it performs the paste.
+        fn paste(body: &str) -> Vec<TmuxKey> {
+            vec![TmuxKey::Paste(body.to_string())]
         }
 
         #[test]
@@ -16208,13 +16202,12 @@ mod live_send_mode {
 
         #[test]
         fn newline_wraps_in_bracketed_paste() {
-            // Two-line paste must wrap in `\e[200~` / `\e[201~` markers,
-            // with the interior newline riding as a raw CR. Without the
-            // wrapping the agent treats the `\n` as Enter -> submit and
-            // posts each line as its own user message (#1546).
+            // Two-line paste travels as one tmux paste. Without it the
+            // agent treats the `\n` as Enter -> submit and posts each
+            // line as its own user message (#1546).
             assert_eq!(
                 split_paste_for_live_send("first\nsecond"),
-                wrap(b"first\x0dsecond"),
+                paste("first\nsecond"),
             );
         }
 
@@ -16226,25 +16219,25 @@ mod live_send_mode {
             // review before sending.
             assert_eq!(
                 split_paste_for_live_send("only line\n"),
-                wrap(b"only line\x0d"),
+                paste("only line\n"),
             );
         }
 
         #[test]
         fn leading_newline_stays_inside_bracketed_paste() {
-            assert_eq!(split_paste_for_live_send("\nbody"), wrap(b"\x0dbody"));
+            assert_eq!(split_paste_for_live_send("\nbody"), paste("\nbody"));
         }
 
         #[test]
         fn crlf_coalesces_to_single_cr() {
-            // Windows-style line endings collapse to one CR inside the
-            // bracketed paste so the agent doesn't see a double newline.
-            assert_eq!(split_paste_for_live_send("a\r\nb"), wrap(b"a\x0db"));
+            // Windows-style line endings collapse to one newline so the
+            // agent doesn't see a double newline.
+            assert_eq!(split_paste_for_live_send("a\r\nb"), paste("a\nb"));
         }
 
         #[test]
         fn bare_cr_becomes_cr_inside_bracketed_paste() {
-            assert_eq!(split_paste_for_live_send("a\rb"), wrap(b"a\x0db"));
+            assert_eq!(split_paste_for_live_send("a\rb"), paste("a\nb"));
         }
 
         #[test]
@@ -16258,10 +16251,9 @@ mod live_send_mode {
 
         #[test]
         fn tab_in_multiline_paste_rides_as_raw_byte() {
-            // Inside a bracketed paste, tab is a literal character of
-            // the paste content, not a key event, so we send it as a
-            // raw 0x09 byte alongside the rest of the payload.
-            assert_eq!(split_paste_for_live_send("a\tb\nc"), wrap(b"a\x09b\x0dc"),);
+            // Inside a paste, tab is a literal character of the paste
+            // content, not a key event, so it rides in the payload.
+            assert_eq!(split_paste_for_live_send("a\tb\nc"), paste("a\tb\nc"),);
         }
 
         #[test]
@@ -16276,38 +16268,57 @@ mod live_send_mode {
 
         #[test]
         fn other_control_bytes_are_dropped_inside_bracketed_paste() {
-            // Same drop policy applies inside the bracketed paste: an
-            // embedded ESC could prematurely close the paste sequence
-            // on the agent's side, so we strip it rather than forward.
-            assert_eq!(
-                split_paste_for_live_send("a\x07b\x1bc\nd"),
-                wrap(b"abc\x0dd"),
-            );
+            // Same drop policy applies inside the paste: an embedded
+            // ESC could prematurely close the paste sequence on the
+            // agent's side, so we strip it rather than forward.
+            assert_eq!(split_paste_for_live_send("a\x07b\x1bc\nd"), paste("abc\nd"),);
+        }
+
+        /// The bug: we used to hand-roll `\e[200~` / `\e[201~` into the
+        /// payload and ship it as raw bytes, so every pane got the markers
+        /// whether or not it had set DECSET 2004. A raw shell or SQL REPL
+        /// parses `\e[2` as a partial Insert-key sequence, discards it, and
+        /// self-inserts the leftover `00~` / `01~` into the user's text.
+        /// The payload must now carry no escape bytes at all; tmux decides.
+        #[test]
+        fn multiline_paste_carries_no_escape_markers() {
+            let keys = split_paste_for_live_send("SELECT id\nFROM users;");
+            assert_eq!(keys, paste("SELECT id\nFROM users;"));
+            match &keys[0] {
+                TmuxKey::Paste(body) => {
+                    assert!(
+                        !body.contains('\x1b'),
+                        "paste payload must not carry ESC: {body:?}"
+                    );
+                    assert!(!body.contains("200~") && !body.contains("201~"));
+                }
+                other => panic!("expected Paste, got {other:?}"),
+            }
         }
 
         #[test]
         fn multiline_drag_select_paste_round_trip() {
             // Exact shape that comes back from drag-select copy: lines
             // joined with `\n` and no trailing newline. After the fix
-            // for #1546 this wraps in bracketed-paste markers so the
-            // agent sees one paste instead of three Enter keypresses.
+            // for #1546 this travels as one paste so the agent sees one
+            // paste instead of three Enter keypresses.
             assert_eq!(
                 split_paste_for_live_send("alpha beta\nsecond line\nthird"),
-                wrap(b"alpha beta\x0dsecond line\x0dthird"),
+                paste("alpha beta\nsecond line\nthird"),
             );
         }
 
         #[test]
-        fn multiline_paste_dispatches_as_one_hex_payload() {
-            // Single-fork dispatch: the entire paste (markers, content,
-            // CRs) is one `HexBytes` so the worker fires exactly one
-            // `tmux send-keys -H` subprocess. Verifies the length-of-1
-            // invariant the worker relies on for paste latency.
+        fn multiline_paste_dispatches_as_one_payload() {
+            // Single-dispatch: the entire paste is one `Paste` action, so
+            // the worker fires exactly one `load-buffer` + `paste-buffer`
+            // pair. Verifies the length-of-1 invariant the worker relies
+            // on for paste latency.
             let out = split_paste_for_live_send("a\nb\nc\nd");
             assert_eq!(out.len(), 1, "multiline paste must be one TmuxKey");
             match &out[0] {
-                TmuxKey::HexBytes(_) => {}
-                other => panic!("expected HexBytes, got {other:?}"),
+                TmuxKey::Paste(_) => {}
+                other => panic!("expected Paste, got {other:?}"),
             }
         }
 
@@ -16317,16 +16328,12 @@ mod live_send_mode {
             // UTF-8 byte sequences so the agent receives the same text
             // the user copied. Regression guard for any future "ASCII
             // only" filter.
-            assert_eq!(
-                split_paste_for_live_send("café\n🚀"),
-                wrap("café\x0d🚀".as_bytes()),
-            );
+            assert_eq!(split_paste_for_live_send("café\n🚀"), paste("café\n🚀"),);
         }
 
         #[test]
         fn empty_paste_is_empty() {
-            // An empty paste should drop the entire bracketed-paste
-            // wrapper too: pushing `\e[200~\e[201~` with no payload
+            // An empty paste emits nothing at all: an empty tmux paste
             // would still flash through some agents' paste handlers.
             assert!(split_paste_for_live_send("").is_empty());
         }

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -713,6 +713,38 @@ last_seen_version = "{}"
         std::thread::sleep(Duration::from_millis(100));
     }
 
+    /// Deliver `text` to the TUI as a bracketed paste, the way a real
+    /// terminal does when the user hits Cmd/Ctrl+V. aoe enables bracketed
+    /// paste at startup, so crossterm turns this into one `Event::Paste`
+    /// rather than N key events, which is the only way to exercise the
+    /// paste path (`handle_paste`) rather than the keystroke path.
+    ///
+    /// Bytes go out as hex so an embedded newline or semicolon in `text`
+    /// cannot be reinterpreted by tmux's literal-mode argument parser.
+    pub fn send_paste(&self, text: &str) {
+        assert!(self.spawned, "must call spawn_tui() or spawn() first");
+        let mut bytes = b"\x1b[200~".to_vec();
+        bytes.extend_from_slice(text.as_bytes());
+        bytes.extend_from_slice(b"\x1b[201~");
+        let hex: Vec<String> = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let output = Command::new("tmux")
+            .arg("-S")
+            .arg(&self.socket_path)
+            .arg("send-keys")
+            .arg("-t")
+            .arg(&self.session_name)
+            .arg("-H")
+            .args(&hex)
+            .output()
+            .expect("failed to send paste");
+        assert!(
+            output.status.success(),
+            "send_paste failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        std::thread::sleep(Duration::from_millis(150));
+    }
+
     /// Send literal text (prevents "Enter" in text from being interpreted as
     /// the Enter key).
     pub fn type_text(&self, text: &str) {

--- a/tests/e2e/live_send_paste_e2e.rs
+++ b/tests/e2e/live_send_paste_e2e.rs
@@ -1,0 +1,120 @@
+//! e2e coverage for multi-line paste in live-send mode.
+//!
+//! aoe used to hand-roll the xterm bracketed-paste markers (`ESC[200~` /
+//! `ESC[201~`) into a raw `send-keys -H` payload, so every pane received them
+//! whether or not it had set DECSET 2004. A raw shell or a SQL REPL parses
+//! `ESC[2` as a partial Insert-key sequence, discards it on the non-matching
+//! next byte, and self-inserts the leftover `00~` / `01~` into the user's
+//! text. Pasting the same query after fully entering the view worked, because
+//! tmux's own paste path only emits the markers when the program asked for
+//! them.
+//!
+//! This drives the real binary from a real bracketed paste at the TUI's stdin
+//! through `handle_paste` -> live-send worker -> tmux, and asserts the agent
+//! pane received the query with no marker debris. Unit tests cover the payload
+//! shape; only an e2e can prove the bytes that land in the pane.
+
+use serial_test::parallel;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::harness::{app_dir_in, require_tmux, TuiTestHarness};
+
+/// Route activation straight into live-send, mirroring `live_takeover`.
+fn write_live_send_config(h: &TuiTestHarness) {
+    let config_dir = app_dir_in(h.home_path());
+    let config_content = format!(
+        r#"[updates]
+update_check_mode = "off"
+
+[app_state]
+has_seen_welcome = true
+has_responded_to_telemetry = true
+last_seen_version = "{version}"
+has_acknowledged_agent_hooks = true
+
+[session]
+default_attach_mode = "live_send"
+"#,
+        version = env!("CARGO_PKG_VERSION"),
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write live-send config");
+}
+
+fn agent_session_on(socket: &std::path::Path) -> String {
+    let output = Command::new("tmux")
+        .arg("-S")
+        .arg(socket)
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()
+        .expect("tmux list-sessions");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find(|name| name.starts_with("aoe_dev_") && !name.starts_with("aoe_e2e_"))
+        .map(String::from)
+        .expect("agent tmux session exists")
+}
+
+fn capture(socket: &std::path::Path, session: &str) -> String {
+    let output = Command::new("tmux")
+        .arg("-S")
+        .arg(socket)
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+/// A multi-line paste into a pane whose program never set DECSET 2004 must
+/// arrive as plain text. `cat -v` renders any escape byte visibly (`^[[200~`),
+/// so marker debris cannot hide inside the captured pane; a plain `cat` would
+/// let the terminal swallow the sequence and the regression would pass.
+#[test]
+#[parallel]
+fn test_live_send_paste_into_non_bracketed_pane_has_no_marker_debris() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("live_send_paste");
+    write_live_send_config(&h);
+
+    // Stand in for a raw shell / SQL REPL: echoes what it receives, never
+    // enables bracketed paste, and outlives the test.
+    let bin = h.install_path_command("claude");
+    std::fs::write(
+        bin.join("claude"),
+        // `-icanon` matters: in canonical mode the tty buffers input until a
+        // complete line, so a paste with no trailing newline would strand its
+        // last line in the line discipline and never reach the program.
+        "#!/bin/sh\nstty -echo -icanon min 1 time 0 2>/dev/null\nexec cat -v\n",
+    )
+    .expect("write cat stub");
+
+    let project = h.project_path();
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "Pasty"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    h.spawn_tui();
+    h.wait_for("Pasty");
+    h.send_keys("Enter");
+    h.wait_for_timeout("LIVE", Duration::from_secs(10));
+
+    h.send_paste("SELECT id\nFROM users;");
+    std::thread::sleep(Duration::from_millis(800));
+
+    let socket = h.home_path().join("tmux.sock");
+    let pane = capture(&socket, &agent_session_on(&socket));
+
+    assert!(
+        pane.contains("SELECT id") && pane.contains("FROM users"),
+        "pasted query should reach the agent pane, got:\n{pane}"
+    );
+    assert!(
+        !pane.contains("200~") && !pane.contains("201~"),
+        "bracketed-paste markers must not reach a pane that never set \
+         DECSET 2004 (this is the `00~` / `01~` bug), got:\n{pane}"
+    );
+}

--- a/tests/e2e/live_send_paste_e2e.rs
+++ b/tests/e2e/live_send_paste_e2e.rs
@@ -103,15 +103,26 @@ fn test_live_send_paste_into_non_bracketed_pane_has_no_marker_debris() {
     h.wait_for_timeout("LIVE", Duration::from_secs(10));
 
     h.send_paste("SELECT id\nFROM users;");
-    std::thread::sleep(Duration::from_millis(800));
 
+    // Poll rather than sleep a fixed span: a paste crosses the TUI, the
+    // live-send worker, a tmux fork, and the pane program, and any fixed
+    // budget is either flaky on a loaded box or slow on an idle one. The
+    // marker assertion below still holds on the buggy build, because the
+    // debris arrives in the same write as the text it brackets.
     let socket = h.home_path().join("tmux.sock");
-    let pane = capture(&socket, &agent_session_on(&socket));
-
-    assert!(
-        pane.contains("SELECT id") && pane.contains("FROM users"),
-        "pasted query should reach the agent pane, got:\n{pane}"
-    );
+    let session = agent_session_on(&socket);
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let pane = loop {
+        let pane = capture(&socket, &session);
+        if pane.contains("SELECT id") && pane.contains("FROM users") {
+            break pane;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "pasted query never reached the agent pane, last capture:\n{pane}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
     assert!(
         !pane.contains("200~") && !pane.contains("201~"),
         "bracketed-paste markers must not reach a pane that never set \

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -44,6 +44,7 @@ mod fork_structured_e2e;
 mod host_before_session_e2e;
 mod intro;
 mod kiro_launch;
+mod live_send_paste_e2e;
 mod live_takeover;
 mod logs;
 mod new_session;


### PR DESCRIPTION
## Description

Pasting a multi-line query into a Terminal View while in **live mode** inserted literal `00~` and `01~` around the text. Pasting the same query after fully entering the view worked.

`split_bracketed_paste` hand-rolled the xterm bracketed-paste markers (`ESC[200~` / `ESC[201~`) into a raw byte payload and shipped it via `send-keys -H`, **unconditionally**. Every pane received the markers whether or not it had set DECSET 2004. A raw shell or a SQL REPL parses `ESC[2` as the start of its Insert-key sequence (`ESC[2~`), fails to match on the next byte, discards the `ESC[2` prefix, and self-inserts the leftover `00~` / `01~` into the user's text.

Full attach worked because tmux's own paste path emits the markers only when the foreground program requested them. Injecting via `send-keys -H` bypasses that decision entirely.

The fix routes multi-line live-send pastes through tmux, reusing the **existing** `send_via_paste_buffer` helper (`load-buffer` + `paste-buffer -p`), which already documents exactly this contract: "`-p` enables bracketed-paste markers when the receiving pane has DECSET 2004 set." The live-send path simply never used it.

### Verified against live panes

Through the real code path, same payload, two panes:

| Pane | Before | After |
| --- | --- | --- |
| never sets `?2004h` (raw shell, SQL REPL) | `^[[200~SELECT id` … `^[[201~` | `SELECT id` (clean) |
| sets `?2004h` (agent) | `^[[200~SELECT id` | `^[[200~SELECT id` (unchanged) |

So the #1546 fix (agents posting one message per pasted line) is preserved exactly.

### Notes for reviewers

- **tmux exposes no format variable for a pane's bracketed-paste mode.** I checked `#{pane_bracketed_paste}` and variants against panes with and without `?2004h`; all return empty. Gating the existing byte-payload path on the pane mode is therefore not possible, and delegating to `paste-buffer -p` is the only correct option rather than merely the tidier one.
- **The vt persistent-input fast path is skipped for `Paste`.** It writes bytes straight to the pty and cannot know the pane's paste mode, so it must not encode this action. Ordering is preserved: the worker dispatches sequentially and `paste-buffer` completes before the next action.
- **Known behavior change, and the right one:** for a pane that never enables bracketed paste, interior newlines now arrive as CRs and submit per line. That is the pre-existing tradeoff already documented on `send_via_paste_buffer`, and it beats injecting `00~` debris into the user's query.
- `BRACKETED_PASTE_START` / `_END` are deleted, since nothing reads them any more.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Rust-only change to the TUI live-send path. The web live view shares `send_raw_bytes`, which is untouched.

**TUI / CLI (e2e test)**
- [ ] N/A
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

`tests/e2e/live_send_paste_e2e.rs` drives the real binary from a bracketed paste at the TUI's stdin, through `handle_paste` -> live-send worker -> tmux, and asserts the agent pane receives the query with no marker debris.

Two details that make it a real test rather than a passing one:

- The agent stub is **`cat -v`**, so any escape byte renders visibly in the captured pane. With a plain `cat` the terminal swallows the sequence and the regression passes silently.
- The stub sets **`-icanon`**. In canonical mode the tty buffers input until a complete line, so a paste with no trailing newline strands its last line in the line discipline and never reaches the program. This cost me a false failure before I spotted it.

**I verified the test fails without the fix.** Reverting `paste_text` to the hand-rolled markers produces:

```
bracketed-paste markers must not reach a pane that never set DECSET 2004
(this is the `00~` / `01~` bug), got:
^[[200~SELECT id
FROM users;^[[201~
```

Unit tests in `src/tui/home/tests.rs` cover the payload shape, including a new `multiline_paste_carries_no_escape_markers` asserting the payload carries no ESC byte at all.

### Verification

Run locally on Rust 1.97.1, tmux 3.6:

| Check | Result |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets --features e2e-tests` | no findings in changed files |
| `cargo test --lib` | 4586 passed, 0 failed |
| `cargo test --features e2e-tests --test e2e` | 155 passed, 1 failed |

The single e2e failure is `resume_fallback::stale_resume_failure_persists_loop_breaker_and_next_restart_starts_fresh`, which is **pre-existing and unrelated**: it fails identically on base commit `9881155b` with none of this work applied, in 0.2s, both in the full suite and in isolation.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Used to trace the paste path, confirm the tmux behavior experimentally, write the patch and tests, and run the checks above. I reviewed the result and will respond to review comments myself.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed multi-line paste handling in live-send mode.
- Routed pastes through tmux so panes receive bracketed-paste markers only when supported.
- Preserved paste order when users type nearby keystrokes.
- Removed manual marker generation.
- Added unit and end-to-end tests for paste content, ordering, normalization, and unsupported bracketed-paste mode.

## Benefits

Pastes no longer insert unwanted `00~` or `01~` text. Input delivery is more consistent, and the implementation is simpler.

4,586 library tests passed. 155 of 156 end-to-end tests passed. The remaining failure is pre-existing and unrelated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->