### PR TITLE
fix(session): require a regular file in the container transcript scan

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -393,6 +393,29 @@ pub(crate) fn claude_poll_fn(
     }
 }
 
+/// The `sh` snippet shipped to `docker exec` to list candidate transcripts.
+///
+/// All three checks dereference: `[ -f ]` for type, `find -L` for freshness,
+/// `ls -tL` for ordering. A symlink's own mtime is frozen at creation, so a
+/// link left undereferenced ages out of the five-minute gate while its target
+/// is still being appended. The host scan reads through links for the same
+/// reason (#3454), and the two have to agree for
+/// `claude_host_transcript_confirmed_absent` to mean anything.
+fn claude_container_list_snippet(dir_name: &str) -> String {
+    format!(
+        r#"
+CLAUDE_HOME="${{CLAUDE_CONFIG_DIR:-$HOME/.claude}}"
+DIR="$CLAUDE_HOME/projects/{dir_name}"
+[ -d "$DIR" ] || exit 0
+for f in $(ls -tL "$DIR"/*.jsonl 2>/dev/null); do
+  [ -f "$f" ] || continue
+  [ -n "$(find -L "$f" -mmin -5 2>/dev/null)" ] || continue
+  basename "$f" .jsonl
+done
+"#
+    )
+}
+
 /// Capture Claude Code session ID inside a Docker container.
 ///
 /// Lists every fresh (≤ 5 min mtime) UUID-named jsonl in
@@ -406,19 +429,7 @@ pub(crate) fn capture_claude_session_id_in_container(
     exclusion: &HashSet<String>,
     known_session_id: Option<&str>,
 ) -> Result<String> {
-    let dir_name = encode_claude_project_path(container_cwd);
-
-    let snippet = format!(
-        r#"
-CLAUDE_HOME="${{CLAUDE_CONFIG_DIR:-$HOME/.claude}}"
-DIR="$CLAUDE_HOME/projects/{dir_name}"
-[ -d "$DIR" ] || exit 0
-for f in $(ls -t "$DIR"/*.jsonl 2>/dev/null); do
-  [ -n "$(find "$f" -mmin -5 2>/dev/null)" ] || continue
-  basename "$f" .jsonl
-done
-"#
-    );
+    let snippet = claude_container_list_snippet(&encode_claude_project_path(container_cwd));
 
     let mut cmd = std::process::Command::new("docker");
     cmd.args(["exec", container_name, "sh", "-c", &snippet]);
@@ -3542,6 +3553,82 @@ mod tests {
             None,
         );
         assert!(result.is_err());
+    }
+
+    /// Runs the production snippet under `sh` against a real directory, so the
+    /// guard is exercised without Docker. `CLAUDE_CONFIG_DIR` goes to the child
+    /// only, so this needs no `EnvGuard` and no serial key.
+    #[cfg(unix)]
+    #[test]
+    fn test_container_list_snippet_lists_only_regular_files() {
+        let sid = "11111111-1111-4111-8111-111111111111";
+        // `listed` is what the snippet should emit for each shape. The glob
+        // does match a directory, but `ls -tL` on one lists its contents
+        // rather than itself, so that entry never reaches `[ -f ]`; the row
+        // pins the listing step, not the guard.
+        let cases = [
+            ("regular", true),
+            ("symlink-to-transcript", true),
+            ("directory", false),
+            ("dangling-link", false),
+            ("symlink-cycle", false),
+            ("fifo", false),
+        ];
+        for (kind, listed) in cases {
+            let home = tempfile::tempdir().unwrap();
+            let project_path = format!("/tmp/container-scan-probe-{kind}");
+            let dir = home
+                .path()
+                .join("projects")
+                .join(encode_claude_project_path(&project_path));
+            std::fs::create_dir_all(&dir).unwrap();
+            let entry = dir.join(format!("{sid}.jsonl"));
+            match kind {
+                "regular" => std::fs::write(&entry, "{}\n").unwrap(),
+                "symlink-to-transcript" => {
+                    let target = dir.join("target.data");
+                    std::fs::write(&target, "{}\n").unwrap();
+                    std::os::unix::fs::symlink(&target, &entry).unwrap();
+                    // Age the link past the five-minute gate while its target
+                    // stays fresh. Without this the row passes on a link too
+                    // young to distinguish lstat from stat, which is the case
+                    // that actually breaks.
+                    let _ = std::process::Command::new("touch")
+                        .args(["-h", "-d", "10 minutes ago"])
+                        .arg(&entry)
+                        .status();
+                }
+                "directory" => std::fs::create_dir(&entry).unwrap(),
+                "dangling-link" => {
+                    std::os::unix::fs::symlink(dir.join("gone.jsonl"), &entry).unwrap()
+                }
+                "symlink-cycle" => std::os::unix::fs::symlink(&entry, &entry).unwrap(),
+                "fifo" => {
+                    // Skipped rather than failed where `mkfifo` is unavailable;
+                    // the other rows still gate the guard.
+                    match std::process::Command::new("mkfifo").arg(&entry).status() {
+                        Ok(s) if s.success() => {}
+                        _ => continue,
+                    }
+                }
+                _ => continue,
+            }
+
+            let out = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(claude_container_list_snippet(&encode_claude_project_path(
+                    &project_path,
+                )))
+                .env("CLAUDE_CONFIG_DIR", home.path())
+                .output()
+                .expect("snippet invocation failed");
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            assert_eq!(
+                stdout.lines().any(|l| l.trim() == sid),
+                listed,
+                "{kind}: unexpected listing, stdout {stdout:?}",
+            );
+        }
     }
 
     #[test]

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -3592,11 +3592,17 @@ mod tests {
                     // Age the link past the five-minute gate while its target
                     // stays fresh. Without this the row passes on a link too
                     // young to distinguish lstat from stat, which is the case
-                    // that actually breaks.
-                    let _ = std::process::Command::new("touch")
+                    // that actually breaks. BSD `touch` rejects this date
+                    // form, so skip the row where it is unavailable rather
+                    // than let it pass without testing anything.
+                    let aged = std::process::Command::new("touch")
                         .args(["-h", "-d", "10 minutes ago"])
                         .arg(&entry)
-                        .status();
+                        .status()
+                        .is_ok_and(|s| s.success());
+                    if !aged {
+                        continue;
+                    }
                 }
                 "directory" => std::fs::create_dir(&entry).unwrap(),
                 "dangling-link" => {


### PR DESCRIPTION
## Description

Follow-up to #3454, which @njbrake asked for in that review:

> Worth a follow up, left alone here: the container mirror in
> `capture_claude_session_id_in_container` has the same defect. I ran the
> snippet and it emits a FIFO and a dangling symlink as candidates.
> `[ -f "$f" ] || continue` fixes it and follows links, so it stays symmetric
> with this change.

The `docker exec` snippet accepted an entry on its `*.jsonl` glob and a fresh
mtime without checking what it is, so a FIFO, a dangling symlink or a symlink
cycle named `<uuid>.jsonl` under the container's
`$CLAUDE_CONFIG_DIR/projects/<encoded>/` was handed back as a resume id with
nothing behind it. As on the host side, these do not merely slip past the
freshness gate, they read as *fresh*: `find` on a named argument lstats it and
reports the creation time, so a newly planted phantom beats a real transcript in
the newest-first ordering.

**Claude's was the only one of the five container list snippets without a type
check.** `PI_CONTAINER_LIST_SCRIPT` and `VIBE_CONTAINER_LIST_SCRIPT` use
`[ -f ]`; `CODEX_CONTAINER_LIST_SCRIPT` and `GEMINI_CONTAINER_LIST_SCRIPT` use
`find -type f`. So this is the odd one out rather than a class-wide gap, and the
fix is the idiom already in the file.

**All three checks dereference**, and that took two more changes than the type
guard. `[ -f ]` already followed links, but `find` and `ls -t` did not: GNU
`find` at its default `-P` lstats a named argument, so it read the *link's* own
mtime, which is frozen at creation. A symlink older than five minutes pointing
at a transcript Claude is still appending to was therefore dropped, and `ls -t`
ordered by the link rather than the target.

#3454 chose `fs::metadata` on the host for exactly this reason, in its own
commit message: *"a link's own mtime is frozen at creation while the two
five-minute freshness gates want the append time."* So the first version of this
PR mirrored the host's type check and inverted its freshness check. `find -L`
and `ls -tL` fix that, and `claude_host_transcript_confirmed_absent` follows
links too, so host and container now agree on all three.

One asymmetry remains and is deliberate: the host applies its five-minute bound
only in the `known_hit` tie-break, while the container hard-filters on it. That
predates this change.

### Reproduction

Running the production snippet under `sh` against a directory holding one of
each shape, before and after:

```
before: 6666(symlink to transcript)  5555(cycle)  3333(dangling)  2222(FIFO)  1111(regular)
after:  6666(symlink to transcript)  1111(regular)
```

Identical under `dash`, which is what the Alpine and Debian bases run.

**One correction to the finding as stated.** The reproduction turns up a third
rejected shape, the symlink cycle, and rules out a fourth: **a directory named
`<uuid>.jsonl` does not reach the loop at all**, because `ls -t "$DIR"/*.jsonl`
without `-d` lists a matching directory's *contents* rather than the directory.
Verified with the directory both empty and non-empty. The host-side scan in
#3454 does reject a directory, because `read_dir` yields it; the container one
never sees it. The test row for that case is marked as pinning the glob rather
than the guard, so it does not read as a guard assertion that cannot fail.

### The snippet moved, so it can be tested

`claude_container_list_snippet(dir_name)` is now a function, which lets the test
run the production string under `sh` against a real directory with
`CLAUDE_CONFIG_DIR` pointed at a tempdir. No Docker needed. This follows the
`PI_CONTAINER_LIST_SCRIPT` precedent already in the file
(`test_select_pi_session_in_container_against_real_script_output`). The env var
goes to the child only, so it needs no `EnvGuard` and no serial key.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No UI change.

## Test Coverage Analysis

One table-driven test, no new test functions beyond it, covering both
directions: the four shapes that must not be listed and the two that must. The
`symlink-to-transcript` row ages the link past the five-minute gate while its
target stays fresh, so it pins the dereference rather than passing on a link too
young to tell `lstat` from `stat`.

Sensitivity checked rather than assumed, in both directions. Removing
`[ -f "$f" ] || continue` fails three of the six rows (`dangling-link`,
`symlink-cycle`, `fifo`); the assertion reports the first:

```
assertion `left == right` failed: dangling-link: unexpected listing,
stdout "11111111-1111-4111-8111-111111111111\n"
  left: true
 right: false
```

Gate, at `003dfb27` against `upstream/main` @ `65001957`:

- `cargo fmt -- --check` clean.
- `cargo clippy --all-targets`: 6 warnings, **0 of them in `capture.rs`**; same
  pre-existing set as on a clean tree.
- `cargo test --lib`: `session::capture` 186/186 pass. Whole lib is 4644 passed
  / 2 failed, and the same run on clean `upstream/main` is 4642 passed / **3**
  failed, so this branch's failures are a strict subset of the tree's. The two
  (`size_owner_lock_claims_rejects_steals_and_releases`,
  `test_content_shows_settings_path`) are environment-dependent on this host and
  pass or fail independently of this change; the first passes in isolation.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The unit test runs the shipped snippet against a real filesystem, which is the
behavior at issue; an e2e would need Docker to add anything over it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation, the code and this
write-up were done by Claude working from that. The finding is @njbrake's from
the #3454 review; what was added here is the reproduction, the correction to the
shape list (cycle in, directory out), and the observation that the other four
container snippets already carry the guard.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved Claude transcript scanning to accept regular files and valid symlinks.
- Excluded directories, FIFOs, dangling symlinks, and symlink cycles.
- Updated freshness and ordering checks to follow symlinks.
- Moved the Docker shell logic into `claude_container_list_snippet` for reuse and testing.
- Added table-driven Unix tests for supported and rejected file types.

## Benefits

- Prevents invalid filesystem entries from entering container capture.
- Preserves support for valid transcript symlinks.
- Enables reliable testing without Docker.

## Validation

- Formatting passes.
- No new Clippy warnings were found in `capture.rs`.
- `session::capture` tests pass.
- Two environment-dependent library test failures remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
