### PR TITLE
fix(containers): bound runtime control commands

### DIFF
--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -23,6 +23,13 @@ pub struct ContainerRuntime {
     pub(crate) kind: RuntimeKind,
 }
 
+fn is_runtime_timeout(error: &DockerError) -> bool {
+    matches!(
+        error,
+        DockerError::IoError(error) if error.kind() == std::io::ErrorKind::TimedOut
+    )
+}
+
 impl ContainerRuntime {
     pub fn docker() -> Self {
         Self {
@@ -71,18 +78,15 @@ impl ContainerRuntime {
                 // `RepoDigests` holds `repo@sha256:...` entries for the pulled
                 // manifest. One subprocess, newline-joined so a multi-registry
                 // image still lets us pick the entry matching this reference.
-                let output = self
-                    .base
-                    .command()
-                    .args([
-                        "image",
-                        "inspect",
-                        "--format",
-                        "{{range .RepoDigests}}{{println .}}{{end}}",
-                        image,
-                    ])
-                    .output()
-                    .ok()?;
+                let mut cmd = self.base.command();
+                cmd.args([
+                    "image",
+                    "inspect",
+                    "--format",
+                    "{{range .RepoDigests}}{{println .}}{{end}}",
+                    image,
+                ]);
+                let output = self.base.probe_output(&mut cmd).ok()?;
                 if !output.status.success() {
                     return None;
                 }
@@ -236,6 +240,58 @@ impl ContainerRuntime {
             })
     }
 
+    /// Read the runtime's authoritative container identifier after a create
+    /// command whose client-side timeout made its result indeterminate.
+    fn inspect_container_id(&self, name: &str) -> Result<String> {
+        let mut cmd = self.base.command();
+        match self.kind {
+            RuntimeKind::Docker | RuntimeKind::Podman => {
+                cmd.args(["container", "inspect", "-f", "{{.Id}}", name]);
+            }
+            RuntimeKind::AppleContainer => {
+                cmd.args(["inspect", name]);
+            }
+        }
+        let output = self.base.probe_output(&mut cmd)?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            self.base.classify_probe_failure(&stderr)?;
+            return Err(DockerError::ContainerNotFound(name.to_string()));
+        }
+
+        let id = match self.kind {
+            RuntimeKind::Docker | RuntimeKind::Podman => {
+                String::from_utf8_lossy(&output.stdout).trim().to_string()
+            }
+            RuntimeKind::AppleContainer => {
+                let payload: Value = serde_json::from_slice(&output.stdout)
+                    .map_err(|error| DockerError::InspectFailed(error.to_string()))?;
+                Self::apple_container_inspect_id(&payload)?.to_string()
+            }
+        };
+        if id.is_empty() {
+            return Err(DockerError::InspectFailed(
+                "container inspect returned an empty id".to_string(),
+            ));
+        }
+        Ok(id)
+    }
+
+    fn apple_container_inspect_id(payload: &Value) -> Result<&str> {
+        payload
+            .pointer("/0/id")
+            .or_else(|| payload.pointer("/0/configuration/id"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| {
+                DockerError::InspectFailed(
+                    "apple container inspect: no non-empty /0/id or /0/configuration/id"
+                        .to_string(),
+                )
+            })
+    }
+
     /// The container's configured working directory (`Config.WorkingDir`), or
     /// `None` if it can't be determined (container gone, inspect failed, or the
     /// field is empty). Used to backfill the create-time-pinned workdir for
@@ -249,12 +305,9 @@ impl ContainerRuntime {
         if !matches!(self.kind, RuntimeKind::Docker | RuntimeKind::Podman) {
             return None;
         }
-        let output = self
-            .base
-            .command()
-            .args(["container", "inspect", "-f", "{{.Config.WorkingDir}}", name])
-            .output()
-            .ok()?;
+        let mut cmd = self.base.command();
+        cmd.args(["container", "inspect", "-f", "{{.Config.WorkingDir}}", name]);
+        let output = self.base.probe_output(&mut cmd).ok()?;
         if !output.status.success() {
             return None;
         }
@@ -280,19 +333,43 @@ impl ContainerRuntime {
         if self.does_container_exist(name)? {
             return Err(DockerError::ContainerAlreadyExists(name.to_string()));
         }
-        self.base.run_create(name, image, config)
+        match self.base.run_create(name, image, config) {
+            Err(error) if is_runtime_timeout(&error) => match self.inspect_container_id(name) {
+                Ok(id) => Ok(id),
+                Err(_) => Err(error),
+            },
+            result => result,
+        }
     }
 
     pub fn start_container(&self, name: &str) -> Result<()> {
-        self.base.start_container(name)
+        match self.base.start_container(name) {
+            Err(error) if is_runtime_timeout(&error) => match self.is_container_running(name) {
+                Ok(true) => Ok(()),
+                _ => Err(error),
+            },
+            result => result,
+        }
     }
 
     pub fn stop_container(&self, name: &str) -> Result<()> {
-        self.base.stop_container(name)
+        match self.base.stop_container(name) {
+            Err(error) if is_runtime_timeout(&error) => match self.is_container_running(name) {
+                Ok(false) => Ok(()),
+                _ => Err(error),
+            },
+            result => result,
+        }
     }
 
     pub fn remove(&self, name: &str, force: bool) -> Result<()> {
-        self.base.remove(name, force)
+        match self.base.remove(name, force) {
+            Err(error) if is_runtime_timeout(&error) => match self.does_container_exist(name) {
+                Ok(false) => Ok(()),
+                _ => Err(error),
+            },
+            result => result,
+        }
     }
 
     pub fn exec_command(&self, name: &str, options: Option<&str>, cmd: &str) -> String {
@@ -368,21 +445,17 @@ impl ContainerRuntime {
     pub fn batch_running_states(&self, prefix: &str) -> HashMap<String, bool> {
         match self.kind {
             RuntimeKind::Docker | RuntimeKind::Podman => {
-                let output = self
-                    .base
-                    .command()
-                    .args([
-                        "ps",
-                        "-a",
-                        "--filter",
-                        &format!("name={}", prefix),
-                        "--format",
-                        "{{.Names}}\t{{.State}}",
-                    ])
-                    .output();
-
-                let output = match output {
-                    Ok(o) if o.status.success() => o,
+                let mut cmd = self.base.command();
+                cmd.args([
+                    "ps",
+                    "-a",
+                    "--filter",
+                    &format!("name={}", prefix),
+                    "--format",
+                    "{{.Names}}\t{{.State}}",
+                ]);
+                let output = match self.base.probe_output(&mut cmd) {
+                    Ok(output) if output.status.success() => output,
                     _ => return HashMap::new(),
                 };
 
@@ -424,22 +497,18 @@ impl ContainerRuntime {
                 // naming containers positionally fails the whole call with
                 // "No such container" if any one of them is gone, which is a
                 // normal state for a session whose sandbox has stopped.
-                let output = self
-                    .base
-                    .command()
-                    .args([
-                        "stats",
-                        "--no-stream",
-                        "--format",
-                        // A literal tab, not the `\t` escape: the argv reaches
-                        // the runtime without a shell, and Go template text is
-                        // emitted verbatim either way.
-                        "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.PIDs}}",
-                    ])
-                    .output();
-
-                let output = match output {
-                    Ok(o) if o.status.success() => o,
+                let mut cmd = self.base.command();
+                cmd.args([
+                    "stats",
+                    "--no-stream",
+                    "--format",
+                    // A literal tab, not the `\t` escape: the argv reaches
+                    // the runtime without a shell, and Go template text is
+                    // emitted verbatim either way.
+                    "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.PIDs}}",
+                ]);
+                let output = match self.base.probe_output(&mut cmd) {
+                    Ok(output) if output.status.success() => output,
                     _ => return super::stats::StatsMap::new(),
                 };
 
@@ -554,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apple_container_inspect_state_shapes() {
+    fn test_apple_container_inspect_shapes() {
         use serde_json::json;
         // Both CLI generations (#3239) plus the drift shapes that must stay
         // Err so lifecycle gates fail closed rather than fail open (#2596).
@@ -584,6 +653,30 @@ mod tests {
                     let parsed = result.unwrap_or_else(|e| panic!("{payload}: {e}"));
                     assert_eq!(parsed, state);
                 }
+                None => assert!(result.is_err(), "expected Err for {payload}"),
+            }
+        }
+
+        let id_cases = [
+            (json!([{"id": "new-id"}]), Some("new-id")),
+            (
+                json!([{"configuration": {"id": "legacy-id"}}]),
+                Some("legacy-id"),
+            ),
+            (json!([{"id": ""}]), None),
+            (json!([{"id": "  trimmed-id  "}]), Some("trimmed-id")),
+            (json!([{"id": "   "}]), None),
+            (json!([{"id": 3}]), None),
+            (json!([{}]), None),
+            (json!([]), None),
+        ];
+        for (payload, expected) in id_cases {
+            let result = ContainerRuntime::apple_container_inspect_id(&payload);
+            match expected {
+                Some(id) => assert_eq!(
+                    result.unwrap_or_else(|error| panic!("{payload}: {error}")),
+                    id
+                ),
                 None => assert!(result.is_err(), "expected Err for {payload}"),
             }
         }

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -10,6 +10,22 @@ use std::time::{Duration, Instant};
 /// image on a slow link still completes; it only fires on a wedged pull.
 const PULL_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// Upper bound on a single short-lived container-runtime control command
+/// (inspect, start, stop, rm, volume ls/rm) issued through
+/// [`RuntimeBase::probe_output`]. Unlike an image pull, these are local
+/// control-plane round-trips that return in well under a second against a
+/// healthy Docker, Podman, or Apple Container runtime; the only way one blocks
+/// is a wedged daemon or a `stop`/`rm -f` whose target ignores SIGTERM through
+/// its grace period. Sized above the default 10s stop grace so a legitimate
+/// slow stop still completes, yet bounded so a hung runtime cannot park a
+/// caller forever.
+const RUNTIME_CMD_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Upper bound for arbitrary commands executed inside a container. The only
+/// direct caller deletes a sandbox worktree tree, which can legitimately take
+/// much longer than a local control-plane probe but must not hang forever.
+const RUNTIME_EXEC_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// Shared implementation for container runtimes.
 ///
 /// Captures the behavioral differences between runtimes (Docker, Apple Container, etc.)
@@ -256,48 +272,72 @@ impl RuntimeBase {
         Command::new(self.binary)
     }
 
-    /// Run `cmd` and capture its output, mapping a missing-binary spawn
-    /// failure to the actionable [`DockerError::NotInstalled`].
+    /// Run `cmd` under `RUNTIME_CMD_TIMEOUT` and capture its output, mapping a
+    /// missing-binary spawn failure to the actionable [`DockerError::NotInstalled`]
+    /// and a timeout to a single-line [`DockerError::IoError`].
     ///
-    /// `Command::output()` short-circuits with `io::ErrorKind::NotFound` when
-    /// the runtime binary is not on `PATH`. The bare `?` conversion routes
-    /// that through `#[from] std::io::Error` into the opaque
-    /// [`DockerError::IoError`], hiding the one variant whose Display tells
-    /// the operator how to fix it ("Docker is not installed or not in PATH.
-    /// Install: ..."). Every `.output()?` call site that propagates its
-    /// error goes through this wrapper so the not-installed case surfaces
-    /// with its remediation intact; all other IO errors propagate unchanged.
+    /// `cmd.spawn()` short-circuits with `io::ErrorKind::NotFound` when the
+    /// runtime binary is not on `PATH`. The bare `?` conversion routes that
+    /// through `#[from] std::io::Error` into the opaque [`DockerError::IoError`],
+    /// hiding the one variant whose Display tells the operator how to fix it
+    /// ("Docker is not installed or not in PATH. Install: ..."). Every call site
+    /// that propagates its error goes through this wrapper so the not-installed
+    /// case surfaces with its remediation intact; all other IO errors propagate
+    /// unchanged.
+    ///
+    /// The timeout is what makes every short container-runtime control command
+    /// (inspect, start, stop, rm, volume ls/rm) bounded: a wedged runtime is
+    /// killed at the deadline instead of blocking the caller forever. A timed-out
+    /// probe surfaces as an `Err`, which the running-state gate treats
+    /// conservatively as [`super::Probe::Unknown`] (fail-closed), and a timed-out
+    /// removal as [`super::Teardown::Failed`]. Stdin is closed so a child that
+    /// unexpectedly reads never blocks on the parent terminal.
     pub fn probe_output(&self, cmd: &mut Command) -> Result<std::process::Output> {
-        cmd.output().map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                DockerError::NotInstalled
-            } else {
-                DockerError::IoError(e)
-            }
-        })
+        self.probe_output_with_timeout(cmd, RUNTIME_CMD_TIMEOUT)
+    }
+
+    fn probe_output_with_timeout(
+        &self,
+        cmd: &mut Command,
+        timeout: Duration,
+    ) -> Result<std::process::Output> {
+        cmd.stdin(Stdio::null());
+        match crate::process::run_with_timeout(cmd, timeout) {
+            Ok(Some(output)) => Ok(output),
+            Ok(None) => Err(DockerError::IoError(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "{} command timed out after {}s and was killed",
+                    self.binary,
+                    timeout.as_secs()
+                ),
+            ))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(DockerError::NotInstalled),
+            Err(e) => Err(DockerError::IoError(e)),
+        }
     }
 
     pub fn is_available(&self) -> bool {
-        self.command()
-            .arg("--version")
-            .output()
-            .map(|o| o.status.success())
+        let mut cmd = self.command();
+        cmd.arg("--version");
+        self.probe_output(&mut cmd)
+            .map(|output| output.status.success())
             .unwrap_or(false)
     }
 
     pub fn is_daemon_running(&self) -> bool {
-        self.command()
-            .args(self.daemon_check_args)
-            .output()
-            .map(|o| o.status.success())
+        let mut cmd = self.command();
+        cmd.args(self.daemon_check_args);
+        self.probe_output(&mut cmd)
+            .map(|output| output.status.success())
             .unwrap_or(false)
     }
 
     pub fn image_exists_locally(&self, image: &str) -> bool {
-        self.command()
-            .args(["image", "inspect", image])
-            .output()
-            .map(|o| o.status.success())
+        let mut cmd = self.command();
+        cmd.args(["image", "inspect", image]);
+        self.probe_output(&mut cmd)
+            .map(|output| output.status.success())
             .unwrap_or(false)
     }
 
@@ -688,9 +728,7 @@ impl RuntimeBase {
 
         let mut command = self.command();
         command.args(&args);
-        let output = self.probe_output(&mut command)?;
-
-        Ok(output)
+        self.probe_output_with_timeout(&mut command, RUNTIME_EXEC_TIMEOUT)
     }
 }
 
@@ -940,6 +978,24 @@ mod tests {
         assert!(matches!(
             RuntimeBase::DOCKER.probe_output(&mut cmd),
             Err(DockerError::NotInstalled)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_output_maps_timeout_to_timed_out_io_error() {
+        assert!(
+            RUNTIME_EXEC_TIMEOUT > RUNTIME_CMD_TIMEOUT,
+            "arbitrary container work must have a wider bound than control probes"
+        );
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 5"]);
+        let result =
+            RuntimeBase::DOCKER.probe_output_with_timeout(&mut cmd, Duration::from_millis(10));
+        assert!(matches!(
+            &result,
+            Err(DockerError::IoError(error))
+                if error.kind() == std::io::ErrorKind::TimedOut
         ));
     }
 


### PR DESCRIPTION
## Description

Bounds short container-runtime control commands to 60 seconds and arbitrary in-container cleanup to 600 seconds. stdin is closed, missing runtimes retain their actionable error, and create, start, stop, and remove reconcile authoritative runtime state after a timeout. Docker, Podman, and Apple Container create recovery returns the runtime's actual container ID.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No UI change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

Merged into `main` as #3458.

- `cargo test --lib containers::runtime -- --nocapture`: 49 passed and 2 ignored
- `cargo clippy --lib --bins -- -D warnings`
- `cargo fmt --check`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex / Oh My Pi

**Any Additional AI Details you'd like to share:** Implementation and validation assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
