### PR TITLE
fix(tmux): anchor the pi hint scan to the input box so derivative footers read Running

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5113,6 +5113,40 @@ You can monitor progress with aoe session logs.\n\
 /Users/nbrake/scm/otari-workspace/otari-worktrees/orchestrator\n\
 ↑45k ↓11k $0.009 9.6%/500k (auto)                    gpt-5.5 • medium\n";
 
+    /// omo (a pi derivative aliased via `agent_detect_as = pi`) renders a
+    /// taller footer than plain pi: two tip lines, the input box (rule,
+    /// prompt, rule), a usage line, and a persistent harness status line.
+    /// Its busy line (`• Running eval ... esc to interrupt`) lands around
+    /// position 8 above the bottom, outside pi's classic footer window.
+    /// Captured shape from #3475's live pane, ANSI stripped, with one
+    /// neutral transcript line of scrollback above it.
+    const OMO_DEEP_FOOTER_BUSY_PANE: &str = "\
+Eval suite streaming results to the report.\n\
+• Running eval (3m 19s • esc to interrupt)\n\
+Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
+↳ Want the full story on any tip? Ask about it in chat.\n\
+────────────────────────────────────────\n\
+❯\n\
+────────────────────────────────────────\n\
+~ • CH93.4% • $2.870 • 115K/1M (11.5%) (auto)      claude-opus-4-6:xhigh\n\
+(😺 OmO Native) Pursuing goal (1m) mem:12k/200k\n";
+
+    /// The same omo frame after the turn ends: the busy line is removed and
+    /// nothing else on the pane carries a running signal. The scrollback
+    /// prose deliberately contains an activity word at position 8, inside
+    /// the widened hint window, so a future move of the activity-word scan
+    /// to that window would fail this row instead of silently pinning idle
+    /// derivative sessions on Running.
+    const OMO_DEEP_FOOTER_PARKED_PANE: &str = "\
+The agent is now working on #443, extending the gate.\n\
+Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
+↳ Want the full story on any tip? Ask about it in chat.\n\
+────────────────────────────────────────\n\
+❯\n\
+────────────────────────────────────────\n\
+~ • CH93.4% • $2.870 • 115K/1M (11.5%) (auto)      claude-opus-4-6:xhigh\n\
+(😺 OmO Native) Pursuing goal (1m) mem:12k/200k\n";
+
     #[test]
     fn test_detect_pi_status_running_spinner_footer() {
         assert_eq!(detect_pi_status(PI_RUNNING_PANE), Status::Running);
@@ -5126,6 +5160,29 @@ You can monitor progress with aoe session logs.\n\
             detect_pi_status(PI_FINISHED_PANE_WITH_ACTIVITY_PROSE),
             Status::Idle
         );
+    }
+
+    #[test]
+    fn test_detect_pi_status_deep_footer_interrupt_hint() {
+        // #3475: a pi derivative's busy line carries `esc to interrupt`
+        // beyond the classic footer window; the parked row is the same pane
+        // without that line, its scrollback prose carrying an activity word
+        // inside the widened window, and must stay Idle.
+        let cases = [
+            (
+                "busy frame, hint at position 8",
+                OMO_DEEP_FOOTER_BUSY_PANE,
+                Status::Running,
+            ),
+            (
+                "parked frame without the busy line",
+                OMO_DEEP_FOOTER_PARKED_PANE,
+                Status::Idle,
+            ),
+        ];
+        for (desc, pane, expected) in cases {
+            assert_eq!(detect_pi_status(pane), expected, "{desc}");
+        }
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1841,8 +1841,9 @@ const PI_FOOTER_WINDOW: usize = 6;
 /// widen only for this signal: rendered on the live busy line, the hint
 /// vanishes when the turn ends, unlike spinners and activity words, which
 /// linger in scrollback. Residual exposure: prose quoting the hint verbatim
-/// within ten lines of a parked pane still reads Running until newer output
-/// ages it out of the window.
+/// within ten non-empty lines of a parked pane still reads Running; live
+/// output eventually ages the quote out of the window, but a pane at rest
+/// holds it until its next turn starts.
 const PI_INTERRUPT_HINT_WINDOW: usize = 10;
 
 /// Pi coding agent status detection via tmux pane parsing.

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1836,13 +1836,26 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
 /// a deeper rule pair is transcript content, not the box.
 const PI_FOOTER_WINDOW: usize = 6;
 
-/// Non-empty position (1 = bottom) of the input box's topmost rule, or
-/// `None` when the pane shows no rule pair. Pi stacks two `────` rules
-/// around its input area and derivatives keep that furniture (omo separates
-/// them with the prompt line), so the second rule counting from the bottom
-/// is the stable anchor; rule lines drawn by transcript content sit higher
-/// and are never reached.
-fn input_box_topmost_rule_depth(non_empty_lines: &[&str]) -> Option<usize> {
+/// How many non-empty lines above the input box's rule anchor the
+/// `esc to interrupt` hint scan covers. Plain pi puts its busy line directly
+/// above the box (anchor + 1); the omo frame in #3475 stacks it behind two
+/// tip lines (anchor + 3). The value is tuned to those captures rather than
+/// derived: sweeping the tip-line count shows the busy line drops out of the
+/// band at three tips, so a derivative carrying one more line of furniture
+/// between its busy line and its box reopens #3475 and widens this by one.
+/// The failure is bounded and degrades to Idle, unlike a window over the
+/// whole tail.
+const PI_HINT_BAND_ABOVE_BOX: usize = 3;
+
+/// Non-empty position (1 = bottom) of the second rule counting from the
+/// bottom, or `None` when the pane shows fewer than two rules. Pi stacks two
+/// `────` rules around its input area and derivatives keep that furniture
+/// (omo separates them with the prompt line), so with the box in the capture
+/// this is the box's topmost rule and rule lines drawn by transcript content
+/// sit higher and are never reached. With the box off-capture it can return a
+/// prose line instead, since pi renders a markdown `---` as the same glyph
+/// run, which is why callers reject an anchor deeper than the footer.
+fn input_box_rule_anchor_depth(non_empty_lines: &[&str]) -> Option<usize> {
     let is_rule = |line: &str| {
         let trimmed = line.trim();
         trimmed.chars().count() >= 3 && trimmed.chars().all(|c| c == '─')
@@ -1879,11 +1892,12 @@ fn input_box_topmost_rule_depth(non_empty_lines: &[&str]) -> Option<usize> {
 /// #443", "reading the file") and a scrollback frame can still hold a
 /// spinner glyph, so scanning the last 30 lines for those substrings pinned
 /// the session on Running forever. The `esc to interrupt` hint is bound to
-/// the input box instead of a line count: the scan covers the three
-/// non-empty lines above the box's rule anchor, where plain pi puts its
-/// busy line (directly above the rule) and where derivatives aliased via
-/// `agent_detect_as = pi` stack theirs behind up to two tip lines (#3475),
-/// so response prose above the box top stays out of reach. An anchor deeper
+/// the input box instead of a line count: the scan covers the
+/// `PI_HINT_BAND_ABOVE_BOX` non-empty lines above the box's rule anchor,
+/// where plain pi puts its busy line (directly above the rule) and where
+/// derivatives aliased via `agent_detect_as = pi` stack theirs behind up to
+/// two tip lines (#3475), so response prose above the box top stays out of
+/// reach. An anchor deeper
 /// than the footer is treated as transcript content and falls back to the
 /// footer window, so a response drawing its own rules with the input box
 /// off-capture cannot float the band to unbounded depth. The footer
@@ -1905,22 +1919,22 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
         return Status::Running;
     }
 
-    // The hint region is the three non-empty lines above the input box's
-    // rule anchor: plain pi puts its busy line directly above the box and
-    // derivatives stack up to two tip lines between busy line and box
-    // (#3475), while response prose always sits above that band. An anchor
+    // The hint region is the `PI_HINT_BAND_ABOVE_BOX` non-empty lines above
+    // the input box's rule anchor: plain pi puts its busy line directly above
+    // the box and derivatives stack up to two tip lines between busy line and
+    // box (#3475), while response prose always sits above that band. An anchor
     // deeper than the footer is rejected: the box is footer furniture, so a
     // deeper rule pair is transcript prose drawing the same glyph run (pi
     // renders a markdown `---` that way), and without the ceiling the band
     // floats to unbounded depth. Panes without a usable rule pair (odd
     // wrappers, synthetic captures, an off-capture box) keep the pre-#3475
     // footer-only hint check.
-    let hint_region = match input_box_topmost_rule_depth(&non_empty_lines)
+    let hint_region = match input_box_rule_anchor_depth(&non_empty_lines)
         .filter(|depth| *depth <= PI_FOOTER_WINDOW)
     {
         Some(rule_depth) => {
             let above_box = &non_empty_lines[..non_empty_lines.len() - rule_depth];
-            tail_lines(above_box, 3).to_vec()
+            tail_lines(above_box, PI_HINT_BAND_ABOVE_BOX).to_vec()
         }
         None => tail_lines(&non_empty_lines, PI_FOOTER_WINDOW).to_vec(),
     };

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1829,18 +1829,20 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
 }
 
 /// How many of the last non-empty pane lines count as plain pi's footer for
-/// the spinner and activity-word running signals. Sized for pi itself, whose
-/// busy line sits ~5 non-empty lines above the bottom; anything deeper is
-/// finished-turn prose where both signals falsely fire.
+/// the spinner and activity-word running signals; the sizing rationale
+/// (measured busy-line depth, prose exclusion) lives at the call site in
+/// `detect_pi_status`.
 const PI_FOOTER_WINDOW: usize = 6;
 
 /// How deep the interrupt-hint scan reaches. pi derivatives with taller
 /// footers (omo, #3475) stack up to two tip lines, the input box, a usage
 /// line, and a harness status line under their busy line, pushing it to
 /// non-empty position 7-8; ten adds slack above that measured bound. Safe to
-/// widen only for this signal: the hint renders on the live busy line and
+/// widen only for this signal: rendered on the live busy line, the hint
 /// vanishes when the turn ends, unlike spinners and activity words, which
-/// linger in scrollback.
+/// linger in scrollback. Residual exposure: prose quoting the hint verbatim
+/// within ten lines of a parked pane still reads Running until newer output
+/// ages it out of the window.
 const PI_INTERRUPT_HINT_WINDOW: usize = 10;
 
 /// Pi coding agent status detection via tmux pane parsing.

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1828,6 +1828,21 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
     Status::Idle
 }
 
+/// How many of the last non-empty pane lines count as plain pi's footer for
+/// the spinner and activity-word running signals. Sized for pi itself, whose
+/// busy line sits ~5 non-empty lines above the bottom; anything deeper is
+/// finished-turn prose where both signals falsely fire.
+const PI_FOOTER_WINDOW: usize = 6;
+
+/// How deep the interrupt-hint scan reaches. pi derivatives with taller
+/// footers (omo, #3475) stack up to two tip lines, the input box, a usage
+/// line, and a harness status line under their busy line, pushing it to
+/// non-empty position 7-8; ten covers that plus footer variants. Safe to
+/// widen only for this signal: the hint renders on the live busy line and
+/// vanishes when the turn ends, unlike spinners and activity words, which
+/// linger in scrollback.
+const PI_INTERRUPT_HINT_WINDOW: usize = 10;
+
 /// Pi coding agent status detection via tmux pane parsing.
 ///
 /// Pi has no status hooks (`hook_config: None`), so this pane detector is the
@@ -1841,13 +1856,16 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
 /// `>` prompt at rest, so the pane's only difference from the running frame is
 /// the absent spinner line.
 ///
-/// That is why the Running signal is scoped to the footer (the last few
-/// non-empty lines) rather than the whole capture: a finished turn's response
-/// prose routinely contains activity words ("now working on #443", "reading
-/// the file") and a scrollback frame can still hold a spinner glyph, so
-/// scanning the last 30 lines for those substrings pinned the session on
-/// Running forever. This mirrors the footer-only approach already used by
-/// `detect_omp_status` and `detect_copilot_status`.
+/// That is why the spinner and activity-word signals are scoped to pi's own
+/// footer (`PI_FOOTER_WINDOW`) rather than the whole capture: a finished
+/// turn's response prose routinely contains activity words ("now working on
+/// #443", "reading the file") and a scrollback frame can still hold a
+/// spinner glyph, so scanning the last 30 lines for those substrings pinned
+/// the session on Running forever. The `esc to interrupt` hint is specific
+/// to the live busy line, so it alone scans deeper
+/// (`PI_INTERRUPT_HINT_WINDOW`), reaching the taller footers of derivatives
+/// aliased via `agent_detect_as = pi` (#3475). This mirrors the footer-only
+/// approach already used by `detect_omp_status` and `detect_copilot_status`.
 pub fn detect_pi_status(raw_content: &str) -> Status {
     let clean = strip_ansi(raw_content);
     let non_empty_lines: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
@@ -1856,22 +1874,21 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
     // (above the input box's two rules, the cwd line, and the status line), so
     // the footer window must reach it while staying tight enough to exclude the
     // bulk of a finished turn's response prose.
-    let footer: Vec<&str> = non_empty_lines
-        .iter()
-        .rev()
-        .take(6)
-        .rev()
-        .copied()
-        .collect();
-    let footer_lower = footer.join("\n").to_lowercase();
+    let footer = tail_lines(&non_empty_lines, PI_FOOTER_WINDOW);
 
     // A spinner glyph in the footer is pi's primary running signal; prose never
     // contains braille spinner chars, so this is the reliable positive marker.
-    if has_any_spinner(&footer) {
+    if has_any_spinner(footer) {
         return Status::Running;
     }
 
-    if footer_lower.contains("esc to interrupt") || footer_lower.contains("ctrl+c to interrupt") {
+    // The hint renders on the live busy line and vanishes with it, so unlike
+    // the signals above it can scan a deeper window without reopening the
+    // pinned-on-Running false positives (#3475).
+    let hint_lower = tail_lines(&non_empty_lines, PI_INTERRUPT_HINT_WINDOW)
+        .join("\n")
+        .to_lowercase();
+    if hint_lower.contains("esc to interrupt") || hint_lower.contains("ctrl+c to interrupt") {
         return Status::Running;
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5151,14 +5151,14 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 
     /// The same omo frame after the turn ends: the busy line is removed and
     /// nothing else on the pane carries a running signal. The scrollback
-    /// prose deliberately carries, at position 8, a leading spinner glyph
+    /// prose deliberately carries, at position 8, an embedded spinner glyph
     /// and an activity-verb start, arming three traps: the row fails if the
     /// spinner scan or the activity-word scan moves to the widened hint
     /// window, and it fails just the same if `PI_FOOTER_WINDOW` widens far
     /// enough to reach the prose, instead of silently pinning idle
     /// derivative sessions on Running.
     const OMO_DEEP_FOOTER_PARKED_PANE: &str = "\
-⠋ Working through the eval matrix, results streaming to the report.\n\
+Working through the eval matrix, results streaming to the report ⠋\n\
 Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 ↳ Want the full story on any tip? Ask about it in chat.\n\
 ────────────────────────────────────────\n\

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1837,7 +1837,7 @@ const PI_FOOTER_WINDOW: usize = 6;
 /// How deep the interrupt-hint scan reaches. pi derivatives with taller
 /// footers (omo, #3475) stack up to two tip lines, the input box, a usage
 /// line, and a harness status line under their busy line, pushing it to
-/// non-empty position 7-8; ten covers that plus footer variants. Safe to
+/// non-empty position 7-8; ten adds slack above that measured bound. Safe to
 /// widen only for this signal: the hint renders on the live busy line and
 /// vanishes when the turn ends, unlike spinners and activity words, which
 /// linger in scrollback.
@@ -5134,7 +5134,7 @@ You can monitor progress with aoe session logs.\n\
     /// taller footer than plain pi: two tip lines, the input box (rule,
     /// prompt, rule), a usage line, and a persistent harness status line.
     /// Its busy line (`• Running eval ... esc to interrupt`) lands around
-    /// position 8 above the bottom, outside pi's classic footer window.
+    /// position 8 above the bottom, outside `PI_FOOTER_WINDOW`.
     /// Captured shape from #3475's live pane, ANSI stripped, with one
     /// neutral transcript line of scrollback above it.
     const OMO_DEEP_FOOTER_BUSY_PANE: &str = "\
@@ -5182,7 +5182,7 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
     #[test]
     fn test_detect_pi_status_deep_footer_interrupt_hint() {
         // #3475: a pi derivative's busy line carries `esc to interrupt`
-        // beyond the classic footer window; the parked row is the same pane
+        // beyond `PI_FOOTER_WINDOW`; the parked row is the same pane
         // without that line, its scrollback prose carrying an activity word
         // inside the widened window, and must stay Idle.
         let cases = [

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1866,8 +1866,8 @@ const PI_INTERRUPT_HINT_WINDOW: usize = 10;
 /// the session on Running forever. The `esc to interrupt` hint is specific
 /// to the live busy line, so it alone scans deeper
 /// (`PI_INTERRUPT_HINT_WINDOW`), reaching the taller footers of derivatives
-/// aliased via `agent_detect_as = pi` (#3475). This mirrors the footer-only
-/// approach already used by `detect_omp_status` and `detect_copilot_status`.
+/// aliased via `agent_detect_as = pi` (#3475). The footer scoping mirrors
+/// the approach already used by `detect_omp_status` and `detect_copilot_status`.
 pub fn detect_pi_status(raw_content: &str) -> Status {
     let clean = strip_ansi(raw_content);
     let non_empty_lines: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5255,7 +5255,7 @@ Final prose line.\n";
     /// A synthetic pane holding `line` at non-empty position `depth`, with
     /// neutral filler lines below it.
     fn pane_with_line_at_depth(line: &str, depth: usize) -> String {
-        let filler = "Footer filler line.\n".repeat(depth - 1);
+        let filler = "Footer filler line.\n".repeat(depth.saturating_sub(1));
         format!("{line}\n{filler}")
     }
 
@@ -5263,7 +5263,7 @@ Final prose line.\n";
     /// rules, cwd line, status line) instead of bare fillers.
     fn boxed_pane_with_line_at_depth(line: &str, depth: usize) -> String {
         let mut lines = vec![line.to_string()];
-        for _ in 0..(depth - 5) {
+        for _ in 0..depth.saturating_sub(5) {
             lines.push("Footer filler line.".to_string());
         }
         lines.push("────────────────────────────────────────".to_string());
@@ -5275,13 +5275,20 @@ Final prose line.\n";
 
     #[test]
     fn test_detect_pi_status_window_bounds() {
-        // Both window knobs at one line of granularity. Footer rows pin
+        // Both scan knobs at one line of granularity; each row names its own
+        // scope in `desc`, so a drift in either direction fails a row rather
+        // than silently widening the Running signal. Footer rows pin
         // `PI_FOOTER_WINDOW`: a spinner at position 6 still reads Running,
         // activity prose at position 7 stays Idle, so drift to 5 or to 7
         // fails a row. Hint rows pin the input-box anchor (#3475): the omo
-        // busy line three lines above the box's topmost rule reads Running,
+        // busy line three lines above the box's rule anchor reads Running,
         // while a finished response quoting the hint past that band stays
-        // Idle, so moving the anchor fails a row either way.
+        // Idle. The position 7 row is the known-bad residual and is asserted
+        // as Running on purpose: in a finished frame the busy line is gone,
+        // so positions 5 through 7 are all prose, and narrowing the band to
+        // close it drops the omo busy line. That is one line of prose
+        // exposure against main's two, and the row is here so the tradeoff
+        // is visible where the bounds are read.
         let quote_line = "You can press esc to interrupt at any time.";
         let cases = [
             (
@@ -5318,6 +5325,11 @@ Final prose line.\n";
                 "hint: quoted hint at position 11, past the anchored band",
                 boxed_pane_with_line_at_depth(quote_line, 11),
                 Status::Idle,
+            ),
+            (
+                "hint: quoted hint at position 7 is the accepted residual",
+                boxed_pane_with_line_at_depth(quote_line, 7),
+                Status::Running,
             ),
             (
                 "hint: prose rules with the box off-capture stay bounded",

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1884,9 +1884,7 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
         return Status::Running;
     }
 
-    // The hint renders on the live busy line and vanishes with it, so unlike
-    // the signals above it can scan a deeper window without reopening the
-    // pinned-on-Running false positives (#3475).
+    // Why only this signal scans deeper: see `PI_INTERRUPT_HINT_WINDOW`.
     let hint_lower = tail_lines(&non_empty_lines, PI_INTERRUPT_HINT_WINDOW)
         .join("\n")
         .to_lowercase();
@@ -5152,10 +5150,11 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 
     /// The same omo frame after the turn ends: the busy line is removed and
     /// nothing else on the pane carries a running signal. The scrollback
-    /// prose deliberately STARTS with an activity word at position 8, so it
-    /// would fire if the activity-word scan ever moved to the widened hint
-    /// window; the row fails then instead of silently pinning idle
-    /// derivative sessions on Running.
+    /// prose deliberately STARTS with an activity word at position 8, which
+    /// arms two traps: the row fails if the activity-word scan moves to the
+    /// widened hint window, and it fails just the same if `PI_FOOTER_WINDOW`
+    /// widens far enough to reach the prose, instead of silently pinning
+    /// idle derivative sessions on Running.
     const OMO_DEEP_FOOTER_PARKED_PANE: &str = "\
 Working through the eval matrix, results streaming to the report.\n\
 Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
@@ -5184,23 +5183,39 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
     #[test]
     fn test_detect_pi_status_deep_footer_interrupt_hint() {
         // #3475: a pi derivative's busy line carries `esc to interrupt`
-        // beyond `PI_FOOTER_WINDOW`; the parked row is the same pane
-        // without that line, its scrollback prose carrying an activity word
-        // inside the widened window, and must stay Idle.
+        // beyond `PI_FOOTER_WINDOW`. The captured rows fix the omo shape;
+        // the depth rows pin the window width itself, Running at position
+        // 10, the last line the window reaches, Idle at 11. The parked row
+        // drops the busy line; its prose starts with an activity word
+        // inside the widened band, arming the traps listed on the fixture.
+        let busy_at_depth = |depth: usize| {
+            let filler = "Footer filler line.\n".repeat(depth - 1);
+            format!("• Running eval (3m 19s • esc to interrupt)\n{filler}")
+        };
         let cases = [
             (
                 "busy frame, hint at position 8",
-                OMO_DEEP_FOOTER_BUSY_PANE,
+                OMO_DEEP_FOOTER_BUSY_PANE.to_string(),
                 Status::Running,
             ),
             (
+                "busy frame aged to position 10",
+                busy_at_depth(10),
+                Status::Running,
+            ),
+            (
+                "busy frame aged to position 11",
+                busy_at_depth(11),
+                Status::Idle,
+            ),
+            (
                 "parked frame without the busy line",
-                OMO_DEEP_FOOTER_PARKED_PANE,
+                OMO_DEEP_FOOTER_PARKED_PANE.to_string(),
                 Status::Idle,
             ),
         ];
-        for (desc, pane, expected) in cases {
-            assert_eq!(detect_pi_status(pane), expected, "{desc}");
+        for (desc, pane, expected) in &cases {
+            assert_eq!(detect_pi_status(pane), *expected, "{desc}");
         }
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5150,12 +5150,12 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 
     /// The same omo frame after the turn ends: the busy line is removed and
     /// nothing else on the pane carries a running signal. The scrollback
-    /// prose deliberately contains an activity word at position 8, inside
-    /// the widened hint window, so a future move of the activity-word scan
-    /// to that window would fail this row instead of silently pinning idle
+    /// prose deliberately STARTS with an activity word at position 8, so it
+    /// would fire if the activity-word scan ever moved to the widened hint
+    /// window; the row fails then instead of silently pinning idle
     /// derivative sessions on Running.
     const OMO_DEEP_FOOTER_PARKED_PANE: &str = "\
-The agent is now working on #443, extending the gate.\n\
+Working through the eval matrix, results streaming to the report.\n\
 Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 ↳ Want the full story on any tip? Ask about it in chat.\n\
 ────────────────────────────────────────\n\

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1831,7 +1831,9 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
 /// How many of the last non-empty pane lines count as plain pi's footer for
 /// the spinner and activity-word running signals; the sizing rationale
 /// (measured busy-line depth, prose exclusion) lives at the call site in
-/// `detect_pi_status`.
+/// `detect_pi_status`. It doubles as the ceiling on the input box rule
+/// anchor: the box is footer furniture (plain pi anchors at 4, omo at 5), so
+/// a deeper rule pair is transcript content, not the box.
 const PI_FOOTER_WINDOW: usize = 6;
 
 /// Non-empty position (1 = bottom) of the input box's topmost rule, or
@@ -1878,10 +1880,13 @@ fn input_box_topmost_rule_depth(non_empty_lines: &[&str]) -> Option<usize> {
 /// spinner glyph, so scanning the last 30 lines for those substrings pinned
 /// the session on Running forever. The `esc to interrupt` hint is bound to
 /// the input box instead of a line count: the scan covers the three
-/// non-empty lines above the box's topmost rule, where plain pi puts its
+/// non-empty lines above the box's rule anchor, where plain pi puts its
 /// busy line (directly above the rule) and where derivatives aliased via
 /// `agent_detect_as = pi` stack theirs behind up to two tip lines (#3475),
-/// so response prose above the box top stays out of reach. The footer
+/// so response prose above the box top stays out of reach. An anchor deeper
+/// than the footer is treated as transcript content and falls back to the
+/// footer window, so a response drawing its own rules with the input box
+/// off-capture cannot float the band to unbounded depth. The footer
 /// scoping mirrors the approach already used by `detect_omp_status` and
 /// `detect_copilot_status`.
 pub fn detect_pi_status(raw_content: &str) -> Status {
@@ -1901,12 +1906,18 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
     }
 
     // The hint region is the three non-empty lines above the input box's
-    // topmost rule: plain pi puts its busy line directly above the box and
+    // rule anchor: plain pi puts its busy line directly above the box and
     // derivatives stack up to two tip lines between busy line and box
-    // (#3475), while response prose always sits above that band. Panes
-    // without a rule pair (odd wrappers, synthetic captures) keep the
-    // pre-#3475 footer-only hint check.
-    let hint_region = match input_box_topmost_rule_depth(&non_empty_lines) {
+    // (#3475), while response prose always sits above that band. An anchor
+    // deeper than the footer is rejected: the box is footer furniture, so a
+    // deeper rule pair is transcript prose drawing the same glyph run (pi
+    // renders a markdown `---` that way), and without the ceiling the band
+    // floats to unbounded depth. Panes without a usable rule pair (odd
+    // wrappers, synthetic captures, an off-capture box) keep the pre-#3475
+    // footer-only hint check.
+    let hint_region = match input_box_topmost_rule_depth(&non_empty_lines)
+        .filter(|depth| *depth <= PI_FOOTER_WINDOW)
+    {
         Some(rule_depth) => {
             let above_box = &non_empty_lines[..non_empty_lines.len() - rule_depth];
             tail_lines(above_box, 3).to_vec()
@@ -5193,6 +5204,25 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 ~ • CH93.4% • $2.870 • 115K/1M (11.5%) (auto)      claude-opus-4-6:xhigh\n\
 (😺 OmO Native) Pursuing goal (1m) mem:12k/200k\n";
 
+    /// A finished turn whose response renders two markdown horizontal rules
+    /// (pi draws them with the same `────` glyph run as its input box) while
+    /// the input box itself is off-capture: startup, a full-screen pager, or
+    /// a derivative that hides the box while streaming. The rule anchor then
+    /// lands on prose at position 7, so without the shallow-anchor guard the
+    /// hint band floats up to positions 8 through 10 and the quoted hint at
+    /// position 8 pins the session on Running with no depth cap.
+    const PI_PROSE_RULES_WITHOUT_BOX_PANE: &str = "\
+Two horizontal rules in this response, and the input box is off-capture.\n\
+Here is the first section of the answer.\n\
+You can press esc to interrupt at any time.\n\
+────────────────────────────────────────\n\
+Second section of the answer.\n\
+More prose in the second section.\n\
+Still more prose in the second section.\n\
+────────────────────────────────────────\n\
+Closing prose line.\n\
+Final prose line.\n";
+
     #[test]
     fn test_detect_pi_status_running_spinner_footer() {
         assert_eq!(detect_pi_status(PI_RUNNING_PANE), Status::Running);
@@ -5273,6 +5303,11 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
             (
                 "hint: quoted hint at position 11, past the anchored band",
                 boxed_pane_with_line_at_depth(quote_line, 11),
+                Status::Idle,
+            ),
+            (
+                "hint: prose rules with the box off-capture stay bounded",
+                PI_PROSE_RULES_WITHOUT_BOX_PANE.to_string(),
                 Status::Idle,
             ),
             (

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5187,7 +5187,7 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
         // the depth rows pin the window width itself, Running at position
         // 10, the last line the window reaches, Idle at 11. The parked row
         // drops the busy line; its prose starts with an activity word
-        // inside the widened band, arming the traps listed on the fixture.
+        // inside the widened hint window, arming the traps listed on the fixture.
         let busy_at_depth = |depth: usize| {
             let filler = "Footer filler line.\n".repeat(depth - 1);
             format!("• Running eval (3m 19s • esc to interrupt)\n{filler}")

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5151,13 +5151,14 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 
     /// The same omo frame after the turn ends: the busy line is removed and
     /// nothing else on the pane carries a running signal. The scrollback
-    /// prose deliberately STARTS with an activity word at position 8, which
-    /// arms two traps: the row fails if the activity-word scan moves to the
-    /// widened hint window, and it fails just the same if `PI_FOOTER_WINDOW`
-    /// widens far enough to reach the prose, instead of silently pinning
-    /// idle derivative sessions on Running.
+    /// prose deliberately carries, at position 8, a leading spinner glyph
+    /// and an activity-verb start, arming three traps: the row fails if the
+    /// spinner scan or the activity-word scan moves to the widened hint
+    /// window, and it fails just the same if `PI_FOOTER_WINDOW` widens far
+    /// enough to reach the prose, instead of silently pinning idle
+    /// derivative sessions on Running.
     const OMO_DEEP_FOOTER_PARKED_PANE: &str = "\
-Working through the eval matrix, results streaming to the report.\n\
+⠋ Working through the eval matrix, results streaming to the report.\n\
 Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
 ↳ Want the full story on any tip? Ask about it in chat.\n\
 ────────────────────────────────────────\n\

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5182,6 +5182,13 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
         );
     }
 
+    /// A synthetic pane holding `line` at non-empty position `depth`, with
+    /// neutral filler lines below it.
+    fn pane_with_line_at_depth(line: &str, depth: usize) -> String {
+        let filler = "Footer filler line.\n".repeat(depth - 1);
+        format!("{line}\n{filler}")
+    }
+
     #[test]
     fn test_detect_pi_status_deep_footer_interrupt_hint() {
         // #3475: a pi derivative's busy line carries `esc to interrupt`
@@ -5190,10 +5197,7 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
         // 10, the last line the window reaches, Idle at 11. The parked row
         // drops the busy line; its prose starts with an activity word
         // inside the widened hint window, arming the traps listed on the fixture.
-        let busy_at_depth = |depth: usize| {
-            let filler = "Footer filler line.\n".repeat(depth - 1);
-            format!("• Running eval (3m 19s • esc to interrupt)\n{filler}")
-        };
+        let busy_line = "• Running eval (3m 19s • esc to interrupt)";
         let cases = [
             (
                 "busy frame, hint at position 8",
@@ -5202,12 +5206,12 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
             ),
             (
                 "busy frame aged to position 10",
-                busy_at_depth(10),
+                pane_with_line_at_depth(busy_line, 10),
                 Status::Running,
             ),
             (
                 "busy frame aged to position 11",
-                busy_at_depth(11),
+                pane_with_line_at_depth(busy_line, 11),
                 Status::Idle,
             ),
             (
@@ -5227,19 +5231,15 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
         // window rows above: a spinner at position 6 still reads Running,
         // while activity prose starting at position 7 stays Idle, so a
         // silent drift of the constant to 5 or to 7 fails a row.
-        let signal_at_depth = |line: &str, depth: usize| {
-            let filler = "Footer filler line.\n".repeat(depth - 1);
-            format!("{line}\n{filler}")
-        };
         let cases = [
             (
                 "spinner at position 6, the last line the footer reaches",
-                signal_at_depth("⠋ Working...", 6),
+                pane_with_line_at_depth("⠋ Working...", 6),
                 Status::Running,
             ),
             (
                 "activity prose at position 7, past the footer",
-                signal_at_depth("Working through the eval matrix.", 7),
+                pane_with_line_at_depth("Working through the eval matrix.", 7),
                 Status::Idle,
             ),
         ];

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1834,17 +1834,29 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
 /// `detect_pi_status`.
 const PI_FOOTER_WINDOW: usize = 6;
 
-/// How deep the interrupt-hint scan reaches. pi derivatives with taller
-/// footers (omo, #3475) stack up to two tip lines, the input box, a usage
-/// line, and a harness status line under their busy line, pushing it to
-/// non-empty position 7-8; ten adds slack above that measured bound. Safe to
-/// widen only for this signal: rendered on the live busy line, the hint
-/// vanishes when the turn ends, unlike spinners and activity words, which
-/// linger in scrollback. Residual exposure: prose quoting the hint verbatim
-/// within ten non-empty lines of a parked pane still reads Running; live
-/// output eventually ages the quote out of the window, but a pane at rest
-/// holds it until its next turn starts.
-const PI_INTERRUPT_HINT_WINDOW: usize = 10;
+/// Non-empty position (1 = bottom) of the input box's topmost rule, or
+/// `None` when the pane shows no rule pair. Pi stacks two `────` rules
+/// around its input area and derivatives keep that furniture (omo separates
+/// them with the prompt line), so the second rule counting from the bottom
+/// is the stable anchor; rule lines drawn by transcript content sit higher
+/// and are never reached.
+fn input_box_topmost_rule_depth(non_empty_lines: &[&str]) -> Option<usize> {
+    let is_rule = |line: &str| {
+        let trimmed = line.trim();
+        trimmed.chars().count() >= 3 && trimmed.chars().all(|c| c == '─')
+    };
+    let mut lowest_seen = false;
+    for (idx, line) in non_empty_lines.iter().enumerate().rev() {
+        if !is_rule(line) {
+            continue;
+        }
+        if lowest_seen {
+            return Some(non_empty_lines.len() - idx);
+        }
+        lowest_seen = true;
+    }
+    None
+}
 
 /// Pi coding agent status detection via tmux pane parsing.
 ///
@@ -1864,11 +1876,14 @@ const PI_INTERRUPT_HINT_WINDOW: usize = 10;
 /// turn's response prose routinely contains activity words ("now working on
 /// #443", "reading the file") and a scrollback frame can still hold a
 /// spinner glyph, so scanning the last 30 lines for those substrings pinned
-/// the session on Running forever. The `esc to interrupt` hint is specific
-/// to the live busy line, so it alone scans deeper
-/// (`PI_INTERRUPT_HINT_WINDOW`), reaching the taller footers of derivatives
-/// aliased via `agent_detect_as = pi` (#3475). The footer scoping mirrors
-/// the approach already used by `detect_omp_status` and `detect_copilot_status`.
+/// the session on Running forever. The `esc to interrupt` hint is bound to
+/// the input box instead of a line count: the scan covers the three
+/// non-empty lines above the box's topmost rule, where plain pi puts its
+/// busy line (directly above the rule) and where derivatives aliased via
+/// `agent_detect_as = pi` stack theirs behind up to two tip lines (#3475),
+/// so response prose above the box top stays out of reach. The footer
+/// scoping mirrors the approach already used by `detect_omp_status` and
+/// `detect_copilot_status`.
 pub fn detect_pi_status(raw_content: &str) -> Status {
     let clean = strip_ansi(raw_content);
     let non_empty_lines: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
@@ -1885,10 +1900,20 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
         return Status::Running;
     }
 
-    // Why only this signal scans deeper: see `PI_INTERRUPT_HINT_WINDOW`.
-    let hint_lower = tail_lines(&non_empty_lines, PI_INTERRUPT_HINT_WINDOW)
-        .join("\n")
-        .to_lowercase();
+    // The hint region is the three non-empty lines above the input box's
+    // topmost rule: plain pi puts its busy line directly above the box and
+    // derivatives stack up to two tip lines between busy line and box
+    // (#3475), while response prose always sits above that band. Panes
+    // without a rule pair (odd wrappers, synthetic captures) keep the
+    // pre-#3475 footer-only hint check.
+    let hint_region = match input_box_topmost_rule_depth(&non_empty_lines) {
+        Some(rule_depth) => {
+            let above_box = &non_empty_lines[..non_empty_lines.len() - rule_depth];
+            tail_lines(above_box, 3).to_vec()
+        }
+        None => tail_lines(&non_empty_lines, PI_FOOTER_WINDOW).to_vec(),
+    };
+    let hint_lower = hint_region.join("\n").to_lowercase();
     if hint_lower.contains("esc to interrupt") || hint_lower.contains("ctrl+c to interrupt") {
         return Status::Running;
     }
@@ -5134,8 +5159,9 @@ You can monitor progress with aoe session logs.\n\
     /// omo (a pi derivative aliased via `agent_detect_as = pi`) renders a
     /// taller footer than plain pi: two tip lines, the input box (rule,
     /// prompt, rule), a usage line, and a persistent harness status line.
-    /// Its busy line (`• Running eval ... esc to interrupt`) lands around
-    /// position 8 above the bottom, outside `PI_FOOTER_WINDOW`.
+    /// Its busy line (`• Running eval ... esc to interrupt`) lands at
+    /// position 8 above the bottom: three lines above the box's topmost
+    /// rule, caught by the input-box hint anchor.
     /// Captured shape from #3475's live pane, ANSI stripped, with one
     /// neutral transcript line of scrollback above it.
     const OMO_DEEP_FOOTER_BUSY_PANE: &str = "\
@@ -5153,8 +5179,8 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
     /// nothing else on the pane carries a running signal. The scrollback
     /// prose deliberately carries, at position 8, an embedded spinner glyph
     /// and an activity-verb start, arming three traps: the row fails if the
-    /// spinner scan or the activity-word scan moves to the widened hint
-    /// window, and it fails just the same if `PI_FOOTER_WINDOW` widens far
+    /// spinner scan or the activity-word scan ever extends above the box
+    /// top, and it fails just the same if `PI_FOOTER_WINDOW` widens far
     /// enough to reach the prose, instead of silently pinning idle
     /// derivative sessions on Running.
     const OMO_DEEP_FOOTER_PARKED_PANE: &str = "\
@@ -5189,58 +5215,70 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
         format!("{line}\n{filler}")
     }
 
-    #[test]
-    fn test_detect_pi_status_deep_footer_interrupt_hint() {
-        // #3475: a pi derivative's busy line carries `esc to interrupt`
-        // beyond `PI_FOOTER_WINDOW`. The captured rows fix the omo shape;
-        // the depth rows pin the window width itself, Running at position
-        // 10, the last line the window reaches, Idle at 11. The parked row
-        // drops the busy line; its prose starts with an activity word
-        // inside the widened hint window, arming the traps listed on the fixture.
-        let busy_line = "• Running eval (3m 19s • esc to interrupt)";
-        let cases = [
-            (
-                "busy frame, hint at position 8",
-                OMO_DEEP_FOOTER_BUSY_PANE.to_string(),
-                Status::Running,
-            ),
-            (
-                "busy frame aged to position 10",
-                pane_with_line_at_depth(busy_line, 10),
-                Status::Running,
-            ),
-            (
-                "busy frame aged to position 11",
-                pane_with_line_at_depth(busy_line, 11),
-                Status::Idle,
-            ),
-            (
-                "parked frame without the busy line",
-                OMO_DEEP_FOOTER_PARKED_PANE.to_string(),
-                Status::Idle,
-            ),
-        ];
-        for (desc, pane, expected) in &cases {
-            assert_eq!(detect_pi_status(pane), *expected, "{desc}");
+    /// The same, ending in plain pi's four-line input box furniture (two
+    /// rules, cwd line, status line) instead of bare fillers.
+    fn boxed_pane_with_line_at_depth(line: &str, depth: usize) -> String {
+        let mut lines = vec![line.to_string()];
+        for _ in 0..(depth - 5) {
+            lines.push("Footer filler line.".to_string());
         }
+        lines.push("────────────────────────────────────────".to_string());
+        lines.push("────────────────────────────────────────".to_string());
+        lines.push("/tmp/proj".to_string());
+        lines.push("0.0%/272k (auto)      gpt-5.5 • medium".to_string());
+        lines.join("\n")
     }
 
     #[test]
-    fn test_detect_pi_status_footer_window_bounds() {
-        // Pins `PI_FOOTER_WINDOW` at one line of granularity, like the hint
-        // window rows above: a spinner at position 6 still reads Running,
-        // while activity prose starting at position 7 stays Idle, so a
-        // silent drift of the constant to 5 or to 7 fails a row.
+    fn test_detect_pi_status_window_bounds() {
+        // Both window knobs at one line of granularity. Footer rows pin
+        // `PI_FOOTER_WINDOW`: a spinner at position 6 still reads Running,
+        // activity prose at position 7 stays Idle, so drift to 5 or to 7
+        // fails a row. Hint rows pin the input-box anchor (#3475): the omo
+        // busy line three lines above the box's topmost rule reads Running,
+        // while a finished response quoting the hint past that band stays
+        // Idle, so moving the anchor fails a row either way.
+        let quote_line = "You can press esc to interrupt at any time.";
         let cases = [
             (
-                "spinner at position 6, the last line the footer reaches",
+                "footer: spinner at position 6, the last line it reaches",
                 pane_with_line_at_depth("⠋ Working...", 6),
                 Status::Running,
             ),
             (
-                "activity prose at position 7, past the footer",
+                "footer: activity prose at position 7, past the footer",
                 pane_with_line_at_depth("Working through the eval matrix.", 7),
                 Status::Idle,
+            ),
+            (
+                "hint: derivative busy line three lines above the box rule",
+                OMO_DEEP_FOOTER_BUSY_PANE.to_string(),
+                Status::Running,
+            ),
+            (
+                "hint: parked frame without the busy line",
+                OMO_DEEP_FOOTER_PARKED_PANE.to_string(),
+                Status::Idle,
+            ),
+            (
+                "hint: quoted hint at position 8, past the anchored band",
+                boxed_pane_with_line_at_depth(quote_line, 8),
+                Status::Idle,
+            ),
+            (
+                "hint: quoted hint at position 10, past the anchored band",
+                boxed_pane_with_line_at_depth(quote_line, 10),
+                Status::Idle,
+            ),
+            (
+                "hint: quoted hint at position 11, past the anchored band",
+                boxed_pane_with_line_at_depth(quote_line, 11),
+                Status::Idle,
+            ),
+            (
+                "hint: bare hint line falls back to the footer when no box",
+                "processing request\nesc to interrupt".to_string(),
+                Status::Running,
             ),
         ];
         for (desc, pane, expected) in &cases {

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -5222,6 +5222,33 @@ Tip: Set thinkingBudgets in settings.json to choose which models think.\n\
     }
 
     #[test]
+    fn test_detect_pi_status_footer_window_bounds() {
+        // Pins `PI_FOOTER_WINDOW` at one line of granularity, like the hint
+        // window rows above: a spinner at position 6 still reads Running,
+        // while activity prose starting at position 7 stays Idle, so a
+        // silent drift of the constant to 5 or to 7 fails a row.
+        let signal_at_depth = |line: &str, depth: usize| {
+            let filler = "Footer filler line.\n".repeat(depth - 1);
+            format!("{line}\n{filler}")
+        };
+        let cases = [
+            (
+                "spinner at position 6, the last line the footer reaches",
+                signal_at_depth("⠋ Working...", 6),
+                Status::Running,
+            ),
+            (
+                "activity prose at position 7, past the footer",
+                signal_at_depth("Working through the eval matrix.", 7),
+                Status::Idle,
+            ),
+        ];
+        for (desc, pane, expected) in &cases {
+            assert_eq!(detect_pi_status(pane), *expected, "{desc}");
+        }
+    }
+
+    #[test]
     fn test_detect_omp_status_running() {
         let pane = "Reply with OK only.\n\
                     ⠋ Working… ⟦esc⟧\n\


### PR DESCRIPTION
## Description

Fixes #3475. Sessions running a pi derivative whose TUI has a taller footer than plain pi (omo, aliased via `[session.agent_detect_as] omo = "pi"`) read Idle for the whole duration of their turns.

### RCA

`detect_pi_status` scoped both of its Running signals to the last 6 non-empty pane lines:

- footer window construction: `src/tmux/status_detection.rs`, former lines 1859 to 1865 (`iter().rev().take(6).rev()`)
- spinner check on that window: former line 1870
- interrupt-hint check (`esc to interrupt` / `ctrl+c to interrupt`) on the same window's lowercase join: former line 1874

Plain pi puts its busy line about 5 non-empty lines above the bottom, inside the window. omo stacks up to two tip lines, the input box (rule, prompt, rule), a usage line, and a persistent harness status line under its busy line (`• Running eval (3m 19s • esc to interrupt)`), pushing it to non-empty position 7 to 8: both checks miss and detection falls through to Idle.

Nothing below rescues it: the prompt check needs a `>` or `pi>` line while omo renders `❯` (a different codepoint), and the activity-word fallback anchors to the start of the line while the omo busy line starts with `•`, which `status_line_starts_with_phrase` does not strip.

Concurrent hypothesis tested and refuted: the failure is not about the spinner glyph. The live capture from the issue contains no braille character anywhere in reach, yet must read Running; the transient `Idle -> Running -> Idle` flaps in debug.log come from spinner-like glyphs landing inside the window in other frames, which makes the glyph the unreliable signal across frames and the hint (rendered continuously during a turn) the stable one.

### Fix

The interrupt hint is no longer scoped by a line count at all; it is anchored to the input box, which is the part of the frame that stays stable across derivatives. Both plain pi and omo draw two `────` rules around their input area, so `input_box_rule_anchor_depth` walks up from the bottom and returns the second rule it finds. The hint scan is the `PI_HINT_BAND_ABOVE_BOX` (3) non-empty lines above that anchor: plain pi puts its busy line directly above the box (anchor + 1) and omo stacks two tip lines behind its own (anchor + 3), so the same band catches both while a finished turn's response prose, which always sits above the box top, stays out of reach. That band is narrower than the 6-line window on `main`, not wider.

An anchor deeper than `PI_FOOTER_WINDOW` is rejected. The box is footer furniture, so its anchor is always shallow (plain pi 4, omo 5); a deeper rule pair means the input box is off-capture and the anchor has latched onto transcript content, since pi renders a markdown `---` with the same glyph run. Without that ceiling a response carrying two horizontal rules floats the band to unbounded depth and a quoted hint pins the session on Running. Panes with no usable rule pair fall back to the pre-#3475 footer-only hint check.

The spinner and activity-word signals stay on the tight 6-line window (now named `PI_FOOTER_WINDOW`): scrollback prose carries activity words and old frames carry spinner glyphs, so widening those would reintroduce the pinned-on-Running false positives this scoping exists for (regression test `test_detect_pi_status_finished_with_activity_prose_is_not_running` still guards it). The alternative from the issue, a configurable depth per `agent_detect_as` target, was rejected as out of proportion: it would touch the config schema and every settings surface for one measured case. Keying on the busy line's own shape (a glyph or a verb) was rejected too, since derivative footer shapes are exactly the unbounded variable that reopens #3475.

The footer slice also reuses the existing `tail_lines` helper instead of a local `rev().take().rev()` collect.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- Skipped a test, because: the changed surface is a pure function over captured pane text; unit tests feed it captures directly, which is cheaper and strictly more precise than driving tmux for the same assertion.

The bounds live in one table-driven test, `test_detect_pi_status_window_bounds`, with each row naming the scope it pins in its `desc` string:

- footer rows pin `PI_FOOTER_WINDOW` at one line of granularity: a spinner at position 6 still reads Running, activity prose at position 7 stays Idle, so drift to 5 or to 7 fails a row;
- hint rows pin the input-box anchor: the omo busy line three lines above the box rule anchor reads Running, its parked twin stays Idle, and quoted hints at positions 8, 10 and 11 in a boxed finished-response pane all stay Idle, so the regressed direction has coverage;
- the position 7 row asserts the known-bad residual as Running on purpose, so the tradeoff is documented where the bounds are read;
- `PI_PROSE_RULES_WITHOUT_BOX_PANE` covers the shallow-anchor ceiling: two prose rules with the input box off-capture and a quoted hint at position 8 must read Idle. That row is red without the ceiling.

Existing plain-pi behavior is unchanged and covered by `test_detect_pi_status_running_spinner_footer` and `test_detect_pi_status_finished_with_activity_prose_is_not_running`; the full `tmux::status_detection` module passes (172 tests).

## Risks

- A parked plain pi pane whose finished response quotes the literal hint within the three non-empty lines above the box's rule anchor (positions 5 to 7 for plain pi) still reads Running. Positions 5 and 6 matched `main`'s behavior before this PR, so the net new exposure is position 7, and it is forced by the omo coverage requirement: omo's busy line sits three lines above the same rule, indistinguishable from such a quote without content assumptions about the busy line. Narrowing the band to close position 7 drops the omo busy line, which is the bug this PR fixes. Quotes deeper than the band stay Idle. Live output eventually ages a quote out of the band; a pane at rest holds it until its next turn starts.
- `PI_HINT_BAND_ABOVE_BOX` is tuned to the captured omo frame rather than derived: sweeping the tip-line count shows the busy line drops out of the band at three tips, so a derivative carrying one more line of furniture between its busy line and its box reopens #3475 and widens the constant by one. The failure is bounded and degrades to Idle rather than to a pinned Running, which is the direction that matters.
- Precedence note: the hint check already outranked the parked-prompt check; the anchored band reaches up to three lines above the box top, so a stale hint inside that band still wins over a fresh prompt. Same semantics as before, smaller reach than `main`'s line-count window.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** ox-alpha (coding agent)

**Any Additional AI Details you'd like to share:** Full cycle run solo: repro-first red test, RCA against the checkout, minimal design, implementation, targeted validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `detect_pi_status` for pi derivatives with taller footers.
- Anchored interrupt-hint detection to the input-box rules when available.
- Preserved the six-line fallback for panes without usable rules.
- Kept spinner and activity-word checks scoped to reduce false `Running` states.
- Added tests for deep hints, scan boundaries, quoted hints, and fallback behavior.
- The status detection module now passes 173 tests.

This improves active-state detection without adding agent-specific configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


