### PR TITLE
chore: release v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,86 @@ All notable changes to Agent of Empires will be documented in this file.
 
 The format follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [1.15.0](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.15.0) - 2026-08-21
+
+
+
+### Bug Fixes
+
+- **session:** Attribute OMP captures to the launching pane in [#3230](https://github.com/agent-of-empires/agent-of-empires/pull/3230) by [@jerome-benoit](https://github.com/jerome-benoit) ([`e7a35d7`](https://github.com/agent-of-empires/agent-of-empires/commit/e7a35d75420e6eee43f409cff0491ca32353064e))
+- **tui:** Keep poller repair off the render loop in [#3348](https://github.com/agent-of-empires/agent-of-empires/pull/3348) by [@njbrake](https://github.com/njbrake) ([`5c79164`](https://github.com/agent-of-empires/agent-of-empires/commit/5c7916444bcca9d9cc1123deb2c7b39f607cbb68))
+- **tui:** Preserve trailing bg fills in preview captures in [#3339](https://github.com/agent-of-empires/agent-of-empires/pull/3339) by [@mikaoelitiana](https://github.com/mikaoelitiana) ([`ca81ec3`](https://github.com/agent-of-empires/agent-of-empires/commit/ca81ec3a0039c6a4ca16ef4a99160c098d2ee4d8))
+- **tui:** Keep held keys out of paste bursts in [#3352](https://github.com/agent-of-empires/agent-of-empires/pull/3352) by [@njbrake](https://github.com/njbrake) ([`76e86b6`](https://github.com/agent-of-empires/agent-of-empires/commit/76e86b635674495a33b9a78e78a71b356a66bc73))
+- **tui:** Truncate settings custom-instruction preview on a char boundary in [#3354](https://github.com/agent-of-empires/agent-of-empires/pull/3354) by [@BTForIT](https://github.com/BTForIT) ([`56ebc37`](https://github.com/agent-of-empires/agent-of-empires/commit/56ebc375fc0c2ca750c1d39718e7615aeeba3e3d))
+- **send:** Claude Enter swallowed by paste-burst window leaves unsubmitted [Pasted text] in [#3355](https://github.com/agent-of-empires/agent-of-empires/pull/3355) by [@BTForIT](https://github.com/BTForIT) ([`9a6db1a`](https://github.com/agent-of-empires/agent-of-empires/commit/9a6db1ab8068779e01c886839c172f2e5a2a7a16))
+- **acp:** Allow switching structured sessions to configured custom agents in [#3338](https://github.com/agent-of-empires/agent-of-empires/pull/3338) by [@karljuhlthefool](https://github.com/karljuhlthefool) ([`44cda8d`](https://github.com/agent-of-empires/agent-of-empires/commit/44cda8d088c48d8c1bd8448b6331cf070610b31e))
+- **config:** Stop advertising inert repo [tmux] and [sound] overrides in [#3359](https://github.com/agent-of-empires/agent-of-empires/pull/3359) by [@MatthewWolff](https://github.com/MatthewWolff) ([`98953c9`](https://github.com/agent-of-empires/agent-of-empires/commit/98953c95506ae7a0635676cb535fc6b1e4df4400))
+- **tui:** Give the synthetic scratch bucket its own group identity in [#3357](https://github.com/agent-of-empires/agent-of-empires/pull/3357) by [@MatthewWolff](https://github.com/MatthewWolff) ([`e7c5780`](https://github.com/agent-of-empires/agent-of-empires/commit/e7c5780c7e79258c1c475a63b03136a318324768))
+- **config:** Surface config load errors and unrecognized keys in [#3358](https://github.com/agent-of-empires/agent-of-empires/pull/3358) by [@MatthewWolff](https://github.com/MatthewWolff) ([`9382840`](https://github.com/agent-of-empires/agent-of-empires/commit/938284044d7786ff808647e017039f67f7180aed))
+- **tui:** Report sandbox container usage in System Health in [#3365](https://github.com/agent-of-empires/agent-of-empires/pull/3365) by [@njbrake](https://github.com/njbrake) ([`dda9a27`](https://github.com/agent-of-empires/agent-of-empires/commit/dda9a27f701d32d50e24c28ca9a21af7df8ac1a8))
+- **test:** Wait for the pane command to exec instead of sleeping 200ms in [#3367](https://github.com/agent-of-empires/agent-of-empires/pull/3367) by [@njbrake](https://github.com/njbrake) ([`05f9206`](https://github.com/agent-of-empires/agent-of-empires/commit/05f9206e6eb68a2b14e52a2c18eb249853f11984))
+- **acp:** Forward non-Claude provider keys to their ACP adapters in [#3360](https://github.com/agent-of-empires/agent-of-empires/pull/3360) by [@MatthewWolff](https://github.com/MatthewWolff) ([`de6dc53`](https://github.com/agent-of-empires/agent-of-empires/commit/de6dc539366d32b51b2cf6b5b05087895f3b735c))
+- **web:** Fall back to main-thread highlighting when the diff worker fails to load in [#3363](https://github.com/agent-of-empires/agent-of-empires/pull/3363) by [@Seluj78](https://github.com/Seluj78) ([`2f106f1`](https://github.com/agent-of-empires/agent-of-empires/commit/2f106f19cb33b786298569ab15d3c7d43e8e1e33))
+- **session:** Resolve a stale agent_detect_as alias instead of freezing at Idle in [#3398](https://github.com/agent-of-empires/agent-of-empires/pull/3398) by [@njbrake](https://github.com/njbrake) ([`9881155`](https://github.com/agent-of-empires/agent-of-empires/commit/9881155bec50631976503b5b3140ab6688df7d6a))
+- **logging:** Keep expected git failures and disabled plugins out of WARN in [#3404](https://github.com/agent-of-empires/agent-of-empires/pull/3404) by [@njbrake](https://github.com/njbrake) ([`82cefed`](https://github.com/agent-of-empires/agent-of-empires/commit/82cefedd11d072f6dd8b02b78fd53b09d02f4134))
+- **serve:** Stop reporting a force-stop teardown race as a server fault in [#3406](https://github.com/agent-of-empires/agent-of-empires/pull/3406) by [@njbrake](https://github.com/njbrake) ([`dd05c9b`](https://github.com/agent-of-empires/agent-of-empires/commit/dd05c9b8dc42d40a98cbc4153161c01dba67fb64))
+- **logging:** Put method and route template on http.request completion in [#3405](https://github.com/agent-of-empires/agent-of-empires/pull/3405) by [@njbrake](https://github.com/njbrake) ([`9b0572f`](https://github.com/agent-of-empires/agent-of-empires/commit/9b0572f7bf4fba2c27f79801ed336f3e90a2ae7b))
+- **config:** Never treat the global config.toml as a repo config in [#3407](https://github.com/agent-of-empires/agent-of-empires/pull/3407) by [@njbrake](https://github.com/njbrake) ([`71bf927`](https://github.com/agent-of-empires/agent-of-empires/commit/71bf927308291a2029b84aa77edc06212128ff2a))
+- **tui:** Confirm the quick-delete shortcut instead of trashing on one keystroke in [#3408](https://github.com/agent-of-empires/agent-of-empires/pull/3408) by [@klubrake](https://github.com/klubrake) ([`efb73ae`](https://github.com/agent-of-empires/agent-of-empires/commit/efb73aef36e82eef36adf187f6eaaea6fc1e388f))
+- **session:** Resolve Claude's config dir per profile when reading its state in [#3410](https://github.com/agent-of-empires/agent-of-empires/pull/3410) by [@njbrake](https://github.com/njbrake) ([`d2b76ff`](https://github.com/agent-of-empires/agent-of-empires/commit/d2b76ff13797dc32ef49bc43697ab662dbd03890))
+- **web:** Let diff comments send to a dormant session, and say why when Send is blocked in [#3416](https://github.com/agent-of-empires/agent-of-empires/pull/3416) by [@Seluj78](https://github.com/Seluj78) ([`26e5fe9`](https://github.com/agent-of-empires/agent-of-empires/commit/26e5fe9399463c1fa7d979f4eee511b092a7431f))
+- **web:** Splice slash commands at the caret through the DOM in [#3420](https://github.com/agent-of-empires/agent-of-empires/pull/3420) by [@Seluj78](https://github.com/Seluj78) ([`c6a41c4`](https://github.com/agent-of-empires/agent-of-empires/commit/c6a41c4069a814243126e30dce5ee5fa2bd5d2f7))
+- **sv:** Adopt the daemon's turn_active so steered prompts stop wedging the composer in [#3419](https://github.com/agent-of-empires/agent-of-empires/pull/3419) by [@Seluj78](https://github.com/Seluj78) ([`5d9dccb`](https://github.com/agent-of-empires/agent-of-empires/commit/5d9dccbdb103cf3b295a9a87c200e96deeb0a351))
+- **session:** Scope hermes conversation capture to the project in [#3381](https://github.com/agent-of-empires/agent-of-empires/pull/3381) by [@jerome-benoit](https://github.com/jerome-benoit) ([`8a5a4ed`](https://github.com/agent-of-empires/agent-of-empires/commit/8a5a4ed867ab0a0d5200f5785f4094e380f8982d))
+- **tmux:** Omp provider errors and retries no longer read Idle in [#3383](https://github.com/agent-of-empires/agent-of-empires/pull/3383) by [@jerome-benoit](https://github.com/jerome-benoit) ([`5e38f7f`](https://github.com/agent-of-empires/agent-of-empires/commit/5e38f7f9db6396c36aaa916aefd0d6a50c5bff94))
+- **tmux:** Read Claude's folder-trust prompt as waiting, not idle in [#3412](https://github.com/agent-of-empires/agent-of-empires/pull/3412) by [@blueagledev](https://github.com/blueagledev) ([`a4361e8`](https://github.com/agent-of-empires/agent-of-empires/commit/a4361e88dae9b037c3ae4d043b4ffea704837567))
+- **tui:** Let tmux decide bracketed paste on live-send multi-line pastes in [#3431](https://github.com/agent-of-empires/agent-of-empires/pull/3431) by [@klubrake](https://github.com/klubrake) ([`0910523`](https://github.com/agent-of-empires/agent-of-empires/commit/0910523bf483fc49187f421ac24575e429654b81))
+- **acp:** Scope ambient Claude credentials in [#3382](https://github.com/agent-of-empires/agent-of-empires/pull/3382) by [@shixi-li](https://github.com/shixi-li) ([`710ac06`](https://github.com/agent-of-empires/agent-of-empires/commit/710ac06eeef8188a75a6c633b588aba6de47e1be))
+- **tmux:** Require an idle pane for the folder-trust arm in [#3447](https://github.com/agent-of-empires/agent-of-empires/pull/3447) by [@njbrake](https://github.com/njbrake) ([`e04d727`](https://github.com/agent-of-empires/agent-of-empires/commit/e04d7270abde31fa9b06b054b160fcc7a4e09cb2))
+- **acp:** Accept standard session/load response in [#3385](https://github.com/agent-of-empires/agent-of-empires/pull/3385) by [@amatouhake](https://github.com/amatouhake) ([`07751aa`](https://github.com/agent-of-empires/agent-of-empires/commit/07751aa1236ccb0c6958832e69df0b849b41018d))
+- **build:** Stop watching .git/index for the build-version rerun trigger in [#3432](https://github.com/agent-of-empires/agent-of-empires/pull/3432) by [@cwrau](https://github.com/cwrau) ([`b094cf9`](https://github.com/agent-of-empires/agent-of-empires/commit/b094cf961f4b2b161c1a1cce2f3ba99839ed57b9))
+- **session:** Require a regular file in the Claude transcript scan in [#3454](https://github.com/agent-of-empires/agent-of-empires/pull/3454) by [@blueagledev](https://github.com/blueagledev) ([`a7ebc08`](https://github.com/agent-of-empires/agent-of-empires/commit/a7ebc08e2095b05667651bff18cd3329e8e0a885))
+- **sv:** Keep workers alive for cwd-stable renames in [#3428](https://github.com/agent-of-empires/agent-of-empires/pull/3428) by [@jerome-benoit](https://github.com/jerome-benoit) ([`5762f00`](https://github.com/agent-of-empires/agent-of-empires/commit/5762f006588742765b877df75135bae3380809e6))
+- **session:** Reject duplicate smart rename titles in [#3426](https://github.com/agent-of-empires/agent-of-empires/pull/3426) by [@jerome-benoit](https://github.com/jerome-benoit) ([`42c9b9d`](https://github.com/agent-of-empires/agent-of-empires/commit/42c9b9dd8e216ffc399f0725eb7bb5a203174e8f))
+- **storage:** Preserve atomic write error contract in [#3423](https://github.com/agent-of-empires/agent-of-empires/pull/3423) by [@jerome-benoit](https://github.com/jerome-benoit) ([`6500195`](https://github.com/agent-of-empires/agent-of-empires/commit/6500195718192b91aa7bb3d8e50b3c008432e308))
+- **tui:** Finalize session creation atomically in [#3424](https://github.com/agent-of-empires/agent-of-empires/pull/3424) by [@jerome-benoit](https://github.com/jerome-benoit) ([`7148ad5`](https://github.com/agent-of-empires/agent-of-empires/commit/7148ad5efac4f44d7ee1598fd9ddd1a71a67d1a1))
+- **session:** Require a regular file in the container transcript scan in [#3467](https://github.com/agent-of-empires/agent-of-empires/pull/3467) by [@blueagledev](https://github.com/blueagledev) ([`4861602`](https://github.com/agent-of-empires/agent-of-empires/commit/48616026b06ebc60a0deca9b1e6e340f2221e9cd))
+- **containers:** Bound runtime control commands in [#3458](https://github.com/agent-of-empires/agent-of-empires/pull/3458) by [@jerome-benoit](https://github.com/jerome-benoit) ([`560d6a8`](https://github.com/agent-of-empires/agent-of-empires/commit/560d6a8d0b63f4e1a285790ffa1ebf898afb7798))
+- **web:** Keep plugin panes closed by default in [#3464](https://github.com/agent-of-empires/agent-of-empires/pull/3464) by [@karljuhlthefool](https://github.com/karljuhlthefool) ([`91e3370`](https://github.com/agent-of-empires/agent-of-empires/commit/91e3370268cd8c919f7da3bb4f48f75886d5da1e))
+- **git:** Bound worktree mutation commands in [#3457](https://github.com/agent-of-empires/agent-of-empires/pull/3457) by [@jerome-benoit](https://github.com/jerome-benoit) ([`d91186f`](https://github.com/agent-of-empires/agent-of-empires/commit/d91186f82c5253c133dd2c24b5064afa778ab62f))
+- **core:** Enforce session rename uniqueness in [#3411](https://github.com/agent-of-empires/agent-of-empires/pull/3411) by [@jerome-benoit](https://github.com/jerome-benoit) ([`c93e0ec`](https://github.com/agent-of-empires/agent-of-empires/commit/c93e0ec4c99c6e69e93d7421fefe20ca2e8f5f2a))
+
+
+### Features
+
+- **tui:** Add codex quick permission responses in [#3347](https://github.com/agent-of-empires/agent-of-empires/pull/3347) by [@athal7](https://github.com/athal7) ([`4768122`](https://github.com/agent-of-empires/agent-of-empires/commit/4768122945874beac2f29ecf95be65ad98bfdd36))
+- **tui:** Add optional memory diagnostics strip in [#3326](https://github.com/agent-of-empires/agent-of-empires/pull/3326) by [@MatthewWolff](https://github.com/MatthewWolff) ([`9ed5799`](https://github.com/agent-of-empires/agent-of-empires/commit/9ed579937cde8bf29c1d2873dd3e7c4612d6ece7))
+- **plugin:** Add home-pane UI extensions in [#3346](https://github.com/agent-of-empires/agent-of-empires/pull/3346) by [@MatthewWolff](https://github.com/MatthewWolff) ([`8d69fb3`](https://github.com/agent-of-empires/agent-of-empires/commit/8d69fb379d3fa0be4f85abfd4cc27b9290cc917e))
+- **web:** Add conversation font size controls to the structured view in [#3299](https://github.com/agent-of-empires/agent-of-empires/pull/3299) by [@summelon](https://github.com/summelon) ([`1dec841`](https://github.com/agent-of-empires/agent-of-empires/commit/1dec8419e69a0a97a5379c9d3c2460ab2b3fab19))
+- **worktree:** Per-repo base branches in multi-repo workspaces, and a per-repo diff base in [#3333](https://github.com/agent-of-empires/agent-of-empires/pull/3333) by [@Seluj78](https://github.com/Seluj78) ([`59628ac`](https://github.com/agent-of-empires/agent-of-empires/commit/59628acac833286e53f0e55323600e37a8885e74))
+- **cli:** Filter and expose session state in `aoe list` in [#3361](https://github.com/agent-of-empires/agent-of-empires/pull/3361) by [@MatthewWolff](https://github.com/MatthewWolff) ([`2110173`](https://github.com/agent-of-empires/agent-of-empires/commit/21101735671f9fef396de098a399920a0df6e6e5))
+- **sv:** Mobile UX fixes, agent inheritance, sandbox sub-agent transcript in [#3386](https://github.com/agent-of-empires/agent-of-empires/pull/3386) by [@njbrake](https://github.com/njbrake) ([`67407b6`](https://github.com/agent-of-empires/agent-of-empires/commit/67407b6e6e5590efbd69979b38e1a650f2a06f8b))
+- **web:** Show hidden folders toggle in the directory browser in [#3443](https://github.com/agent-of-empires/agent-of-empires/pull/3443) by [@Seluj78](https://github.com/Seluj78) ([`a412957`](https://github.com/agent-of-empires/agent-of-empires/commit/a41295782a3bf029f0f11639f9b8af78bf9f0147))
+- **cli:** Add state and timestamps to `session show --json` in [#3414](https://github.com/agent-of-empires/agent-of-empires/pull/3414) by [@blueagledev](https://github.com/blueagledev) ([`a5d33d0`](https://github.com/agent-of-empires/agent-of-empires/commit/a5d33d06ce3b6ba65addcb8dbedfed14eafed5c0))
+
+
+### Other
+
+- Merge pull request #3345 from jerome-benoit/test/absolute-shell-path-independent in [#3345](https://github.com/agent-of-empires/agent-of-empires/pull/3345) by [@njbrake](https://github.com/njbrake) ([`b25f96d`](https://github.com/agent-of-empires/agent-of-empires/commit/b25f96d51c1353d24ec8c9516e672eb8b2a69362))
+- Remove Star History section from README by [@njbrake](https://github.com/njbrake) ([`f1177fc`](https://github.com/agent-of-empires/agent-of-empires/commit/f1177fc289fad11e75d5d2be2b27daf1d36b7b31))
+
+
+
+### New Contributors
+
+- [@karljuhlthefool](https://github.com/karljuhlthefool) made their first contribution in [#3464](https://github.com/agent-of-empires/agent-of-empires/pull/3464)
+- [@blueagledev](https://github.com/blueagledev) made their first contribution in [#3467](https://github.com/agent-of-empires/agent-of-empires/pull/3467)
+- [@amatouhake](https://github.com/amatouhake) made their first contribution in [#3385](https://github.com/agent-of-empires/agent-of-empires/pull/3385)
+- [@klubrake](https://github.com/klubrake) made their first contribution in [#3431](https://github.com/agent-of-empires/agent-of-empires/pull/3431)
+- [@floze-the-genius](https://github.com/floze-the-genius) made their first contribution in [#3356](https://github.com/agent-of-empires/agent-of-empires/pull/3356)
+- [@mikaoelitiana](https://github.com/mikaoelitiana) made their first contribution in [#3339](https://github.com/agent-of-empires/agent-of-empires/pull/3339)
+
+**Full Changelog**: https://github.com/agent-of-empires/agent-of-empires/compare/v1.14.1...v1.15.0
 ## [1.14.1](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.14.1) - 2026-08-12
 
 
@@ -3355,4 +3435,5 @@ The format follows [Conventional Commits](https://www.conventionalcommits.org/).
 ### New Contributors
 
 - [@njbrake](https://github.com/njbrake) made their first contribution in [#](https://github.com/agent-of-empires/agent-of-empires/pull/)
+
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agent-of-empires"
-version = "1.14.1"
+version = "1.15.0"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask", "aoe-settings-derive", "aoe-plugin-api"]
 
 [package]
 name = "agent-of-empires"
-version = "1.14.1"
+version = "1.15.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Agent of Empires Contributors"]


### PR DESCRIPTION
<!-- release-version: 1.15.0 -->

Automated weekly release-staging PR (#1140).

**Current:** `v1.14.1`  
**Proposed:** `v1.15.0` (bump: `minor`)

If you want a different semver bump, edit `Cargo.toml` + `Cargo.lock` on this branch, push the change, and the merge tagger will use whatever version is in `Cargo.toml` at merge time. The `<!-- release-version: ... -->` marker above is cross-checked by the tagger and must match.

## Changes since v1.14.1

- fix(core): enforce session rename uniqueness (#3411) (`c93e0ec4`, Jérôme Benoit, 2026-08-21)
- fix(git): bound worktree mutation commands (#3457) (`d91186f8`, Jérôme Benoit, 2026-08-21)
- fix(web): keep plugin panes closed by default (#3464) (`91e33702`, Karl Juhl, 2026-08-21)
- fix(containers): bound runtime control commands (#3458) (`560d6a8d`, Jérôme Benoit, 2026-08-21)
- docs(worktrees): qualify running rename exception (#3455) (`2a82eb23`, Jérôme Benoit, 2026-08-21)
- fix(session): require a regular file in the container transcript scan (#3467) (`48616026`, blueagle.dev, 2026-08-21)
- fix(tui): finalize session creation atomically (#3424) (`7148ad5e`, Jérôme Benoit, 2026-08-21)
- docs(contrib): archived_at and trashed_at do not clear alike (#3470) (`10f6e0c2`, blueagle.dev, 2026-08-21)
- docs(session): archive() is not cleared by the attention signal (#3453) (`f257883d`, blueagle.dev, 2026-08-21)
- fix(storage): preserve atomic write error contract (#3423) (`65001957`, Jérôme Benoit, 2026-08-20)
- fix(session): reject duplicate smart rename titles (#3426) (`42c9b9dd`, Jérôme Benoit, 2026-08-20)
- test(session): pin SHELL in the hook tests that spawn one (#3451) (`a69b29d5`, blueagle.dev, 2026-08-20)
- test(session): move the launch-path test onto the default serial key (#3452) (`d282b0ea`, blueagle.dev, 2026-08-20)
- fix(sv): keep workers alive for cwd-stable renames (#3428) (`5762f006`, Jérôme Benoit, 2026-08-20)
- fix(session): require a regular file in the Claude transcript scan (#3454) (`a7ebc08e`, blueagle.dev, 2026-08-20)
- test(session): stop assuming an FHS layout in the launch-path tests (#3421) (`24226821`, blueagle.dev, 2026-08-19)
- fix(build): stop watching .git/index for the build-version rerun trigger (#3432) (`b094cf96`, Chris Werner Rau, 2026-08-19)
- feat(cli): add state and timestamps to `session show --json` (#3414) (`a5d33d06`, blueagle.dev, 2026-08-19)
- fix(acp): accept standard session/load response (#3385) (`07751aa1`, amatouhake, 2026-08-19)
- fix(tmux): require an idle pane for the folder-trust arm (#3447) (`e04d7270`, Nathan Brake, 2026-08-19)
- Remove Star History section from README (`f1177fc2`, Nathan Brake, 2026-08-19)
- chore(deps-dev): bump eslint-plugin-react-refresh from 0.5.3 to 0.5.4 in /web (#3436) (`40ce862b`, dependabot[bot], 2026-08-19)
- fix(acp)!: scope ambient Claude credentials (#3382) (`710ac06e`, Shixi Li, 2026-08-19)
- chore(deps): bump @assistant-ui/react from 0.15.1 to 0.15.14 in /web (#3434) (`587ee1e4`, dependabot[bot], 2026-08-19)
- chore(deps): bump the web-minor-patch group across 1 directory with 5 updates (#3433) (`1a972438`, dependabot[bot], 2026-08-19)
- feat(web): show hidden folders toggle in the directory browser (#3443) (`a4129578`, Jules Lasne, 2026-08-19)
- chore(deps): bump the ai-sdk group (#3439) (`aaddf6af`, dependabot[bot], 2026-08-18)
- fix(tui): let tmux decide bracketed paste on live-send multi-line pastes (#3431) (`0910523b`, klubrake, 2026-08-18)
- fix(tmux): read Claude's folder-trust prompt as waiting, not idle (#3412) (`a4361e88`, blueagle.dev, 2026-08-18)
- chore(deps-dev): bump oxfmt from 0.61.0 to 0.62.0 in /web (#3435) (`a79f9a83`, dependabot[bot], 2026-08-18)
- chore(deps): bump the cargo-minor-patch group with 2 updates (#3438) (`61061a8c`, dependabot[bot], 2026-08-18)
- chore(deps): bump astro in /website in the website-minor-patch group (#3437) (`3525d416`, dependabot[bot], 2026-08-18)
- chore(deps): keep pre-1.0 web packages out of the grouped minor bumps (#3409) (`286fc117`, Nathan Brake, 2026-08-18)
- fix(tmux): omp provider errors and retries no longer read Idle (#3383) (`5e38f7f9`, Jérôme Benoit, 2026-08-18)
- fix(session): scope hermes conversation capture to the project (#3381) (`8a5a4ed8`, Jérôme Benoit, 2026-08-18)
- fix(sv): adopt the daemon's turn_active so steered prompts stop wedging the composer (#3419) (`5d9dccbd`, Jules Lasne, 2026-08-18)
- fix(web): splice slash commands at the caret through the DOM (#3420) (`c6a41c40`, Jules Lasne, 2026-08-18)
- fix(web): let diff comments send to a dormant session, and say why when Send is blocked (#3416) (`26e5fe93`, Jules Lasne, 2026-08-18)
- fix(session): resolve Claude's config dir per profile when reading its state (#3410) (`d2b76ff1`, Nathan Brake, 2026-08-17)
- chore(deps): bump the web-minor-patch group in /web with 16 updates (#3394) (`2b6386a4`, dependabot[bot], 2026-08-17)
- refactor(sv): move structured-view state ownership to the daemon (#3390) (`23f5bc5b`, Nathan Brake, 2026-08-17)
- feat(sv): mobile UX fixes, agent inheritance, sandbox sub-agent transcript (#3386) (`67407b6e`, Nathan Brake, 2026-08-17)
- fix(tui): confirm the quick-delete shortcut instead of trashing on one keystroke (#3408) (`efb73aef`, klubrake, 2026-08-17)
- chore(deps): bump @agentclientprotocol/codex-acp (#3396) (`78914226`, dependabot[bot], 2026-08-17)
- chore(deps): bump the ai-sdk group (#3395) (`bf85989a`, dependabot[bot], 2026-08-17)
- chore(deps): bump the actions-minor-patch group with 2 updates (#3393) (`6de49d33`, dependabot[bot], 2026-08-17)
- chore(deps): bump syn from 2.0.119 to 3.0.2 (#3392) (`87ebec72`, dependabot[bot], 2026-08-17)
- chore(deps): bump the cargo-minor-patch group with 8 updates (#3391) (`31a802e3`, dependabot[bot], 2026-08-17)
- fix(config): never treat the global config.toml as a repo config (#3407) (`71bf9273`, Nathan Brake, 2026-08-17)
- fix(logging): put method and route template on http.request completion (#3405) (`9b0572f7`, Nathan Brake, 2026-08-17)
- fix(serve): stop reporting a force-stop teardown race as a server fault (#3406) (`dd05c9b8`, Nathan Brake, 2026-08-17)
- fix(logging): keep expected git failures and disabled plugins out of WARN (#3404) (`82cefedd`, Nathan Brake, 2026-08-17)
- fix(session): resolve a stale agent_detect_as alias instead of freezing at Idle (#3398) (`9881155b`, Nathan Brake, 2026-08-17)
- fix(web): fall back to main-thread highlighting when the diff worker fails to load (#3363) (`2f106f19`, Jules Lasne, 2026-08-17)
- refactor(tmux): dedupe the managed-setting write emitter (#3366) (`0e8d263b`, Jérôme Benoit, 2026-08-14)
- fix(acp): forward non-Claude provider keys to their ACP adapters (#3360) (`de6dc539`, Matthew Wolff, 2026-08-14)
- feat(cli): filter and expose session state in `aoe list` (#3361) (`21101735`, Matthew Wolff, 2026-08-14)
- fix(test): wait for the pane command to exec instead of sleeping 200ms (#3367) (`05f9206e`, Nathan Brake, 2026-08-14)
- fix(tui): report sandbox container usage in System Health (#3365) (`dda9a27f`, Nathan Brake, 2026-08-14)
- fix(config): surface config load errors and unrecognized keys (#3358) (`93828404`, Matthew Wolff, 2026-08-14)
- fix(tui): give the synthetic scratch bucket its own group identity (#3357) (`e7c5780c`, Matthew Wolff, 2026-08-14)
- fix(config): stop advertising inert repo [tmux] and [sound] overrides (#3359) (`98953c95`, Matthew Wolff, 2026-08-14)
- fix(acp): allow switching structured sessions to configured custom agents (#3338) (`44cda8d0`, Karl Juhl, 2026-08-14)
- refactor(tmux): drive tmux setting application from the managed-settings table (#3351) (`0d0a5473`, Jérôme Benoit, 2026-08-14)
- feat(worktree): per-repo base branches in multi-repo workspaces, and a per-repo diff base (#3333) (`59628aca`, Jules Lasne, 2026-08-14)
- feat(web): add conversation font size controls to the structured view (#3299) (`1dec8419`, summelon, 2026-08-14)
- fix(send): claude Enter swallowed by paste-burst window leaves unsubmitted [Pasted text] (#3355) (`9a6db1ab`, Benjamin Thomas, 2026-08-13)
- docs: add Otari telemetry guide (#3356) (`5a48fbe4`, Floze, 2026-08-13)
- fix(tui): truncate settings custom-instruction preview on a char boundary (#3354) (`56ebc375`, Benjamin Thomas, 2026-08-13)
- feat(plugin): add home-pane UI extensions (#3346) (`8d69fb37`, Matthew Wolff, 2026-08-13)
- feat(tui): add optional memory diagnostics strip (#3326) (`9ed57993`, Matthew Wolff, 2026-08-13)
- feat(tui): add codex quick permission responses (#3347) (`47681229`, Andrew Thal, 2026-08-13)
- test(session): make OMP mtime fixtures portable (#3353) (`fb7a4126`, Nathan Brake, 2026-08-13)
- fix(tui): keep held keys out of paste bursts (#3352) (`76e86b63`, Nathan Brake, 2026-08-13)
- fix(tui): preserve trailing bg fills in preview captures (#3339) (`ca81ec3a`, Mika Andrianarijaona, 2026-08-13)
- fix(tui): keep poller repair off the render loop (#3348) (`5c791644`, Nathan Brake, 2026-08-13)
- fix(session): attribute OMP captures to the launching pane (#3230) (`e7a35d75`, Jérôme Benoit, 2026-08-12)
- test: make absolute_shell resolution independent of $PATH (`4102088b`, Jérôme Benoit, 2026-08-12)

## Maintainer checklist

- [ ] Version bump is appropriate for the change set
- [ ] No breaking changes hidden under `refactor:` / `chore:`
- [ ] CI is green
- [ ] Ready to ship — merge this PR to publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Released version `1.15.0`.
- Updated the package version in `Cargo.toml`.
- Added the `1.15.0` changelog entry with documented fixes, features, and other changes.

## Benefits

- Keeps package metadata and release documentation aligned.
- Provides a clear record of changes for users.

## Potential follow-up

- Verify that all release artifacts and publication workflows use version `1.15.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->