### PR TITLE
test(session): pin SHELL in the hook tests that spawn one

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10719,9 +10719,9 @@ mod tests {
             return;
         };
         // The guard restores on unwind; the resolved path matters separately,
-        // because `test_support::ENV_LOCK` is taken only by `EnvGuard` and 12
-        // of the 14 `repo_config` hook tests take none, so they read this
-        // override regardless and must not read a path that cannot run.
+        // because `wrap_command_ignore_suspend` execs `$SHELL` below. The
+        // `repo_config` hook tests used to read this override too and now pin
+        // their own (#3449).
         let _shell = EnvGuard::set(&[("SHELL", &bash)]);
         let temp = tempfile::tempdir().unwrap();
         let working_dir = temp.path().join("some project's dir");

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -1717,7 +1717,10 @@ mod tests {
     /// `ENV_LOCK`, which closes the window from the writer side. See #3449.
     #[must_use = "bind it to `_shell`; dropped immediately, it unpins SHELL again"]
     fn pin_host_shell() -> Option<crate::session::test_support::EnvGuard> {
-        let sh = which::which("sh").ok()?;
+        let Ok(sh) = which::which("sh") else {
+            eprintln!("not pinning SHELL: sh not found on PATH");
+            return None;
+        };
         Some(crate::session::test_support::EnvGuard::set(&[(
             "SHELL", &sh,
         )]))

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -1709,6 +1709,20 @@ mod tests {
     use super::*;
     use tracing_test::traced_test;
 
+    /// Pin `SHELL` for a test that spawns a local hook. `build_hook_command`'s
+    /// local arm runs `user_shell()`, so an ambient `SHELL` this host cannot
+    /// run, or one another test is mid-way through exporting, surfaces here as
+    /// a hook failure naming the wrong cause. Resolved rather than hardcoded so
+    /// the FHS assumption #3421 removed stays removed; the guard also takes
+    /// `ENV_LOCK`, which closes the window from the writer side. See #3449.
+    #[must_use = "bind it to `_shell`; dropped immediately, it unpins SHELL again"]
+    fn pin_host_shell() -> Option<crate::session::test_support::EnvGuard> {
+        let sh = which::which("sh").ok()?;
+        Some(crate::session::test_support::EnvGuard::set(&[(
+            "SHELL", &sh,
+        )]))
+    }
+
     #[test]
     fn test_hooks_config_empty() {
         let hooks = HooksConfig::default();
@@ -1793,7 +1807,8 @@ mod tests {
 
     #[test]
     fn test_run_before_start_hooks_collects_kv() {
-        // Real host shell; multiple commands, later command's keys appended.
+        let _shell = pin_host_shell();
+        // Multiple commands; later command's keys appended.
         let tmp = tempfile::tempdir().unwrap();
         let cmds = vec![
             "echo GH_TOKEN=ghs_abc".to_string(),
@@ -1812,6 +1827,7 @@ mod tests {
 
     #[test]
     fn test_run_before_start_hooks_reads_session_env() {
+        let _shell = pin_host_shell();
         // A per-session value reaches the hook and can scope what it mints.
         let tmp = tempfile::tempdir().unwrap();
         let cmds = vec!["echo \"GH_TOKEN=tok-$TEST_VAR\"".to_string()];
@@ -1826,6 +1842,7 @@ mod tests {
 
     #[test]
     fn test_run_before_start_hooks_hard_fail() {
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let cmds = vec!["exit 3".to_string()];
         let err = run_before_start_hooks(&cmds, tmp.path(), &[], &[])
@@ -1835,6 +1852,7 @@ mod tests {
 
     #[test]
     fn test_run_before_start_hooks_error_omits_stdout_secret() {
+        let _shell = pin_host_shell();
         // A failing hook may have already printed secret KEY=VALUE lines; those
         // must never appear in the error (which can be logged/displayed). The
         // secret is supplied via env so it lives only in the hook's stdout, not
@@ -1888,6 +1906,7 @@ mod tests {
 
     #[test]
     fn test_run_before_session_hooks_collects_kv() {
+        let _shell = pin_host_shell();
         // The host counterpart of `before_start`: same stdout contract, so the
         // account/provider env a switcher prints is picked up verbatim.
         let tmp = tempfile::tempdir().unwrap();
@@ -1914,6 +1933,7 @@ mod tests {
 
     #[test]
     fn test_run_before_session_hooks_reads_lifecycle_env() {
+        let _shell = pin_host_shell();
         // The hook resolves what to mint from the session's identity, which is
         // the whole point of running it per launch rather than reading a file.
         let tmp = tempfile::tempdir().unwrap();
@@ -1932,6 +1952,7 @@ mod tests {
 
     #[test]
     fn test_run_before_session_hooks_error_names_before_session() {
+        let _shell = pin_host_shell();
         // A failure must point at the config key the user wrote, not at
         // `before_start`, and must still withhold stdout (the secret channel).
         let tmp = tempfile::tempdir().unwrap();
@@ -2729,6 +2750,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     ///   3. `GIT_ASKPASS` / `SSH_ASKPASS` are defanged
     #[test]
     fn streamed_hook_detached_from_tty() {
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let probe = r#"
             if [ -t 0 ]; then echo "STDIN=tty"; else echo "STDIN=notty"; fi
@@ -2779,6 +2801,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     /// that explains why the hook failed.
     #[test]
     fn streamed_hook_failure_error_includes_output() {
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         // The failure detail lives in a script file, not the hook command
         // line, mirroring real hooks (`npm install`, `./setup.sh`) whose
@@ -2808,6 +2831,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     /// later hooks ran.
     #[test]
     fn streamed_hook_failure_names_position_when_multiple() {
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let hooks = vec![
             "true".to_string(),
@@ -2829,6 +2853,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     /// text omits the "remaining hooks skipped" suffix.
     #[test]
     fn streamed_hook_failure_omits_skip_note_for_last_hook() {
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let hooks = vec!["true".to_string(), "sh -c 'exit 7'".to_string()];
         let (tx, _rx) = mpsc::channel();
@@ -2842,6 +2867,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     /// A single hook keeps the error free of position noise.
     #[test]
     fn streamed_hook_failure_omits_position_when_single() {
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let (tx, _rx) = mpsc::channel();
         let err = execute_hooks_streamed(&["sh -c 'exit 7'".to_string()], tmp.path(), &tx, &[])
@@ -2858,6 +2884,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     #[serial_test::serial]
     fn captured_hook_does_not_force_git_env() {
         let _env = crate::session::test_support::EnvGuard::unset(&["GIT_TERMINAL_PROMPT"]);
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let probe = "echo \"GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-unset}\" > out.txt";
         execute_hooks(&[probe.to_string()], tmp.path(), &[]).unwrap();
@@ -2927,6 +2954,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     /// `detach_tty` flag on `execute_hooks_best_effort` actually flows through.
     #[test]
     fn best_effort_hook_detaches_when_requested() {
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let probe = "echo \"GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-unset}\" > out.txt";
         let errors = execute_hooks_best_effort(&[probe.to_string()], tmp.path(), true, &[]);
@@ -2947,6 +2975,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     #[serial_test::serial]
     fn best_effort_hook_attached_for_cli() {
         let _env = crate::session::test_support::EnvGuard::unset(&["GIT_TERMINAL_PROMPT"]);
+        let _shell = pin_host_shell();
         let tmp = tempfile::tempdir().unwrap();
         let probe = "echo \"GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-unset}\" > out.txt";
         let errors = execute_hooks_best_effort(&[probe.to_string()], tmp.path(), false, &[]);
@@ -3027,6 +3056,7 @@ trusted_at = "2026-01-31T00:00:00Z"
     /// paths so a regression in any one of them fails this test.
     #[test]
     fn local_hooks_see_session_env_vars() {
+        let _shell = pin_host_shell();
         use crate::session::Instance;
 
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Description

Closes #3449.

`build_hook_command`'s `HookTarget::Local` arm runs `user_shell()`, which reads
the process-global `SHELL`, and spawns it. Sixteen `repo_config` tests reach a
hook runner and fourteen of them took no guard, while twelve `EnvGuard` sites
across `session::environment`, `session::instance` and `tmux::terminal_session`
touch `SHELL` to exercise the launch wrapper (eleven exporting one, eight of
those a path that need not exist on the host). Those writers hold
`test_support::ENV_LOCK`; the readers took nothing, so a concurrent one could
be read here and fail the spawn as a hook error naming the wrong cause.

Your #3421 approval counted nine of those, which was right for the
`set_var("SHELL", ...)` sites `d84c6349` converted; eight is the same set after
the conversion, minus the one that sets whitespace.

The readers now pin it themselves, which is the direction you suggested on
#3421 and is local to them: it needs no change to the writers. The pin goes
through `EnvGuard`, so it also takes `ENV_LOCK` and closes the window from the
writer side as well.

The effect is easiest to see with a real shell rather than a contrived path.
With fish as `$SHELL`, which is a supported login shell and cannot parse the
POSIX hook bodies these tests use:

```
env SHELL=$(command -v fish) cargo test --lib -- session::repo_config
  before (24226821):  64 passed; 5 failed
  after  (bc3d06cc):  69 passed; 0 failed
```

and with a path that does not resolve at all, which is the shape a mid-read
write produces:

```
env SHELL=/nonexistent/nu cargo test --lib -- session::repo_config
  before (24226821):  55 passed; 14 failed
  after  (bc3d06cc):  69 passed;  0 failed
```

(The fourteen that fail there and the fourteen that took no guard are
overlapping but different sets; twelve are in both.)

It costs the sixteen a place in the `ENV_LOCK` queue: the module goes from
about 0.02s to about 0.09s. I judged that worth it, but it is a real cost and
the sibling PR argues partly from serialisation cost, so it should be stated.

Two notes on the shape:

- `sh` is resolved through `which` rather than hardcoded. `/bin/sh` was not
  one of the paths #3421 removed and does exist on the host that motivated it,
  so this is not undoing that work, just not adding a new assumption.
- `pin_host_shell` is `#[must_use]`. Wrapping the guard in an `Option` would
  otherwise discard `EnvGuard`'s own annotation, and a bare call would compile
  clean while pinning nothing.

While here it corrects the comment I added in #3421 at `instance.rs:10721`. It
counted these as "12 of the 14" (it is 14 of 16) and rested on them reading the
override, which after this is no longer true. Per your nit on `67e28071` about
counts that rot, the replacement states the invariant and cites #3449 rather
than carrying numbers.

### Approaches tried and dropped

- **Hardcode `/bin/sh`.** Works, and would not have failed on the host that
  motivated #3421, but it adds an assumption that PR was written to remove.
  Resolving costs one line.
- **Convert the writers instead of the readers.** A wider diff across three
  modules for the same property, and your suggestion was reader-local.
- **Have the readers take a bare `EnvGuard` without pinning**, as the two
  `GIT_TERMINAL_PROMPT` tests already do. This is the one worth recording,
  because it looks sufficient and is not: a guard that does not name `SHELL`
  still leaves the ambient value in play. Both of those tests are in the five
  that fail under fish on `main`. Pinning fixes the race and the ambient value
  together, which is why the fish column moves at all.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

This is a change to test hygiene, so the measurement above is the evidence
rather than a new test: the same suite under a hostile `SHELL` goes from 14
failures to 0. `cargo fmt --check` clean, `cargo clippy --lib --tests` at the
same 6 warnings as `main`, `session::repo_config` 69/69.

The lib suite does not go green on my machine either way (rotating `tmux::*`
failures plus one `$HOME`-dependent dialog test, all present on unpatched
`main` here), so I am comparing against `main` rather than claiming a green
suite.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation, the code and this
write-up were done by Claude working from that. The hostile-`SHELL` framing came
out of an adversarial review round rather than the original patch, which argued
from the race alone and was weaker for it.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `repo_config` hook tests to pin `SHELL` with `EnvGuard`.
- Added a clear diagnostic when `sh` is not available on `PATH`.
- Corrected the `session::instance` test comment.

## Benefits

- Prevents concurrent environment changes from causing misleading hook failures.
- Improves test reliability under hostile or changing `SHELL` values.
- Keeps shell setup local to the tests that depend on it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->