### PR TITLE
docs(session): drop archive()'s pointer to the paragraph below

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2244,7 +2244,7 @@ impl Instance {
     /// attention sort short-circuits the row to its bottom tier.
     ///
     /// Cleared by `unarchive`, by `touch_last_accessed`, and by `favorite`
-    /// and `pin` through the mutual exclusion below; not by `snooze`.
+    /// and `pin`; not by `snooze`.
     /// `merge_user_action_diff` mirrors those onto disk, and #3465 tracks a
     /// status transition reaching that mirror without a user gesture.
     ///


### PR DESCRIPTION
## Description

Closes out the non-blocking note on your #3453 approval.

"through the mutual exclusion below" sends the reader to the paragraph
documenting archiving clearing `favorited_at`, `snoozed_until` and `pinned_at`,
which is the other direction. The clears of `archived_at` are not there, so the
pointer costs a lookup and returns nothing.

The list is complete without it. `favorite` (doc `src/session/instance.rs:2404-2416`,
body `2417-2421`) and `pin` (doc `2541-2550`, body `2551-2555`) each clear
`archived_at` and `snoozed_until`, and each states it under the same "Mutual
exclusion with the sink states" heading. `snooze` (`2478-2481`) touches
`snoozed_until` and `pinned_at` only, so its exclusion from the list stays
correct. Line numbers are against `48616026`.

A deletion rather than a rewording: every substitution I drafted put back the
mechanism narration your #3453 review asked to drop, and the two mutators
already document this about themselves.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

No test added: the diff is one line of doc comment, so there is no behaviour to
pin and a test here would be the tautological kind `AGENTS.md` says not to add.

`cargo fmt --check`, `cargo clippy --all-targets` and
`cargo test --lib session::instance::` are clean at `48616026` (315 passed,
4320 filtered out), but none of them can discriminate on doc prose. The one
gate with power here is rustdoc, since `src/lib.rs` denies both intra-doc-link
lints, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features serve` is
clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation and this write-up were
done by Claude working from that. The finding is yours, from the #3453 approval.

- [x] I am an AI Agent filling out this form (check box if true)
