### PR TITLE
fix(web): cap tool-call group size and memoize group children

### DIFF
--- a/web/src/components/acp/AcpRuntime.test.ts
+++ b/web/src/components/acp/AcpRuntime.test.ts
@@ -106,6 +106,44 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     expect(toolParts[0]!.toolName).toBe(TOOL_GROUP_NAME);
   });
 
+  it("chunks long runs into bounded groups (#3477)", () => {
+    const runOf = (n: number): ActivityRow[] => [
+      userRow("go"),
+      ...Array.from({ length: n }, (_, i) => toolStart(`t${i}`)),
+    ];
+    const groupsIn = (n: number) => {
+      const messages = activityToThreadMessages(runOf(n), false);
+      const assistant = messages.find((m) => m.role === "assistant")!;
+      const parts = assistant.content as Array<{
+        type: string;
+        toolName?: string;
+        argsText?: string;
+      }>;
+      return {
+        groups: parts.filter((p) => p.type === "tool-call" && p.toolName === TOOL_GROUP_NAME),
+        inline: parts.filter((p) => p.type === "tool-call" && p.toolName !== TOOL_GROUP_NAME),
+      };
+    };
+
+    // At the max chunk size, still one group.
+    const ten = groupsIn(10);
+    expect(ten.groups).toHaveLength(1);
+    expect(ten.inline).toHaveLength(0);
+    expect(JSON.parse(ten.groups[0]!.argsText!).children).toHaveLength(10);
+
+    // Just over the max: first chunk groups, tail is too short to group.
+    const eleven = groupsIn(11);
+    expect(eleven.groups).toHaveLength(1);
+    expect(eleven.inline).toHaveLength(1);
+
+    // Long enough to fill multiple chunks.
+    const twentyFive = groupsIn(25);
+    expect(twentyFive.groups).toHaveLength(3);
+    expect(twentyFive.inline).toHaveLength(0);
+    const grouped = twentyFive.groups.reduce((sum, g) => sum + JSON.parse(g.argsText!).children.length, 0);
+    expect(grouped).toBe(25);
+  });
+
   it("does not group runs of 1 or 2 tool calls", () => {
     const messages = activityToThreadMessages([userRow("go"), toolStart("t1"), toolStart("t2")], false);
     const assistant = messages.find((m) => m.role === "assistant")!;

--- a/web/src/components/acp/AcpRuntime.test.ts
+++ b/web/src/components/acp/AcpRuntime.test.ts
@@ -129,19 +129,40 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     const ten = groupsIn(10);
     expect(ten.groups).toHaveLength(1);
     expect(ten.inline).toHaveLength(0);
-    expect(JSON.parse(ten.groups[0]!.argsText!).children).toHaveLength(10);
+    const tenChildren = JSON.parse(ten.groups[0]!.argsText!).children as Array<{ toolCallId: string }>;
+    expect(tenChildren.map((c) => c.toolCallId)).toEqual(["t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9"]);
 
     // Just over the max: first chunk groups, tail is too short to group.
     const eleven = groupsIn(11);
     expect(eleven.groups).toHaveLength(1);
     expect(eleven.inline).toHaveLength(1);
+    const elevenChildren = JSON.parse(eleven.groups[0]!.argsText!).children as Array<{ toolCallId: string }>;
+    expect(elevenChildren.map((c) => c.toolCallId)).toEqual([
+      "t0",
+      "t1",
+      "t2",
+      "t3",
+      "t4",
+      "t5",
+      "t6",
+      "t7",
+      "t8",
+      "t9",
+    ]);
+    expect((eleven.inline[0] as { toolCallId?: string }).toolCallId).toBe("t10");
 
     // Long enough to fill multiple chunks.
     const twentyFive = groupsIn(25);
     expect(twentyFive.groups).toHaveLength(3);
     expect(twentyFive.inline).toHaveLength(0);
-    const grouped = twentyFive.groups.reduce((sum, g) => sum + JSON.parse(g.argsText!).children.length, 0);
-    expect(grouped).toBe(25);
+    const chunkSizes = twentyFive.groups.map(
+      (g) => (JSON.parse(g.argsText!).children as Array<{ toolCallId: string }>).length,
+    );
+    expect(chunkSizes).toEqual([10, 10, 5]);
+    const allIds = twentyFive.groups.flatMap((g) =>
+      (JSON.parse(g.argsText!).children as Array<{ toolCallId: string }>).map((c) => c.toolCallId),
+    );
+    expect(allIds).toEqual(Array.from({ length: 25 }, (_, i) => `t${i}`));
   });
 
   it("does not group runs of 1 or 2 tool calls", () => {

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -881,6 +881,12 @@ function collapseSubagents(parts: DraftPart[], profile: AgentProfile): DraftPart
  *  block (#1057). */
 const TOOL_GROUP_MIN_RUN = 3;
 
+/** Maximum run length that stays in a single group card. Longer runs are
+ *  chunked so one agent turn (e.g. Kimi streaming many tool calls in a
+ *  single batch) doesn't collapse the whole turn into one enormous,
+ *  slow-loading card. See #3477. */
+const TOOL_GROUP_MAX_RUN = 10;
+
 /** Synthetic toolName used for the folded group card. Namespaced with
  *  the `_aoe_` prefix so it can't collide with a real ACP tool kind. */
 export const TOOL_GROUP_NAME = "_aoe_tool_group";
@@ -929,10 +935,12 @@ function buildGroupChildren(run: DraftPart[]): {
 
 /** Walk an assistant message's parts and collapse runs of consecutive
  *  tool-call parts (regardless of kind) into one synthetic group part
- *  when the run is ≥ TOOL_GROUP_MIN_RUN long. The grouping boundary is
- *  ANY non-tool-call part (text, callout, etc.); matching the "what
+ *  when the run is ≥ TOOL_GROUP_MIN_RUN long. Runs longer than
+ *  TOOL_GROUP_MAX_RUN are chunked into multiple bounded groups so one
+ *  agent turn can't swallow the whole timeline. The grouping boundary
+ *  is ANY non-tool-call part (text, callout, etc.); matching the "what
  *  did the agent do silently before its next sentence?" UX shape. The
- *  underlying tool-call data is preserved verbatim inside the group's
+ *  underlying tool-call data is preserved verbatim inside each group's
  *  argsText payload so the renderer can expand back to the original
  *  per-tool cards on click. */
 function collapseToolRuns(parts: DraftPart[], todosEnabled: boolean): DraftPart[] {
@@ -985,16 +993,26 @@ function collapseToolRuns(parts: DraftPart[], todosEnabled: boolean): DraftPart[
         run = [];
         return;
       }
-      const { childIds, children } = buildGroupChildren(run);
-      out.push({
-        type: "tool-call",
-        // Anchor the group's React identity to the first child (see the
-        // TodoGroup note above and #2802): the full-join key changed on
-        // every append, remounting the card and re-collapsing it.
-        toolCallId: `group-${childIds[0]}`,
-        toolName: TOOL_GROUP_NAME,
-        argsText: JSON.stringify({ children }),
-      });
+      // Chunk long generic runs so one turn can't produce a single
+      // monolithic "N actions" card. The last chunk falls back to inline
+      // cards if it's too short to group on its own. See #3477.
+      for (let i = 0; i < run.length; i += TOOL_GROUP_MAX_RUN) {
+        const chunk = run.slice(i, i + TOOL_GROUP_MAX_RUN);
+        if (chunk.length < TOOL_GROUP_MIN_RUN) {
+          for (const p of chunk) out.push(p);
+          continue;
+        }
+        const { childIds, children } = buildGroupChildren(chunk);
+        out.push({
+          type: "tool-call",
+          // Anchor the group's React identity to the first child (see the
+          // TodoGroup note above and #2802): the full-join key changed on
+          // every append, remounting the card and re-collapsing it.
+          toolCallId: `group-${childIds[0]}`,
+          toolName: TOOL_GROUP_NAME,
+          argsText: JSON.stringify({ children }),
+        });
+      }
     }
     run = [];
   };

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -14,7 +14,7 @@
 // AcpRuntime.tsx. We never let assistant-ui own the chat state; it
 // only renders what we feed it and surfaces user actions back.
 
-import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { MessagePrimitive, ThreadPrimitive, useAuiState } from "@assistant-ui/react";
 import {
   AlertTriangle,
@@ -1294,12 +1294,12 @@ function groupChildToItem(c: GroupChild): {
 }
 
 function AssistantToolGroup({ argsText }: { argsText?: string }) {
-  const items = parseGroupChildren(argsText).map(groupChildToItem);
+  const items = useMemo(() => parseGroupChildren(argsText).map(groupChildToItem), [argsText]);
   return <ToolGroupCard items={items} />;
 }
 
 function AssistantTodoGroup({ argsText }: { argsText?: string }) {
-  const items = parseGroupChildren(argsText).map(groupChildToItem);
+  const items = useMemo(() => parseGroupChildren(argsText).map(groupChildToItem), [argsText]);
   return <TodoGroupCard items={items} />;
 }
 


### PR DESCRIPTION
## Description

Fixes #3477.

When Kimi streams many tool calls in one turn without interleaving text, the web structured view folds the entire turn into a single "N actions" group card. That card carries a huge JSON payload and re-parses all children on every render, making the view slow to load and re-render.

This change:

1. Caps generic tool-call grouping in `collapseToolRuns` at `TOOL_GROUP_MAX_RUN = 10`. Runs longer than that are split into multiple bounded groups (any trailing chunk smaller than `TOOL_GROUP_MIN_RUN` falls back to inline cards).
2. Memoizes child reconstruction in `AssistantToolGroup` and `AssistantTodoGroup` with `useMemo` keyed by `argsText`, so re-renders don't re-parse the full children payload.

Short "silent investigation" runs (3–10 tools) still group exactly as before. The native TUI is unaffected.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Vitest spec (`src/components/acp/AcpRuntime.test.ts`) for the new chunking behavior. The existing `coverage-matrix.json` entries already cover `AcpRuntime.tsx` and `StructuredView.tsx`.
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Kimi Code CLI / Agent of Empires session.

**Any Additional AI Details you'd like to share:**

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The web structured view now splits long consecutive tool-call runs into groups of up to 10 items. Short runs retain their existing grouping, and small trailing runs remain inline.

Tool-group child reconstruction now uses memoization to reduce repeated parsing during re-renders. Group IDs remain anchored to the first child, and native TUI rendering is unchanged.

Tests verify tool-call order, completeness, and IDs for runs of 10, 11, and 25 calls. This prevents oversized group cards and improves rendering performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->