### PR TITLE
fix(git): bound worktree mutation commands

### DIFF
--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -6,8 +6,8 @@
 
 use std::ffi::OsStr;
 use std::path::Path;
-use std::process::{Command, Output};
-use std::time::Instant;
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
 
 /// Run `git <args>` in `cwd`, instrumented with target `git.command`.
 /// Logs a debug line before, then debug (success) or warn (failure)
@@ -96,6 +96,71 @@ where
     Ok(output)
 }
 
+/// Like [`run_git`], but kills the child if it outlives `timeout` and reports
+/// the timeout as `Ok(None)`.
+///
+/// Used for bounded git mutations that normally finish quickly but could
+/// otherwise hang indefinitely on a stalled filesystem. stdin is nulled so a
+/// child can never block on a prompt, and `run_with_timeout` drains
+/// stdout/stderr on a deadline so a grandchild holding a pipe cannot stall the
+/// wait past `timeout`.
+pub fn run_git_with_timeout<I, S>(
+    cwd: &Path,
+    args: I,
+    timeout: Duration,
+) -> std::io::Result<Option<Output>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let argv: Vec<std::ffi::OsString> = args.into_iter().map(|a| a.as_ref().to_owned()).collect();
+    let redacted: Vec<String> = argv.iter().map(|a| redact(a.as_os_str())).collect();
+    let start = Instant::now();
+    tracing::debug!(
+        target: "git.command",
+        args = ?redacted,
+        cwd = %cwd.display(),
+        timeout_s = timeout.as_secs(),
+        "running git with timeout"
+    );
+    let mut cmd = Command::new("git");
+    cmd.args(&argv)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .env("LC_ALL", "C");
+    let result = crate::process::run_with_timeout_process_group(&mut cmd, timeout)?;
+    let dur = start.elapsed().as_millis() as u64;
+    match &result {
+        Some(output) if output.status.success() => tracing::debug!(
+            target: "git.command",
+            args = ?redacted,
+            exit = output.status.code(),
+            duration_ms = dur,
+            "git command completed"
+        ),
+        Some(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr_summary: String = stderr.chars().take(200).collect();
+            tracing::warn!(
+                target: "git.command",
+                args = ?redacted,
+                exit = output.status.code(),
+                duration_ms = dur,
+                stderr_summary = %stderr_summary,
+                "git command failed"
+            );
+        }
+        None => tracing::warn!(
+            target: "git.command",
+            args = ?redacted,
+            duration_ms = dur,
+            timeout_s = timeout.as_secs(),
+            "git command timed out and was killed"
+        ),
+    }
+    Ok(result)
+}
+
 fn redact(arg: &OsStr) -> String {
     let s = arg.to_string_lossy();
     if let Some(scheme_end) = s.find("://") {
@@ -146,6 +211,22 @@ mod tests {
                 )),
             }
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_git_with_timeout_kills_a_stalled_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fifo = tmp.path().join("blocked-input");
+        let status = Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo should spawn");
+        assert!(status.success(), "mkfifo should create the fixture");
+        let args = [OsString::from("hash-object"), fifo.into_os_string()];
+        let result = run_git_with_timeout(tmp.path(), args, Duration::from_millis(10))
+            .expect("git should spawn");
+        assert!(result.is_none(), "git blocked on the FIFO must time out");
     }
 
     #[test]

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -101,13 +101,42 @@ where
 ///
 /// Used for bounded git mutations that normally finish quickly but could
 /// otherwise hang indefinitely on a stalled filesystem. stdin is nulled so a
-/// child can never block on a prompt, and `run_with_timeout` drains
-/// stdout/stderr on a deadline so a grandchild holding a pipe cannot stall the
-/// wait past `timeout`.
+/// child can never block on a prompt, and `run_with_timeout_process_group`
+/// captures stdout/stderr in temporary regular files rather than pipes, so a
+/// grandchild that inherits the handles cannot stall the wait past `timeout`.
 pub fn run_git_with_timeout<I, S>(
     cwd: &Path,
     args: I,
     timeout: Duration,
+) -> std::io::Result<Option<Output>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    run_timed(cwd, args, timeout, false)
+}
+
+/// [`run_git_with_timeout`] for callers that have already classified a
+/// non-zero exit as an expected, no-op outcome, mirroring the
+/// [`run_git`] / [`run_git_quiet`] pair. The timeout itself still logs at
+/// WARN: a killed child is never routine.
+pub fn run_git_quiet_with_timeout<I, S>(
+    cwd: &Path,
+    args: I,
+    timeout: Duration,
+) -> std::io::Result<Option<Output>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    run_timed(cwd, args, timeout, true)
+}
+
+fn run_timed<I, S>(
+    cwd: &Path,
+    args: I,
+    timeout: Duration,
+    quiet: bool,
 ) -> std::io::Result<Option<Output>>
 where
     I: IntoIterator<Item = S>,
@@ -141,14 +170,25 @@ where
         Some(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stderr_summary: String = stderr.chars().take(200).collect();
-            tracing::warn!(
-                target: "git.command",
-                args = ?redacted,
-                exit = output.status.code(),
-                duration_ms = dur,
-                stderr_summary = %stderr_summary,
-                "git command failed"
-            );
+            if quiet {
+                tracing::debug!(
+                    target: "git.command",
+                    args = ?redacted,
+                    exit = output.status.code(),
+                    duration_ms = dur,
+                    stderr_summary = %stderr_summary,
+                    "git command failed (expected by caller)"
+                );
+            } else {
+                tracing::warn!(
+                    target: "git.command",
+                    args = ?redacted,
+                    exit = output.status.code(),
+                    duration_ms = dur,
+                    stderr_summary = %stderr_summary,
+                    "git command failed"
+                );
+            }
         }
         None => tracing::warn!(
             target: "git.command",

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -30,9 +30,10 @@ pub fn clone_bare_repo(url: &str, destination: &Path) -> Result<String> {
         "spawning git clone --bare"
     );
     // Stdin is piped to null so SSH passphrase prompts fail immediately;
-    // stdout/stderr draining and the kill-on-deadline are handled by
-    // run_with_timeout, so a grandchild holding the pipe (credential
-    // helper, pager) cannot block past the timeout.
+    // output capture and the kill-on-deadline are handled by
+    // run_with_timeout, which writes stdout/stderr to temporary regular
+    // files, so a grandchild that inherits them (credential helper, pager)
+    // cannot block past the timeout.
     let mut cmd = std::process::Command::new("git");
     cmd.args(["clone", "--bare", url, bare_str])
         .stdin(std::process::Stdio::null());
@@ -238,9 +239,9 @@ pub fn clone_repo(url: &str, destination: &Path, shallow: bool) -> Result<()> {
     let mut cmd = std::process::Command::new("git");
     cmd.args(&args).stdin(std::process::Stdio::null());
 
-    // 5-minute timeout to avoid blocking the thread pool forever; output
-    // draining is deadline-bounded too, so a grandchild holding the pipe
-    // cannot hang the wait.
+    // 5-minute timeout to avoid blocking the thread pool forever; output is
+    // captured in temporary regular files, so a grandchild that inherits the
+    // handles cannot hang the wait.
     let timeout = std::time::Duration::from_secs(300);
 
     match crate::process::run_with_timeout(&mut cmd, timeout) {

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -56,6 +56,120 @@ fn classify_worktree_add_failure(combined: &str, branch: &str) -> GitError {
 /// yet" path.
 const FETCH_REMOTE: &str = "origin";
 
+/// Upper bound for local git metadata mutations that normally complete in
+/// milliseconds but could otherwise hang indefinitely on a stalled filesystem.
+const WORKTREE_MUTATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const MUTATION_OBSERVATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[derive(Debug, PartialEq, Eq)]
+enum TimedMutationOutcome {
+    Applied,
+    Unchanged,
+    Indeterminate,
+}
+
+fn classify_timed_mutation(old_exists: bool, new_exists: bool) -> TimedMutationOutcome {
+    match (old_exists, new_exists) {
+        (false, true) => TimedMutationOutcome::Applied,
+        (true, false) => TimedMutationOutcome::Unchanged,
+        _ => TimedMutationOutcome::Indeterminate,
+    }
+}
+
+fn classify_ref_observations(
+    old_exists: Option<bool>,
+    new_exists: Option<bool>,
+) -> TimedMutationOutcome {
+    match (old_exists, new_exists) {
+        (Some(old_exists), Some(new_exists)) => classify_timed_mutation(old_exists, new_exists),
+        _ => TimedMutationOutcome::Indeterminate,
+    }
+}
+
+/// Parse `git worktree list --porcelain -z` and classify a timed-out move.
+///
+/// Porcelain records begin with `worktree <absolute-path>` and are separated
+/// by an empty NUL-delimited field. Paths are compared byte-for-byte: any
+/// relative path, alternate spelling, or malformed listing fails closed to an
+/// indeterminate result rather than guessing from the filesystem.
+fn classify_worktree_move_listing(
+    output: &[u8],
+    from: &Path,
+    to: &Path,
+) -> Option<TimedMutationOutcome> {
+    let from = from.as_os_str().as_encoded_bytes();
+    let to = to.as_os_str().as_encoded_bytes();
+    let mut from_registered = false;
+    let mut to_registered = false;
+    let mut at_record_start = true;
+    let mut fields = output.split(|byte| *byte == 0);
+
+    while let Some(field) = fields.next() {
+        if field.is_empty() {
+            if at_record_start {
+                return fields
+                    .all(|remaining| remaining.is_empty())
+                    .then(|| classify_timed_mutation(from_registered, to_registered));
+            }
+            at_record_start = true;
+            continue;
+        }
+
+        if at_record_start {
+            let path = field.strip_prefix(b"worktree ")?;
+            if path.is_empty() {
+                return None;
+            }
+            from_registered |= path == from;
+            to_registered |= path == to;
+            at_record_start = false;
+        }
+    }
+
+    None
+}
+
+fn canonicalize_move_endpoint(path: &Path) -> PathBuf {
+    path.canonicalize()
+        .or_else(|_| {
+            let parent = path.parent().ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no parent")
+            })?;
+            let file_name = path.file_name().ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
+            })?;
+            parent.canonicalize().map(|parent| parent.join(file_name))
+        })
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn observe_worktree_move(repo_path: &Path, from: &Path, to: &Path) -> TimedMutationOutcome {
+    match super::command::run_git_with_timeout(
+        repo_path,
+        ["worktree", "list", "--porcelain", "-z"],
+        MUTATION_OBSERVATION_TIMEOUT,
+    ) {
+        Ok(Some(output)) if output.status.success() => {
+            classify_worktree_move_listing(&output.stdout, from, to)
+                .unwrap_or(TimedMutationOutcome::Indeterminate)
+        }
+        _ => TimedMutationOutcome::Indeterminate,
+    }
+}
+
+fn observe_local_branch_ref(repo_path: &Path, branch: &str) -> Option<bool> {
+    let refname = format!("refs/heads/{branch}");
+    match super::command::run_git_with_timeout(
+        repo_path,
+        ["show-ref", "--verify", "--quiet", &refname],
+        MUTATION_OBSERVATION_TIMEOUT,
+    ) {
+        Ok(Some(output)) if output.status.success() => Some(true),
+        Ok(Some(output)) if output.status.code() == Some(1) => Some(false),
+        _ => None,
+    }
+}
+
 /// Reason recorded on every aoe-created worktree's `git worktree lock`. The
 /// lock makes `git worktree prune` skip the admin entry, so a prune run from a
 /// context that cannot see this checkout (a sibling sandbox, or the host when
@@ -1327,6 +1441,11 @@ impl GitWorktree {
         if to.exists() {
             return Err(GitError::WorktreeAlreadyExists(to.to_path_buf()));
         }
+        // Git reports canonical worktree paths. Resolve both spellings while
+        // the source and destination parent still exist, so a symlinked parent
+        // cannot make a completed timed-out move look indeterminate.
+        let observation_from = canonicalize_move_endpoint(from);
+        let observation_to = canonicalize_move_endpoint(to);
         let from_str = from
             .to_str()
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
@@ -1343,8 +1462,44 @@ impl GitWorktree {
         // re-lock at the destination so the relocated checkout keeps its prune
         // protection.
         self.unlock_worktree(from);
-        let output =
-            super::command::run_git(&self.repo_path, ["worktree", "move", from_str, to_str])?;
+        let Some(output) = super::command::run_git_with_timeout(
+            &self.repo_path,
+            ["worktree", "move", from_str, to_str],
+            WORKTREE_MUTATION_TIMEOUT,
+        )?
+        else {
+            match observe_worktree_move(&self.repo_path, &observation_from, &observation_to) {
+                TimedMutationOutcome::Applied => {
+                    if let Err(e) = self.lock_worktree(to) {
+                        tracing::warn!(target: "git.worktree",
+                            to = %to.display(),
+                            error = %e,
+                            "move_worktree: could not re-lock worktree at new path"
+                        );
+                    }
+                    tracing::warn!(target: "git.worktree", to = %to.display(), "timed-out worktree move completed before termination");
+                    return Ok(());
+                }
+                TimedMutationOutcome::Unchanged
+                    if matches!(from.try_exists(), Ok(true))
+                        && matches!(to.try_exists(), Ok(false)) =>
+                {
+                    let _ = self.lock_worktree(from);
+                }
+                TimedMutationOutcome::Unchanged | TimedMutationOutcome::Indeterminate => {
+                    let _ = self.lock_worktree(from);
+                    let _ = self.lock_worktree(to);
+                    return Err(GitError::WorktreeCommandFailed(format!(
+                        "`git worktree move` timed out after {}s and its final location is indeterminate",
+                        WORKTREE_MUTATION_TIMEOUT.as_secs()
+                    )));
+                }
+            }
+            return Err(GitError::WorktreeCommandFailed(format!(
+                "`git worktree move` timed out after {}s without moving",
+                WORKTREE_MUTATION_TIMEOUT.as_secs()
+            )));
+        };
         if !output.status.success() {
             // Restore the lock on the unmoved source so a failed move does not
             // silently leave it unprotected.
@@ -1371,7 +1526,33 @@ impl GitWorktree {
             repo = %self.repo_path.display(),
             "rename_branch: invoking `git branch -m`"
         );
-        let output = super::command::run_git(&self.repo_path, ["branch", "-m", old, new])?;
+        let Some(output) = super::command::run_git_with_timeout(
+            &self.repo_path,
+            ["branch", "-m", old, new],
+            WORKTREE_MUTATION_TIMEOUT,
+        )?
+        else {
+            let old_exists = observe_local_branch_ref(&self.repo_path, old);
+            let new_exists = observe_local_branch_ref(&self.repo_path, new);
+            match classify_ref_observations(old_exists, new_exists) {
+                TimedMutationOutcome::Applied => {
+                    tracing::warn!(target: "git.worktree", old, new, "timed-out branch rename completed before termination");
+                    return Ok(());
+                }
+                TimedMutationOutcome::Unchanged => {
+                    return Err(GitError::WorktreeCommandFailed(format!(
+                        "`git branch -m` timed out after {}s without renaming",
+                        WORKTREE_MUTATION_TIMEOUT.as_secs()
+                    )));
+                }
+                TimedMutationOutcome::Indeterminate => {
+                    return Err(GitError::WorktreeCommandFailed(format!(
+                        "`git branch -m` timed out after {}s and ref state is indeterminate",
+                        WORKTREE_MUTATION_TIMEOUT.as_secs()
+                    )));
+                }
+            }
+        };
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             return Err(GitError::WorktreeCommandFailed(stderr));
@@ -1581,6 +1762,105 @@ fn walk_worktree_stats(root: &Path) -> WorktreeWalkStats {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn timed_mutation_outcome_requires_exactly_one_observed_side() {
+        let cases = [
+            (false, true, TimedMutationOutcome::Applied),
+            (true, false, TimedMutationOutcome::Unchanged),
+            (false, false, TimedMutationOutcome::Indeterminate),
+            (true, true, TimedMutationOutcome::Indeterminate),
+        ];
+        for (old_exists, new_exists, expected) in cases {
+            assert_eq!(classify_timed_mutation(old_exists, new_exists), expected);
+        }
+    }
+
+    #[test]
+    fn ref_observations_fail_closed_when_either_probe_is_indeterminate() {
+        let cases = [
+            (Some(false), Some(true), TimedMutationOutcome::Applied),
+            (Some(true), Some(false), TimedMutationOutcome::Unchanged),
+            (
+                Some(false),
+                Some(false),
+                TimedMutationOutcome::Indeterminate,
+            ),
+            (Some(true), Some(true), TimedMutationOutcome::Indeterminate),
+            (None, Some(true), TimedMutationOutcome::Indeterminate),
+            (Some(false), None, TimedMutationOutcome::Indeterminate),
+            (None, None, TimedMutationOutcome::Indeterminate),
+        ];
+        for (old_exists, new_exists, expected) in cases {
+            assert_eq!(classify_ref_observations(old_exists, new_exists), expected);
+        }
+    }
+
+    #[test]
+    fn worktree_porcelain_classification_is_exact_and_conservative() {
+        let from = Path::new("/repo/old");
+        let to = Path::new("/repo/new");
+        let cases: &[(&[u8], Option<TimedMutationOutcome>)] = &[
+            (
+                b"worktree /repo/old\0HEAD abc\0branch refs/heads/topic\0\0",
+                Some(TimedMutationOutcome::Unchanged),
+            ),
+            (
+                b"worktree /repo/new\0HEAD abc\0branch refs/heads/topic\0\0",
+                Some(TimedMutationOutcome::Applied),
+            ),
+            (
+                b"worktree /repo/old\0HEAD abc\0\0worktree /repo/new\0HEAD abc\0\0",
+                Some(TimedMutationOutcome::Indeterminate),
+            ),
+            (
+                b"worktree /repo/other\0HEAD abc\0\0",
+                Some(TimedMutationOutcome::Indeterminate),
+            ),
+            (
+                b"worktree /repo/old-suffix\0HEAD abc\0\0",
+                Some(TimedMutationOutcome::Indeterminate),
+            ),
+            (b"HEAD abc\0worktree /repo/new\0\0", None),
+            (b"worktree /repo/new\0HEAD abc\0", None),
+        ];
+
+        for (listing, expected) in cases {
+            let actual = classify_worktree_move_listing(listing, from, to);
+            assert_eq!(
+                actual.as_ref(),
+                expected.as_ref(),
+                "listing: {:?}",
+                String::from_utf8_lossy(listing)
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn worktree_move_observation_canonicalizes_symlinked_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_parent = dir.path().join("real");
+        std::fs::create_dir(&real_parent).unwrap();
+        let linked_parent = dir.path().join("linked");
+        std::os::unix::fs::symlink(&real_parent, &linked_parent).unwrap();
+        let from = linked_parent.join("old");
+        std::fs::create_dir(&from).unwrap();
+        let to = linked_parent.join("new");
+
+        let observed_from = canonicalize_move_endpoint(&from);
+        let observed_to = canonicalize_move_endpoint(&to);
+        assert_eq!(observed_from, real_parent.join("old"));
+        assert_eq!(observed_to, real_parent.join("new"));
+
+        let mut completed_listing = b"worktree ".to_vec();
+        completed_listing.extend_from_slice(observed_to.as_os_str().as_encoded_bytes());
+        completed_listing.extend_from_slice(b"\0HEAD abc\0branch refs/heads/topic\0\0");
+        assert_eq!(
+            classify_worktree_move_listing(&completed_listing, &observed_from, &observed_to),
+            Some(TimedMutationOutcome::Applied),
+        );
+    }
 
     fn run_git(path: &Path, args: &[&str]) {
         let output = std::process::Command::new("git")

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -389,8 +389,8 @@ impl GitWorktree {
         let timeout = std::time::Duration::from_secs(10);
         let start = std::time::Instant::now();
 
-        // run_with_timeout drains stderr with a deadline-bounded read, so a
-        // grandchild holding the pipe (credential helper) cannot block this
+        // run_with_timeout captures stderr in a temporary regular file, so a
+        // grandchild that inherits the handle cannot block this
         // past the timeout.
         match crate::process::run_with_timeout(&mut cmd, timeout) {
             Ok(Some(output)) => {
@@ -973,7 +973,7 @@ impl GitWorktree {
         let path_str = path
             .to_str()
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
-        let output = super::command::run_git(
+        let Some(output) = super::command::run_git_with_timeout(
             &self.repo_path,
             [
                 "worktree",
@@ -982,7 +982,14 @@ impl GitWorktree {
                 WORKTREE_LOCK_REASON,
                 path_str,
             ],
-        )?;
+            WORKTREE_MUTATION_TIMEOUT,
+        )?
+        else {
+            return Err(GitError::WorktreeCommandFailed(format!(
+                "`git worktree lock` timed out after {}s",
+                WORKTREE_MUTATION_TIMEOUT.as_secs()
+            )));
+        };
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             return Err(GitError::WorktreeCommandFailed(stderr));
@@ -998,13 +1005,23 @@ impl GitWorktree {
     /// still clears the lock when the checkout directory is already gone, and a
     /// non-zero exit (already unlocked, or no such worktree) is a harmless
     /// no-op rather than an error. That classification is why the call goes
-    /// through `run_git_quiet`: the routine non-zero exit belongs at DEBUG,
+    /// through the quiet helper: the routine non-zero exit belongs at DEBUG,
     /// not in the WARN stream.
+    ///
+    /// Bounded like the mutations it precedes. `move_worktree` calls this
+    /// immediately before its own bounded `git worktree move`, and both touch
+    /// the same `.git/worktrees/<name>/` metadata, so leaving this one
+    /// unbounded would let a stalled filesystem pin every caller's locks
+    /// through the call that runs first.
     pub fn unlock_worktree(&self, path: &Path) {
         let Some(path_str) = path.to_str() else {
             return;
         };
-        let _ = super::command::run_git_quiet(&self.repo_path, ["worktree", "unlock", path_str]);
+        let _ = super::command::run_git_quiet_with_timeout(
+            &self.repo_path,
+            ["worktree", "unlock", path_str],
+            WORKTREE_MUTATION_TIMEOUT,
+        );
     }
 
     /// Convert a worktree's .git file from absolute to relative path.
@@ -1389,12 +1406,22 @@ impl GitWorktree {
         // all subprocess-driven for consistent stderr / exit-code
         // semantics. The subprocess is why `Err(_)` is a real possibility
         // here even though the repo is already open.
-        let output = super::command::run_git(
+        let output = super::command::run_git_with_timeout(
             &self.repo_path,
             ["show-ref", "--verify", "--quiet", &refname],
+            MUTATION_OBSERVATION_TIMEOUT,
         )
         .map_err(|e| {
             GitError::WorktreeCommandFailed(format!("git show-ref --verify {refname}: {e}"))
+        })?
+        .ok_or_else(|| {
+            // Tri-state contract: a timeout is "could not determine", which
+            // must surface as Err so the caller fails closed rather than
+            // treating an unknown ref as absent.
+            GitError::WorktreeCommandFailed(format!(
+                "git show-ref --verify {refname} timed out after {}s",
+                MUTATION_OBSERVATION_TIMEOUT.as_secs()
+            ))
         })?;
         match output.status.code() {
             Some(0) => Ok(true),
@@ -1832,6 +1859,56 @@ mod tests {
                 expected.as_ref(),
                 "listing: {:?}",
                 String::from_utf8_lossy(listing)
+            );
+        }
+    }
+
+    /// Every git subprocess reachable from `move_worktree` /
+    /// `edit_worktree_workdir` is bounded. The profile-move transaction runs
+    /// them while holding the app-global identity flock, both per-session
+    /// locks, and both profile storage flocks, so one unbounded call pins every
+    /// peer `aoe` process. Pins the whole set rather than one call: the gap
+    /// this closes was `unlock_worktree` sitting one line above an already
+    /// bounded `git worktree move`.
+    ///
+    /// Source-level rather than behavioural because making git itself block on
+    /// `.git` metadata is not reproducible in a unit test; the failure mode is
+    /// a future caller reaching for the unbounded helper, which this catches.
+    #[test]
+    fn every_worktree_mutation_subprocess_is_bounded() {
+        // Whitespace-normalised so rustfmt's line wrapping cannot change the
+        // result: the point is which helper is called, not how it is laid out.
+        let source = include_str!("worktree.rs");
+        let region = source
+            .split_once("impl GitWorktree {")
+            .expect("GitWorktree impl block")
+            .1
+            .split_once("\n#[cfg(test)]")
+            .expect("test module terminates the scanned region")
+            .0;
+        let flat = region.split_whitespace().collect::<Vec<_>>().join(" ");
+        let cases = [
+            ("\"worktree\", \"lock\"", "git worktree lock"),
+            ("\"worktree\", \"unlock\"", "git worktree unlock"),
+            ("\"show-ref\", \"--verify\"", "git show-ref --verify"),
+            ("\"worktree\", \"move\"", "git worktree move"),
+            ("\"branch\", \"-m\"", "git branch -m"),
+        ];
+        for (needle, label) in cases {
+            let at = flat
+                .find(needle)
+                .unwrap_or_else(|| panic!("{label} should still be issued from this module"));
+            // The helper name precedes its argument list, so scan back to the
+            // nearest `run_git*` and require one of the timed variants.
+            let call = flat[..at]
+                .rfind("run_git")
+                .map(|i| &flat[i..])
+                .unwrap_or_default();
+            assert!(
+                call.starts_with("run_git_with_timeout")
+                    || call.starts_with("run_git_quiet_with_timeout"),
+                "{label} must go through a bounded helper, found `{}`",
+                call.split('(').next().unwrap_or(call)
             );
         }
     }

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -6,6 +6,10 @@ use std::path::Path;
 #[cfg(feature = "serve")]
 use std::process::{Child, ChildStdin, Command, Stdio};
 
+pub(super) use super::unix::{
+    configure_process_group, kill_process_group, terminate_process_group,
+};
+
 /// Collect `pid` and every descendant by walking `/proc` once to build a
 /// parent -> children map, then descending it. One `/proc` scan regardless of
 /// tree depth.

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -3,6 +3,10 @@
 use std::collections::HashMap;
 use std::process::Command;
 
+pub(super) use super::unix::{
+    configure_process_group, kill_process_group, terminate_process_group,
+};
+
 /// Collect `pid` and every descendant by parsing `ps -A` once and walking the map.
 pub(super) fn collect_pid_tree(pid: u32) -> Vec<u32> {
     let children_map = build_children_map();

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::io::Read;
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -18,6 +17,21 @@ mod linux;
 
 #[cfg(target_os = "macos")]
 mod macos;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod unix;
+
+#[cfg(target_os = "linux")]
+use linux as platform;
+#[cfg(target_os = "macos")]
+use macos as platform;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod platform {
+    pub(super) fn configure_process_group(_: &mut std::process::Command) {}
+
+    pub(super) fn kill_process_group(_: &std::process::Child) {}
+
+    pub(super) fn terminate_process_group(_: &std::process::Child) {}
+}
 
 /// System memory + agent-count sampling for the TUI diagnostics strip.
 pub(crate) mod metrics;
@@ -45,6 +59,7 @@ pub mod worker_registry;
 pub mod runner;
 
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const PROCESS_GROUP_TERMINATION_GRACE: Duration = Duration::from_millis(250);
 
 /// Wait for `child` to exit, killing and reaping it if it outlives `timeout`.
 /// Returns `Ok(None)` when the timeout fired and the child was killed.
@@ -56,65 +71,95 @@ pub fn wait_with_timeout(
     child: &mut Child,
     timeout: Duration,
 ) -> std::io::Result<Option<ExitStatus>> {
+    wait_with_timeout_inner(child, timeout, false)
+}
+
+/// When `kill_process_group` is true, the caller MUST have configured `child`
+/// as a process-group leader, so its process-group id equals `child.id()`.
+/// Otherwise the kill path could signal the parent's process group.
+fn wait_with_timeout_inner(
+    child: &mut Child,
+    timeout: Duration,
+    kill_process_group: bool,
+) -> std::io::Result<Option<ExitStatus>> {
     let deadline = Instant::now() + timeout;
+    let termination_grace = (timeout / 4).min(PROCESS_GROUP_TERMINATION_GRACE);
+    let terminate_at = deadline.checked_sub(termination_grace).unwrap_or(deadline);
+    let mut termination_requested = false;
     loop {
         if let Some(status) = child.try_wait()? {
-            return Ok(Some(status));
+            if !termination_requested {
+                return Ok(Some(status));
+            }
         }
-        if Instant::now() >= deadline {
+        let now = Instant::now();
+        if kill_process_group && !termination_requested && now >= terminate_at {
+            platform::terminate_process_group(child);
+            termination_requested = true;
+            continue;
+        }
+        if now >= deadline {
+            if kill_process_group {
+                platform::kill_process_group(child);
+            }
             let _ = child.kill();
             let _ = child.wait();
             return Ok(None);
         }
-        std::thread::sleep(WAIT_POLL_INTERVAL);
+        std::thread::sleep(WAIT_POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
     }
 }
 
-/// Spawn `cmd` with piped stdout/stderr and wait for it to exit, killing it
-/// if it outlives `timeout`. Returns `Ok(None)` when the timeout fired and
-/// the child was killed; `Err` covers spawn/wait failures.
+/// Spawn `cmd` with stdout/stderr captured in temporary regular files and wait
+/// for it to exit, killing it if it outlives `timeout`. Returns `Ok(None)` when
+/// the timeout fired and the child was killed; `Err` covers spawn/wait failures.
 ///
-/// stdout/stderr are drained on dedicated threads so a full pipe buffer
-/// cannot wedge the child (and thus this wait) before the deadline. The
-/// caller keeps control of stdin; pipe it to null when the child might
+/// Regular temporary files prevent a full pipe buffer from wedging the child
+/// before the deadline and keep capture independent of inherited writers.
+/// The caller keeps control of stdin; pipe it to null when the child might
 /// prompt (SSH passphrases, credential helpers).
 pub fn run_with_timeout(cmd: &mut Command, timeout: Duration) -> std::io::Result<Option<Output>> {
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
+    run_with_timeout_inner(cmd, timeout, false)
+}
+
+/// [`run_with_timeout`] variant that makes the child a process-group leader
+/// and kills the whole group on timeout on Linux and macOS. Other platforms
+/// still bound output capture independently of descendant-owned handles and
+/// fall back to killing and reaping the direct child.
+pub fn run_with_timeout_process_group(
+    cmd: &mut Command,
+    timeout: Duration,
+) -> std::io::Result<Option<Output>> {
+    platform::configure_process_group(cmd);
+    run_with_timeout_inner(
+        cmd,
+        timeout,
+        cfg!(any(target_os = "linux", target_os = "macos")),
+    )
+}
+
+fn run_with_timeout_inner(
+    cmd: &mut Command,
+    timeout: Duration,
+    kill_process_group: bool,
+) -> std::io::Result<Option<Output>> {
+    let mut stdout_file = tempfile::NamedTempFile::new()?;
+    let mut stderr_file = tempfile::NamedTempFile::new()?;
+    cmd.stdout(Stdio::from(stdout_file.reopen()?));
+    cmd.stderr(Stdio::from(stderr_file.reopen()?));
     let mut child = cmd.spawn()?;
 
-    let mut stdout_pipe = child.stdout.take();
-    let mut stderr_pipe = child.stderr.take();
-    let (otx, orx) = mpsc::channel();
-    let (etx, erx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(ref mut p) = stdout_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        let _ = otx.send(buf);
-    });
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(ref mut p) = stderr_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        let _ = etx.send(buf);
-    });
-
-    let deadline = Instant::now() + timeout;
-    let Some(status) = wait_with_timeout(&mut child, timeout)? else {
+    let Some(status) = wait_with_timeout_inner(&mut child, timeout, kill_process_group)? else {
         return Ok(None);
     };
-    // The child exited, but if it spawned a grandchild that inherited the
-    // pipe (credential helper, pager, backgrounded job), `read_to_end` (and
-    // thus an unbounded `recv`) would block forever. Cap the drain at the
-    // remaining deadline so the timeout guarantee holds even then; the exit
-    // status is already in hand.
-    let remaining = deadline.saturating_duration_since(Instant::now());
-    let stdout = orx.recv_timeout(remaining).unwrap_or_default();
-    let remaining = deadline.saturating_duration_since(Instant::now());
-    let stderr = erx.recv_timeout(remaining).unwrap_or_default();
+    // Regular files, rather than pipes drained by background threads, keep
+    // output capture bounded when a descendant outlives the direct child. A
+    // read reaches the current EOF without waiting for every inherited writer
+    // handle to close.
+    let mut stdout = Vec::new();
+    stdout_file.as_file_mut().read_to_end(&mut stdout)?;
+    let mut stderr = Vec::new();
+    stderr_file.as_file_mut().read_to_end(&mut stderr)?;
     Ok(Some(Output {
         status,
         stdout,
@@ -969,14 +1014,60 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn run_with_timeout_process_group_kills_descendants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pid_path = tmp.path().join("descendant.pid");
+        let term_path = tmp.path().join("terminated");
+        let mut cmd = Command::new("sh");
+        cmd.args([
+            "-c",
+            "trap 'printf term > \"$2\"' TERM; sleep 10 & child=$!; printf %s \"$child\" > \"$1\"; wait",
+            "sh",
+        ])
+        .arg(&pid_path)
+        .arg(&term_path);
+
+        let result = run_with_timeout_process_group(&mut cmd, Duration::from_secs(2)).unwrap();
+        assert!(result.is_none(), "process group should time out");
+        assert_eq!(
+            std::fs::read_to_string(term_path).expect("SIGTERM trap should run"),
+            "term",
+            "the process-group leader must receive SIGTERM before escalation"
+        );
+
+        let pid: i32 = std::fs::read_to_string(pid_path)
+            .expect("shell should publish descendant pid")
+            .parse()
+            .unwrap();
+        let process_is_running = |pid: i32| {
+            let output = Command::new("ps")
+                .args(["-o", "stat=", "-p", &pid.to_string()])
+                .output()
+                .expect("ps should inspect descendant state");
+            let state = String::from_utf8_lossy(&output.stdout);
+            output.status.success()
+                && !state.trim().is_empty()
+                && !state.trim_start().starts_with('Z')
+        };
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while process_is_running(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !process_is_running(pid),
+            "descendant must be exited or a terminated zombie after the timeout"
+        );
+    }
+
+    #[test]
     #[cfg(unix)]
-    fn run_with_timeout_bounds_drain_when_grandchild_holds_pipe() {
+    fn run_with_timeout_does_not_wait_for_descendant_output_writer() {
         // The immediate child (sh) exits fast but backgrounds a `sleep` that
-        // inherits the pipes, so they never close. The drain must still
-        // return by the deadline rather than blocking on read_to_end; this is
-        // the exact shape of the git-clone hang (a credential helper or pager
-        // grandchild outliving the parent). `sleep 10` (>> the 4s assertion)
-        // ensures an unbounded recv would visibly fail.
+        // retains stdout/stderr. Output capture must read the current regular
+        // file contents without waiting for that descendant to close its
+        // inherited handles. `sleep 10` (>> the 4s assertion) ensures an
+        // inherited pipe plus an unbounded drain would visibly fail.
         let mut cmd = Command::new("sh");
         cmd.args(["-c", "sleep 10 & printf done"]);
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1077,7 +1077,7 @@ mod tests {
             .expect("the sh child exits quickly, so an Output is produced");
         assert!(
             start.elapsed() < Duration::from_secs(4),
-            "drain must be bounded by the deadline even while the pipe stays open"
+            "output capture must not wait on a descendant that still holds the handle"
         );
         assert!(output.status.success());
     }

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -1,0 +1,22 @@
+use std::process::{Child, Command};
+
+pub(super) fn configure_process_group(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt as _;
+
+    cmd.process_group(0);
+}
+
+pub(super) fn terminate_process_group(child: &Child) {
+    signal_process_group(child, nix::sys::signal::Signal::SIGTERM);
+}
+
+pub(super) fn kill_process_group(child: &Child) {
+    signal_process_group(child, nix::sys::signal::Signal::SIGKILL);
+}
+
+fn signal_process_group(child: &Child, signal: nix::sys::signal::Signal) {
+    let Ok(pid) = i32::try_from(child.id()) else {
+        return;
+    };
+    let _ = nix::sys::signal::killpg(nix::unistd::Pid::from_raw(pid), signal);
+}

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -117,9 +117,9 @@ fn probe_brew_aoe_path_with_timeout(timeout: std::time::Duration) -> Option<Path
     let mut cmd = Command::new("brew");
     cmd.args(["list", "aoe"]);
 
-    // run_with_timeout kills brew at the deadline and bounds the output
-    // drain by it too, so neither a hung brew nor a grandchild holding the
-    // pipe can block the probe.
+    // run_with_timeout kills brew at the deadline and captures output in a
+    // temporary regular file, so neither a hung brew nor a grandchild that
+    // inherits the handle can block the probe.
     let output = crate::process::run_with_timeout(&mut cmd, timeout)
         .ok()
         .flatten()?;


### PR DESCRIPTION
## Description

Bounds `git worktree move` and `git branch -m` to 30 seconds. Timed-out mutations are reconciled from Git's authoritative state before AoE reports applied, unchanged, or indeterminate. Unix commands use process-group termination; other platforms kill the direct child. Worktree locks follow the observed final location.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No UI change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: deterministic unit tests exercise timeout, process cleanup, reconciliation, and symlinked path handling.

## Dependencies

No prerequisite PR. #3411 depends on this change.

## Validation

Head: `95faf93e`, based on `upstream/main` `91e33702`.

- `cargo test run_with_timeout -- --nocapture`: 5 passed
- Cumulative stack on #3427: `cargo test --features serve`, 6,645 passed and 8 ignored
- Cumulative stack on #3427: `cargo clippy --features serve --lib --bins -- -D warnings`
- `cargo fmt --check`

CI status was not checked in this update.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you'd like to share:** Implementation, validation, and review assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
