### PR TITLE
docs(session): archive() is not cleared by the attention signal

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2238,8 +2238,15 @@ impl Instance {
     }
 
     /// Mark the session archived. Archived sessions sink to the bottom of
-    /// the Attention sort and render in italic+dim style, but remain
-    /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.
+    /// the Attention sort and render in italic+dim style, but remain visible.
+    /// Archive suppresses the attention signal rather than the signal
+    /// clearing archive: `is_urgent` returns false while archived, and the
+    /// attention sort short-circuits the row to its bottom tier.
+    ///
+    /// Cleared by `unarchive`, by `touch_last_accessed`, and by `favorite`
+    /// and `pin` through the mutual exclusion below; not by `snooze`.
+    /// `merge_user_action_diff` mirrors those onto disk, and #3465 tracks a
+    /// status transition reaching that mirror without a user gesture.
     ///
     /// Mutual exclusion with `favorite`, `snooze`, and `pin`: archiving
     /// clears `favorited_at`, `snoozed_until`, and `pinned_at`. Archive


### PR DESCRIPTION
## Description

A doc-comment correction on `Instance::archive()`. It currently ends:

> Auto-cleared by the attention-signal hook on Waiting/Error.

Nothing does that, and the hook does the inverse: `is_urgent` returns false
while a session is archived, so archive suppresses the attention signal rather
than the signal clearing archive. Both were added in the same commit (#1084),
and `git log -G "archived_at = None"` shows no clearer has since been removed.

What holds the property is that no status path clears the flag, rather than any
guard doing so. The replacement says that, names the wake paths, and names the
one edge that is easy to miss: `merge_user_action_diff` mirrors a wake onto disk
on any advance of `last_accessed_at` whoever wrote it, and `apply_status_intent`
advances that on a status transition without checking `is_archived`.

It deliberately does not enumerate every clearer. I tried that and got it wrong
twice, most recently by omitting the arm the TUI's own unarchive reaches disk
through, and #3421's review already nitted a count off a comment for the same
reason.

Doc only; no behaviour change.

### One wording worth recording

"Cleared only by `unarchive` and `touch_last_accessed`" and "never cleared by a
status change" are both natural things to write here and both are wrong, in the
same direction as the line being replaced. The second is the subtle one: a
status transition on the row cannot clear the flag, but `apply_status_intent`
stamps `last_accessed_at` on a transition without an archived guard, and
`merge_user_action_diff` mirrors any advance of that field.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No test: the diff is a doc comment, and it now describes an absence (no status
path clears the flag) rather than a mechanism, so there is nothing new to pin.
`test_attention_tier_archived_returns_99` pins `unarchive` and only that, which
is why I stopped citing it as the guarantee.

`cargo fmt --check` clean, `cargo clippy --lib --tests` at the same 6 warnings
as `main`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation and this write-up were
done by Claude working from that. Relevant here because it is a doc PR whose
whole value is one sentence's accuracy: earlier drafts of that sentence were
wrong twice, each time by claiming a completeness the code does not support, so
the version above deliberately describes an absence and enumerates nothing.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Updated `Instance::archive()` documentation to reflect actual archive behavior.
- Clarified that attention signals do not clear the archive flag.
- Documented relevant archive-clearing paths without claiming the list is complete.
- Kept the change documentation-only.

### Benefits
- Improves documentation accuracy.
- Reduces confusion about archived session handling.
- Introduces no behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->