### PR TITLE
test(session): move the launch-path test onto the default serial key

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10710,6 +10710,7 @@ mod tests {
     /// the agent in the wrong directory. The wrapper must re-assert
     /// `working_dir` inside the login shell's own script, after profile
     /// sourcing, so it wins regardless of what those files did.
+    ///
     /// `#[serial]` on the default key, not `shell_env`: this resolves `bash`
     /// through the inherited `PATH`, and every test that mutates `PATH`
     /// process-globally (`update::install`, `acp::node`, `acp::acp_client`)

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -10710,8 +10710,16 @@ mod tests {
     /// the agent in the wrong directory. The wrapper must re-assert
     /// `working_dir` inside the login shell's own script, after profile
     /// sourcing, so it wins regardless of what those files did.
+    /// `#[serial]` on the default key, not `shell_env`: this resolves `bash`
+    /// through the inherited `PATH`, and every test that mutates `PATH`
+    /// process-globally (`update::install`, `acp::node`, `acp::acp_client`)
+    /// carries the default key, so `shell_env` bought no exclusion against
+    /// them. Since #3421 a scrub racing the `which` is a silent skip rather
+    /// than a failure. The `shell_env` holder this stops excluding touches
+    /// only `TERM`/`COLORTERM`/`FORCE_COLOR`/`NO_COLOR`, and `Command`
+    /// snapshots the environment at spawn, so the exposure is that instant.
     #[test]
-    #[serial_test::serial(shell_env)]
+    #[serial_test::serial]
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
         // The wrapper execs `$SHELL`, so it has to be a shell that exists here.
         let Ok(bash) = which::which("bash") else {
@@ -10737,7 +10745,7 @@ mod tests {
             wrapped.contains("|| exit 1\nstty susp undef"),
             "the cd must exit-on-failure before disabling suspend: {wrapped}",
         );
-        let output = std::process::Command::new("bash")
+        let output = std::process::Command::new(&bash)
             .args(["-c", &wrapped])
             .output()
             .unwrap();


### PR DESCRIPTION
## Description

Closes #3450.

`test_wrap_command_reasserts_working_dir_after_login_shell` carried
`#[serial(shell_env)]`. A named key only excludes other holders of that key,
and every test that mutates `PATH` process-globally carries the default one, so
`shell_env` bought this test no exclusion against them. It resolves `bash`
through the inherited `PATH` at `which::which("bash")`, and since #3421 that
skips with a message instead of hard-failing, so a scrub racing it turns a
failure into a silent skip. That is what makes this worth changing rather than
merely inconsistent.

It also spawned `bash` a second time by bare name, which the same scrub would
break. That now reuses the already-resolved path, which is the one-token half
of #3450 and closes the second window outright.

What leaving the group costs, stated plainly rather than waved off. Of the 49
`shell_env` holders, 48 take an `EnvGuard`, which holds `test_support::ENV_LOCK`
whatever the serial key says, and so does this test, so those stay excluded. The
49th takes no guard at all,
`test_validate_env_entries_skips_default_terminal_vars_when_unset`, and this
does open a window against it. It is narrow and I think acceptable:
`std::process::Command` snapshots the environment at spawn, so the exposure is
that instant rather than the child's lifetime, and that test only removes and
restores `TERM`, `COLORTERM`, `FORCE_COLOR` and `NO_COLOR`. The residual is a
profile file that both writes to stdout and gates on one of those, since the
inner shell is a login shell.

In the other direction it joins the default key's roughly 1350 members, which is
a real cost for a test that spawns a process.

### Approaches tried and dropped

- **Move all 49 `shell_env` holders onto the default key.** It buys them
  nothing: 48 already hold `ENV_LOCK` through an `EnvGuard`, whatever the key
  says. It would put 49 more tests into the roughly 1350-member default chain
  for a property they already have.
- **Rely on the `EnvGuard` this test already holds, and drop the serial key.**
  The tempting one, since the guard is right there and it does have to set
  `SHELL` regardless. It does not cover `PATH`, and `instance.rs:11871` already
  says why: "none of them takes `test_support::ENV_LOCK`, so a guard would
  exclude unrelated guard users and leave this window open."

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No new test: the change is one attribute and one argument on an existing test,
and the property it buys (exclusion against a process-global `PATH` mutation) is
not observable from inside the suite without staging the race itself. The
rationale is in a comment on the test, matching the pattern at
`instance.rs:11871` and `tmux/session.rs:4037` that #3421 established.

`cargo fmt --check` clean, `cargo clippy --lib --tests` at the same 6 warnings
as `main`, the moved test passing. As on the sibling PR, the lib suite does not
go green on my machine either way, so this is a comparison against `main`
rather than a claim of a green suite.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation, the code and this
write-up were done by Claude working from that. An adversarial review round
caught two false statements in the first draft of this description, including a
claim that every `shell_env` holder takes an `EnvGuard`, which is not true.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Moved the working-directory wrapper test to the default serial group.
- Reused the resolved `bash` path for shell execution.
- Documented the concurrency trade-offs of the change.

## Benefits

The test now avoids conflicts with tests that modify the process-wide `PATH`. This prevents silent skips and shell launch failures caused by concurrent environment changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->