### PR TITLE
fix(web): keep plugin panes closed by default

### DIFF
--- a/web/src/components/settings/__tests__/PanelsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PanelsSettings.test.tsx
@@ -2,8 +2,9 @@
 //
 // Contract test for the PanelsSettings panel (#3035). Like DiffSettings, this
 // persists through useWebSettings + localStorage (key `aoe-web-settings`), not
-// PATCH /api/settings. The contract is the JSON shape written to that key: the
-// three auto-open-pane booleans default true and flip independently.
+// PATCH /api/settings. The contract is the JSON shape written to that key:
+// diff/terminal default true, plugin panes default false, and all three flip
+// independently.
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
@@ -21,11 +22,14 @@ beforeEach(() => {
 });
 
 describe("PanelsSettings localStorage contract", () => {
-  it("all three toggles default on", () => {
+  it("diff and terminal toggles default on, plugin toggle defaults off", () => {
     const { container } = render(<PanelsSettings />);
     const boxes = container.querySelectorAll("input[type=checkbox]");
     expect(boxes).toHaveLength(3);
-    for (const box of boxes) expect((box as HTMLInputElement).checked).toBe(true);
+    const [diff, terminal, plugins] = Array.from(boxes) as HTMLInputElement[];
+    expect(diff!.checked).toBe(true);
+    expect(terminal!.checked).toBe(true);
+    expect(plugins!.checked).toBe(false);
   });
 
   it("each toggle writes its own key independently", () => {
@@ -37,13 +41,13 @@ describe("PanelsSettings localStorage contract", () => {
     fireEvent.click(diff!);
     expect(readStored().autoOpenDiffPane).toBe(false);
     expect(readStored().autoOpenTerminalPane).not.toBe(false);
-    expect(readStored().autoOpenPluginPanes).not.toBe(false);
+    expect(readStored().autoOpenPluginPanes).toBe(false);
 
     fireEvent.click(terminal!);
     expect(readStored().autoOpenTerminalPane).toBe(false);
 
     fireEvent.click(plugins!);
-    expect(readStored().autoOpenPluginPanes).toBe(false);
+    expect(readStored().autoOpenPluginPanes).toBe(true);
 
     // Flipping back restores true.
     fireEvent.click(diff!);

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -39,8 +39,10 @@ export interface WebSettings {
   /** Auto-open a terminal pane in newly opened sessions (#3035). */
   autoOpenTerminalPane: boolean;
   /** Auto-open plugin panes (e.g. the GitHub PR pane) when available (#3035).
-   *  Unlike the diff/terminal flags this is an ongoing policy: turning it back
-   *  on can add newly available plugin panes to existing sessions too. */
+   *  Off keeps plugin panes closed by default; the activity-bar toggle still
+   *  opens them on demand. Unlike the diff/terminal flags this is an ongoing
+   *  policy: turning it back on can add newly available plugin panes to
+   *  existing sessions too. */
   autoOpenPluginPanes: boolean;
 }
 
@@ -62,7 +64,7 @@ function getDefaults(): WebSettings {
     sidebarCompact: false,
     autoOpenDiffPane: true,
     autoOpenTerminalPane: true,
-    autoOpenPluginPanes: true,
+    autoOpenPluginPanes: false,
   };
 }
 

--- a/web/tests/pane-docking.spec.ts
+++ b/web/tests/pane-docking.spec.ts
@@ -122,11 +122,17 @@ test.describe("Dockable pane system", () => {
 
     await page.goto(`/session/${SESSION}`);
 
-    // The plugin pane gets its own activity-bar toggle and a dock tab.
+    // The plugin pane gets its own activity-bar toggle, but no tab until asked
+    // for: `autoOpenPluginPanes` defaults off, so an installed plugin does not
+    // push its pane into every session. Opening it from the activity bar is
+    // the on-demand path that default now relies on.
     const paneId = "plugin:acme.demo:demo_pane";
     await expect(page.locator(`[data-testid="pane-toggle-${paneId}"]`)).toBeVisible();
-    // Only the active tab's body mounts, so activate the plugin tab first.
-    await page.getByTestId(`pane-tab-${paneId}`).click();
+    await expect(page.getByTestId(`pane-tab-${paneId}`)).toHaveCount(0);
+    // openOrRevealTab both adds the tab and activates it, and only the active
+    // tab's body mounts, so the pane body follows from the one click.
+    await page.locator(`[data-testid="pane-toggle-${paneId}"]`).click();
+    await expect(page.getByTestId(`pane-tab-${paneId}`)).toBeVisible();
     await expect(page.locator('[data-testid="plugin-pane-body"][data-plugin-id="acme.demo"]')).toBeVisible();
 
     // Clicking the pane's action button forwards its method to the worker.
@@ -160,8 +166,10 @@ test.describe("Dockable pane system", () => {
 
     await page.goto(`/session/${SESSION}`);
 
+    // Plugin panes default closed, so open this one from the activity bar
+    // before checking that a collapse round-trip preserves it.
     const paneId = "plugin:acme.demo:demo_pane";
-    await page.getByTestId(`pane-tab-${paneId}`).click();
+    await page.locator(`[data-testid="pane-toggle-${paneId}"]`).click();
     await expect(page.locator('[data-testid="plugin-pane-body"][data-plugin-id="acme.demo"]')).toBeVisible();
 
     const handle = page.getByTestId("content-split-resize-handle");


### PR DESCRIPTION
## Description

Changes the client-side default for `autoOpenPluginPanes` from `true` to `false`.

Before this change, installing a plugin such as `github-lite` caused its pane to open automatically every time a chat was selected, which is noisy when a user only wants the pane on demand. After this change, plugin panes stay closed until the user explicitly opens them from the activity bar or enables the "Open plugin panels automatically" toggle in Settings > Panels.

Diff and terminal panes continue to default to open, so only plugin-contributed panes are affected.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass (`npx vitest run src/components/settings/__tests__/PanelsSettings.test.tsx src/lib/__tests__/paneLayout.test.ts`)
- [x] `npm run format:check` and `npm run lint` pass
- [ ] Documentation was updated where necessary (n/a: behavior change is self-described by the existing settings label)
- [ ] For UI changes: included screenshot or recording (n/a: default state change only)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] Skipped a test, because: the default is already covered by the existing `PanelsSettings` Vitest contract test, which now asserts the plugin toggle defaults off. A Playwright spec would test the same localStorage default.

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:**
Kimi Code CLI

**Any Additional AI Details you would like to share:**
Change suggested during review of the github-lite plugin PR (#3462).

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Plugin panes now stay closed by default when users select chats. Users can open them from the activity bar or enable **Open plugin panels automatically** in Settings > Panels.

Diff and terminal panes continue to open automatically. Documentation and tests now reflect these settings and verify on-demand plugin-pane opening.

## Benefits

This keeps the chat workspace less cluttered and gives users control over when plugin panes appear. Updated tests and documentation make the behavior clear and easier to maintain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->