### PR TITLE
feat(web): persistent structured-view sessions (#3466)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1877,21 +1877,25 @@ function AppContent({
             left={
               <div className="flex-1 flex flex-col min-h-0 overflow-hidden relative">
                 <div className={selectedFilePath ? "hidden" : "relative flex-1 flex flex-col min-h-0 overflow-hidden"}>
-                  <Suspense fallback={<AcpLoadingFallback />}>
-                    <StructuredViewStack
-                      activeSessionId={activeSessionId}
-                      sessions={sessions}
-                      persistent={webSettings.persistentStructuredViews}
-                      maxPersistentStructuredViews={webSettings.maxPersistentStructuredViews}
-                      visible={activeSession?.view === "structured"}
-                      onOpenFileRef={handleOpenFileRef}
-                      onOpenAgentsPane={openAgentsPane}
-                      onRestoreSession={async (sessionId) => {
-                        const restored = await handleRestoreSession(trashedWorkspaceRestoreIds(workspaces, sessionId));
-                        return restored;
-                      }}
-                    />
-                  </Suspense>
+                  {(activeSession?.view === "structured" || webSettings.persistentStructuredViews) && (
+                    <Suspense fallback={<AcpLoadingFallback />}>
+                      <StructuredViewStack
+                        activeSessionId={activeSessionId}
+                        sessions={sessions}
+                        persistent={webSettings.persistentStructuredViews}
+                        maxPersistentStructuredViews={webSettings.maxPersistentStructuredViews}
+                        visible={activeSession?.view === "structured"}
+                        onOpenFileRef={handleOpenFileRef}
+                        onOpenAgentsPane={openAgentsPane}
+                        onRestoreSession={async (sessionId) => {
+                          const restored = await handleRestoreSession(
+                            trashedWorkspaceRestoreIds(workspaces, sessionId),
+                          );
+                          return restored;
+                        }}
+                      />
+                    </Suspense>
+                  )}
                   {activeSession?.view !== "structured" && (
                     <TerminalSessionStack
                       activeSessionId={activeSessionId!}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -114,10 +114,8 @@ import { TerminalSessionStack } from "./components/TerminalSessionStack";
 // dependency tree. Cuts ~hundreds of KB off the cold-start bundle
 // for the (currently default) tmux-only flow. The Suspense fallback
 // below covers the brief load while the chunk arrives.
-const StructuredView = lazy(() =>
-  import("./components/acp/StructuredView").then((m) => ({
-    default: m.StructuredView,
-  })),
+const StructuredViewStack = lazy(() =>
+  import("./components/StructuredViewStack").then((m) => ({ default: m.StructuredViewStack })),
 );
 import { type PaneDisplay } from "./components/Dock";
 import { DockGroups, type DockGroupView } from "./components/DockGroups";
@@ -1878,31 +1876,23 @@ function AppContent({
             onToggleCollapse={toggleRightDock}
             left={
               <div className="flex-1 flex flex-col min-h-0 overflow-hidden relative">
-                <div className={selectedFilePath ? "hidden" : "flex-1 flex flex-col min-h-0 overflow-hidden"}>
-                  {activeSession?.view === "structured" ? (
-                    <Suspense fallback={<AcpLoadingFallback />}>
-                      <StructuredView
-                        key={activeSessionId}
-                        sessionId={activeSessionId!}
-                        acpWorkerState={activeSession.acp_worker_state ?? "absent"}
-                        tool={activeSession.tool}
-                        acpAgent={activeSession.acp_agent ?? null}
-                        clearAliases={activeSession.clear_aliases}
-                        archivedAt={activeSession.archived_at ?? null}
-                        snoozedUntil={activeSession.snoozed_until ?? null}
-                        trashedAt={activeSession.trashed_at ?? null}
-                        onRestore={
-                          activeSession.trashed_at
-                            ? () => handleRestoreSession(trashedWorkspaceRestoreIds(workspaces, activeSessionId!))
-                            : undefined
-                        }
-                        onOpenFileRef={handleOpenFileRef}
-                        fileRefSession={activeSession}
-                        onOpenAgentsPane={openAgentsPane}
-                        isSandboxed={activeSession.is_sandboxed}
-                      />
-                    </Suspense>
-                  ) : (
+                <div className={selectedFilePath ? "hidden" : "relative flex-1 flex flex-col min-h-0 overflow-hidden"}>
+                  <Suspense fallback={<AcpLoadingFallback />}>
+                    <StructuredViewStack
+                      activeSessionId={activeSessionId}
+                      sessions={sessions}
+                      persistent={webSettings.persistentStructuredViews}
+                      maxPersistentStructuredViews={webSettings.maxPersistentStructuredViews}
+                      visible={activeSession?.view === "structured"}
+                      onOpenFileRef={handleOpenFileRef}
+                      onOpenAgentsPane={openAgentsPane}
+                      onRestoreSession={async (sessionId) => {
+                        const restored = await handleRestoreSession(trashedWorkspaceRestoreIds(workspaces, sessionId));
+                        return restored;
+                      }}
+                    />
+                  </Suspense>
+                  {activeSession?.view !== "structured" && (
                     <TerminalSessionStack
                       activeSessionId={activeSessionId!}
                       sessions={sessions.filter((session) => session.view !== "structured")}

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -12,8 +12,11 @@ import { isPluginPaneId, type PluginPane } from "../lib/pluginPanes";
 import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
 import type { useDiffComments } from "../hooks/useDiffComments";
 import type { FileRef } from "../lib/fileRef";
+import type { WebSettings } from "../hooks/useWebSettings";
 
-const StructuredView = lazy(() => import("./acp/StructuredView").then((m) => ({ default: m.StructuredView })));
+const StructuredViewStack = lazy(() =>
+  import("./StructuredViewStack").then((m) => ({ default: m.StructuredViewStack })),
+);
 
 interface Props {
   view: RightPanelView;
@@ -23,7 +26,12 @@ interface Props {
   activeSession: SessionResponse | null;
   activeSessionId: string | null;
   sessions: SessionResponse[];
-  webSettings: { persistentTerminals: boolean; maxPersistentTerminals: number };
+  webSettings: Pick<
+    WebSettings,
+    "persistentTerminals" | "maxPersistentTerminals" | "persistentStructuredViews" | "maxPersistentStructuredViews"
+  >;
+  onOpenAgentsPane?: () => void;
+  onRestoreSession?: (sessionId: string) => Promise<boolean> | void;
   selectedFilePath: string | null;
   selectedRepoName: string | undefined;
   selectedFileLine: number | undefined;
@@ -66,6 +74,8 @@ export function MobileMainPane({
   activeSessionId,
   sessions,
   webSettings,
+  onOpenAgentsPane,
+  onRestoreSession,
   selectedFilePath,
   selectedRepoName,
   selectedFileLine,
@@ -108,24 +118,19 @@ export function MobileMainPane({
       )}
       <div className="relative flex-1 flex flex-col min-h-0 overflow-hidden">
         <div className={layerClass(view === "agent")} inert={view !== "agent"}>
-          {activeSession?.view === "structured" ? (
-            <Suspense fallback={null}>
-              <StructuredView
-                key={activeSessionId}
-                sessionId={activeSessionId!}
-                acpWorkerState={activeSession.acp_worker_state ?? "absent"}
-                tool={activeSession.tool}
-                acpAgent={activeSession.acp_agent ?? null}
-                clearAliases={activeSession.clear_aliases}
-                archivedAt={activeSession.archived_at ?? null}
-                snoozedUntil={activeSession.snoozed_until ?? null}
-                trashedAt={activeSession.trashed_at ?? null}
-                onOpenFileRef={onOpenFileRef}
-                fileRefSession={activeSession}
-                isSandboxed={activeSession.is_sandboxed}
-              />
-            </Suspense>
-          ) : (
+          <Suspense fallback={null}>
+            <StructuredViewStack
+              activeSessionId={activeSessionId}
+              sessions={sessions}
+              persistent={webSettings.persistentStructuredViews}
+              maxPersistentStructuredViews={webSettings.maxPersistentStructuredViews}
+              visible={view === "agent"}
+              onOpenFileRef={onOpenFileRef}
+              onOpenAgentsPane={onOpenAgentsPane}
+              onRestoreSession={onRestoreSession}
+            />
+          </Suspense>
+          {activeSession?.view !== "structured" && (
             // Reserve the bottom home-indicator inset on this wrapper (the App
             // root no longer does; see index.css .safe-area-inset) so the last
             // terminal row clears it. Kept off the pane root itself, which owns

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -118,18 +118,20 @@ export function MobileMainPane({
       )}
       <div className="relative flex-1 flex flex-col min-h-0 overflow-hidden">
         <div className={layerClass(view === "agent")} inert={view !== "agent"}>
-          <Suspense fallback={null}>
-            <StructuredViewStack
-              activeSessionId={activeSessionId}
-              sessions={sessions}
-              persistent={webSettings.persistentStructuredViews}
-              maxPersistentStructuredViews={webSettings.maxPersistentStructuredViews}
-              visible={view === "agent"}
-              onOpenFileRef={onOpenFileRef}
-              onOpenAgentsPane={onOpenAgentsPane}
-              onRestoreSession={onRestoreSession}
-            />
-          </Suspense>
+          {(activeSession?.view === "structured" || webSettings.persistentStructuredViews) && (
+            <Suspense fallback={null}>
+              <StructuredViewStack
+                activeSessionId={activeSessionId}
+                sessions={sessions}
+                persistent={webSettings.persistentStructuredViews}
+                maxPersistentStructuredViews={webSettings.maxPersistentStructuredViews}
+                visible={view === "agent"}
+                onOpenFileRef={onOpenFileRef}
+                onOpenAgentsPane={onOpenAgentsPane}
+                onRestoreSession={onRestoreSession}
+              />
+            </Suspense>
+          )}
           {activeSession?.view !== "structured" && (
             // Reserve the bottom home-indicator inset on this wrapper (the App
             // root no longer does; see index.css .safe-area-inset) so the last

--- a/web/src/components/StructuredViewStack.tsx
+++ b/web/src/components/StructuredViewStack.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from "react";
+import type { SessionResponse } from "../lib/types";
+import type { FileRef } from "../lib/fileRef";
+import { normalizePersistentStructuredViewLimit } from "../lib/persistentStructuredViews";
+import { StructuredView } from "./acp/StructuredView";
+
+interface Props {
+  activeSessionId: string | null;
+  sessions: SessionResponse[];
+  persistent: boolean;
+  maxPersistentStructuredViews?: number;
+  /** On desktop this is true whenever the active session is structured.
+   *  On mobile it is true only when `view === "agent"`. The stack uses it to
+   *  decide whether the active structured session is actually interactive. */
+  visible: boolean;
+  onOpenFileRef?: (ref: FileRef) => void;
+  onOpenAgentsPane?: () => void;
+  /** Restore a trashed session by id. If absent, trashed sessions render
+   *  their banner read-only. */
+  onRestoreSession?: (sessionId: string) => Promise<boolean> | void;
+}
+
+export function StructuredViewStack({
+  activeSessionId,
+  sessions,
+  persistent,
+  maxPersistentStructuredViews,
+  visible,
+  onOpenFileRef,
+  onOpenAgentsPane,
+  onRestoreSession,
+}: Props) {
+  const [recentIds, setRecentIds] = useState<string[]>([]);
+  const limit = normalizePersistentStructuredViewLimit(maxPersistentStructuredViews);
+  const sessionsById = useMemo(() => new Map(sessions.map((session) => [session.id, session])), [sessions]);
+
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      if (!persistent) {
+        setRecentIds([]);
+        return;
+      }
+      if (!activeSessionId) {
+        setRecentIds((ids) => ids.filter((id) => sessionsById.has(id)));
+        return;
+      }
+      const activeSession = sessionsById.get(activeSessionId);
+      if (!activeSession || activeSession.view !== "structured") {
+        // Active session is not structured; keep recent structured sessions warm
+        // but do not add the active id.
+        setRecentIds((ids) => ids.filter((id) => id !== activeSessionId && sessionsById.has(id)).slice(0, limit));
+        return;
+      }
+      setRecentIds((ids) => {
+        const inactive = ids.filter((id) => id !== activeSessionId && sessionsById.has(id));
+        const next = [activeSessionId, ...inactive].slice(0, limit);
+        return next.join("\0") === ids.join("\0") ? ids : next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, limit, persistent, sessionsById]);
+
+  if (!persistent && !activeSessionId) return null;
+
+  const visibleIds = persistent
+    ? recentIds.filter((id) => sessionsById.has(id))
+    : activeSessionId && sessionsById.get(activeSessionId)?.view === "structured"
+      ? [activeSessionId]
+      : [];
+
+  if (visibleIds.length === 0) return null;
+
+  return (
+    <div className="relative flex-1 min-h-0 overflow-hidden">
+      {visibleIds.map((sessionId) => {
+        const session = sessionsById.get(sessionId);
+        if (!session) return null;
+        const active = visible && sessionId === activeSessionId;
+        return (
+          <div
+            key={sessionId}
+            aria-hidden={!active}
+            inert={!active}
+            className={
+              active
+                ? "absolute inset-0 flex flex-col min-h-0"
+                : "absolute inset-0 flex flex-col min-h-0 invisible pointer-events-none"
+            }
+          >
+            <StructuredView
+              sessionId={sessionId}
+              active={active}
+              acpWorkerState={session.acp_worker_state ?? "absent"}
+              tool={session.tool}
+              acpAgent={session.acp_agent ?? null}
+              clearAliases={session.clear_aliases}
+              archivedAt={session.archived_at ?? null}
+              snoozedUntil={session.snoozed_until ?? null}
+              trashedAt={session.trashed_at ?? null}
+              onRestore={session.trashed_at ? () => onRestoreSession?.(sessionId) : undefined}
+              onOpenFileRef={onOpenFileRef}
+              fileRefSession={session}
+              onOpenAgentsPane={onOpenAgentsPane}
+              isSandboxed={session.is_sandboxed}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/StructuredViewStack.tsx
+++ b/web/src/components/StructuredViewStack.tsx
@@ -42,19 +42,19 @@ export function StructuredViewStack({
         setRecentIds([]);
         return;
       }
-      if (!activeSessionId) {
-        setRecentIds((ids) => ids.filter((id) => sessionsById.has(id)));
-        return;
-      }
-      const activeSession = sessionsById.get(activeSessionId);
-      if (!activeSession || activeSession.view !== "structured") {
-        // Active session is not structured; keep recent structured sessions warm
-        // but do not add the active id.
-        setRecentIds((ids) => ids.filter((id) => id !== activeSessionId && sessionsById.has(id)).slice(0, limit));
-        return;
-      }
       setRecentIds((ids) => {
-        const inactive = ids.filter((id) => id !== activeSessionId && sessionsById.has(id));
+        // Drop sessions whose view is no longer structured and remove duplicates.
+        const structuredIds = ids.filter((id) => sessionsById.get(id)?.view === "structured");
+        if (!activeSessionId) {
+          return structuredIds;
+        }
+        const activeSession = sessionsById.get(activeSessionId);
+        if (!activeSession || activeSession.view !== "structured") {
+          // Active session is not structured; keep recent structured sessions warm
+          // but do not add the active id.
+          return structuredIds.filter((id) => id !== activeSessionId).slice(0, limit);
+        }
+        const inactive = structuredIds.filter((id) => id !== activeSessionId);
         const next = [activeSessionId, ...inactive].slice(0, limit);
         return next.join("\0") === ids.join("\0") ? ids : next;
       });
@@ -64,13 +64,19 @@ export function StructuredViewStack({
     };
   }, [activeSessionId, limit, persistent, sessionsById]);
 
-  if (!persistent && !activeSessionId) return null;
+  const activeStructuredId =
+    activeSessionId && sessionsById.get(activeSessionId)?.view === "structured" ? activeSessionId : null;
 
-  const visibleIds = persistent
-    ? recentIds.filter((id) => sessionsById.has(id))
-    : activeSessionId && sessionsById.get(activeSessionId)?.view === "structured"
-      ? [activeSessionId]
-      : [];
+  const visibleIds = useMemo(() => {
+    const retained = recentIds.filter((id) => {
+      const session = sessionsById.get(id);
+      return session && session.view === "structured" && id !== activeStructuredId;
+    });
+    if (!persistent) {
+      return activeStructuredId ? [activeStructuredId] : [];
+    }
+    return activeStructuredId ? [activeStructuredId, ...retained].slice(0, limit) : retained.slice(0, limit);
+  }, [activeStructuredId, limit, persistent, recentIds, sessionsById]);
 
   if (visibleIds.length === 0) return null;
 

--- a/web/src/components/__tests__/MobileMainPane.test.tsx
+++ b/web/src/components/__tests__/MobileMainPane.test.tsx
@@ -34,8 +34,8 @@ vi.mock("../diff/comments/SendCommentsDialog", () => ({
     </button>
   ),
 }));
-vi.mock("../acp/StructuredView", () => ({
-  StructuredView: () => <div data-testid="acp-view" />,
+vi.mock("../StructuredViewStack", () => ({
+  StructuredViewStack: () => <div data-testid="acp-view" />,
 }));
 
 import { MobileMainPane } from "../MobileMainPane";
@@ -90,7 +90,14 @@ function setup(overrides: Partial<Parameters<typeof MobileMainPane>[0]> = {}) {
     activeSessionId: "s1",
     sessions: [session()],
     serverAbout: null,
-    webSettings: { persistentTerminals: false, maxPersistentTerminals: 3 },
+    webSettings: {
+      persistentTerminals: false,
+      maxPersistentTerminals: 3,
+      persistentStructuredViews: false,
+      maxPersistentStructuredViews: 2,
+    },
+    onOpenAgentsPane: vi.fn(),
+    onRestoreSession: vi.fn(),
     selectedFilePath: null,
     selectedRepoName: undefined,
     revision: 0,

--- a/web/src/components/__tests__/StructuredViewStack.test.tsx
+++ b/web/src/components/__tests__/StructuredViewStack.test.tsx
@@ -175,6 +175,51 @@ describe("StructuredViewStack", () => {
     });
   });
 
+  it("shows the newly active structured session immediately on switch", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2")];
+    const { rerender } = render(
+      <StructuredViewStack activeSessionId="s1" sessions={sessions} persistent={true} visible={true} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+    });
+
+    rerender(<StructuredViewStack activeSessionId="s2" sessions={sessions} persistent={true} visible={true} />);
+
+    // The active session must be visible synchronously on the render that changes
+    // it, before the queued microtask updates recentIds.
+    expect(screen.getByTestId("structured-s2").dataset.active).toBe("true");
+    expect(screen.getByTestId("structured-s1").dataset.active).toBe("false");
+  });
+
+  it("prunes a warm session from the recent list when its view becomes terminal", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2")];
+    const { rerender } = render(
+      <StructuredViewStack activeSessionId="s1" sessions={sessions} persistent={true} visible={true} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+    });
+
+    rerender(<StructuredViewStack activeSessionId="s2" sessions={sessions} persistent={true} visible={true} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+    });
+
+    // Now s2 flips to terminal; it must drop out of the stack promptly.
+    rerender(
+      <StructuredViewStack
+        activeSessionId="s1"
+        sessions={[makeSession("s1"), makeSession("s2", "terminal")]}
+        persistent={true}
+        visible={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("structured-s2")).toBeNull();
+    });
+  });
+
   it("counts the configured limit as the total mounted structured view count", async () => {
     const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
     const { rerender } = render(

--- a/web/src/components/__tests__/StructuredViewStack.test.tsx
+++ b/web/src/components/__tests__/StructuredViewStack.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { SessionResponse } from "../../lib/types";
+
+vi.mock("../acp/StructuredView", () => ({
+  StructuredView: ({ sessionId, active }: { sessionId: string; active: boolean }) => (
+    <div data-testid={`structured-${sessionId}`} data-active={String(active)}>
+      {sessionId}
+    </div>
+  ),
+}));
+
+import { normalizePersistentStructuredViewLimit } from "../../lib/persistentStructuredViews";
+import { StructuredViewStack } from "../StructuredViewStack";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSession(id: string, view: "structured" | "terminal" = "structured"): SessionResponse {
+  return {
+    id,
+    title: id,
+    project_path: `/tmp/${id}`,
+    artifact_dir: `/tmp/artifacts/${id}`,
+    group_path: "/tmp",
+    tool: "claude",
+    status: "Running",
+    dormant: false,
+    yolo_mode: false,
+    created_at: new Date().toISOString(),
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    scratch: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: false,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    remote_owner_key: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    view,
+  };
+}
+
+describe("StructuredViewStack", () => {
+  it("renders only the active session when persistence is disabled", () => {
+    const sessions = [makeSession("s1"), makeSession("s2")];
+    const { rerender } = render(
+      <StructuredViewStack activeSessionId="s1" sessions={sessions} persistent={false} visible={true} />,
+    );
+
+    expect(screen.getByTestId("structured-s1").dataset.active).toBe("true");
+    expect(screen.queryByTestId("structured-s2")).toBeNull();
+
+    rerender(<StructuredViewStack activeSessionId="s2" sessions={sessions} persistent={false} visible={true} />);
+
+    expect(screen.queryByTestId("structured-s1")).toBeNull();
+    expect(screen.getByTestId("structured-s2").dataset.active).toBe("true");
+  });
+
+  it("renders nothing when the active session is terminal", () => {
+    const sessions = [makeSession("s1", "terminal")];
+    render(<StructuredViewStack activeSessionId="s1" sessions={sessions} persistent={false} visible={true} />);
+    expect(screen.queryByTestId("structured-s1")).toBeNull();
+  });
+
+  it("keeps recent inactive structured sessions mounted when persistence is enabled", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2")];
+    const { rerender } = render(
+      <StructuredViewStack activeSessionId="s1" sessions={sessions} persistent={true} visible={true} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1").dataset.active).toBe("true");
+    });
+
+    rerender(<StructuredViewStack activeSessionId="s2" sessions={sessions} persistent={true} visible={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1").dataset.active).toBe("false");
+      expect(screen.getByTestId("structured-s2").dataset.active).toBe("true");
+    });
+  });
+
+  it("marks inactive sessions as not interactive when the stack is not visible", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2")];
+    const { rerender } = render(
+      <StructuredViewStack activeSessionId="s1" sessions={sessions} persistent={true} visible={true} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1").dataset.active).toBe("true");
+    });
+
+    rerender(<StructuredViewStack activeSessionId="s2" sessions={sessions} persistent={true} visible={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1").dataset.active).toBe("false");
+      expect(screen.getByTestId("structured-s2").dataset.active).toBe("false");
+    });
+  });
+
+  it("does not add terminal sessions to the recent list", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2", "terminal")];
+    const { rerender } = render(
+      <StructuredViewStack activeSessionId="s1" sessions={sessions} persistent={true} visible={true} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+    });
+
+    rerender(<StructuredViewStack activeSessionId="s2" sessions={sessions} persistent={true} visible={true} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("structured-s2")).toBeNull();
+    });
+  });
+
+  it("evicts older inactive sessions beyond the configured limit", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
+    const { rerender } = render(
+      <StructuredViewStack
+        activeSessionId="s1"
+        sessions={sessions}
+        persistent={true}
+        visible={true}
+        maxPersistentStructuredViews={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+    });
+
+    rerender(
+      <StructuredViewStack
+        activeSessionId="s2"
+        sessions={sessions}
+        persistent={true}
+        visible={true}
+        maxPersistentStructuredViews={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+      expect(screen.getByTestId("structured-s2")).toBeDefined();
+    });
+
+    rerender(
+      <StructuredViewStack
+        activeSessionId="s3"
+        sessions={sessions}
+        persistent={true}
+        visible={true}
+        maxPersistentStructuredViews={1}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("structured-s1")).toBeNull();
+      expect(screen.queryByTestId("structured-s2")).toBeNull();
+      expect(screen.getByTestId("structured-s3").dataset.active).toBe("true");
+    });
+  });
+
+  it("counts the configured limit as the total mounted structured view count", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
+    const { rerender } = render(
+      <StructuredViewStack
+        activeSessionId="s1"
+        sessions={sessions}
+        persistent={true}
+        visible={true}
+        maxPersistentStructuredViews={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+    });
+
+    rerender(
+      <StructuredViewStack
+        activeSessionId="s2"
+        sessions={sessions}
+        persistent={true}
+        visible={true}
+        maxPersistentStructuredViews={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-s1")).toBeDefined();
+      expect(screen.getByTestId("structured-s2")).toBeDefined();
+    });
+
+    rerender(
+      <StructuredViewStack
+        activeSessionId="s3"
+        sessions={sessions}
+        persistent={true}
+        visible={true}
+        maxPersistentStructuredViews={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("structured-s1")).toBeNull();
+      expect(screen.getByTestId("structured-s2").dataset.active).toBe("false");
+      expect(screen.getByTestId("structured-s3").dataset.active).toBe("true");
+    });
+  });
+
+  it("normalizes configured limits to the supported range", () => {
+    expect(normalizePersistentStructuredViewLimit(0)).toBe(1);
+    expect(normalizePersistentStructuredViewLimit(5.4)).toBe(5);
+    expect(normalizePersistentStructuredViewLimit(99)).toBe(5);
+    expect(normalizePersistentStructuredViewLimit("10")).toBe(2);
+  });
+});

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -72,6 +72,11 @@ interface Props {
    *  has forgotten. The `ClearedTurnsBanner` in `StructuredView` provides
    *  the toggle. See #1101. */
   showClearedTurns?: boolean;
+  /** When false the session is mounted but inactive (kept warm by the
+   *  persistent structured-view stack). The runtime skips localStorage
+   *  cache writes and avoids aggressive reconnects so inactive sessions
+   *  stay warm without stealing resources. */
+  active?: boolean;
   children: (ctx: AcpContext) => ReactNode;
 }
 
@@ -135,9 +140,10 @@ export function AcpRuntime({
   archivedAt = null,
   snoozedUntil = null,
   showClearedTurns = false,
+  active = true,
   children,
 }: Props) {
-  const acp = useAcpSession(sessionId, acpWorkerState, archivedAt, snoozedUntil);
+  const acp = useAcpSession(sessionId, active, acpWorkerState, archivedAt, snoozedUntil);
   const agentProfile = useAgentProfile();
   // Staged attachments for the next prompt. A ref mirror keeps `onNew`
   // (recreated each render by useExternalStoreRuntime) reading the

--- a/web/src/components/acp/AttentionChime.tsx
+++ b/web/src/components/acp/AttentionChime.tsx
@@ -5,6 +5,9 @@ interface Props {
   approvals: number;
   /** Number of pending AskUserQuestion elicitations. */
   elicitations: number;
+  /** When false the session is mounted but inactive; suppress the chime so
+   *  backgrounded sessions don't steal audio focus. */
+  active?: boolean;
 }
 
 // Browser-side attention chime, extracted from StructuredView so the wiring
@@ -15,7 +18,7 @@ interface Props {
 // backgrounded) and the in-app toast (when foregrounded). A question
 // arriving while an approval is already pending does not re-chime, but its
 // OS push still fires on the live event edge regardless. See #1038, #2146.
-export function AttentionChime({ approvals, elicitations }: Props): null {
-  useApprovalSound(approvals + elicitations);
+export function AttentionChime({ approvals, elicitations, active = true }: Props): null {
+  useApprovalSound(active ? approvals + elicitations : 0);
   return null;
 }

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -729,18 +729,20 @@ export function Composer({
       }
       if (operation.kind === "set-text") {
         composerRuntime.setText(operation.text);
-        requestAnimationFrame(() => {
-          const el = taRef.current;
-          if (!el) return;
-          focusTextArea();
-          el.style.height = "auto";
-          el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
-        });
+        if (active) {
+          requestAnimationFrame(() => {
+            const el = taRef.current;
+            if (!el) return;
+            focusTextArea();
+            el.style.height = "auto";
+            el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+          });
+        }
         return;
       }
-      insertRawTextAtCaret(ta, operation.text, operation.kind === "replace-selection");
+      insertRawTextAtCaret(ta, operation.text, operation.kind === "replace-selection", active);
     },
-    [composerRuntime, focusTextArea],
+    [active, composerRuntime, focusTextArea],
   );
   const pluginUiEntries = usePluginUiEntries();
   const pluginComposerEntries = useMemo(
@@ -1393,10 +1395,17 @@ export function insertSlashCommand(ref: React.RefObject<HTMLTextAreaElement | nu
  *  the text, and assigning `value` parks the caret at the end, so
  *  dispatching first hands the popover a cursor pointing past the text
  *  it is about to detect against. */
-function writeComposerValue(ta: HTMLTextAreaElement, next: string, caret: number, inputType: string, data?: string) {
+function writeComposerValue(
+  ta: HTMLTextAreaElement,
+  next: string,
+  caret: number,
+  inputType: string,
+  data?: string,
+  focus = true,
+) {
   const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
   setter?.call(ta, next);
-  ta.focus();
+  if (focus) ta.focus();
   ta.setSelectionRange(caret, caret);
   ta.dispatchEvent(new InputEvent("input", { bubbles: true, inputType, ...(data === undefined ? {} : { data }) }));
 }
@@ -1443,11 +1452,11 @@ export function insertAtCaret(ref: React.RefObject<HTMLTextAreaElement | null>, 
   writeComposerValue(ta, next, before.length + needsSpace.length + text.length, "insertText", text);
 }
 
-function insertRawTextAtCaret(ta: HTMLTextAreaElement, text: string, replaceSelection: boolean) {
+function insertRawTextAtCaret(ta: HTMLTextAreaElement, text: string, replaceSelection: boolean, focus = true) {
   const start = ta.selectionStart ?? ta.value.length;
   const end = replaceSelection ? (ta.selectionEnd ?? start) : start;
   const next = ta.value.slice(0, start) + text + ta.value.slice(end);
-  writeComposerValue(ta, next, start + text.length, "insertText", text);
+  writeComposerValue(ta, next, start + text.length, "insertText", text, focus);
   ta.style.height = "auto";
   ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
 }

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -451,7 +451,7 @@ export function Composer({
   // already physically occludes, leaving a visible gap between the
   // composer and the top of the keyboard. Cancel that reservation and
   // drop our own bottom padding while the keyboard is open. See #1143.
-  const { keyboardOpen } = useMobileKeyboard();
+  const { keyboardOpen } = useMobileKeyboard(active);
 
   // On an installed iOS PWA the keyboard's accessory bar (predictive / AutoFill
   // strip) floats over the bottom of the page and covers Send, because the

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -344,6 +344,10 @@ interface Props {
    *  when the user submits while browsing the queue, so an edit does not
    *  enqueue a duplicate. */
   editQueuedPrompt: (id: string, text: string) => void;
+  /** When false the session is mounted but inactive (kept warm by the
+   *  persistent structured-view stack). The composer avoids autofocus,
+   *  imperative focus, and draft persistence work. */
+  active?: boolean;
 }
 
 export function Composer({
@@ -366,8 +370,29 @@ export function Composer({
   primerPrefill,
   queuedPrompts,
   editQueuedPrompt,
+  active = true,
 }: Props) {
   const taRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Imperative focus helper. Inactive sessions stay in the background; they
+  // must never steal focus from the active session or other surfaces.
+  const focusTextArea = useCallback(
+    (end = true) => {
+      if (!active) return;
+      const el = taRef.current;
+      if (!el) return;
+      el.focus();
+      if (end) {
+        const len = el.value.length;
+        try {
+          el.setSelectionRange(len, len);
+        } catch {
+          // ignore: setSelectionRange can throw on detached nodes
+        }
+      }
+    },
+    [active],
+  );
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { files } = useFilesIndex(sessionId);
 
@@ -598,18 +623,12 @@ export function Composer({
       requestAnimationFrame(() => {
         const el = taRef.current;
         if (!el) return;
-        el.focus();
-        const len = el.value.length;
-        try {
-          el.setSelectionRange(len, len);
-        } catch {
-          // ignore: setSelectionRange can throw on detached nodes
-        }
+        focusTextArea();
         el.style.height = "auto";
         el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
       });
     },
-    [composerRuntime],
+    [composerRuntime, focusTextArea],
   );
 
   // Apply a pure recall navigation decision to the composer.
@@ -713,9 +732,7 @@ export function Composer({
         requestAnimationFrame(() => {
           const el = taRef.current;
           if (!el) return;
-          el.focus();
-          const len = operation.text.length;
-          el.setSelectionRange(len, len);
+          focusTextArea();
           el.style.height = "auto";
           el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
         });
@@ -723,7 +740,7 @@ export function Composer({
       }
       insertRawTextAtCaret(ta, operation.text, operation.kind === "replace-selection");
     },
-    [composerRuntime],
+    [composerRuntime, focusTextArea],
   );
   const pluginUiEntries = usePluginUiEntries();
   const pluginComposerEntries = useMemo(
@@ -752,7 +769,10 @@ export function Composer({
     getPendingSwitchAgent,
     () => null,
   );
-  const switchAgentOpen = pendingSwitchAgentSessionId === sessionId;
+  // Inactive sessions must not keep the switch-agent modal open; it is a
+  // portal outside the inert subtree and would stay open over the active
+  // session. Derive the effective open state and clear the trigger on close.
+  const switchAgentOpen = active && pendingSwitchAgentSessionId === sessionId;
 
   // iOS Safari native dictation (#1431): WebKit fires `beforeinput` /
   // `input` with `inputType: "insertReplacementText"` per partial
@@ -791,17 +811,11 @@ export function Composer({
     requestAnimationFrame(() => {
       const el = taRef.current;
       if (!el) return;
-      el.focus();
-      const len = el.value.length;
-      try {
-        el.setSelectionRange(len, len);
-      } catch {
-        // ignore: non-text inputs can throw here
-      }
+      focusTextArea();
       el.style.height = "auto";
       el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
     });
-  }, [composerRuntime, primerId]);
+  }, [composerRuntime, focusTextArea, primerId]);
 
   // Auto-grow the textarea up to ~6 visible lines.
   const onInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
@@ -874,15 +888,18 @@ export function Composer({
   // the soft keyboard on every session open / switch, which is the wrong
   // default for the read-traffic that dominates mobile usage. Users tap
   // the composer when they want to type.
+  //
+  // focusTextArea returns early for inactive sessions, so only the active
+  // structured-view session claims keyboard focus.
   useEffect(() => {
     if (isMobile) return;
     const el = taRef.current;
     if (!el) return;
-    el.focus();
+    focusTextArea();
     const reclaim = () => {
-      const active = document.activeElement as HTMLElement | null;
-      if (!active || active === document.body || active === el) {
-        el.focus();
+      const focused = document.activeElement as HTMLElement | null;
+      if (!focused || focused === document.body || focused === el) {
+        focusTextArea();
       }
     };
     const t1 = window.setTimeout(reclaim, 250);
@@ -891,14 +908,14 @@ export function Composer({
       window.clearTimeout(t1);
       window.clearTimeout(t2);
     };
-  }, [isMobile]);
+  }, [focusTextArea, isMobile]);
 
   // Explicit focus from sidebar session selection (#1454). Lands focus on
   // the composer even when it is already mounted (re-selecting the active
   // session, where the keyed remount above never fires); the latch inside
   // the hook covers the first-open race. App only dispatches "composer" on
   // desktop, so no coarse-pointer gate is needed here.
-  useFocusTerminalTarget("composer", taRef);
+  useFocusTerminalTarget("composer", taRef, active);
 
   const wrapperLayout = composerWrapperLayout({
     keyboardOpen,
@@ -1140,7 +1157,7 @@ export function Composer({
                 e.preventDefault();
                 void addFiles(files);
               }}
-              autoFocus={!isMobile}
+              autoFocus={active && !isMobile}
               className={[
                 "min-h-[56px] max-h-[200px] resize-none bg-transparent",
                 "px-4 pt-3 pb-1 text-sm leading-6 text-text-primary",
@@ -1279,13 +1296,7 @@ export function Composer({
           requestAnimationFrame(() => {
             const el = taRef.current;
             if (!el) return;
-            el.focus();
-            const len = el.value.length;
-            try {
-              el.setSelectionRange(len, len);
-            } catch {
-              // ignore: non-text inputs can throw here
-            }
+            focusTextArea();
             el.style.height = "auto";
             el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
           });

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -430,7 +430,7 @@ function AcpChrome({
   const [atBottom, setAtBottom] = useState(true);
   // Soft-keyboard state, so we can hold the bottom pin across the keyboard
   // open/close animation (see the effect below).
-  const { keyboardOpen } = useMobileKeyboard();
+  const { keyboardOpen } = useMobileKeyboard(active);
   const scrollToBottom = useCallback(() => {
     const vp = viewportRef.current;
     if (!vp) return;

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -150,6 +150,11 @@ interface Props {
   /** Open (or focus) the Sub agents dock pane. Lets an inline async
    *  sub-agent card jump to its panel entry. */
   onOpenAgentsPane?: () => void;
+  /** When false the session is mounted but inactive (kept warm by the
+   *  persistent structured-view stack). It stays subscribed and renders,
+   *  but scroll observers, autofocus, audio, and reconnect storms are
+   *  gated so only the active session is interactive. */
+  active?: boolean;
 }
 
 const STARTER_PROMPTS = [
@@ -173,6 +178,7 @@ export function StructuredView(props: Props) {
     fileRefSession,
     onOpenAgentsPane,
     isSandboxed,
+    active = true,
   } = props;
   // Folds rows above the most recent `/clear` divider out of the
   // thread by default; the disclosure banner toggles this. Lives on
@@ -193,6 +199,7 @@ export function StructuredView(props: Props) {
               archivedAt={archivedAt}
               snoozedUntil={snoozedUntil}
               showClearedTurns={showClearedTurns}
+              active={active}
             >
               {(ctx) => (
                 <BackgroundAgentsContext.Provider
@@ -211,6 +218,7 @@ export function StructuredView(props: Props) {
                     trashedAt={trashedAt}
                     onRestore={onRestore}
                     isSandboxed={isSandboxed}
+                    active={active}
                     {...ctx}
                   />
                 </BackgroundAgentsContext.Provider>
@@ -267,15 +275,15 @@ function structuredViewFontStyle(
  *  reservation (see {@link structuredViewRootStyle}). Exported and kept tiny so
  *  the hook-to-style wiring is testable without mounting the assistant-ui
  *  runtime, mirroring the #1282 rate-limit-recovery extraction. */
-export function StructuredViewRoot({ children }: { children: React.ReactNode }) {
-  const { keyboardHeight } = useMobileKeyboard();
+export function StructuredViewRoot({ active = true, children }: { active?: boolean; children: React.ReactNode }) {
+  const { keyboardHeight } = useMobileKeyboard(active);
   const { settings } = useWebSettings();
   return (
     <div
       data-testid="structured-view-root"
       className="acp-conversation-scope flex h-full flex-col bg-surface-900 text-text-primary"
       style={structuredViewFontStyle(
-        keyboardHeight,
+        active ? keyboardHeight : 0,
         settings.structuredMobileFontSize,
         settings.structuredDesktopFontSize,
       )}
@@ -329,6 +337,7 @@ function AcpChrome({
   loadEarlierHistory,
   loadingEarlierHistory,
   isSandboxed,
+  active,
 }: AcpContext & {
   sessionId: string;
   acpWorkerState: "absent" | "resuming" | "running";
@@ -342,6 +351,7 @@ function AcpChrome({
   trashedAt: string | null;
   onRestore?: () => Promise<boolean> | void;
   isSandboxed?: boolean;
+  active: boolean;
 }) {
   // Count how many activity rows precede the latest `session_cleared`
   // divider so the banner can say "12 earlier turns hidden". The
@@ -500,6 +510,7 @@ function AcpChrome({
   }, [loadingEarlierHistory]);
 
   useLayoutEffect(() => {
+    if (!active) return;
     const vp = viewportRef.current;
     const below = belowViewportRef.current;
     const content = messagesContentRef.current;
@@ -666,7 +677,7 @@ function AcpChrome({
       saveScroll();
       if (gestureClearTimer) window.clearTimeout(gestureClearTimer);
     };
-  }, [requestEarlierHistory, isCoarse, sessionId]);
+  }, [active, requestEarlierHistory, isCoarse, sessionId]);
 
   // Hold the bottom pin across a chrome transition that resizes the viewport:
   // the soft keyboard opening/closing, and the composer ("hide text input")
@@ -682,7 +693,8 @@ function AcpChrome({
     // The first paint's scroll-to-bottom is handled by autoScroll + the content
     // observer, and pinning here on mount would fight a user scrolling up right
     // after the view appears.
-    if (chromeTransitionInitRef.current) {
+    // Inactive sessions don't own the viewport; skip the animation pinning.
+    if (!active || chromeTransitionInitRef.current) {
       chromeTransitionInitRef.current = false;
       return;
     }
@@ -706,7 +718,58 @@ function AcpChrome({
     };
     raf = requestAnimationFrame(pin);
     return () => cancelAnimationFrame(raf);
-  }, [keyboardOpen, composerCollapsed]);
+  }, [active, keyboardOpen, composerCollapsed]);
+
+  // Save/restore scroll position when the session is deactivated or
+  // reactivated by the persistent structured-view stack. Save on
+  // active -> inactive; restore on inactive -> active once the
+  // transcript has stabilized. A ref latch prevents rapid toggles from
+  // interleaving save and restore.
+  const activeTransitionLatchRef = useRef(false);
+  const prevActiveRef = useRef(active);
+  /* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
+  useEffect(() => {
+    const prev = prevActiveRef.current;
+    prevActiveRef.current = active;
+    if (active === prev || activeTransitionLatchRef.current) return;
+
+    const vp = viewportRef.current;
+    if (!vp) return;
+
+    if (active) {
+      // Activation: restore the saved scroll intent once the transcript is
+      // stable (open connection or non-empty activity).
+      if (!hasEverOpened && status !== "open" && state.activity.length === 0) return;
+      activeTransitionLatchRef.current = true;
+      const saved = loadScrollState(sessionId);
+      const stick = !saved || saved.stuck;
+      wasAtBottomRef.current = stick;
+      if (stick) lastAtBottomAtRef.current = performance.now();
+      const applyStart = () => {
+        if (stick) {
+          vp.scrollTop = vp.scrollHeight;
+        } else if (saved) {
+          vp.scrollTop = Math.max(0, Math.min(saved.top, vp.scrollHeight - vp.clientHeight));
+        }
+      };
+      requestAnimationFrame(() => requestAnimationFrame(applyStart));
+      if (stick) window.setTimeout(applyStart, 150);
+      requestAnimationFrame(() => {
+        activeTransitionLatchRef.current = false;
+      });
+      return;
+    }
+
+    // Deactivation: persist the current scroll intent so reactivation can
+    // pick up where the user left off.
+    activeTransitionLatchRef.current = true;
+    saveScrollState(sessionId, { stuck: wasAtBottomRef.current, top: vp.scrollTop });
+    requestAnimationFrame(() => {
+      activeTransitionLatchRef.current = false;
+    });
+  }, [active, sessionId, status, hasEverOpened, state.activity.length]);
+  /* eslint-enable react-you-might-not-need-an-effect/no-event-handler */
+
   // Short-circuit: when the per-adapter compatibility check rejected
   // the adapter, replace the chat layout with a dedicated screen that
   // renders the exact remediation command. We never reach Running, so
@@ -721,14 +784,19 @@ function AcpChrome({
     );
   }
   return (
-    <StructuredViewRoot>
-      <AttentionChime approvals={state.pendingApprovals.length} elicitations={state.pendingElicitations.length} />
+    <StructuredViewRoot active={active}>
+      <AttentionChime
+        approvals={state.pendingApprovals.length}
+        elicitations={state.pendingElicitations.length}
+        active={active}
+      />
       <PlanStrip plan={state.plan} />
 
       <RateLimitRecoverySection
         sessionId={sessionId}
         currentAgent={state.agent ?? acpAgent}
         onPrefill={recoveryHandoffPrefill}
+        active={active}
       >
         {({ onSwitchAgent }) =>
           status !== "open" || state.lagged || state.rateLimit || reconnecting ? (
@@ -802,7 +870,7 @@ function AcpChrome({
             the bottom of the scroll area, just above the composer. */}
         <div className="relative flex min-h-0 flex-1 flex-col">
           <ThreadPrimitive.Viewport
-            autoScroll
+            autoScroll={active}
             ref={viewportRef}
             data-testid="acp-viewport"
             className="flex-1 overflow-x-hidden overflow-y-auto"
@@ -993,9 +1061,10 @@ function AcpChrome({
                   promptCapabilities={state.promptCapabilities}
                   pendingAttachments={pendingAttachments}
                   setPendingAttachments={setPendingAttachments}
-                  primerPrefill={primerPrefill}
+                  primerPrefill={active ? primerPrefill : null}
                   queuedPrompts={state.queuedPrompts}
                   editQueuedPrompt={editQueuedPrompt}
+                  active={active}
                 />
               </CollapsibleRegion>
             </>
@@ -1730,19 +1799,24 @@ export function RateLimitRecoverySection({
   sessionId,
   currentAgent,
   onPrefill,
+  active = true,
   children,
 }: {
   sessionId: string;
   currentAgent: string | null;
   onPrefill: (text: string) => void;
+  active?: boolean;
   children: (renderProps: { onSwitchAgent: () => void }) => React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  // Close the modal when this session becomes inactive; derive the effective
+  // open state so no setState in an effect is needed.
+  const effectiveOpen = active && open;
   return (
     <>
       {children({ onSwitchAgent: () => setOpen(true) })}
       <SwitchAgentModal
-        open={open}
+        open={effectiveOpen}
         sessionId={sessionId}
         currentAgent={currentAgent}
         onClose={() => setOpen(false)}

--- a/web/src/components/acp/__tests__/AttentionChime.test.tsx
+++ b/web/src/components/acp/__tests__/AttentionChime.test.tsx
@@ -58,17 +58,25 @@ afterEach(() => {
 
 describe("AttentionChime", () => {
   it("chimes once when a question arrives (0 -> >=1 combined edge)", async () => {
-    const { rerender } = render(<AttentionChime approvals={0} elicitations={0} />);
+    const { rerender } = render(<AttentionChime approvals={0} elicitations={0} active={true} />);
     await vi.advanceTimersByTimeAsync(1500);
-    rerender(<AttentionChime approvals={0} elicitations={1} />);
+    rerender(<AttentionChime approvals={0} elicitations={1} active={true} />);
     await vi.runAllTimersAsync();
     expect(audioCount).toBe(1);
   });
 
   it("does not re-chime when a second item arrives (>=1 -> >=2)", async () => {
-    const { rerender } = render(<AttentionChime approvals={1} elicitations={0} />);
+    const { rerender } = render(<AttentionChime approvals={1} elicitations={0} active={true} />);
     await vi.advanceTimersByTimeAsync(1500);
-    rerender(<AttentionChime approvals={1} elicitations={1} />);
+    rerender(<AttentionChime approvals={1} elicitations={1} active={true} />);
+    await vi.runAllTimersAsync();
+    expect(audioCount).toBe(0);
+  });
+
+  it("suppresses the chime when inactive", async () => {
+    const { rerender } = render(<AttentionChime approvals={0} elicitations={0} active={false} />);
+    await vi.advanceTimersByTimeAsync(1500);
+    rerender(<AttentionChime approvals={0} elicitations={1} active={false} />);
     await vi.runAllTimersAsync();
     expect(audioCount).toBe(0);
   });

--- a/web/src/components/acp/__tests__/StructuredViewRoot.test.tsx
+++ b/web/src/components/acp/__tests__/StructuredViewRoot.test.tsx
@@ -78,4 +78,14 @@ describe("StructuredViewRoot (#2011)", () => {
     expect(root.style.getPropertyValue("--acp-conversation-font-size-mobile")).toBe("0.875rem");
     expect(root.style.getPropertyValue("--acp-conversation-font-size-desktop")).toBe("0.875rem");
   });
+
+  it("reserves no keyboard padding when inactive even if the keyboard is open", () => {
+    mockKeyboard.current = { isMobile: true, keyboardOpen: true, keyboardHeight: 280 };
+    render(
+      <StructuredViewRoot active={false}>
+        <div>child</div>
+      </StructuredViewRoot>,
+    );
+    expect(screen.getByTestId("structured-view-root").style.paddingBottom).toBe("");
+  });
 });

--- a/web/src/components/settings/StructuredViewDisplaySettings.tsx
+++ b/web/src/components/settings/StructuredViewDisplaySettings.tsx
@@ -1,4 +1,9 @@
 import { useWebSettings } from "../../hooks/useWebSettings";
+import {
+  MAX_PERSISTENT_STRUCTURED_VIEWS,
+  MIN_PERSISTENT_STRUCTURED_VIEWS,
+  normalizePersistentStructuredViewLimit,
+} from "../../lib/persistentStructuredViews";
 import { FontSizeControl } from "./FontSizeControl";
 
 /** Dashboard display preferences for the structured view. These are not agent
@@ -11,6 +16,7 @@ import { FontSizeControl } from "./FontSizeControl";
  *  `normalizeSnapshot`, so no re-clamping is needed here. */
 export function StructuredViewDisplaySettings() {
   const { settings, update } = useWebSettings();
+  const maxPersistentStructuredViews = normalizePersistentStructuredViewLimit(settings.maxPersistentStructuredViews);
 
   return (
     <div className="space-y-4">
@@ -31,6 +37,68 @@ export function StructuredViewDisplaySettings() {
         onChange={(value) => update({ structuredDesktopFontSize: value })}
         description="Font size for Structured View conversation content on desktop devices. Separate from the terminal font size, and shared with your other browsers like the rest of the dashboard preferences."
       />
+
+      <div>
+        <div className="space-y-3">
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">
+                Keep recently viewed structured-view sessions loaded
+              </div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Keep recent structured-view sessions mounted for faster switching. Uses more browser memory and keeps
+                extra WebSocket connections open.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              data-testid="persistent-structured-views-toggle"
+              checked={settings.persistentStructuredViews}
+              onChange={(e) => update({ persistentStructuredViews: e.target.checked })}
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+
+          {settings.persistentStructuredViews && (
+            <div>
+              <label className="block text-[13px] text-text-secondary mb-2">Loaded session limit</label>
+              <div className="flex items-center gap-3">
+                <input
+                  type="range"
+                  min={MIN_PERSISTENT_STRUCTURED_VIEWS}
+                  max={MAX_PERSISTENT_STRUCTURED_VIEWS}
+                  step={1}
+                  value={maxPersistentStructuredViews}
+                  onChange={(e) =>
+                    update({
+                      maxPersistentStructuredViews: normalizePersistentStructuredViewLimit(Number(e.target.value)),
+                    })
+                  }
+                  className="flex-1 accent-brand-600 h-1.5"
+                />
+                <input
+                  type="number"
+                  min={MIN_PERSISTENT_STRUCTURED_VIEWS}
+                  max={MAX_PERSISTENT_STRUCTURED_VIEWS}
+                  step={1}
+                  data-testid="max-persistent-structured-views"
+                  value={maxPersistentStructuredViews}
+                  onChange={(e) =>
+                    update({
+                      maxPersistentStructuredViews: normalizePersistentStructuredViewLimit(Number(e.target.value)),
+                    })
+                  }
+                  className="bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono w-16 text-center"
+                />
+              </div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Higher limits improve switching across large workspaces but keep more assistant-ui runtimes and
+                WebSockets alive.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/components/settings/StructuredViewDisplaySettings.tsx
+++ b/web/src/components/settings/StructuredViewDisplaySettings.tsx
@@ -61,10 +61,13 @@ export function StructuredViewDisplaySettings() {
 
           {settings.persistentStructuredViews && (
             <div>
-              <label className="block text-[13px] text-text-secondary mb-2">Loaded session limit</label>
+              <span id="max-persistent-structured-views-label" className="block text-[13px] text-text-secondary mb-2">
+                Loaded session limit
+              </span>
               <div className="flex items-center gap-3">
                 <input
                   type="range"
+                  aria-labelledby="max-persistent-structured-views-label"
                   min={MIN_PERSISTENT_STRUCTURED_VIEWS}
                   max={MAX_PERSISTENT_STRUCTURED_VIEWS}
                   step={1}
@@ -78,6 +81,7 @@ export function StructuredViewDisplaySettings() {
                 />
                 <input
                   type="number"
+                  aria-labelledby="max-persistent-structured-views-label"
                   min={MIN_PERSISTENT_STRUCTURED_VIEWS}
                   max={MAX_PERSISTENT_STRUCTURED_VIEWS}
                   step={1}

--- a/web/src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx
@@ -82,6 +82,22 @@ describe("StructuredViewDisplaySettings localStorage contract", () => {
     expect((getByTestId("structured-desktop-font-size-select") as HTMLInputElement).value).toBe("10");
   });
 
+  it("associates the limit label with both controls for screen readers", () => {
+    const { getByTestId } = render(<StructuredViewDisplaySettings />);
+    fireEvent.click(getByTestId("persistent-structured-views-toggle"));
+
+    const labelId = "max-persistent-structured-views-label";
+    const label = document.getElementById(labelId);
+    expect(label).not.toBeNull();
+    expect(label?.textContent).toBe("Loaded session limit");
+    expect((getByTestId("max-persistent-structured-views") as HTMLInputElement).getAttribute("aria-labelledby")).toBe(
+      labelId,
+    );
+    // The range input is not test-id tagged; locate it by type within the same container.
+    const range = label?.nextElementSibling?.querySelector('input[type="range"]') as HTMLInputElement | null;
+    expect(range?.getAttribute("aria-labelledby")).toBe(labelId);
+  });
+
   it("defaults persistent structured views off and hides the limit input", () => {
     const { getByTestId, queryByTestId } = render(<StructuredViewDisplaySettings />);
     expect((getByTestId("persistent-structured-views-toggle") as HTMLInputElement).checked).toBe(false);

--- a/web/src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx
@@ -82,6 +82,30 @@ describe("StructuredViewDisplaySettings localStorage contract", () => {
     expect((getByTestId("structured-desktop-font-size-select") as HTMLInputElement).value).toBe("10");
   });
 
+  it("defaults persistent structured views off and hides the limit input", () => {
+    const { getByTestId, queryByTestId } = render(<StructuredViewDisplaySettings />);
+    expect((getByTestId("persistent-structured-views-toggle") as HTMLInputElement).checked).toBe(false);
+    expect(queryByTestId("max-persistent-structured-views")).toBeNull();
+  });
+
+  it("persists the toggle and reveals the limit input when enabled", () => {
+    const { getByTestId } = render(<StructuredViewDisplaySettings />);
+    fireEvent.click(getByTestId("persistent-structured-views-toggle"));
+    expect(readStored().persistentStructuredViews).toBe(true);
+    expect((getByTestId("max-persistent-structured-views") as HTMLInputElement).value).toBe("2");
+  });
+
+  it("persists and clamps the limit input", () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ persistentStructuredViews: true }));
+    const { getByTestId } = render(<StructuredViewDisplaySettings />);
+    fireEvent.change(getByTestId("max-persistent-structured-views"), { target: { value: "0" } });
+    expect(readStored().maxPersistentStructuredViews).toBe(1);
+    fireEvent.change(getByTestId("max-persistent-structured-views"), { target: { value: "99" } });
+    expect(readStored().maxPersistentStructuredViews).toBe(5);
+    fireEvent.change(getByTestId("max-persistent-structured-views"), { target: { value: "3" } });
+    expect(readStored().maxPersistentStructuredViews).toBe(3);
+  });
+
   it("survives a reread and reflects the stored values on remount", () => {
     const first = render(<StructuredViewDisplaySettings />);
     fireEvent.change(first.getByTestId("structured-mobile-font-size-slider"), { target: { value: "12" } });

--- a/web/src/hooks/__tests__/useAcpSession.deactivation.test.ts
+++ b/web/src/hooks/__tests__/useAcpSession.deactivation.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+//
+// Regression tests for the persistent structured-view stack: an inactive session
+// must stop its reconnect backoff and not schedule new retries, but should
+// reconnect when it becomes active again.
+
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentProfileProvider } from "../../lib/agentProfileContext";
+import { useAcpSession } from "../useAcpSession";
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: ((ev: Event) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  close: () => void;
+  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
+}
+
+const sockets: FakeSocket[] = [];
+let originalWebSocket: typeof WebSocket;
+
+class FakeWebSocket implements FakeSocket {
+  url: string;
+  readyState: number = 0;
+  onopen: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  constructor(url: string) {
+    this.url = url;
+    sockets.push(this);
+  }
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+  send(): void {
+    /* no-op */
+  }
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+function advanceTimers(ms: number): void {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(AgentProfileProvider, { toolKey: "claude" }, children);
+
+describe("useAcpSession deactivation reconnect handling", () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ frames: [], lost: false, highest_seq: 0 }), { status: 200 });
+      }),
+    );
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("does not schedule a retry while the session is inactive", async () => {
+    const sessionId = "sess-inactive-retry";
+    const { rerender } = renderHook(({ active }) => useAcpSession(sessionId, active), {
+      wrapper,
+      initialProps: { active: true },
+    });
+    await flushAsync();
+
+    expect(sockets).toHaveLength(1);
+    const ws = sockets[0]!;
+
+    // Flip to inactive before the close, then simulate a disconnect.
+    rerender({ active: false });
+    await flushAsync();
+
+    act(() => {
+      ws.readyState = FakeWebSocket.CLOSED;
+      ws.onclose?.(new CloseEvent("close"));
+    });
+    await flushAsync();
+
+    // Advance well past the first retry delay; no new socket should be created.
+    advanceTimers(5000);
+    expect(sockets).toHaveLength(1);
+  });
+
+  it("triggers a reconnect when the session becomes active again after a disconnect", async () => {
+    const sessionId = "sess-active-again";
+    const { rerender } = renderHook(({ active }) => useAcpSession(sessionId, active), {
+      wrapper,
+      initialProps: { active: false },
+    });
+    await flushAsync();
+
+    // The initial mount connects even while inactive; close it and confirm no
+    // retry is scheduled while still inactive.
+    expect(sockets).toHaveLength(1);
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.CLOSED;
+      ws.onclose?.(new CloseEvent("close"));
+    });
+    await flushAsync();
+    advanceTimers(5000);
+    expect(sockets).toHaveLength(1);
+
+    // Becoming active should reconnect immediately.
+    rerender({ active: true });
+    await flushAsync();
+    expect(sockets).toHaveLength(2);
+  });
+});

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -1143,6 +1143,22 @@ export function useAcpSession(
     connectRef.current?.();
   };
 
+  // Cancel any pending reconnect backoff when this session becomes inactive,
+  // and trigger one reconnect when it becomes active again so the user doesn't
+  // stare at a stale disconnected warm session.
+  const wasActiveRef = useRef(active);
+  useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+    if (active && !wasActiveRef.current) {
+      tryAutoReconnectRef.current();
+    }
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+    if (!active) {
+      clearRetryTimers();
+    }
+    wasActiveRef.current = active;
+  }, [active, clearRetryTimers]);
+
   // Liveness watchdog: a foreground-visible idle tab fires neither
   // visibilitychange nor online, so a zombie socket would otherwise sit
   // forever. Poll while the socket reports OPEN and let
@@ -1457,6 +1473,7 @@ export function useAcpSession(
 
     const scheduleReconnect = () => {
       if (cancelled) return;
+      if (!activeRef.current) return;
       if (retryCountRef.current >= ACP_MAX_RETRIES) {
         setReconnectingRef.current(false);
         setRetryCountRef.current(retryCountRef.current);
@@ -1480,6 +1497,7 @@ export function useAcpSession(
           clearInterval(countdownTimerRef.current);
           countdownTimerRef.current = null;
         }
+        if (!activeRef.current) return;
         connectRef.current?.();
       }, delayMs);
     };

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -947,6 +947,10 @@ function optimisticPromptId(): string {
 
 export function useAcpSession(
   sessionId: string | null,
+  /** When false the session is mounted but inactive (kept warm by the
+   *  persistent structured-view stack). Cache writes and aggressive
+   *  reconnects are skipped. Defaults to true. */
+  active = true,
   /** Live structured view worker lifecycle from `SessionResponse.acp_worker_state`.
    *  When not `"running"`, the drain effect parks queued prompts so they
    *  don't dispatch into a worker that isn't online yet. Defaults to
@@ -1004,8 +1008,10 @@ export function useAcpSession(
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+    if (!active) return;
     if (sessionIdRef.current) cacheSet(sessionIdRef.current, state);
-  }, [state]);
+  }, [active, state]);
   const wsRef = useRef<WebSocket | null>(null);
   // Auto-reconnect machinery (#1130). retryCountRef is the persistent
   // attempt counter across `onclose` -> scheduled `connect()` cycles;
@@ -1114,8 +1120,11 @@ export function useAcpSession(
   // Stable callback ref for visibility/online/pageshow triggers so the
   // reactive effects below can reconnect without depending on sessionId
   // (satisfies react-you-might-not-need-an-effect/no-event-handler).
+  const activeRef = useRef(active);
+  activeRef.current = active;
   const tryAutoReconnectRef = useRef<() => void>(() => {});
   tryAutoReconnectRef.current = () => {
+    if (!activeRef.current) return;
     const ws = wsRef.current;
     const ready = ws?.readyState;
     if (ready === WebSocket.CONNECTING) return;

--- a/web/src/hooks/useAcpSession.wake.test.ts
+++ b/web/src/hooks/useAcpSession.wake.test.ts
@@ -122,7 +122,9 @@ describe("useAcpSession auto-wake on sendPrompt (#1581)", () => {
 
   it("clears the archived flag via PATCH before enqueueing the prompt", async () => {
     const sessionId = "sess-wake-archive";
-    const { result } = renderHook(() => useAcpSession(sessionId, "absent", "2026-01-01T00:00:00Z", null), { wrapper });
+    const { result } = renderHook(() => useAcpSession(sessionId, true, "absent", "2026-01-01T00:00:00Z", null), {
+      wrapper,
+    });
     await flushAsync();
 
     await act(async () => {
@@ -143,7 +145,9 @@ describe("useAcpSession auto-wake on sendPrompt (#1581)", () => {
 
   it("clears the snoozed flag via PATCH before enqueueing the prompt", async () => {
     const sessionId = "sess-wake-snooze";
-    const { result } = renderHook(() => useAcpSession(sessionId, "absent", null, "2099-01-01T00:00:00Z"), { wrapper });
+    const { result } = renderHook(() => useAcpSession(sessionId, true, "absent", null, "2099-01-01T00:00:00Z"), {
+      wrapper,
+    });
     await flushAsync();
 
     await act(async () => {
@@ -159,7 +163,7 @@ describe("useAcpSession auto-wake on sendPrompt (#1581)", () => {
 
   it("does not call wake endpoints when the session is live", async () => {
     const sessionId = "sess-wake-live";
-    const { result } = renderHook(() => useAcpSession(sessionId, "absent", null, null), { wrapper });
+    const { result } = renderHook(() => useAcpSession(sessionId, true, "absent", null, null), { wrapper });
     await flushAsync();
 
     await act(async () => {
@@ -206,7 +210,9 @@ describe("useAcpSession auto-wake on sendPrompt (#1581)", () => {
       }),
     );
 
-    const { result } = renderHook(() => useAcpSession(sessionId, "absent", "2026-01-01T00:00:00Z", null), { wrapper });
+    const { result } = renderHook(() => useAcpSession(sessionId, true, "absent", "2026-01-01T00:00:00Z", null), {
+      wrapper,
+    });
     await flushAsync();
 
     await act(async () => {
@@ -244,7 +250,9 @@ describe("useAcpSession auto-wake on sendPrompt (#1581)", () => {
       }),
     );
 
-    const { result } = renderHook(() => useAcpSession(sessionId, "absent", null, "2099-01-01T00:00:00Z"), { wrapper });
+    const { result } = renderHook(() => useAcpSession(sessionId, true, "absent", null, "2099-01-01T00:00:00Z"), {
+      wrapper,
+    });
     await flushAsync();
 
     await act(async () => {
@@ -265,7 +273,7 @@ describe("useAcpSession auto-wake on sendPrompt (#1581)", () => {
     // merge_user_action_diff on the server side.
     const sessionId = "sess-wake-both";
     const { result } = renderHook(
-      () => useAcpSession(sessionId, "absent", "2026-01-01T00:00:00Z", "2099-01-01T00:00:00Z"),
+      () => useAcpSession(sessionId, true, "absent", "2026-01-01T00:00:00Z", "2099-01-01T00:00:00Z"),
       { wrapper },
     );
     await flushAsync();

--- a/web/src/hooks/useFocusTerminalTarget.ts
+++ b/web/src/hooks/useFocusTerminalTarget.ts
@@ -20,8 +20,14 @@ import {
  * Mirrors the inline wiring TerminalView uses for the "agent" target; the
  * structured view Composer uses it for "composer".
  */
-export function useFocusTerminalTarget(target: TerminalFocusTarget, ref: React.RefObject<HTMLElement | null>): void {
+export function useFocusTerminalTarget(
+  target: TerminalFocusTarget,
+  ref: React.RefObject<HTMLElement | null>,
+  enabled = true,
+): void {
+  /* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
   useEffect(() => {
+    if (!enabled) return;
     const onFocusEvent = (e: Event) => {
       const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
       if (detail?.target !== target) return;
@@ -31,9 +37,11 @@ export function useFocusTerminalTarget(target: TerminalFocusTarget, ref: React.R
     };
     window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
     return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
-  }, [target, ref]);
+  }, [target, ref, enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (consumePendingTerminalFocus(target)) ref.current?.focus();
-  }, [target, ref]);
+  }, [target, ref, enabled]);
+  /* eslint-enable react-you-might-not-need-an-effect/no-event-handler */
 }

--- a/web/src/hooks/useMobileKeyboard.ts
+++ b/web/src/hooks/useMobileKeyboard.ts
@@ -47,9 +47,9 @@ function createKeyboardStore() {
 
 type KeyboardStore = ReturnType<typeof createKeyboardStore>;
 
-export function useMobileKeyboard() {
+export function useMobileKeyboard(enabled = true) {
   const [store] = useState<KeyboardStore>(() => createKeyboardStore());
-  const state = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  const state = useSyncExternalStore(enabled ? store.subscribe : () => () => {}, store.getSnapshot);
 
   const rafRef = useRef(0);
   const stableCountRef = useRef(0);
@@ -57,6 +57,7 @@ export function useMobileKeyboard() {
   const fullHeightRef = useRef(0);
 
   useEffect(() => {
+    if (!enabled) return;
     if (typeof window === "undefined" || !window.matchMedia) return;
     const mql = window.matchMedia("(pointer: coarse)");
     const onChange = () => {
@@ -74,9 +75,10 @@ export function useMobileKeyboard() {
     };
     mql.addEventListener?.("change", onChange);
     return () => mql.removeEventListener?.("change", onChange);
-  }, [store]);
+  }, [enabled, store]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (!state.isMobile) return;
     const vv = window.visualViewport;
     if (!vv) return;
@@ -170,7 +172,7 @@ export function useMobileKeyboard() {
       window.removeEventListener("orientationchange", handleOrientationChange);
       window.removeEventListener("scroll", handleViewportChange);
     };
-  }, [state.isMobile, store]);
+  }, [enabled, state.isMobile, store]);
 
   return {
     isMobile: state.isMobile,

--- a/web/src/hooks/useMobileKeyboard.ts
+++ b/web/src/hooks/useMobileKeyboard.ts
@@ -57,7 +57,12 @@ export function useMobileKeyboard(enabled = true) {
   const fullHeightRef = useRef(0);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      // Reset stored keyboard metrics when tracking is disabled so an inactive
+      // session can't leave stale open/height values behind for the next render.
+      store.update({ keyboardOpen: false, keyboardHeight: 0 });
+      return;
+    }
     if (typeof window === "undefined" || !window.matchMedia) return;
     const mql = window.matchMedia("(pointer: coarse)");
     const onChange = () => {

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -2,6 +2,10 @@ import { useCallback, useSyncExternalStore } from "react";
 
 import { DEFAULT_CONVERSATION_FONT_SIZE, normalizeConversationFontSize } from "../lib/conversationFontSize";
 import { DEFAULT_PERSISTENT_TERMINALS, normalizePersistentTerminalLimit } from "../lib/persistentTerminals";
+import {
+  DEFAULT_PERSISTENT_STRUCTURED_VIEWS,
+  normalizePersistentStructuredViewLimit,
+} from "../lib/persistentStructuredViews";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 
 const STORAGE_KEY = "aoe-web-settings";
@@ -42,6 +46,13 @@ export interface WebSettings {
    *  Unlike the diff/terminal flags this is an ongoing policy: turning it back
    *  on can add newly available plugin panes to existing sessions too. */
   autoOpenPluginPanes: boolean;
+  /** Keep recently viewed structured-view sessions mounted (but inert) so
+   *  switching back to them is instant. Default off to avoid extra resource
+   *  use; capped by `maxPersistentStructuredViews`. See #persistent-structured-views. */
+  persistentStructuredViews: boolean;
+  /** Maximum number of recent structured-view sessions to keep mounted when
+   *  `persistentStructuredViews` is enabled. Clamped 1-5; default 2. */
+  maxPersistentStructuredViews: number;
 }
 
 function getDefaults(): WebSettings {
@@ -63,6 +74,8 @@ function getDefaults(): WebSettings {
     autoOpenDiffPane: true,
     autoOpenTerminalPane: true,
     autoOpenPluginPanes: true,
+    persistentStructuredViews: false,
+    maxPersistentStructuredViews: DEFAULT_PERSISTENT_STRUCTURED_VIEWS,
   };
 }
 
@@ -93,6 +106,8 @@ function normalizeSnapshot(settings: WebSettings): WebSettings {
       settings.markdownPreview === "rendered" || settings.markdownPreview === "raw"
         ? settings.markdownPreview
         : defaults.markdownPreview,
+    persistentStructuredViews: normalizeBool(settings.persistentStructuredViews, defaults.persistentStructuredViews),
+    maxPersistentStructuredViews: normalizePersistentStructuredViewLimit(settings.maxPersistentStructuredViews),
   };
 }
 

--- a/web/src/lib/persistentStructuredViews.ts
+++ b/web/src/lib/persistentStructuredViews.ts
@@ -1,0 +1,10 @@
+export const MIN_PERSISTENT_STRUCTURED_VIEWS = 1;
+export const MAX_PERSISTENT_STRUCTURED_VIEWS = 5;
+export const DEFAULT_PERSISTENT_STRUCTURED_VIEWS = 2;
+
+export function normalizePersistentStructuredViewLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_PERSISTENT_STRUCTURED_VIEWS;
+  }
+  return Math.min(MAX_PERSISTENT_STRUCTURED_VIEWS, Math.max(MIN_PERSISTENT_STRUCTURED_VIEWS, Math.round(value)));
+}


### PR DESCRIPTION
## Description

Adds an opt-in, default-off dashboard setting that keeps the N most recently viewed structured-view sessions mounted (but inert and idled) so switching back to a recent structured chat is instant and avoids the "Starting structured view…" reconnect banner.

- New web-settings fields: `persistentStructuredViews` (default false) and `maxPersistentStructuredViews` (default 2, clamped 1–5).
- New `StructuredViewStack` component renders the active session plus recent inactive structured sessions behind an `inert` / `aria-hidden` / `pointer-events-none` layer.
- Threads `active: boolean` through `StructuredView` → `AcpChrome` → `Composer`, `AttentionChime`, and `StructuredViewRoot` to gate autofocus, audio, mobile keyboard reservation, auto-scroll, scroll observers, and reconnect behavior.
- Inactive `useAcpSession` instances skip `localStorage` cache writes and defer aggressive wake/online reconnects.
- Saves/restores scroll position across active ↔ inactive transitions.
- Wires the stack into `App.tsx` (desktop) and `MobileMainPane.tsx` (mobile).

Closes #3466

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the new behavior is covered by unit tests for `StructuredViewStack` and the settings component. A live Playwright story would need to assert across multiple WebSocket reconnects, which is better validated by the existing structured-view suite once the feature is enabled.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Kimi Code CLI / Claude Code assisted with implementation planning and code changes.

**Any Additional AI Details you'd like to share:**

Implementation followed the plan in `.plan-persistent-structured-view.md` and the two-iteration generic review loop the user requested.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an opt-in setting to keep recent structured-view sessions mounted.
- Added a configurable limit of one to five sessions, with a default of two.
- Added `StructuredViewStack` for desktop and mobile session handling.
- Preserved session state and scroll positions during view changes.
- Disabled inactive-session focus, keyboard handling, audio alerts, auto-scroll, cache writes, and reconnect retries.
- Prevented inactive plugin drafts from moving focus to the composer.
- Added session filtering, terminal-session pruning, accessibility labels, and conditional loading.
- Added regression tests for persistence, limits, visibility, reconnects, keyboard behavior, draft focus, and attention chimes.
- The full web unit suite passes with 3,705 tests.

## Benefits

- Recent chats reopen without the “Starting structured view…” delay.
- Inactive sessions do not interfere with the active session.
- The session limit helps control memory and WebSocket usage.

## Further enhancement

- Monitor resource usage with higher session limits to validate the default cap in typical workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->