### PR TITLE
docs(contrib): archived_at and trashed_at do not clear alike

### DIFF
--- a/contrib/hermes-skill/SKILL.md
+++ b/contrib/hermes-skill/SKILL.md
@@ -89,7 +89,7 @@ aoe list --json --state=live   # skip trashed and archived rows
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently, and trashing leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it, so key off `state` rather than caching a timestamp. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently, and trashing leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither timestamp is durable, but they do not clear alike: `archived_at` is cleared by `aoe session unarchive`, by `aoe session favorite`, and by anything that wakes the session (`aoe send`, and `aoe session restart` when it sends its wake message), while `trashed_at` is cleared only by `aoe session restore`. Key off `state` rather than caching a timestamp. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
 
 ## Session Lifecycle
 
@@ -143,7 +143,7 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-`parent_session_id` is included only for sub-sessions. `state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently, and `trash()` deliberately leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it (`aoe session restart`, `aoe send`, favourite, pin), so read the current `state` rather than caching a timestamp; `status` is the pane's live status and does not carry it, since an archived session can still be running.
+`parent_session_id` is included only for sub-sessions. `state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently, and trashing deliberately leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither timestamp is durable, and they do not clear alike: `archived_at` is cleared by `aoe session unarchive`, by `aoe session favorite`, and by anything that wakes the session, which means `aoe send` and `aoe session restart` when it sends its wake message (with `session.restart_wake_message` set to the empty string it does not send one, and the archive survives the restart). `trashed_at` is cleared only by `aoe session restore`. Read the current `state` rather than caching a timestamp; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON shape** (`aoe status --json`):
 ```json

--- a/contrib/openclaw-skill/SKILL.md
+++ b/contrib/openclaw-skill/SKILL.md
@@ -92,7 +92,7 @@ aoe list --json --state=live
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently, and trashing leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it, so key off `state` rather than caching a timestamp. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`; `trashed_at` and `archived_at` are set independently, and trashing leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither timestamp is durable, but they do not clear alike: `archived_at` is cleared by `aoe session unarchive`, by `aoe session favorite`, and by anything that wakes the session (`aoe send`, and `aoe session restart` when it sends its wake message), while `trashed_at` is cleared only by `aoe session restore`. Key off `state` rather than caching a timestamp. A trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
 
 ### Session lifecycle
 
@@ -146,7 +146,7 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-`state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently, and `trash()` deliberately leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither is durable: each is cleared when the session leaves that state, including by anything that wakes it (`aoe session restart`, `aoe send`, favourite, pin), so read the current `state` rather than caching a timestamp; `status` is the pane's live status and does not carry it, since an archived session can still be running.
+`state` is `live`, `archived`, or `trashed`, the same vocabulary `aoe list --json` uses; `trashed_at` and `archived_at` are set independently, and trashing deliberately leaves `archived_at` alone, so a session archived and then trashed carries both keys and reports `trashed`. Neither timestamp is durable, and they do not clear alike: `archived_at` is cleared by `aoe session unarchive`, by `aoe session favorite`, and by anything that wakes the session, which means `aoe send` and `aoe session restart` when it sends its wake message (with `session.restart_wake_message` set to the empty string it does not send one, and the archive survives the restart). `trashed_at` is cleared only by `aoe session restore`. Read the current `state` rather than caching a timestamp; `status` is the pane's live status and does not carry it, since an archived session can still be running.
 
 **JSON output shape** (`aoe status --json`):
 ```json


### PR DESCRIPTION
## Description

Follow-up to the three doc nits @njbrake raised on #3414, which were marked
non-blocking and not actioned since. One of them is a factual error rather than
a wording nit.

**The durability rule is false for `trashed_at`.** Four paragraphs across the two
skill docs said:

> Neither is durable: each is cleared when the session leaves that state,
> including by anything that wakes it

`touch_last_accessed` clears `archived_at`, `snoozed_until` and
`idle_dormant_since`, never `trashed_at`. Only `untrash` clears that, and only
`aoe session restore` reaches it. A consumer following the old sentence would
expect a trashed row to come back on the next `aoe send`, and would key off a
cached timestamp accordingly.

As @njbrake noted at the time, two of the four paragraphs predate #3414 (the
`list --json` ones at `hermes:92` / `openclaw:95`); the other two are the ones
that PR added.

**The waker list was wrong in both directions.**

- `pin` has no CLI surface at all. `aoe session` has `archive`, `unarchive`,
  `favorite`, `unfavorite`, `snooze`, `unsnooze`, `restore` and `restart`, and
  no `pin`. It does not belong in a CLI skill doc.
- `aoe session restart` clears only when it actually sends its wake message.
  `wake_succeeded` gates the `touch_last_accessed` call
  (`src/cli/session.rs:1490-1493`), and it is false when
  `session.restart_wake_message` is empty, which is the documented opt-out, or
  when the outcome is `ResumeFailed`. So restarting an archived session with the
  wake message disabled leaves it archived. The docs now say so.

**Two wording nits from the same review**, both still present:

- `trash()` named an internal Rust method to third-party consumers; "trashing"
  reads the same.
- `favourite` was the only British spelling in the repo; the command is
  `aoe session favorite`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No UI change.

## Test Coverage Analysis

`cargo xtask check-skill` passes. That is the gate that matters here: it
validates every `aoe ...` command named in these docs against the real CLI
surface, so the replacement text's `aoe session unarchive`, `aoe session
favorite` and `aoe session restore` are checked rather than asserted. It is also
what would have caught `pin` had it been written as a command rather than as
bare prose.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Docs only, no behavior change. The `restart` conditional described above is
existing behavior that the docs were describing wrongly; if you would rather the
gate on `wake_succeeded` changed instead, that is a code change and I would send
it separately.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation, the code and this
write-up were done by Claude working from that. The three nits are @njbrake's
from the #3414 review. What was added here is checking them against the tree,
which turned the durability sentence from a wording nit into a correctness one
and turned up the `aoe session restart` conditional that none of us had noticed.
Every command name in the new text was verified against `docs/cli/reference.md`
and by `check-skill` rather than recalled.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated contributor skill documentation for `archived_at` and `trashed_at` behavior.
- Documented the commands and wake conditions that clear each timestamp.
- Removed the incorrect `pin` behavior and replaced the internal `trash()` reference.
- Standardized `favorite` terminology.
- Confirmed the documentation checks pass.

## Benefits

The documentation now matches actual session behavior and gives contributors clearer guidance about lifecycle state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->