### PR TITLE
feat(web): show hidden folders toggle in the directory browser

### DIFF
--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -1156,6 +1156,11 @@ pub struct BrowseQuery {
     pub path: String,
     pub limit: Option<usize>,
     pub filter: Option<String>,
+    /// Include dotfile-prefixed directories in the listing. Mirrors the TUI
+    /// picker's Ctrl+H toggle (`src/tui/components/dir_picker.rs`). Omitted
+    /// means false, so existing callers keep the old behavior.
+    #[serde(default)]
+    pub show_hidden: bool,
 }
 
 #[derive(Serialize)]
@@ -1247,7 +1252,7 @@ pub async fn browse_filesystem(
 
         for entry in read_dir.flatten() {
             let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with('.') {
+            if !query.show_hidden && name.starts_with('.') {
                 continue;
             }
             let entry_path = entry.path();

--- a/tests/e2e/archive_restore.rs
+++ b/tests/e2e/archive_restore.rs
@@ -459,12 +459,21 @@ fn test_tui_bulk_archive_group_tears_down_all_tmux_off_thread() {
         );
     }
 
-    // Groups render before ungrouped rows, so the group header is the top row;
-    // pressing up past the top clamps the cursor onto it. `z` on a selected
-    // group opens the archive-confirm dialog; `y` submits it.
-    for _ in 0..sessions.len() + 2 {
-        h.send_keys("k");
-    }
+    // Groups render before ungrouped rows, so the group header is the top row.
+    // `Home` jumps the cursor there in one keystroke; `z` on a selected group
+    // opens the archive-confirm dialog and `y` submits it.
+    //
+    // Deliberately `Home` rather than a run of `k` presses. The app coalesces
+    // printable keys arriving less than PASTE_BURST_INTER_KEY_MS apart into a
+    // paste burst (src/tui/app.rs), for Mosh clients that strip bracketed-paste
+    // markers. A burst of identical keys is exempt via `is_auto_repeat_burst`,
+    // but "kkz" is not: when a loaded CI box stalls the TUI long enough for the
+    // queued keystrokes to be read back to back, the mixed run is routed to
+    // `handle_paste`, the `z` lands in `pending_paste` instead of opening the
+    // dialog, and the wait below times out. `Home` is not a burst candidate
+    // (only `Char` and `Enter` are), and two keys can never reach
+    // PASTE_BURST_MIN_LEN, so this sequence cannot be misread as a paste.
+    h.send_keys("Home");
     h.send_keys("z");
     h.wait_for("Archive all 3 sessions");
     h.send_keys("y");

--- a/web/src/components/DirectoryBrowser.tsx
+++ b/web/src/components/DirectoryBrowser.tsx
@@ -225,7 +225,8 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
             type="checkbox"
             checked={showHidden}
             onChange={toggleHidden}
-            className="accent-brand-600 cursor-pointer"
+            disabled={!currentPath}
+            className="accent-brand-600 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
           />
           Show hidden folders
         </label>

--- a/web/src/components/DirectoryBrowser.tsx
+++ b/web/src/components/DirectoryBrowser.tsx
@@ -27,6 +27,7 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
+  const [showHidden, setShowHidden] = useState(false);
   const initialized = useRef(false);
   const loadSeq = useRef(0);
   const loadedFilter = useRef("");
@@ -39,7 +40,11 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
   }, []);
 
   const loadPath = useCallback(
-    async (path: string, limit: number, options: { filter?: string; resetFilter?: boolean } = {}): Promise<boolean> => {
+    async (
+      path: string,
+      limit: number,
+      options: { filter?: string; resetFilter?: boolean; showHidden?: boolean } = {},
+    ): Promise<boolean> => {
       const seq = loadSeq.current + 1;
       loadSeq.current = seq;
       setLoading(true);
@@ -50,7 +55,7 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
         setFilter("");
       }
       try {
-        const resp = await browseFilesystem(path, limit, options.filter);
+        const resp = await browseFilesystem(path, limit, options.filter, options.showHidden ?? showHidden);
         if (seq !== loadSeq.current) return false;
         if (!resp.ok) {
           setError("Can't access this folder. It may not exist or is outside the home directory.");
@@ -72,13 +77,23 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
         if (seq === loadSeq.current) setLoading(false);
       }
     },
-    [clearFilterDebounce],
+    [clearFilterDebounce, showHidden],
   );
 
   const navigate = useCallback(
     async (path: string): Promise<boolean> => loadPath(path, BROWSE_PAGE_SIZE, { resetFilter: true }),
     [loadPath],
   );
+
+  // A toggle is a discrete action, unlike typing, so it reloads immediately
+  // instead of waiting out the filter debounce. Pass the new value explicitly:
+  // the `showHidden` state update has not propagated to `loadPath` yet.
+  const toggleHidden = useCallback(() => {
+    const next = !showHidden;
+    setShowHidden(next);
+    clearFilterDebounce();
+    void loadPath(currentPath, BROWSE_PAGE_SIZE, { filter: filter.trim(), showHidden: next });
+  }, [clearFilterDebounce, currentPath, filter, loadPath, showHidden]);
 
   const loadMore = useCallback(() => {
     if (loading) return;
@@ -205,6 +220,15 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
           placeholder="Type to filter..."
           className="w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
         />
+        <label className="mt-2 inline-flex items-center gap-2 text-xs text-text-dim cursor-pointer hover:text-text-secondary">
+          <input
+            type="checkbox"
+            checked={showHidden}
+            onChange={toggleHidden}
+            className="accent-brand-600 cursor-pointer"
+          />
+          Show hidden folders
+        </label>
       </div>
 
       {/* Directory listing */}
@@ -251,9 +275,13 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
             {entries.length === 0 && (
               <div className="px-4 py-6 text-center">
                 <p className="text-sm text-text-dim">
-                  {filter ? "No folders match your filter" : "No visible subfolders here"}
+                  {filter
+                    ? "No folders match your filter"
+                    : showHidden
+                      ? "No subfolders here"
+                      : "No visible subfolders here"}
                 </p>
-                {!filter && (
+                {!filter && !showHidden && (
                   <p className="text-xs text-text-dim mt-1">Hidden folders (starting with .) are not shown</p>
                 )}
               </div>

--- a/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -41,8 +41,8 @@ describe("DirectoryBrowser", () => {
     render(<DirectoryBrowser initialPath="/missing" onSelect={vi.fn()} />);
 
     await expect(screen.findByRole("option", { name: /project/i })).resolves.toBeTruthy();
-    expect(browseFilesystem).toHaveBeenNthCalledWith(1, "/missing", 100, undefined);
-    expect(browseFilesystem).toHaveBeenNthCalledWith(2, "/home/user", 100, undefined);
+    expect(browseFilesystem).toHaveBeenNthCalledWith(1, "/missing", 100, undefined, false);
+    expect(browseFilesystem).toHaveBeenNthCalledWith(2, "/home/user", 100, undefined, false);
   });
 
   it("ignores stale browse responses after a newer navigation finishes", async () => {
@@ -64,7 +64,7 @@ describe("DirectoryBrowser", () => {
     fireEvent.click(screen.getByRole("button", { name: "user" }));
 
     await waitFor(() => {
-      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 100, undefined);
+      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 100, undefined, false);
     });
 
     expect(resolveSlow).toBeDefined();
@@ -107,8 +107,42 @@ describe("DirectoryBrowser", () => {
     });
 
     await waitFor(() => {
-      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 100, "z");
+      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 100, "z", false);
     });
     await expect(screen.findByRole("option", { name: /z-project/i })).resolves.toBeTruthy();
+  });
+
+  it("requests hidden folders when the toggle is on, keeping the filter and resetting pagination", async () => {
+    getHomePath.mockResolvedValue("/home/user");
+    const firstPage = Array.from({ length: 100 }, (_, i) => dir(`project-${i + 1}`));
+    browseFilesystem.mockImplementation(
+      async (_path: string, _limit: number, _filter?: string, showHidden?: boolean) => {
+        if (showHidden) return response([dir(".hidden-proj", "/home/user/.hidden-proj")]);
+        return { entries: firstPage, has_more: true, ok: true };
+      },
+    );
+
+    render(<DirectoryBrowser onSelect={vi.fn()} />);
+
+    await screen.findByRole("option", { name: "project-1" });
+    // Page past the first 100 so the toggle has an expanded limit to reset.
+    fireEvent.click(screen.getByRole("button", { name: /load 100 more/i }));
+    await waitFor(() => {
+      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 200, "", false);
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Type to filter..."), {
+      target: { value: "proj" },
+    });
+    await waitFor(() => {
+      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 100, "proj", false);
+    });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /show hidden folders/i }));
+
+    await waitFor(() => {
+      expect(browseFilesystem).toHaveBeenLastCalledWith("/home/user", 100, "proj", true);
+    });
+    await expect(screen.findByRole("option", { name: /\.hidden-proj/ })).resolves.toBeTruthy();
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1729,10 +1729,12 @@ export async function browseFilesystem(
   path: string,
   limit?: number,
   filter?: string,
+  showHidden = false,
 ): Promise<BrowseResponse & { ok: boolean }> {
   const params = new URLSearchParams({ path });
   if (limit != null) params.set("limit", String(limit));
   if (filter) params.set("filter", filter);
+  if (showHidden) params.set("show_hidden", "true");
   const data = await fetchJson<BrowseResponse>(`/api/filesystem/browse?${params}`);
   if (!data) return { entries: [], has_more: false, ok: false };
   return { ...data, ok: true };

--- a/web/tests/live/directory-browser.spec.ts
+++ b/web/tests/live/directory-browser.spec.ts
@@ -28,6 +28,8 @@ base("DirectoryBrowser: home -> projects -> repo-a -> persisted last dir", async
       mkdirSync(join(repoA, ".git"), { recursive: true });
       writeFileSync(join(repoA, ".git", "HEAD"), "ref: refs/heads/main\n");
       mkdirSync(repoB, { recursive: true });
+      // Dotfile-prefixed dir for the "Show hidden folders" toggle (#3430).
+      mkdirSync(join(home, ".hidden-proj"), { recursive: true });
     },
   });
 
@@ -52,6 +54,16 @@ base("DirectoryBrowser: home -> projects -> repo-a -> persisted last dir", async
     // the Browse tab. Wait for the projects entry to appear under home.
     const projectsEntry = page.getByRole("option").filter({ hasText: "projects" });
     await expect(projectsEntry).toBeVisible({ timeout: 10_000 });
+
+    // Hidden folders are filtered server-side until the toggle asks for
+    // them, so this also covers the `show_hidden` query param (#3430).
+    const hiddenEntry = page.getByRole("option").filter({ hasText: ".hidden-proj" });
+    await expect(hiddenEntry).toHaveCount(0);
+    const hiddenToggle = page.getByRole("checkbox", { name: "Show hidden folders" });
+    await hiddenToggle.check();
+    await expect(hiddenEntry).toBeVisible({ timeout: 10_000 });
+    await hiddenToggle.uncheck();
+    await expect(hiddenEntry).toHaveCount(0);
 
     await projectsEntry.click();
     // Inside `projects`, repo-a should carry the repo badge.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
The web dashboard's project folder browse dialog could not reach a project living under a dotfile-prefixed path. `browse_filesystem` in `src/server/api/system.rs` filtered every entry whose name starts with `.`, unconditionally, and `DirectoryBrowser.tsx` has no filtering of its own, so there was no client-side workaround either.

This adds an opt-in `show_hidden` query param to `GET /api/filesystem/browse` (`#[serde(default)]`, so omitting it keeps the exact previous behavior) and a "Show hidden folders" checkbox in the directory browser that requests it. It mirrors the TUI picker's existing `Ctrl+H` toggle in `src/tui/components/dir_picker.rs`, including the default-off, not-persisted semantics.

Two deliberate calls worth flagging for review:

The toggle lives as local state inside `DirectoryBrowser` rather than as a prop threaded down from `ProjectStep.tsx`, which is what the issue text asked for. The component already owns every other browse knob (current path, text filter, pagination limit), and both call sites (`ProjectStep.tsx`, `ProjectFormModal.tsx`) pass no config props at all. Lifting only this one knob into the wizard would create a second source of truth for browse state without any caller needing to read or set it.

It is not persisted, matching the TUI. A persisted opt-in would mean a user who peeked at hidden folders once keeps surfacing hidden directory names in every later session without asking for it.

On the security question: this widens discoverability, not the authorization boundary. `?path=$HOME/.ssh` already worked before this change, so the dotfile filter only ever blocked discovery from the parent listing, never access. Browsing stays confined to `$HOME`, only directories are returned, and file contents are never exposed. No deny-list for `.ssh` / `.aws` / `.gnupg`: it would be incomplete, platform-specific, and misleading as a control. Dashboard auth is the real boundary. `.git` directories do show up when the toggle is on, which is correct; "show hidden except the ones we picked for you" would be worse.

Closes #3430

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a dotfile-prefixed folder under your home, e.g. `mkdir -p ~/.hidden-proj`, then run `aoe serve` and open the dashboard.
- [ ] Open the new-session wizard, switch to the Browse tab. Confirm `.hidden-proj` is not listed and the hint reads "Hidden folders (starting with .) are not shown".
- [ ] Tick "Show hidden folders". Confirm the listing reloads and `.hidden-proj` now appears alongside the visible folders.
- [ ] Type something into the filter box, then tick the toggle. Confirm the filter text is preserved and still applied to the results.
- [ ] In a folder with more than 100 subfolders, click "Load 100 more", then tick the toggle. Confirm the listing resets to the first page rather than re-requesting the expanded limit.
- [ ] Untick the toggle. Confirm hidden folders disappear again.
- [ ] Close and reopen the wizard. Confirm the toggle is back to off (it is intentionally not persisted).
- [ ] Navigate into a git repo with the toggle on. Confirm `.git` is listed as an ordinary folder, which is expected.
- [ ] Confirm nothing changed for existing callers: `curl "http://localhost:8080/api/filesystem/browse?path=$HOME"` still omits dotfiles.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Extended the existing live spec `web/tests/live/directory-browser.spec.ts` rather than adding a second live test: it seeds `$HOME/.hidden-proj`, asserts it is absent, ticks the toggle, asserts it appears, unticks, asserts it is gone. That is the cheapest tier that can actually fail if either side of the wiring regresses, since the mocked Vitest suite cannot catch a server that keeps filtering dotfiles unconditionally. No `coverage-matrix.json` change was needed: `web/src/components/DirectoryBrowser.tsx` is already mapped to the `directory-browser` entry, and `node web/tests/validate-coverage-matrix.mjs` passes.

Also extended `web/src/components/__tests__/DirectoryBrowser.test.tsx` with one test covering the client side (toggle sends `showHidden: true`, keeps the active filter, resets the limit to 100), and updated the four existing call assertions for the new argument. Verified the new test goes red without the component wiring.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No docs change: the toggle is a visible control in the browse dialog, so it is discoverable rather than something a user has to be told about.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The design was pressure-tested against two other models before any code was written; I made the calls on state ownership, persistence, and the security posture, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an opt-in `show_hidden` parameter to `GET /api/filesystem/browse`.
- Added a default-off “Show hidden folders” toggle to the web directory browser.
- Preserved active filters and reset pagination when the toggle changes.
- Disabled the toggle until the browse path resolves.
- Added server, component, and live browser tests for hidden directories.
- Improved a TUI archive test to select group headers more reliably.

## Benefits

Users can access projects under dot-prefixed paths without changing default behavior. Hidden folders remain excluded unless users enable the toggle. The updated TUI test is less sensitive to rapid, queued key input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->