### PR TITLE
fix(session): stop passive status stamps from wiping concurrent archives

### DIFF
--- a/docs/development/internals/sessions.md
+++ b/docs/development/internals/sessions.md
@@ -33,7 +33,7 @@ The canonical glossary lives on `PassiveStatusPatch` in [`src/session/instance.r
 
 Authority rule:
 
-- **Plain tmux sessions**: the poller is authoritative on `status` / `idle_entered_at` / `last_accessed_at`. `Instance::update_status_with_metadata` reads pane metadata + tmux state, compares against `live_status_baseline`, and mutates in place. `merge_passive_status_patch` on disk applies the same fields per patch.
+- **Plain tmux sessions**: the poller is authoritative on `status` / `idle_entered_at`. `last_accessed_at` is user-gesture-only since #3465: passive patches carry it through unchanged and the monotone guard turns that into a disk no-op. `Instance::update_status_with_metadata` reads pane metadata + tmux state, compares against `live_status_baseline`, and mutates in place. `merge_passive_status_patch` on disk applies the same fields per patch.
 - **Structured / ACP sessions**: `apply_acp_overlay_inplace` in `src/server/mod.rs` is the sole authority. `decide_passive_transition` returns `patch: None` for `is_structured()` rows, so the passive-status writers deliberately skip them. Post-daemon-restart the row's `idle_entered_at` resets to the last durable value (either creation-time, or the last explicit user action); ACP event handlers re-emit as they observe new state.
 
 Writer shapes:

--- a/docs/development/internals/sessions.md
+++ b/docs/development/internals/sessions.md
@@ -33,7 +33,7 @@ The canonical glossary lives on `PassiveStatusPatch` in [`src/session/instance.r
 
 Authority rule:
 
-- **Plain tmux sessions**: the poller is authoritative on `status` / `idle_entered_at`. `last_accessed_at` is user-gesture-only since #3465: passive patches carry it through unchanged and the monotone guard turns that into a disk no-op. `Instance::update_status_with_metadata` reads pane metadata + tmux state, compares against `live_status_baseline`, and mutates in place. `merge_passive_status_patch` on disk applies the same fields per patch.
+- **Plain tmux sessions**: the poller is authoritative on `status` / `idle_entered_at`. `last_accessed_at` is user-gesture-only since #3465: passive patches carry it through unchanged and the monotone guard turns that into a disk no-op. `Instance::update_status_with_metadata` reads pane metadata + tmux state, compares against `live_status_baseline`, and mutates in place. `merge_passive_status_patch` on disk applies the patch's `status` and `idle_entered_at` writes, the monotone `last_accessed_at` carry-through, and the lifecycle generation.
 - **Structured / ACP sessions**: `apply_acp_overlay_inplace` in `src/server/mod.rs` is the sole authority. `decide_passive_transition` returns `patch: None` for `is_structured()` rows, so the passive-status writers deliberately skip them. Post-daemon-restart the row's `idle_entered_at` resets to the last durable value (either creation-time, or the last explicit user action); ACP event handlers re-emit as they observe new state.
 
 Writer shapes:

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4561,7 +4561,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
         // that finds disk out of sync with live reality (the common case,
         // since nothing persists a passive transition until the patch below
         // lands) misreads that mismatch as a brand new transition and
-        // restamps idle_entered_at/last_accessed_at. See #2690.
+        // restamps idle_entered_at. See #2690.
         let prev_for_poll = prev.clone();
         // Invariant 8: read before `load_all_instances()` below. The tmux
         // scrape that follows it can block for seconds when the tmux server is

--- a/src/session/idle_reap.rs
+++ b/src/session/idle_reap.rs
@@ -88,10 +88,9 @@ pub fn idle_reap_candidates(
 /// - the idle anchor is at least `threshold_secs` in the past.
 ///
 /// The anchor is `max(idle_entered_at, last_accessed_at)`: `last_accessed_at`
-/// is bumped on user interaction (and equals `idle_entered_at` at the moment a
-/// session enters `Idle`), so a session the user recently touched is spared
-/// even if the agent went idle earlier. A negative elapsed (clock skew, anchor
-/// in the future) is treated as not-yet-eligible rather than panicking.
+/// is bumped on user interaction, so a session the user recently touched is
+/// spared even if the agent went idle earlier. A negative elapsed (clock skew,
+/// anchor in the future) is treated as not-yet-eligible rather than panicking.
 pub fn should_auto_stop_session(
     now: DateTime<Utc>,
     status: Status,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -9415,6 +9415,69 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_diff_passive_transition_stamp_does_not_wipe_concurrent_archive() {
+        // #3465: a passive status transition restamps last_accessed_at on
+        // disk (update_status_with_metadata writes Some(now) on every
+        // detected transition, with no user gesture behind it), and the
+        // stamp reaches disk through PassiveStatusPatch while an archive
+        // is landing concurrently. The writer's pre snapshot is then
+        // stale, so the deliberate `touched` arm below reads the stamp's
+        // advance as a peer touch and wipes sink state the user just set.
+        // That arm is correct for real gestures (pinned by
+        // test_merge_diff_peer_touch_clears_tui_archive, the
+        // messaging-unarchives rule); a poller stamp is not a gesture and
+        // must not dethrone a concurrent triage action.
+        //
+        // The stamp is modeled as the raw field write
+        // update_status_with_metadata performs rather than via
+        // touch_last_accessed(), because the latter would be a genuine
+        // gesture, which this suite deliberately lets win.
+        let cases: &[(&str, fn(&mut Instance), fn(&Instance) -> bool)] = &[
+            // The issue's headline victim: a concurrent archive.
+            ("archived_at", |i| i.archive(), |i| i.archived_at.is_some()),
+            // Same touched arm, same wipe, for the other two sinks.
+            (
+                "snoozed_until",
+                |i| i.snooze(15),
+                |i| i.snoozed_until.is_some(),
+            ),
+            (
+                "idle_dormant_since",
+                |i| i.idle_dormant_since = Some(Utc::now()),
+                |i| i.idle_dormant_since.is_some(),
+            ),
+        ];
+        let stale_pre_stamp = Utc::now() - chrono::Duration::seconds(60);
+        let passive_stamp = Utc::now();
+        for (field, seed_sink, sink_present) in cases {
+            // Snapshot the archiving writer held before the poller tick.
+            let mut pre = Instance::new("s", "/tmp/x");
+            pre.status = Status::Running;
+            pre.last_accessed_at = Some(stale_pre_stamp);
+
+            // Passive poller observes Running -> Idle and restamps disk,
+            // mirroring update_status_with_metadata's transition block
+            // (idle_entered_at plus last_accessed_at = Some(now)).
+            let mut disk = pre.clone();
+            disk.status = Status::Idle;
+            disk.idle_entered_at = Some(passive_stamp);
+            disk.last_accessed_at = Some(passive_stamp);
+
+            // The concurrent user action seeds the sink on the writer's
+            // post snapshot.
+            let mut post = pre.clone();
+            seed_sink(&mut post);
+
+            disk.merge_user_action_diff(&pre, &post);
+
+            assert!(
+                sink_present(&disk),
+                "passive transition stamp must not wipe concurrent {field} (#3465)"
+            );
+        }
+    }
+
+    #[test]
     fn test_merge_diff_peer_archive_clears_concurrent_tui_snooze() {
         // The web/TUI/CLI contract treats pinned/archived/snoozed as
         // mutually exclusive (the sidebar tier comparator assumes a

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -9422,7 +9422,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn test_merge_diff_passive_transition_stamp_does_not_wipe_concurrent_archive() {
+    fn test_merge_diff_passive_transition_stamp_does_not_wipe_concurrent_sink_state() {
         // #3465: a passive status transition restamped last_accessed_at
         // (update_status_with_metadata wrote Some(now) on every detected
         // transition, with no user gesture behind it), and the stamp

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -6722,12 +6722,14 @@ impl Instance {
     /// Update status using pre-fetched pane metadata to avoid per-instance
     /// subprocess spawns. Falls back to subprocess calls if metadata is missing.
     ///
-    /// Restamps `idle_entered_at`/`last_accessed_at` only when the detected
-    /// status differs from [`Self::live_status_baseline`]. The baseline
-    /// invariant lives on the field itself; this method's job is the
-    /// guard shape (baseline vs. newly detected). Every call re-seeds the
-    /// baseline at exit, so the next call compares against a value this
-    /// method itself wrote.
+    /// Restamps `idle_entered_at` only when the detected status differs from
+    /// [`Self::live_status_baseline`]. `last_accessed_at` is deliberately not
+    /// written here (#3465): it is a user-gesture signal, and a poller stamp
+    /// that advanced it on disk let `merge_user_action_diff`'s touched arm
+    /// erase a concurrently archived row. The baseline invariant lives on the
+    /// field itself; this method's job is the guard shape (baseline vs. newly
+    /// detected). Every call re-seeds the baseline at exit, so the next call
+    /// compares against a value this method itself wrote.
     pub fn update_status_with_metadata(
         &mut self,
         metadata: Option<&tmux::PaneMetadata>,
@@ -6738,8 +6740,12 @@ impl Instance {
         if let Some(prev) = baseline {
             if prev != self.status {
                 self.log_status_transition(prev);
+                // last_accessed_at is deliberately NOT restamped here
+                // (#3465): a passive advance reaches disk through
+                // PassiveStatusPatch, and merge_user_action_diff's touched
+                // arm reads any advance as a peer touch, wiping concurrent
+                // archive/snooze/dormancy writes.
                 let now = Utc::now();
-                self.last_accessed_at = Some(now);
                 self.idle_entered_at = if self.status == Status::Idle {
                     Some(now)
                 } else {
@@ -9415,53 +9421,50 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_merge_diff_passive_transition_stamp_does_not_wipe_concurrent_archive() {
-        // #3465: a passive status transition restamps last_accessed_at on
-        // disk (update_status_with_metadata writes Some(now) on every
-        // detected transition, with no user gesture behind it), and the
-        // stamp reaches disk through PassiveStatusPatch while an archive
-        // is landing concurrently. The writer's pre snapshot is then
-        // stale, so the deliberate `touched` arm below reads the stamp's
-        // advance as a peer touch and wipes sink state the user just set.
-        // That arm is correct for real gestures (pinned by
-        // test_merge_diff_peer_touch_clears_tui_archive, the
-        // messaging-unarchives rule); a poller stamp is not a gesture and
-        // must not dethrone a concurrent triage action.
+        // #3465: a passive status transition restamped last_accessed_at
+        // (update_status_with_metadata wrote Some(now) on every detected
+        // transition, with no user gesture behind it), and the stamp
+        // reached disk through PassiveStatusPatch while a user action was
+        // in flight. The writer's stale pre snapshot then made the
+        // deliberate touched arm read the advance as a peer touch and wipe
+        // sink state the user had just set. That arm is correct for real
+        // gestures (pinned by test_merge_diff_peer_touch_clears_tui_archive,
+        // the messaging-unarchives rule); the poller stamp was the lie.
         //
-        // The stamp is modeled as the raw field write
-        // update_status_with_metadata performs rather than via
-        // touch_last_accessed(), because the latter would be a genuine
-        // gesture, which this suite deliberately lets win.
-        let cases: &[(&str, fn(&mut Instance), fn(&Instance) -> bool)] = &[
+        // Driven through the real transition path: the
+        // update_status_with_metadata call below detects a genuine
+        // Idle -> Error flip (session forced Absent, see #2936), which on
+        // the pre-fix tree restamped last_accessed_at between the pre
+        // snapshot and the merge.
+        type SinkCase = (&'static str, fn(&mut Instance), fn(&Instance) -> bool);
+        let cases: &[SinkCase] = &[
             // The issue's headline victim: a concurrent archive.
             ("archived_at", |i| i.archive(), |i| i.archived_at.is_some()),
-            // Same touched arm, same wipe, for the other two sinks.
+            // Same touched arm, same wipe, for a concurrent snooze.
             (
                 "snoozed_until",
                 |i| i.snooze(15),
                 |i| i.snoozed_until.is_some(),
             ),
-            (
-                "idle_dormant_since",
-                |i| i.idle_dormant_since = Some(Utc::now()),
-                |i| i.idle_dormant_since.is_some(),
-            ),
         ];
-        let stale_pre_stamp = Utc::now() - chrono::Duration::seconds(60);
-        let passive_stamp = Utc::now();
+        let user_touch = Utc::now() - chrono::Duration::seconds(60);
         for (field, seed_sink, sink_present) in cases {
-            // Snapshot the archiving writer held before the poller tick.
+            // Snapshot the acting writer held before the poller tick.
             let mut pre = Instance::new("s", "/tmp/x");
-            pre.status = Status::Running;
-            pre.last_accessed_at = Some(stale_pre_stamp);
+            pre.live_status_baseline = Some(Status::Idle);
+            pre.status = Status::Idle;
+            pre.last_accessed_at = Some(user_touch);
 
-            // Passive poller observes Running -> Idle and restamps disk,
-            // mirroring update_status_with_metadata's transition block
-            // (idle_entered_at plus last_accessed_at = Some(now)).
+            // One passive poller tick observes Idle -> Error. On the
+            // pre-fix tree this restamped last_accessed_at on the row that
+            // lands on disk; post-fix it leaves the user-gesture stamp
+            // alone and only updates idle_entered_at bookkeeping.
             let mut disk = pre.clone();
-            disk.status = Status::Idle;
-            disk.idle_entered_at = Some(passive_stamp);
-            disk.last_accessed_at = Some(passive_stamp);
+            let _cache = force_session_absent();
+            disk.update_status_with_metadata(None, None);
+            assert_eq!(disk.status, Status::Error);
 
             // The concurrent user action seeds the sink on the writer's
             // post snapshot.
@@ -9472,7 +9475,7 @@ mod tests {
 
             assert!(
                 sink_present(&disk),
-                "passive transition stamp must not wipe concurrent {field} (#3465)"
+                "passive transition must not wipe concurrent {field} (#3465)"
             );
         }
     }
@@ -9498,6 +9501,37 @@ mod tests {
         assert!(
             disk.snoozed_until.is_none(),
             "archive() invariant must clear a concurrent TUI snooze"
+        );
+    }
+    #[test]
+    #[serial_test::serial]
+    fn test_merge_diff_passive_transition_stamp_does_not_wake_dormant_row() {
+        // Dormancy is the third field the touched arm wipes (#3465), with
+        // one structural difference from the archive/snooze cases: it is
+        // never spliced from post, so the wipe only hits a value already
+        // on the row. Seed it on the base instance, drive one passive
+        // poller tick through the real transition path (session forced
+        // Absent, see #2936), and confirm an unrelated user action does
+        // not wake the row just because the pre-fix tree restamped
+        // last_accessed_at in between.
+        let mut pre = Instance::new("s", "/tmp/x");
+        pre.live_status_baseline = Some(Status::Idle);
+        pre.status = Status::Idle;
+        pre.last_accessed_at = Some(Utc::now() - chrono::Duration::seconds(60));
+        pre.idle_dormant_since = Some(Utc::now() - chrono::Duration::hours(5));
+
+        let mut disk = pre.clone();
+        let _cache = force_session_absent();
+        disk.update_status_with_metadata(None, None);
+        assert_eq!(disk.status, Status::Error);
+
+        let mut post = pre.clone();
+        post.favorite();
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(
+            disk.idle_dormant_since.is_some(),
+            "a passive transition must not wake a dormant row (#3465)"
         );
     }
 
@@ -10244,29 +10278,33 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn test_update_status_with_metadata_restamps_on_genuine_transition() {
+    fn test_update_status_with_metadata_keeps_last_accessed_at_on_transition() {
         // Once a live baseline is established, a real status change still
-        // restamps normally (no regression from the #2690 fix).
+        // re-anchors idle_entered_at bookkeeping, but must NOT restamp
+        // last_accessed_at (#3465): the field is a user-gesture signal, and
+        // passive stamps reaching disk let merge_user_action_diff's touched
+        // arm wipe concurrently archived rows.
         let mut inst = Instance::new("test", "/tmp/test");
         inst.live_status_baseline = Some(Status::Idle);
         inst.status = Status::Idle;
         inst.idle_entered_at = Some(Utc::now() - chrono::Duration::hours(2));
-        inst.last_accessed_at = Some(Utc::now() - chrono::Duration::hours(2));
+        let user_touch = Some(Utc::now() - chrono::Duration::hours(2));
+        inst.last_accessed_at = user_touch;
 
         // Force detection to resolve to `Absent` -> Error deterministically
         // (see #2936; without this the outcome is schedule-dependent).
         let _cache = force_session_absent();
 
-        let before = Utc::now();
         inst.update_status_with_metadata(None, None);
-        let after = Utc::now();
 
         // Detection confirms the session Absent, resolving to Error: a
         // genuine transition away from the established Idle baseline.
         assert_eq!(inst.status, Status::Error);
         assert_eq!(inst.idle_entered_at, None);
-        let last_accessed = inst.last_accessed_at.expect("must be restamped");
-        assert!(last_accessed >= before && last_accessed <= after);
+        assert_eq!(
+            inst.last_accessed_at, user_touch,
+            "a passive transition must not fabricate a user-gesture stamp"
+        );
         assert_eq!(inst.live_status_baseline, Some(Status::Error));
     }
 
@@ -10313,10 +10351,11 @@ mod tests {
     }
 
     #[test]
-    fn test_update_status_with_metadata_twice_different_statuses_both_restamp() {
-        // Two back-to-back genuine transitions must both restamp, and the
-        // baseline must update between calls so the second comparison is
-        // against the first call's result, not the original value.
+    fn test_update_status_with_metadata_transitions_never_stamp_last_accessed_at() {
+        // Two back-to-back genuine transitions update the idle_entered_at
+        // bookkeeping and re-seed the baseline between calls, but neither
+        // may touch last_accessed_at (#3465): passive stamps wiped
+        // concurrent archives through merge_user_action_diff's touched arm.
         //
         // Archiving short-circuits update_status_with_metadata_inner before
         // it touches `status` (see the `is_archived()` guard), which lets
@@ -10326,35 +10365,27 @@ mod tests {
         inst.archive();
         inst.live_status_baseline = Some(Status::Idle);
         inst.status = Status::Running;
+        let user_touch = Some(Utc::now() - chrono::Duration::hours(2));
+        inst.last_accessed_at = user_touch;
 
-        let before1 = Utc::now();
         inst.update_status_with_metadata(None, None);
-        let after1 = Utc::now();
         assert_eq!(
             inst.status,
             Status::Running,
             "archived guard preserves status"
         );
         assert_eq!(inst.idle_entered_at, None, "non-idle transition clears it");
-        let first_stamp = inst
-            .last_accessed_at
-            .expect("first transition must restamp");
-        assert!(first_stamp >= before1 && first_stamp <= after1);
+        assert_eq!(inst.last_accessed_at, user_touch);
         assert_eq!(inst.live_status_baseline, Some(Status::Running));
 
         inst.status = Status::Idle;
-        let before2 = Utc::now();
         inst.update_status_with_metadata(None, None);
-        let after2 = Utc::now();
         assert_eq!(inst.status, Status::Idle);
-        let second_idle = inst
-            .idle_entered_at
-            .expect("second transition must restamp");
-        assert!(second_idle >= before2 && second_idle <= after2);
         assert!(
-            second_idle >= first_stamp,
-            "second restamp must not be older than the first"
+            inst.idle_entered_at.is_some(),
+            "entering Idle re-anchors idle_entered_at"
         );
+        assert_eq!(inst.last_accessed_at, user_touch);
         assert_eq!(inst.live_status_baseline, Some(Status::Idle));
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -9503,6 +9503,7 @@ mod tests {
             "archive() invariant must clear a concurrent TUI snooze"
         );
     }
+
     #[test]
     #[serial_test::serial]
     fn test_merge_diff_passive_transition_stamp_does_not_wake_dormant_row() {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2254,8 +2254,8 @@ impl Instance {
     ///
     /// Cleared by `unarchive`, by `touch_last_accessed`, and by `favorite`
     /// and `pin`; not by `snooze`.
-    /// `merge_user_action_diff` mirrors those onto disk, and #3465 tracks a
-    /// status transition reaching that mirror without a user gesture.
+    /// `merge_user_action_diff` mirrors those onto disk; #3465 was a status
+    /// transition reaching that mirror without a user gesture.
     ///
     /// Mutual exclusion with `favorite`, `snooze`, and `pin`: archiving
     /// clears `favorited_at`, `snoozed_until`, and `pinned_at`. Archive

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1538,9 +1538,9 @@ fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
 ///   poller from tmux pane state or ACP overlay, not by an explicit user
 ///   action.
 /// - **passive status patch**: a minimal `PassiveStatusPatch` carrying
-///   the fields a passive-status writer touches (`status`,
-///   `idle_entered_at`, `last_accessed_at`), applied on disk via
-///   [`Instance::merge_passive_status_patch`].
+///   the `status` / `idle_entered_at` writes plus the monotone
+///   `last_accessed_at` carry-through (user-gesture-only since #3465),
+///   applied on disk via [`Instance::merge_passive_status_patch`].
 /// - **live status baseline**: the last `Status` a caller has actually
 ///   observed live for an in-memory `Instance`. Held on
 ///   `Instance::live_status_baseline` (`#[serde(skip)]`). `None` means


### PR DESCRIPTION
## Description

A passive status transition could erase a concurrent user archive through `merge_user_action_diff`'s `touched` arm (#3465, maintainer-reproduced). This PR removes the lying stamp rather than touching the deliberate arm.

### RCA (all links verified on this branch)

1. `Instance::update_status_with_metadata` (`src/session/instance.rs`, transition block) wrote `last_accessed_at = Some(now)` on every detected status change, with no user gesture behind it. Introduced by 16bdfad3 (#762) to power a "last activity" column/sort treating transitions as activity.
2. The stamp reaches disk through `PassiveStatusPatch::from_instance` (`src/session/instance.rs:1574`) via both producers: the daemon's `decide_passive_transition` (`src/server/mod.rs:4312`, patch for every non-structured row) and the TUI's `persist_passive_status_transition` (`src/tui/home/mod.rs:6892`).
3. A writer surface acting on a stale in-memory snapshot hits the wipe: `apply_user_action` captures `before` from TUI memory (`src/tui/home/mod.rs:6963`); if the daemon stamped disk in between, `merge_user_action_diff` computes `touched = self.last_accessed_at > pre.last_accessed_at` (`src/session/instance.rs:2205`) and clears `archived_at` / `snoozed_until` / `idle_dormant_since` (`instance.rs:2232`). The arm is deliberate (messaging-unarchives rule, pinned by `test_merge_diff_peer_touch_clears_tui_archive`), so the fix targets the stamp.

Competing hypotheses checked and refuted:

- "The passive patch itself clears triage fields": `merge_passive_status_patch` writes only `status`, `idle_entered_at`, monotone `last_accessed_at` and lifecycle generation (`instance.rs:2100`).
- "`update_status_with_metadata_inner`'s `is_archived()` short-circuit prevents stamping archived rows": it only tests the polling process's own copy, so the cross-process window (daemon stamps disk while the TUI holds an older snapshot) bypasses it entirely.
- "Consumers need the transition stamp": idle-reap anchors on `max(idle_entered_at, last_accessed_at)` and `idle_entered_at` still re-anchors on every Idle entry (`idle_reap.rs:90`, set in the same block). Display already prefers `idle_entered_at` for Idle rows since #872, which called `last_accessed_at` a liar after attach/send-keys. Freshness/Attention sorts document the field as user engagement.

### Fix

`update_status_with_metadata` no longer writes `last_accessed_at`; it keeps the `idle_entered_at` bookkeeping and baseline seeding untouched. Passive patches now carry the loaded value, which the monotone guard turns into a disk no-op. `merge_user_action_diff` and its pinned test are unchanged. `apply_status_intent` (defined at `src/server/mod.rs:5734`, stamping at :5777) stamps daemon memory for structured rows too; left untouched here. Its value can still reach disk indirectly through the TUI relay (`GET /api/sessions`, parsed by `DaemonStatusPoller`, written into TUI memory by `apply_status_update`, persisted by `save`'s monotone max), keeping a narrow #3465-shaped window alive for structured rows only; flagged as the follow-up.

### Behavior changes to be aware of

- `SortOrder::LastActivity` ("Recent") now ranks by last user interaction instead of last status flip, matching every doc comment on the field. Surfacing "just did something" stays the job of Attention sort, unread marks, and the fresh-idle pulse.
- Smart-attach fallback ranking and recent-projects recency now reflect user interaction rather than poller flips.
- Sidebar activity column: non-Idle rows now show time since the last user interaction rather than time since the last status flip, and a never-touched row shows an empty slot instead of an age.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the bug is a cross-process timestamp race; it is covered deterministically at the unit layer by four regression tests (red before the fix, verified by re-introducing the stamp): `test_merge_diff_passive_transition_stamp_does_not_wipe_concurrent_sink_state`, `test_merge_diff_passive_transition_stamp_does_not_wake_dormant_row`, and the rewritten `test_update_status_with_metadata_*` pair. An e2e reproduction would need to interleave a daemon tick between snapshot and action, which is not deterministic.

Regression suite:

- `test_merge_diff_*` family: 13 tests; full merge filter (`cargo test --lib merge`, all merge surfaces): 124 passed
- `*_status_with_metadata*`: 4 passed
- serve-gated `decide_passive_transition_*` / `flush_passive_transition_*` filters: 7 passed
- `cargo fmt --all -- --check`: clean
- `cargo clippy -- -D warnings`: clean

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** ox-alpha (via Oh My Pi harness)

**Any Additional AI Details you'd like to share:** Full cycle executed autonomously: repro, RCA, design, fix, validation, two review cycles (initial + fresh-eyes) with convergence loops described in the comments below.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

Ref #3465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Passive status changes no longer update `last_accessed_at`.
- User activity timestamps now reflect user interaction instead of background polling.
- Idle tracking still updates `idle_entered_at`, so idle-reap timing remains unchanged.
- Added regression tests for archive, snooze, dormancy, and status metadata preservation.
- Updated documentation to clarify timestamp ownership and passive patch behavior.
- Structured rows still retain a narrow related window through `apply_status_intent`; this remains follow-up work.

## Benefits

This prevents stale background updates from clearing archived, snoozed, or dormant state. It also improves activity sorting, smart-attach ranking, recent-project ordering, and sidebar timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->