### PR TITLE
fix: cancel timed-out ACP runner handshakes

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -12,6 +12,7 @@
 //! mpsc channel into ACP requests until shutdown.
 
 use std::collections::{HashMap, VecDeque};
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
@@ -2767,6 +2768,7 @@ impl AcpClient {
         .await;
         let external_terminal_guard = control_client.as_ref().map(|_| guard);
         let external_prompt_in_flight = control_client.as_ref().map(|_| prompt_in_flight);
+        let mut handshake_control = ShutdownControlOnDrop(control_client.clone());
 
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
 
@@ -2799,8 +2801,8 @@ impl AcpClient {
             )
             .instrument(conn_span),
         );
-
         wait_for_handshake(&session_label, ready_rx, None, &install_binary).await?;
+        handshake_control.0.take();
 
         Ok(Self {
             session_id,
@@ -3200,6 +3202,19 @@ impl AcpClient {
     /// mutex (which would deadlock send_prompt).
     pub fn take_inbound(&mut self) -> Option<mpsc::Receiver<Event>> {
         self.inbound.take()
+    }
+}
+
+/// Cancel a socket handshake if its constructor is dropped before completion.
+/// Closing the exact runner control channel cancels only that runner.
+struct ShutdownControlOnDrop(Option<Arc<DaemonControlClient>>);
+
+impl Drop for ShutdownControlOnDrop {
+    fn drop(&mut self) {
+        if let Some(control) = self.0.take() {
+            // SAFETY: `control` keeps this exact socket alive for the call.
+            unsafe { libc::shutdown(control.raw_fd, libc::SHUT_RDWR) };
+        }
     }
 }
 
@@ -4043,6 +4058,7 @@ struct DaemonControlClient {
     write: Mutex<tokio::net::unix::OwnedWriteHalf>,
     handshake_rx: Mutex<mpsc::Receiver<ControlBody>>,
     completion: Arc<std::sync::Mutex<Option<oneshot::Sender<control_protocol::PromptOutcome>>>>,
+    raw_fd: RawFd,
 }
 
 impl DaemonControlClient {
@@ -4286,10 +4302,12 @@ async fn connect_runner_control_v2(
         }
     });
 
+    let raw_fd = write_half.as_ref().as_raw_fd();
     Some(Arc::new(DaemonControlClient {
         write: Mutex::new(write_half),
         handshake_rx: Mutex::new(hs_rx),
         completion,
+        raw_fd,
     }))
 }
 

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -55,7 +55,7 @@ use serde::Deserialize;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::process::{Child, Command};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, watch, Mutex};
 use tracing::{debug, info, warn};
 
 use super::worker_registry::{self, WorkerRecord};
@@ -360,7 +360,7 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
     let control_shared = Arc::clone(&shared);
     let control_session = args.session_id.clone();
     let control_stdin = Arc::clone(&agent_stdin);
-    let control_accept_task = tokio::spawn(async move {
+    let mut control_accept_task = tokio::spawn(async move {
         loop {
             match control_listener.accept().await {
                 Ok((stream, _addr)) => {
@@ -369,13 +369,16 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
                         session = %control_session,
                         "daemon connected (control channel)"
                     );
-                    handle_control_connection(
+                    if handle_control_connection(
                         stream,
                         Arc::clone(&control_shared),
                         Arc::clone(&control_stdin),
                         control_session.clone(),
                     )
-                    .await;
+                    .await
+                    {
+                        return;
+                    }
                     info!(
                         target: "acp.runner",
                         session = %control_session,
@@ -517,6 +520,21 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         }
         _ = accept_loop => {
             warn!(target: "acp.runner", session = %session_id, "accept loop exited unexpectedly");
+        }
+        result = &mut control_accept_task => {
+            match result {
+                Ok(()) => {
+                    // The daemon owns path cleanup after cancelling an
+                    // incomplete handshake and may already have spawned a
+                    // replacement. Never unlink that replacement here.
+                    preserve_registry = true;
+                }
+                Err(error) => {
+                    warn!(target: "acp.runner", session = %session_id, "control accept task failed: {error}");
+                }
+            }
+            let _ = agent_child.start_kill();
+            let _ = agent_child.wait().await;
         }
     }
 
@@ -1704,6 +1722,27 @@ async fn handle_connection(
     shared.clear_outbound().await;
 }
 
+enum ControlRead {
+    Frame(ControlBody),
+    Closed,
+    Failed(String),
+}
+
+async fn await_handshake_or_control_loss<T>(
+    control_closed: &mut watch::Receiver<bool>,
+    handshake: impl std::future::Future<Output = T>,
+) -> Option<T> {
+    if *control_closed.borrow() {
+        return None;
+    }
+    tokio::pin!(handshake);
+    tokio::select! {
+        biased;
+        _ = control_closed.changed() => None,
+        result = &mut handshake => Some(result),
+    }
+}
+
 /// Handle one control-channel connection (#2976 Phase B). Greets with
 /// `Hello`, installs the persistent write half (draining any completion
 /// buffered across a no-daemon gap), then drives the runner-owned protocol:
@@ -1724,7 +1763,7 @@ async fn handle_control_connection(
     shared: Arc<RunnerShared>,
     agent_stdin: Arc<Mutex<tokio::process::ChildStdin>>,
     session_id: String,
-) {
+) -> bool {
     let (mut read_half, write_half) = stream.into_split();
     let mut write_half = Some(write_half);
     if !shared
@@ -1732,25 +1771,60 @@ async fn handle_control_connection(
         .await
     {
         shared.clear_control_outbound().await;
-        return;
+        return false;
     }
-    loop {
-        let body = match control_protocol::read_frame(&mut read_half).await {
-            Ok(Some(body)) => body,
-            Ok(None) => break, // clean EOF: daemon closed the control socket.
-            Err(e) => {
-                warn!(
-                    target: "acp.runner",
-                    session = %session_id,
-                    "control read error: {e}"
-                );
-                break;
+
+    let (frame_tx, mut frame_rx) = mpsc::channel(8);
+    let (control_closed_tx, mut control_closed_rx) = watch::channel(false);
+    let reader_session = session_id.clone();
+    let frame_reader = tokio::spawn(async move {
+        loop {
+            match control_protocol::read_frame(&mut read_half).await {
+                Ok(Some(frame)) => match frame_tx.try_send(ControlRead::Frame(frame)) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Closed(_)) => return,
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        warn!(target: "acp.runner", session = %reader_session, "control command queue exceeded capacity");
+                        let _ = control_closed_tx.send(true);
+                        return;
+                    }
+                },
+                Ok(None) => {
+                    let _ = frame_tx.try_send(ControlRead::Closed);
+                    let _ = control_closed_tx.send(true);
+                    return;
+                }
+                Err(error) => {
+                    let _ = frame_tx.try_send(ControlRead::Failed(error.to_string()));
+                    let _ = control_closed_tx.send(true);
+                    return;
+                }
+            }
+        }
+    });
+
+    let mut handshake_complete = shared.acp_session_id().await.is_some();
+    let terminate_runner = 'connection: loop {
+        let body = match frame_rx.recv().await {
+            Some(ControlRead::Frame(frame)) => frame,
+            Some(ControlRead::Closed) | None => break 'connection !handshake_complete,
+            Some(ControlRead::Failed(error)) => {
+                warn!(target: "acp.runner", session = %session_id, "control read error: {error}");
+                break 'connection !handshake_complete;
             }
         };
         match body {
             ControlBody::Attach { .. } => {}
             ControlBody::Initialize { request } => {
-                let frame = match shared.run_or_replay_initialize(&agent_stdin, request).await {
+                let Some(result) = await_handshake_or_control_loss(
+                    &mut control_closed_rx,
+                    shared.run_or_replay_initialize(&agent_stdin, request),
+                )
+                .await
+                else {
+                    break 'connection true;
+                };
+                let frame = match result {
                     Ok(result) => ControlBody::Initialized { result },
                     Err(error) => {
                         warn!(target: "acp.runner", session = %session_id, "initialize failed: {error}");
@@ -1760,14 +1834,22 @@ async fn handle_control_connection(
                 shared.emit_control(frame).await;
             }
             ControlBody::EstablishSession { method, request } => {
-                let frame = match shared
-                    .run_or_replay_session(&agent_stdin, &method, request)
-                    .await
-                {
-                    Ok((acp_session_id, result)) => ControlBody::SessionReady {
-                        acp_session_id,
-                        result,
-                    },
+                let Some(result) = await_handshake_or_control_loss(
+                    &mut control_closed_rx,
+                    shared.run_or_replay_session(&agent_stdin, &method, request),
+                )
+                .await
+                else {
+                    break 'connection true;
+                };
+                let frame = match result {
+                    Ok((acp_session_id, result)) => {
+                        handshake_complete = true;
+                        ControlBody::SessionReady {
+                            acp_session_id,
+                            result,
+                        }
+                    }
                     Err(error) => {
                         warn!(target: "acp.runner", session = %session_id, "{method} failed: {error}");
                         ControlBody::HandshakeFailed { error }
@@ -1792,8 +1874,10 @@ async fn handle_control_connection(
             // Runner -> daemon frames should never arrive here; ignore.
             _ => {}
         }
-    }
+    };
+    frame_reader.abort();
     shared.clear_control_outbound().await;
+    terminate_runner
 }
 
 fn spawn_agent(

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -84,7 +84,7 @@ fn wait_for_u32(path: &Path, what: &str) -> u32 {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(value) = std::fs::read_to_string(path) {
-            if let Ok(value) = value.parse() {
+            if let Ok(value) = value.trim().parse() {
                 return value;
             }
         }

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -22,6 +22,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
+use agent_of_empires::acp::acp_client::AcpClient;
+use agent_of_empires::acp::state::AcpSessionId;
+
 /// App data dir for the debug binary under this test's env, mirroring the
 /// XDG resolution the runner uses.
 fn app_dir(home: &Path, xdg: &Path) -> PathBuf {
@@ -73,6 +76,51 @@ fn wait_for(path: &Path, what: &str) {
         if Instant::now() > deadline {
             panic!("{what} never appeared at {}", path.display());
         }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for_u32(path: &Path, what: &str) -> u32 {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(value) = std::fs::read_to_string(path) {
+            if let Ok(value) = value.parse() {
+                return value;
+            }
+        }
+        if Instant::now() > deadline {
+            panic!("{what} never became a u32 at {}", path.display());
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for_runner_exit(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if child.try_wait().expect("inspect runner").is_some() {
+            return;
+        }
+        assert!(Instant::now() < deadline, "timed-out runner stayed live");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for_record_pid(path: &Path, pid: u32) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if std::fs::read(path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+            .and_then(|record| record["pid"].as_u64())
+            == Some(u64::from(pid))
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "replacement record never appeared"
+        );
         std::thread::sleep(Duration::from_millis(50));
     }
 }
@@ -177,11 +225,14 @@ fn runner_reports_native_prompt_complete_over_control_socket() {
 
 /// Write a length-prefixed control frame (4-byte big-endian length, then
 /// the JSON body).
-fn write_frame(stream: &mut UnixStream, body: &serde_json::Value) {
+fn encode_frame(body: &serde_json::Value) -> Vec<u8> {
     let json = serde_json::to_vec(body).expect("serialize frame");
     let len = (json.len() as u32).to_be_bytes();
-    stream.write_all(&len).expect("write frame length");
-    stream.write_all(&json).expect("write frame body");
+    [len.as_slice(), &json].concat()
+}
+
+fn write_frame(stream: &mut UnixStream, body: &serde_json::Value) {
+    stream.write_all(&encode_frame(body)).expect("write frame");
     stream.flush().expect("flush frame");
 }
 
@@ -198,6 +249,217 @@ fn find_python3() -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[tokio::test]
+async fn cancelled_attach_reaps_runner_and_replacement_survives_load_fallback() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    let Some(python3) = find_python3() else {
+        eprintln!("skipping: python3 not found for fake ACP agent");
+        return;
+    };
+
+    let scratch = Scratch::new("latehs");
+    let home = scratch.0.join("home");
+    let xdg = scratch.0.join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+
+    let agent_log = scratch.0.join("agent-methods.log");
+    let agent_pid_file = scratch.0.join("agent.pid");
+    let agent_py = scratch.0.join("delayed_agent.py");
+    std::fs::write(
+        &agent_py,
+        r#"
+import json, os, sys, time
+with open(os.environ["AOE_FAKE_AGENT_PID"], "w") as f:
+    f.write(str(os.getpid()))
+for line in sys.stdin:
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    method = msg.get("method")
+    mid = msg.get("id")
+    if method is None or mid is None:
+        continue
+    with open(os.environ["AOE_FAKE_AGENT_LOG"], "a") as f:
+        f.write(method + "\n")
+    if method == "initialize":
+        time.sleep(int(os.environ["AOE_FAKE_INIT_DELAY_MS"]) / 1000)
+        result = {"protocolVersion": 1, "agentCapabilities": {"loadSession": True, "promptCapabilities": {}}}
+    elif method == "session/load" and os.environ["AOE_FAKE_LOAD_ERROR"] == "1":
+        error = {"code": -32000, "message": "stored session unavailable"}
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": mid, "error": error}) + "\n")
+        sys.stdout.flush()
+        continue
+    elif method == "session/new":
+        result = {"sessionId": "fresh-thread"}
+    else:
+        result = {}
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": mid, "result": result}) + "\n")
+    sys.stdout.flush()
+"#,
+    )
+    .unwrap();
+
+    let session_id = "slate001";
+    let workers = app_dir(&home, &xdg).join("acp-workers");
+    let socket = workers.join(format!("{session_id}.sock"));
+    let control = workers.join(format!("{session_id}.control.sock"));
+    let record = workers.join(format!("{session_id}.json"));
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let spawn_runner = |delay: &str, fail_load: bool| {
+        Command::new(bin)
+            .args([
+                "__acp-runner",
+                "--socket",
+                socket.to_str().unwrap(),
+                "--session-id",
+                session_id,
+                "--agent-name",
+                "fake-agent",
+                "--cwd",
+                home.to_str().unwrap(),
+                "--",
+                python3.to_str().unwrap(),
+                agent_py.to_str().unwrap(),
+            ])
+            .env("HOME", &home)
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("AOE_FAKE_AGENT_LOG", &agent_log)
+            .env("AOE_FAKE_AGENT_PID", &agent_pid_file)
+            .env("AOE_FAKE_INIT_DELAY_MS", delay)
+            .env("AOE_FAKE_LOAD_ERROR", if fail_load { "1" } else { "0" })
+            .env("AOE_ACP_WATCHDOG_POLL_MS", "5000")
+            .spawn()
+            .expect("spawn acp runner")
+    };
+
+    let mut old = KillOnDrop(spawn_runner("2000", false));
+    wait_for(&record, "old registry record");
+    wait_for(&control, "old control socket");
+    wait_for(&socket, "old relay socket");
+    let old_agent_pid = wait_for_u32(&agent_pid_file, "old agent pid");
+
+    let attach = async {
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            AcpClient::attach(
+                socket.clone(),
+                home.clone(),
+                vec![],
+                "stored-codex-thread".into(),
+                false,
+                AcpSessionId(session_id.into()),
+                None,
+                "fake-agent".into(),
+                None,
+            ),
+        )
+        .await
+    };
+    let spawn_replacement = async {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while !std::fs::read_to_string(&agent_log)
+            .unwrap_or_default()
+            .lines()
+            .any(|method| method == "initialize")
+        {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "old runner never began initialize"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let replacement = KillOnDrop(spawn_runner("750", true));
+        wait_for_record_pid(&record, replacement.0.id());
+        replacement
+    };
+    let (attach, mut replacement) = tokio::join!(attach, spawn_replacement);
+    assert!(
+        attach.is_err(),
+        "delayed initialize must exceed the attach budget"
+    );
+    wait_for_runner_exit(&mut old.0);
+    assert!(
+        !agent_of_empires::process::worker_registry::is_pid_alive(old_agent_pid),
+        "timed-out agent {old_agent_pid} stayed live"
+    );
+    assert!(
+        replacement
+            .0
+            .try_wait()
+            .expect("inspect replacement")
+            .is_none()
+            && record.exists()
+            && socket.exists()
+            && control.exists(),
+        "old runner teardown removed the replacement runner's files"
+    );
+
+    let baseline = std::fs::read_to_string(&agent_log)
+        .unwrap_or_default()
+        .lines()
+        .filter(|method| *method == "initialize")
+        .count();
+    let mut ctl = UnixStream::connect(&control).expect("connect replacement control");
+    ctl.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    assert_eq!(read_frame(&mut ctl)["kind"], "hello");
+    write_frame(
+        &mut ctl,
+        &serde_json::json!({"kind": "attach", "control_protocol_version": 2}),
+    );
+    write_frame(
+        &mut ctl,
+        &serde_json::json!({"kind": "initialize", "request": {"protocolVersion": 1}}),
+    );
+    let load = encode_frame(&serde_json::json!({
+        "kind": "establish_session",
+        "method": "session/load",
+        "request": {"sessionId": "stored-codex-thread", "cwd": home.to_str().unwrap()}
+    }));
+    ctl.write_all(&load[..2]).expect("write partial frame");
+    ctl.flush().expect("flush partial frame");
+    std::thread::sleep(Duration::from_millis(150));
+    assert_eq!(read_frame(&mut ctl)["kind"], "initialized");
+    ctl.write_all(&load[2..]).expect("finish partial frame");
+    ctl.flush().expect("flush completed frame");
+    assert_eq!(read_frame(&mut ctl)["kind"], "handshake_failed");
+    assert!(
+        replacement
+            .0
+            .try_wait()
+            .expect("inspect replacement")
+            .is_none()
+            && record.exists()
+            && socket.exists()
+            && control.exists(),
+        "recoverable session/load error tore down the replacement runner"
+    );
+    write_frame(
+        &mut ctl,
+        &serde_json::json!({
+            "kind": "establish_session",
+            "method": "session/new",
+            "request": {"cwd": home.to_str().unwrap()}
+        }),
+    );
+    let ready = read_frame(&mut ctl);
+    assert_eq!(ready["kind"], "session_ready");
+    assert_eq!(ready["acp_session_id"], "fresh-thread");
+
+    let methods = std::fs::read_to_string(&agent_log).unwrap_or_default();
+    assert_eq!(
+        methods.lines().filter(|m| *m == "initialize").count(),
+        baseline + 1
+    );
+    assert_eq!(methods.lines().filter(|m| *m == "session/load").count(), 1);
+    assert_eq!(methods.lines().filter(|m| *m == "session/new").count(), 1);
+
+    drop(replacement);
 }
 
 /// #2976 Phase B: the runner owns the ACP handshake. Drive it as a v2


### PR DESCRIPTION
Fixes #3474.

## Summary

- close the exact runner control socket when daemon attach is cancelled
- keep one task as the control-frame reader so cancelling handshake work cannot discard a partial frame
- terminate the runner only when control is lost before its ACP session is established
- keep agent-returned handshake errors recoverable so `session/load` can fall back to `session/new`
- retain the existing registry cleanup for timeout paths with no usable v2 control channel

The broader lifecycle redesign raised during review remains deferred to #3487.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --test acp_runner_control --features serve` (5/5)
- `AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo clippy --all-features -- -D warnings -A clippy::duplicated-attributes`

The narrow Clippy allowance is for one unchanged current-main lint emitted by the local Rust 1.93.1 toolchain in `src/tui/dialogs/serve.rs`; current upstream-main CI is green.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing affected tests pass
- [x] Documentation was updated where necessary: N/A; no documented interface changed
- [x] For UI changes: N/A; no UI changes

## Test Coverage Analysis

**Web dashboard / structured view**
- [x] N/A: backend runner lifecycle only
- [ ] Added or updated a Playwright spec
- [ ] Skipped a test, because:

**TUI / CLI**
- [x] N/A: no TUI or CLI behavior changed
- [ ] Added or updated an e2e test
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

- [x] I am an AI Agent filling out this form
