### PR TITLE
fix(session): require a regular file in the Claude transcript scan

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -241,10 +241,20 @@ fn scan_claude_project_dir(
             continue;
         }
 
-        let modified = entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        // `fs::metadata` rather than `DirEntry::metadata`/`file_type`, which
+        // describe the link rather than its target. A symlinked transcript has
+        // to keep counting (#3399's workaround tells users to make one), and
+        // following the link reports the target's mtime, the one that advances
+        // as Claude appends. A directory, FIFO or dangling link named
+        // `<uuid>.jsonl` is otherwise handed back as a resume id with no
+        // transcript behind it.
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let modified = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
 
         if known == Some(stem) && !exclusion.contains(stem) {
             known_hit = Some((stem.to_string(), modified));
@@ -6600,5 +6610,42 @@ mod tests {
             "drain must be bounded by the deadline even while the pipe stays open"
         );
         assert!(out.is_empty() || out == b"done");
+    }
+
+    #[test]
+    fn test_scan_skips_a_directory_named_like_a_transcript() {
+        let home = tempfile::tempdir().unwrap();
+        let project = std::path::Path::new("/tmp/scan-dir-probe");
+        let dir = home
+            .path()
+            .join("projects")
+            .join(encode_claude_project_path(&project.to_string_lossy()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // Same shape a real transcript has: `.jsonl` extension, UUID stem.
+        std::fs::create_dir(dir.join("11111111-1111-4111-8111-111111111111.jsonl")).unwrap();
+
+        assert_eq!(
+            scan_claude_project_dir(home.path(), project, None, &HashSet::new()).unwrap(),
+            None,
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_scan_follows_a_symlinked_transcript() {
+        let home = tempfile::tempdir().unwrap();
+        let project = std::path::Path::new("/tmp/scan-link-probe");
+        let dir = home
+            .path()
+            .join("projects")
+            .join(encode_claude_project_path(&project.to_string_lossy()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let real = home.path().join("real.jsonl");
+        std::fs::write(&real, "{}\n").unwrap();
+        let sid = "22222222-2222-4222-8222-222222222222";
+        std::os::unix::fs::symlink(&real, dir.join(format!("{sid}.jsonl"))).unwrap();
+
+        let found = scan_claude_project_dir(home.path(), project, None, &HashSet::new()).unwrap();
+        assert_eq!(found.map(|(id, _)| id), Some(sid.to_string()));
     }
 }

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -6618,22 +6618,52 @@ mod tests {
         assert!(out.is_empty() || out == b"done");
     }
 
+    /// Every entry here has the exact shape a real transcript has, a `.jsonl`
+    /// extension and a UUID stem, and nothing behind it. `main` hands all four
+    /// back as resume ids: `DirEntry::metadata` is an `lstat`, which succeeds
+    /// on all of them and reports the creation time, so they read as *fresh*
+    /// and win the `best` comparison outright.
     #[test]
-    fn test_scan_skips_a_directory_named_like_a_transcript() {
-        let home = tempfile::tempdir().unwrap();
-        let project = std::path::Path::new("/tmp/scan-dir-probe");
-        let dir = home
-            .path()
-            .join("projects")
-            .join(encode_claude_project_path(&project.to_string_lossy()));
-        std::fs::create_dir_all(&dir).unwrap();
-        // Same shape a real transcript has: `.jsonl` extension, UUID stem.
-        std::fs::create_dir(dir.join("11111111-1111-4111-8111-111111111111.jsonl")).unwrap();
+    fn test_scan_skips_entries_that_are_not_regular_files() {
+        let sid = "11111111-1111-4111-8111-111111111111";
+        for kind in ["directory", "dangling-link", "symlink-cycle", "fifo"] {
+            let home = tempfile::tempdir().unwrap();
+            let project_path = format!("/tmp/scan-probe-{kind}");
+            let project = std::path::Path::new(&project_path);
+            let dir = home
+                .path()
+                .join("projects")
+                .join(encode_claude_project_path(&project.to_string_lossy()));
+            std::fs::create_dir_all(&dir).unwrap();
+            let entry = dir.join(format!("{sid}.jsonl"));
+            match kind {
+                "directory" => std::fs::create_dir(&entry).unwrap(),
+                #[cfg(unix)]
+                "dangling-link" => {
+                    std::os::unix::fs::symlink(dir.join("gone.jsonl"), &entry).unwrap()
+                }
+                // `fs::metadata` returns `ELOOP` here rather than spinning, so
+                // the `Err` arm is what rejects this one, not `is_file`.
+                #[cfg(unix)]
+                "symlink-cycle" => std::os::unix::fs::symlink(&entry, &entry).unwrap(),
+                #[cfg(unix)]
+                "fifo" => {
+                    // Skipped rather than failed where `mkfifo` is unavailable;
+                    // the other three rows still gate the guard.
+                    match std::process::Command::new("mkfifo").arg(&entry).status() {
+                        Ok(s) if s.success() => {}
+                        _ => continue,
+                    }
+                }
+                _ => continue,
+            }
 
-        assert_eq!(
-            scan_claude_project_dir(home.path(), project, None, &HashSet::new()).unwrap(),
-            None,
-        );
+            assert_eq!(
+                scan_claude_project_dir(home.path(), project, None, &HashSet::new()).unwrap(),
+                None,
+                "{kind} must not be handed back as a resume id",
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -15,8 +15,14 @@ pub(crate) use omp::*;
 /// Iterate directory entries, silently skipping unreadable ones.
 ///
 /// Wraps `std::fs::read_dir` and filters out individual entry errors (e.g.
-/// broken symlinks, transient permission failures) so that one bad entry
-/// doesn't abort the entire directory scan.
+/// transient permission failures) so that one bad entry doesn't abort the
+/// entire directory scan.
+///
+/// This filters `read_dir`'s per-entry `Err` only, which is a much narrower
+/// guarantee than it sounds. Nothing here stats the entry, so a dangling
+/// symlink, a symlink cycle, a directory, or a FIFO is yielded as an ordinary
+/// entry. Callers that need a real file behind the name have to check for
+/// themselves; see `scan_claude_project_dir`.
 pub(crate) fn resilient_read_dir(
     dir: &std::path::Path,
 ) -> Result<impl Iterator<Item = std::fs::DirEntry> + '_> {


### PR DESCRIPTION
## Description

`scan_claude_project_dir` accepts an entry on its `.jsonl` extension and a UUID
stem and never checks what it is, so a directory, FIFO, dangling symlink or
symlink cycle named `<uuid>.jsonl` under `~/.claude/projects/<encoded>/` is
handed back as a resume id with nothing behind it. There is no type check to
fail: the existing stat feeds `unwrap_or(UNIX_EPOCH)`, so even a stat error
leaves the entry accepted.

`resilient_read_dir`'s doc says it skips "broken symlinks", which reads like
this is already handled. It is not: that function filters `read_dir`'s per-entry
`Err`, and a dangling symlink does not produce one. Measured, a directory
containing one broken symlink yields one entry.

Found by CodeRabbit on #3413. Split out per the call you made on #3412: real,
but pre-existing and untouched by that diff, so it belongs in its own PR.

Nothing in aoe creates one and I have not seen one in the wild. The value is
that the scan states the property it relies on.

**On following symlinks**, since #2221 hardened the hook dir the other way.
This uses `fs::metadata` rather than `DirEntry::file_type`/`DirEntry::metadata`,
which describe the link rather than its target. Three reasons, strongest first:

1. **#3399's documented workaround tells users to create exactly this.** It
   suggests symlinking a profile's project dir into `~/.claude/projects/`, and
   "for cwds where a real directory already exists, a file-level symlink of the
   single `<sid>.jsonl` works instead". A guard that did not follow links would
   break the workaround the tracker is currently handing out.
2. A link's own mtime is frozen at creation, so following reports when the
   transcript was last appended. That is what the two five-minute freshness
   gates want; on `main` a symlinked transcript goes stale five minutes after
   the link is made.
3. It keeps this consistent with `claude_host_transcript_confirmed_absent` fifty
   lines above, which uses `Path::is_file` and follows, so the two cannot
   disagree about whether a transcript exists.

Two things worth naming rather than leaving you to find. Same syscall count as
before, but the call goes from a dirfd-relative `statx` to an absolute one, so
it drops the anchoring half of #2221's posture as well as the `NOFOLLOW` half.
I think that is fine here and it is worth saying why: this is a read-only stat
for an mtime, aoe never opens the transcript, and the id is handed to `claude`
to resolve under its own config dir, so there is no clobber and no pre-image.
The path is also `$HOME`-owned rather than a world-writable `/tmp` name, which
is the case #2221 was written for.

Adjacent, not overlapping: #3399 is still open, but its read-path half already
landed in #3410, which is in this branch's base, so there is nothing pending to
collide with.

### Approaches tried and dropped

Worth writing down, because the first one is what this looks like it should be
and it is a regression:

- **`entry.file_type()`.** The obvious spelling, and it was the first version of
  this patch. `DirEntry::file_type` describes the link, not the target, so a
  transcript reached through a symlink reports `is_symlink()` and gets skipped.
  The scan then returns `None`, the launch mints a fresh id, and the existing
  conversation is orphaned. That is a worse failure than the one being fixed,
  which is why `scan_follows_a_symlinked_transcript` is in the diff: it fails
  under this spelling.
- **`DirEntry::metadata()`.** The natural correction to the above, and it has
  the same problem for the same reason: it is also `lstat`.
- **`path.is_file()`**, which is CodeRabbit's literal suggestion on #3413.
  Correct, and it follows links, but it discards the metadata so the mtime needs
  a second stat: measured at exactly 2x the stat calls over the same directory.
  `fs::metadata` gives the same answer and the mtime in one call.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the two unit tests below cover it exactly, and
      nothing creates such an entry, so there is no end-to-end user story to
      drive. (`seed_claude_transcript` in `tests/e2e/resume_fallback.rs` would
      make one cheap if you would rather have it.)

Two unit tests, and they gate different things:

- `test_scan_skips_a_directory_named_like_a_transcript` fails without the guard.
- `test_scan_follows_a_symlinked_transcript` passes on `main` and fails if this
  is written with `file_type()`. It guards the fix's shape rather than the
  original bug; see the dropped approaches above for why that is worth a test.

`cargo fmt --check` clean, `cargo clippy --lib --tests` at the same 6 warnings
as `main`, `session::capture` green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation, the code and this
write-up were done by Claude working from that.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Claude transcript scanning now accepts only entries that resolve to regular files.
- It rejects directories, FIFOs, dangling symlinks, symlink cycles, and entries with unreadable metadata.
- Valid symlinked transcripts remain supported.
- Clarified `resilient_read_dir` documentation.
- Added table-driven tests for rejected entries and valid symlinked transcripts.

## Benefits

This prevents invalid entries from being used as resume IDs while preserving symlink support and accurate freshness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->