### PR TITLE
test(tmux): fold the three trust-prompt cases into one table

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -3019,14 +3019,6 @@ enter to select · esc to cancel";
    2. No, exit
 ";
 
-    #[test]
-    fn claude_folder_trust_prompt_narrow_is_waiting() {
-        assert_eq!(
-            detect_claude_status(CLAUDE_FOLDER_TRUST_PROMPT_NARROW),
-            Status::Waiting
-        );
-    }
-
     /// The label match is anchored to the choice block, not the whole window.
     /// Window-wide collapsing found the label in ordinary prose, and because a
     /// blocking rule outranks the running signal these all reported `Waiting`
@@ -3119,19 +3111,15 @@ enter to select · esc to cancel";
     }
 
     #[test]
-    fn claude_folder_trust_prompt_wrapped_is_waiting() {
-        assert_eq!(
-            detect_claude_status(CLAUDE_FOLDER_TRUST_PROMPT_WRAPPED),
-            Status::Waiting
-        );
-    }
-
-    #[test]
     fn claude_folder_trust_prompt_is_waiting() {
-        assert_eq!(
-            detect_claude_status(CLAUDE_FOLDER_TRUST_PROMPT),
-            Status::Waiting
-        );
+        let cases = [
+            ("default", CLAUDE_FOLDER_TRUST_PROMPT),
+            ("wrapped", CLAUDE_FOLDER_TRUST_PROMPT_WRAPPED),
+            ("narrow", CLAUDE_FOLDER_TRUST_PROMPT_NARROW),
+        ];
+        for (name, fixture) in cases {
+            assert_eq!(detect_claude_status(fixture), Status::Waiting, "{name}");
+        }
     }
 
     /// The shapes the label anchor admits: an unprefixed verbatim menu row, a


### PR DESCRIPTION
## Description

Closes out the optional note on your #3412 approval: "the three
`..._is_waiting` tests could be one table-driven test over the fixture
constants, per the house one-test-per-behavior style."

The three differ only in which fixture constant they hand to
`detect_claude_status`. Two test functions go, the three assertions still run,
and the surviving name is the one that already existed. The fixtures stay where
they are; it is the assertions that come together.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed: test code only)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Test code only, and the assertion count is unchanged.

The risk in folding three cases into a loop is that one stops being exercised
and nothing says so, so I broke each row in turn. Every one fails by name:

```
break the question literal              -> failed: default
drop collapse_ascii_whitespace          -> failed: wrapped
CLAUDE_TRUST_LABEL_WRAP_LINES 4 -> 1    -> failed: narrow
```

The last of those is the label window, which only `_NARROW` needs: the other
two carry the whole label on the choice row, and what wraps in `_WRAPPED` is
the question prose. Each row is independently breakable and says which fixture
regressed, which is what the three separate names used to give. Unmutated
before and after each one: `1 passed`.

Gate against `062aa3a8`, base `74813729`:

```
cargo fmt --all --check      exit=0
cargo clippy --all-targets   exit=0   (6 warnings, none naming status_detection.rs)
```

As on #3451 and #3452, the lib suite does not go green here either way: one
`$HOME`-dependent `hooks_install` test plus a rotating set of live-tmux
`tmux::session` cases fail on unmodified `74813729` too. Neither module is in
this diff, and the failing set is not stable enough here to quote a count.

What is stable is the population. `cargo test --lib -- --list` reports 4662
tests at the base and 4660 on this branch, which is the two functions removed
and nothing else.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**
The direction and decisions are mine; the investigation, the change and this
write-up were done by Claude working from that. The suggestion is yours, from
the #3412 review.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Consolidates three Claude trust-prompt waiting tests into one table-driven test.
- Keeps all three fixture cases and labels each case for clear failure reporting.
- Removes two duplicate test functions without changing production code or fixtures.

## Benefits

- Reduces test duplication.
- Keeps coverage for default, wrapped, and narrow prompt fixtures.
- Makes future fixture additions easier.
- Formatting and Clippy checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->