### PR TITLE
fix: acp doctor flags adapters below the version floor aoe enforces

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3391,10 +3391,7 @@ fn path_copy_below_floor(command: &str, path: &std::path::Path) -> bool {
     let Some(raw) = probe_version_bounded(path) else {
         return false;
     };
-    raw.split_whitespace()
-        .filter_map(|tok| semver::Version::parse(tok.trim_start_matches('v')).ok())
-        .next()
-        .is_some_and(|found| found < min)
+    crate::acp::version_probe::whitespace_token_below_floor(&raw, min)
 }
 
 /// Run `<path> --version` with a deadline and return its stdout.

--- a/src/acp/version_probe.rs
+++ b/src/acp/version_probe.rs
@@ -94,17 +94,31 @@ pub fn extract_semver(raw: &str) -> Option<Version> {
 /// what spawn will do must ask this exact predicate instead of reusing
 /// the lenient parse.
 pub fn whitespace_token_below_floor(raw: &str, min: Version) -> bool {
+    whitespace_token_semver(raw).is_some_and(|found| found < min)
+}
+
+/// The strict token itself, for callers that need to compare against a
+/// floor in either direction (spawn keeps the PATH copy when this is
+/// `None`, and a pinned bundle only counts as backing when its own
+/// stdout parses at or above the floor).
+pub fn whitespace_token_semver(raw: &str) -> Option<Version> {
     raw.split_whitespace()
         .filter_map(|tok| Version::parse(tok.trim_start_matches('v')).ok())
         .next()
-        .is_some_and(|found| found < min)
 }
 
 pub async fn probe_binary_version(binary: &str) -> ProbeStatus {
-    let Ok(path) = which::which(binary) else {
-        return ProbeStatus::Missing;
-    };
-    let child = tokio::process::Command::new(&path)
+    match which::which(binary) {
+        Ok(path) => probe_path_version(&path).await,
+        Err(_) => ProbeStatus::Missing,
+    }
+}
+
+/// Probe an explicit executable path. Same budget and stream handling
+/// as [`probe_binary_version`], for callers that resolved the binary
+/// themselves (the pinned bundled copies never sit on PATH).
+pub async fn probe_path_version(path: &std::path::Path) -> ProbeStatus {
+    let child = tokio::process::Command::new(path)
         .arg("--version")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src/acp/version_probe.rs
+++ b/src/acp/version_probe.rs
@@ -76,6 +76,19 @@ pub fn extract_semver(raw: &str) -> Option<Version> {
         .next()
 }
 
+/// The spawn side's tokenizer (`path_copy_below_floor`): the first
+/// whitespace-delimited token that parses as strict semver once a
+/// leading `v` is stripped. The doctor's probe parser is more lenient
+/// (stderr folded in, punctuation-split tokens), so code that predicts
+/// what spawn will do must ask this exact predicate instead of reusing
+/// the lenient parse.
+pub fn whitespace_token_below_floor(raw: &str, min: Version) -> bool {
+    raw.split_whitespace()
+        .filter_map(|tok| Version::parse(tok.trim_start_matches('v')).ok())
+        .next()
+        .is_some_and(|found| found < min)
+}
+
 pub async fn probe_binary_version(binary: &str) -> ProbeStatus {
     let Ok(path) = which::which(binary) else {
         return ProbeStatus::Missing;
@@ -249,6 +262,36 @@ mod tests {
         assert!(extract_semver("not-semver").is_none());
     }
 
+    /// This predicate IS the spawn-side decision, so its table pins the
+    /// strict tokenizer: whitespace-delimited, `v`-stripped, first
+    /// parseable token wins. Formats the lenient doctor parser accepts
+    /// (like `version=0.37.0`, split on punctuation) must read as
+    /// unproven here.
+    #[test]
+    fn whitespace_token_below_floor_mirrors_spawn_parsing() {
+        let min = Version::parse(CLAUDE_AGENT_ACP_MIN_VERSION).unwrap();
+        // (raw, below_floor)
+        let cases = [
+            ("0.37.0", true),
+            ("claude-agent-acp 0.37.0", true),
+            ("v0.37.0", true),
+            ("0.55.0", false),
+            ("0.56.0", false),
+            // Punctuation-joined output has no whitespace token that
+            // parses strictly: spawn keeps the PATH copy.
+            ("version=0.37.0", false),
+            ("0.37.0-beta.1", true),
+            ("junk", false),
+            ("", false),
+        ];
+        for (raw, below) in cases {
+            assert_eq!(
+                whitespace_token_below_floor(raw, min.clone()),
+                below,
+                "{raw:?}"
+            );
+        }
+    }
     #[test]
     fn warning_for_probe_flags_only_unusable_versions() {
         let gate = claude_gate();

--- a/src/acp/version_probe.rs
+++ b/src/acp/version_probe.rs
@@ -13,9 +13,20 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProbeStatus {
     Missing,
-    Version { raw: String, parsed: Version },
-    Unparseable { raw: String },
-    Failed { message: String },
+    Version {
+        raw: String,
+        parsed: Version,
+        /// stdout only, what the spawn-side tokenizer sees; stderr is
+        /// folded into `raw`. Bundle-backed suppression must judge
+        /// spawn's stream view, not this probe's lenient fold.
+        stdout_raw: String,
+    },
+    Unparseable {
+        raw: String,
+    },
+    Failed {
+        message: String,
+    },
     TimedOut,
 }
 
@@ -110,13 +121,10 @@ pub async fn probe_binary_version(binary: &str) -> ProbeStatus {
     };
     match tokio::time::timeout(PROBE_TIMEOUT, child.wait_with_output()).await {
         Ok(Ok(output)) => {
-            let raw = format!(
-                "{}{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr),
-            )
-            .trim()
-            .to_string();
+            let stdout_raw = String::from_utf8_lossy(&output.stdout).to_string();
+            let raw = format!("{}{}", stdout_raw, String::from_utf8_lossy(&output.stderr),)
+                .trim()
+                .to_string();
             if !output.status.success() {
                 return ProbeStatus::Failed {
                     message: if raw.is_empty() {
@@ -127,7 +135,11 @@ pub async fn probe_binary_version(binary: &str) -> ProbeStatus {
                 };
             }
             match extract_semver(&raw) {
-                Some(parsed) => ProbeStatus::Version { raw, parsed },
+                Some(parsed) => ProbeStatus::Version {
+                    raw,
+                    parsed,
+                    stdout_raw,
+                },
                 None => ProbeStatus::Unparseable { raw },
             }
         }
@@ -301,6 +313,7 @@ mod tests {
                 &ProbeStatus::Version {
                     raw: "0.0.1".to_string(),
                     parsed: Version::parse("0.0.1").unwrap(),
+                    stdout_raw: "0.0.1".to_string(),
                 },
             )
             .unwrap()
@@ -312,6 +325,7 @@ mod tests {
             &ProbeStatus::Version {
                 raw: CLAUDE_AGENT_ACP_MIN_VERSION.to_string(),
                 parsed: Version::parse(CLAUDE_AGENT_ACP_MIN_VERSION).unwrap(),
+                stdout_raw: CLAUDE_AGENT_ACP_MIN_VERSION.to_string(),
             },
         )
         .is_none());
@@ -320,6 +334,7 @@ mod tests {
             &ProbeStatus::Version {
                 raw: "999.0.0".to_string(),
                 parsed: Version::parse("999.0.0").unwrap(),
+                stdout_raw: "999.0.0".to_string(),
             },
         )
         .is_none());

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -336,10 +336,10 @@ fn doctor_version_issue(
             // like `version=0.37.0` parses here but not at spawn. When
             // spawn would keep the PATH copy, keep the flag.
             let bundle_backs_spawn = match probe {
-                ProbeStatus::Version { raw, .. } => {
+                ProbeStatus::Version { stdout_raw, .. } => {
                     let min = semver::Version::parse(gate.min_version)
                         .expect("gate min_version must be valid semver");
-                    crate::acp::version_probe::whitespace_token_below_floor(raw, min)
+                    crate::acp::version_probe::whitespace_token_below_floor(stdout_raw, min)
                 }
                 // Without a parseable version spawn cannot prove
                 // below-floor either, so it keeps the PATH copy.
@@ -522,6 +522,7 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
     let registry = AgentRegistry::with_defaults();
 
     let node_status = check_node();
+    #[cfg(feature = "serve")]
     let mut gate_issues: Vec<(&'static str, Option<AgentVersionIssue>)> = Vec::new();
     let mut agent_entries: Vec<AgentDoctorEntry> = Vec::new();
     for (name, spec) in registry.list() {
@@ -1204,6 +1205,7 @@ mod tests {
                 &crate::acp::version_probe::ProbeStatus::Version {
                     raw: "0.0.1".to_string(),
                     parsed: semver::Version::parse("0.0.1").unwrap(),
+                    stdout_raw: "0.0.1".to_string(),
                 },
             ),
             DoctorFixAction::PrintHint { .. }
@@ -1225,6 +1227,7 @@ mod tests {
                         crate::acp::agent_compat::CLAUDE_AGENT_ACP_MIN_VERSION,
                     )
                     .unwrap(),
+                    stdout_raw: crate::acp::agent_compat::CLAUDE_AGENT_ACP_MIN_VERSION.to_string(),
                 },
             ),
             DoctorFixAction::Skip,
@@ -1279,6 +1282,7 @@ mod tests {
                 &crate::acp::version_probe::ProbeStatus::Version {
                     raw: "1.15.0".to_string(),
                     parsed: semver::Version::parse("1.15.0").unwrap(),
+                    stdout_raw: "1.15.0".to_string(),
                 },
             ),
             DoctorFixAction::PrintHint { .. }
@@ -1305,6 +1309,7 @@ mod tests {
         let stale = crate::acp::version_probe::ProbeStatus::Version {
             raw: "0.37.0".to_string(),
             parsed: semver::Version::parse("0.37.0").unwrap(),
+            stdout_raw: "0.37.0".to_string(),
         };
         let issue = doctor_version_issue(&gate, &stale, false)
             .expect("a below-floor adapter must produce a version issue");
@@ -1330,6 +1335,7 @@ mod tests {
         let ver = |v: &str| ProbeStatus::Version {
             raw: v.to_string(),
             parsed: semver::Version::parse(v).unwrap(),
+            stdout_raw: v.to_string(),
         };
         // (label, probe, bundle_installed, expect_issue)
         let cases: Vec<(&str, ProbeStatus, bool, bool)> = vec![
@@ -1355,6 +1361,20 @@ mod tests {
                 ProbeStatus::Version {
                     raw: "version=0.37.0".to_string(),
                     parsed: semver::Version::parse("0.37.0").unwrap(),
+                    stdout_raw: "version=0.37.0".to_string(),
+                },
+                true,
+                true,
+            ),
+            // Spawn's probe reads stdout only (stderr is nulled), so a
+            // version printed solely to stderr is invisible to it even
+            // though this probe folded it into `raw`: keep flagging.
+            (
+                "stderr_only_but_bundled",
+                ProbeStatus::Version {
+                    raw: "0.37.0".to_string(),
+                    parsed: semver::Version::parse("0.37.0").unwrap(),
+                    stdout_raw: String::new(),
                 },
                 true,
                 true,

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -443,21 +443,8 @@ async fn bundled_copy_strict_version(binary: &str) -> Option<semver::Version> {
 /// looks stale and validate() then rejects the handshake.
 #[cfg(feature = "serve")]
 async fn bundled_copy_meets_floor(gate: &crate::acp::agent_compat::VersionGate) -> bool {
-    let Some(path) = crate::session::get_app_dir()
-        .ok()
-        .and_then(|app_dir| crate::acp::adapters::bundled_adapter_bin(&app_dir, gate.binary))
-    else {
-        return false;
-    };
-    match crate::acp::version_probe::probe_path_version(&path).await {
-        crate::acp::version_probe::ProbeStatus::Version { stdout_raw, .. } => {
-            semver::Version::parse(gate.min_version).is_ok_and(|min| {
-                crate::acp::version_probe::whitespace_token_semver(stdout_raw.as_str())
-                    .is_some_and(|found| found >= min)
-            })
-        }
-        _ => false,
-    }
+    let found = bundled_copy_strict_version(gate.binary).await;
+    semver::Version::parse(gate.min_version).is_ok_and(|min| found.is_some_and(|v| v >= min))
 }
 
 #[cfg(feature = "serve")]

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -336,11 +336,14 @@ fn doctor_version_issue(
             // like `version=0.37.0` parses here but not at spawn. When
             // spawn would keep the PATH copy, keep the flag.
             let bundle_backs_spawn = match probe {
-                ProbeStatus::Version { stdout_raw, .. } => {
-                    let min = semver::Version::parse(gate.min_version)
-                        .expect("gate min_version must be valid semver");
-                    crate::acp::version_probe::whitespace_token_below_floor(stdout_raw, min)
-                }
+                ProbeStatus::Version { stdout_raw, .. } => semver::Version::parse(gate.min_version)
+                    // Like the sibling consumers of the floor (spawn's
+                    // path_copy_below_floor, doctor_fix_action), an
+                    // unparseable floor degrades to conservative: no
+                    // bundle credit, flag stays.
+                    .is_ok_and(|min| {
+                        crate::acp::version_probe::whitespace_token_below_floor(stdout_raw, min)
+                    }),
                 // Without a parseable version spawn cannot prove
                 // below-floor either, so it keeps the PATH copy.
                 _ => false,
@@ -551,8 +554,6 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
         } else {
             None
         };
-        #[cfg(not(feature = "serve"))]
-        let version_issue = None;
         agent_entries.push(AgentDoctorEntry {
             name: name.clone(),
             command_present,

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -308,11 +308,12 @@ fn skip_gate_check(binary: &str, on_path: bool) -> bool {
 
 /// Version-gate finding for one configured agent, the listing-side twin
 /// of `doctor_fix_action`: same verdicts, plus the one distinction the
-/// plain listing needs that `--fix` does not. A pinned bundled copy
-/// satisfies the floor even when the PATH copy is stale or absent,
-/// because the spawn resolver switches to it below-floor (see #1017).
-/// Absence with nothing installed stays the presence check's report;
-/// probing cannot sharpen it.
+/// plain listing needs that `--fix` does not. Only a PATH copy whose
+/// version parses below the floor is backed by a pinned bundled copy,
+/// because that is the only case `path_copy_below_floor` proves at spawn
+/// (see #1017); an unparseable or failed probe keeps the PATH copy at
+/// spawn, so it stays flagged here. Absence with nothing installed stays
+/// the presence check's report; probing cannot sharpen it.
 #[cfg(feature = "serve")]
 fn doctor_version_issue(
     gate: &crate::acp::agent_compat::VersionGate,
@@ -326,7 +327,7 @@ fn doctor_version_issue(
     match doctor_fix_action(Some(*gate), probe) {
         DoctorFixAction::Skip => None,
         DoctorFixAction::PrintHint { reason } => {
-            if bundle_installed {
+            if bundle_installed && matches!(probe, ProbeStatus::Version { .. }) {
                 return None;
             }
             Some(AgentVersionIssue {
@@ -335,6 +336,16 @@ fn doctor_version_issue(
             })
         }
     }
+}
+
+/// True when aoe's pinned bundled copy of `binary` is actually installed
+/// in the app data dir, not merely bundleable. Shared by the `--fix`
+/// reporter and the plain listing so the #1017 fallback semantics have
+/// one definition.
+#[cfg(feature = "serve")]
+fn bundled_copy_installed(binary: &str) -> bool {
+    crate::session::get_app_dir()
+        .is_ok_and(|app_dir| crate::acp::adapters::bundled_adapter_bin(&app_dir, binary).is_some())
 }
 
 /// Resolve whether `gate`'s adapter would miss its version floor at
@@ -347,9 +358,7 @@ async fn run_doctor_version_issue(
     gate: &crate::acp::agent_compat::VersionGate,
 ) -> Option<AgentVersionIssue> {
     let on_path = find_in_path(gate.binary).is_some();
-    let bundle_installed = crate::session::get_app_dir().is_ok_and(|app_dir| {
-        crate::acp::adapters::bundled_adapter_bin(&app_dir, gate.binary).is_some()
-    });
+    let bundle_installed = bundled_copy_installed(gate.binary);
     if !on_path && !bundle_installed {
         return None;
     }
@@ -370,9 +379,7 @@ async fn run_doctor_fix_action(binary: &str) {
             // actually installed. Since #1017, resolution prefers the pinned
             // bundle whenever it can prove the PATH copy is below the floor, so
             // with a bundle present the shadowing advice is simply false.
-            let bundle_installed = crate::session::get_app_dir().is_ok_and(|app_dir| {
-                crate::acp::adapters::bundled_adapter_bin(&app_dir, binary).is_some()
-            });
+            let bundle_installed = bundled_copy_installed(binary);
             if crate::acp::adapters::is_bundled(binary) && !bundle_installed {
                 println!(
                     "{binary}: {reason}. That copy is on your PATH and no bundled copy is \
@@ -1323,13 +1330,24 @@ mod tests {
             // Absence is reported by the presence branch either way.
             ("missing_but_bundled", ProbeStatus::Missing, true, false),
             ("absent_unbundled", ProbeStatus::Missing, false, false),
-            // Unprobeable copies cannot prove compatibility.
+            // Unprobeable copies cannot prove compatibility, with or
+            // without a bundle: path_copy_below_floor only rescues a
+            // parsed below-floor version, so spawn keeps the PATH copy
+            // and the listing must flag it.
             (
                 "unparseable",
                 ProbeStatus::Unparseable {
                     raw: "junk".to_string(),
                 },
                 false,
+                true,
+            ),
+            (
+                "unparseable_but_bundled",
+                ProbeStatus::Unparseable {
+                    raw: "junk".to_string(),
+                },
+                true,
                 true,
             ),
             (
@@ -1340,7 +1358,16 @@ mod tests {
                 false,
                 true,
             ),
+            (
+                "failed_but_bundled",
+                ProbeStatus::Failed {
+                    message: "boom".to_string(),
+                },
+                true,
+                true,
+            ),
             ("timed_out", ProbeStatus::TimedOut, false, true),
+            ("timed_out_but_bundled", ProbeStatus::TimedOut, true, true),
         ];
         for (label, probe, bundled, expect_issue) in cases {
             let issue = doctor_version_issue(&gate, &probe, bundled);

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -229,6 +229,18 @@ struct AgentDoctorEntry {
     name: String,
     command_present: bool,
     description: String,
+    /// Set when the copy aoe would spawn misses the adapter's minimum
+    /// version (#3267); the listing must not read `[OK]` then.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version_issue: Option<AgentVersionIssue>,
+}
+
+/// A version-gate finding for one configured agent: the remediation is
+/// the same `install_command` the startup error carries.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct AgentVersionIssue {
+    reason: String,
+    install_command: String,
 }
 
 #[cfg(feature = "serve")]
@@ -292,6 +304,57 @@ fn doctor_fix_action(
 #[cfg(feature = "serve")]
 fn skip_gate_check(binary: &str, on_path: bool) -> bool {
     !on_path && crate::acp::adapters::is_bundled(binary)
+}
+
+/// Version-gate finding for one configured agent, the listing-side twin
+/// of `doctor_fix_action`: same verdicts, plus the one distinction the
+/// plain listing needs that `--fix` does not. A pinned bundled copy
+/// satisfies the floor even when the PATH copy is stale or absent,
+/// because the spawn resolver switches to it below-floor (see #1017).
+/// Absence with nothing installed stays the presence check's report;
+/// probing cannot sharpen it.
+#[cfg(feature = "serve")]
+fn doctor_version_issue(
+    gate: &crate::acp::agent_compat::VersionGate,
+    probe: &crate::acp::version_probe::ProbeStatus,
+    bundle_installed: bool,
+) -> Option<AgentVersionIssue> {
+    use crate::acp::version_probe::ProbeStatus;
+    if matches!(probe, ProbeStatus::Missing) {
+        return None;
+    }
+    match doctor_fix_action(Some(*gate), probe) {
+        DoctorFixAction::Skip => None,
+        DoctorFixAction::PrintHint { reason } => {
+            if bundle_installed {
+                return None;
+            }
+            Some(AgentVersionIssue {
+                reason,
+                install_command: gate.install_command.to_string(),
+            })
+        }
+    }
+}
+
+/// Resolve whether `gate`'s adapter would miss its version floor at
+/// spawn time: probe the PATH copy (the one `--fix`'s gate loop checks)
+/// and account for a bundled copy that backs it. Skips the probe
+/// subprocess entirely when nothing usable is installed; the presence
+/// branch already reports that.
+#[cfg(feature = "serve")]
+async fn run_doctor_version_issue(
+    gate: &crate::acp::agent_compat::VersionGate,
+) -> Option<AgentVersionIssue> {
+    let on_path = find_in_path(gate.binary).is_some();
+    let bundle_installed = crate::session::get_app_dir().is_ok_and(|app_dir| {
+        crate::acp::adapters::bundled_adapter_bin(&app_dir, gate.binary).is_some()
+    });
+    if !on_path && !bundle_installed {
+        return None;
+    }
+    let probe = crate::acp::version_probe::probe_binary_version(gate.binary).await;
+    doctor_version_issue(gate, &probe, bundle_installed)
 }
 
 #[cfg(feature = "serve")]
@@ -434,25 +497,48 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
     let registry = AgentRegistry::with_defaults();
 
     let node_status = check_node();
-    let agent_entries: Vec<AgentDoctorEntry> = registry
-        .list()
-        .into_iter()
-        .map(|(name, spec)| AgentDoctorEntry {
+    let mut gate_issues: Vec<(&'static str, Option<AgentVersionIssue>)> = Vec::new();
+    let mut agent_entries: Vec<AgentDoctorEntry> = Vec::new();
+    for (name, spec) in registry.list() {
+        let command_present = command_present(&spec.command);
+        #[cfg(feature = "serve")]
+        let version_issue = if command_present {
+            let expected = crate::acp::agent_compat::ExpectedAgent::from_command(&spec.command);
+            match crate::acp::agent_compat::version_gate_for(expected) {
+                None => None,
+                Some(gate) => {
+                    // Aliases share a binary (claude / claude-code);
+                    // probe each gated binary once.
+                    match gate_issues
+                        .iter()
+                        .find(|(binary, _)| *binary == gate.binary)
+                    {
+                        Some((_, cached)) => cached.clone(),
+                        None => {
+                            let issue = run_doctor_version_issue(&gate).await;
+                            gate_issues.push((gate.binary, issue.clone()));
+                            issue
+                        }
+                    }
+                }
+            }
+        } else {
+            None
+        };
+        #[cfg(not(feature = "serve"))]
+        let version_issue = None;
+        agent_entries.push(AgentDoctorEntry {
             name: name.clone(),
-            command_present: command_present(&spec.command),
+            command_present,
             description: spec.description.clone(),
-        })
-        .collect();
+            version_issue,
+        });
+    }
 
     let any_agent_ok = agent_entries.iter().any(|e| e.command_present);
+    let any_agent_stale = agent_entries.iter().any(|e| e.version_issue.is_some());
     let node_ok = node_status.meets_minimum.unwrap_or(false);
-    let overall = if node_ok && any_agent_ok {
-        "ok"
-    } else if node_ok || any_agent_ok {
-        "partial"
-    } else {
-        "fail"
-    };
+    let overall = overall_status(node_ok, any_agent_ok, any_agent_stale);
     let report = DoctorReport {
         node: node_status,
         agents: agent_entries,
@@ -490,11 +576,7 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
     println!("Configured agents:");
     let registry_for_hints = AgentRegistry::with_defaults();
     for entry in &report.agents {
-        let mark = if entry.command_present {
-            "[OK]"
-        } else {
-            "[!! ]"
-        };
+        let mark = agent_mark(entry);
         println!("{} {}  ({})", mark, entry.name, entry.description);
         if !entry.command_present {
             // Look up the binary name via the registry so we can
@@ -506,6 +588,9 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
                     println!("    install: {hint}");
                 }
             }
+        } else if let Some(issue) = &entry.version_issue {
+            println!("    {}", issue.reason);
+            println!("    install: {}", issue.install_command);
         }
     }
     println!();
@@ -515,6 +600,29 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
         std::process::exit(if overall == "partial" { 2 } else { 1 });
     }
     Ok(())
+}
+
+/// `[OK]` only when the binary exists AND the version gate is satisfied;
+/// presence alone is not compatibility (#3267).
+fn agent_mark(entry: &AgentDoctorEntry) -> &'static str {
+    if entry.command_present && entry.version_issue.is_none() {
+        "[OK]"
+    } else {
+        "[!! ]"
+    }
+}
+
+/// Overall verdict. A version issue means configured sessions die at
+/// startup even though the binary exists, so it caps the verdict at
+/// partial exactly like a missing prerequisite (#3267).
+fn overall_status(node_ok: bool, any_agent_ok: bool, any_agent_stale: bool) -> &'static str {
+    if node_ok && any_agent_ok && !any_agent_stale {
+        "ok"
+    } else if node_ok || any_agent_ok {
+        "partial"
+    } else {
+        "fail"
+    }
 }
 
 fn check_node() -> NodeStatus {
@@ -1150,6 +1258,139 @@ mod tests {
             ),
             DoctorFixAction::PrintHint { .. }
         ));
+    }
+
+    /// Gate fixture for the doctor version-issue tests.
+    #[cfg(feature = "serve")]
+    fn claude_gate() -> crate::acp::agent_compat::VersionGate {
+        crate::acp::agent_compat::version_gate_for(
+            crate::acp::agent_compat::ExpectedAgent::ClaudeAgentAcp,
+        )
+        .expect("claude-agent-acp must carry a version gate")
+    }
+
+    /// #3267: the plain doctor listing applies the runtime's version
+    /// gate, not mere binary presence. The exact repro from the issue:
+    /// global adapter at 0.37.0 against the 0.55.0 floor, on PATH,
+    /// nothing bundled, sessions dying at initialize.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn doctor_flags_stale_gated_adapter_with_remediation() {
+        let gate = claude_gate();
+        let stale = crate::acp::version_probe::ProbeStatus::Version {
+            raw: "0.37.0".to_string(),
+            parsed: semver::Version::parse("0.37.0").unwrap(),
+        };
+        let issue = doctor_version_issue(&gate, &stale, false)
+            .expect("a below-floor adapter must produce a version issue");
+        assert!(issue.reason.contains("0.37.0"), "{}", issue.reason);
+        assert!(
+            issue.reason.contains(gate.min_version),
+            "reason must name the required floor: {}",
+            issue.reason
+        );
+        assert_eq!(issue.install_command, gate.install_command);
+    }
+
+    /// The listing borrows `--fix`'s verdicts verbatim and adds only the
+    /// bundle-awareness the spawn resolver acts on: a pinned bundled
+    /// copy satisfies the floor even when the PATH copy is stale or
+    /// absent, and absence with nothing installed stays the presence
+    /// check's report instead of a second complaint.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn doctor_version_issue_verdicts() {
+        use crate::acp::version_probe::ProbeStatus;
+        let gate = claude_gate();
+        let ver = |v: &str| ProbeStatus::Version {
+            raw: v.to_string(),
+            parsed: semver::Version::parse(v).unwrap(),
+        };
+        // (label, probe, bundle_installed, expect_issue)
+        let cases: Vec<(&str, ProbeStatus, bool, bool)> = vec![
+            // At-floor and above satisfy the gate; no false positive.
+            (
+                "at_floor",
+                ver(crate::acp::agent_compat::CLAUDE_AGENT_ACP_MIN_VERSION),
+                false,
+                false,
+            ),
+            ("above_floor", ver("1.0.0"), false, false),
+            // A pinned bundled copy backs the spawn below the floor
+            // (resolve_agent_command switches to it), so nothing to
+            // report.
+            ("stale_but_bundled", ver("0.37.0"), true, false),
+            // Absence is reported by the presence branch either way.
+            ("missing_but_bundled", ProbeStatus::Missing, true, false),
+            ("absent_unbundled", ProbeStatus::Missing, false, false),
+            // Unprobeable copies cannot prove compatibility.
+            (
+                "unparseable",
+                ProbeStatus::Unparseable {
+                    raw: "junk".to_string(),
+                },
+                false,
+                true,
+            ),
+            (
+                "failed",
+                ProbeStatus::Failed {
+                    message: "boom".to_string(),
+                },
+                false,
+                true,
+            ),
+            ("timed_out", ProbeStatus::TimedOut, false, true),
+        ];
+        for (label, probe, bundled, expect_issue) in cases {
+            let issue = doctor_version_issue(&gate, &probe, bundled);
+            assert_eq!(issue.is_some(), expect_issue, "{label}: {issue:?}");
+        }
+        // Non-npm gated adapter: remediation is its own hint.
+        let opencode = crate::acp::agent_compat::version_gate_for(
+            crate::acp::agent_compat::ExpectedAgent::OpenCode,
+        )
+        .expect("opencode must carry a version gate");
+        let issue = doctor_version_issue(&opencode, &ver("1.15.0"), false)
+            .expect("stale opencode must produce a version issue");
+        assert_eq!(issue.install_command, opencode.install_command);
+    }
+
+    /// The `[!! ]` mark and the overall verdict must react to version
+    /// issues, not only to missing binaries (#3267).
+    #[test]
+    fn doctor_mark_and_overall_demote_on_version_issue() {
+        let entry = |present: bool, issue: Option<AgentVersionIssue>| AgentDoctorEntry {
+            name: "claude".to_string(),
+            command_present: present,
+            description: String::new(),
+            version_issue: issue,
+        };
+        let stale_issue = AgentVersionIssue {
+            reason: "installed 0.37.0; requires >=0.55.0".to_string(),
+            install_command: "npm install -g @x/y@latest".to_string(),
+        };
+        let marks = [
+            (entry(true, None), "[OK]"),
+            (entry(true, Some(stale_issue.clone())), "[!! ]"),
+            (entry(false, None), "[!! ]"),
+        ];
+        for (e, mark) in &marks {
+            assert_eq!(&agent_mark(e), mark);
+        }
+        // (node_ok, any_agent_ok, any_agent_stale, expected)
+        let overall = [
+            (true, true, false, "ok"),
+            // The #3267 regression row: everything installed but stale
+            // must not read as fully green.
+            (true, true, true, "partial"),
+            (true, false, false, "partial"),
+            (false, true, false, "partial"),
+            (false, false, false, "fail"),
+        ];
+        for (node_ok, agents_ok, stale, expected) in overall {
+            assert_eq!(overall_status(node_ok, agents_ok, stale), expected);
+        }
     }
 
     /// #1858: `aoe acp cancel` must explain the conditional

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -329,7 +329,23 @@ fn doctor_version_issue(
     match doctor_fix_action(Some(*gate), probe) {
         DoctorFixAction::Skip => None,
         DoctorFixAction::PrintHint { reason } => {
-            if bundle_installed && matches!(probe, ProbeStatus::Version { .. }) {
+            // The bundle only backs the PATH copy when the SPAWN-side
+            // tokenizer agrees the version parses below the floor: it
+            // splits on whitespace and parses strictly, while this
+            // probe folds stderr in and splits on punctuation, so a raw
+            // like `version=0.37.0` parses here but not at spawn. When
+            // spawn would keep the PATH copy, keep the flag.
+            let bundle_backs_spawn = match probe {
+                ProbeStatus::Version { raw, .. } => {
+                    let min = semver::Version::parse(gate.min_version)
+                        .expect("gate min_version must be valid semver");
+                    crate::acp::version_probe::whitespace_token_below_floor(raw, min)
+                }
+                // Without a parseable version spawn cannot prove
+                // below-floor either, so it keeps the PATH copy.
+                _ => false,
+            };
+            if bundle_installed && bundle_backs_spawn {
                 return None;
             }
             Some(AgentVersionIssue {
@@ -545,9 +561,9 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
     }
 
     let any_agent_ok = agent_entries.iter().any(|e| e.command_present);
-    let any_agent_stale = agent_entries.iter().any(|e| e.version_issue.is_some());
+    let any_version_issue = agent_entries.iter().any(|e| e.version_issue.is_some());
     let node_ok = node_status.meets_minimum.unwrap_or(false);
-    let overall = overall_status(node_ok, any_agent_ok, any_agent_stale);
+    let overall = overall_status(node_ok, any_agent_ok, any_version_issue);
     let report = DoctorReport {
         node: node_status,
         agents: agent_entries,
@@ -624,8 +640,8 @@ fn agent_mark(entry: &AgentDoctorEntry) -> &'static str {
 /// Overall verdict. A version issue means configured sessions die at
 /// startup even though the binary exists, so it caps the verdict at
 /// partial exactly like a missing prerequisite (#3267).
-fn overall_status(node_ok: bool, any_agent_ok: bool, any_agent_stale: bool) -> &'static str {
-    if node_ok && any_agent_ok && !any_agent_stale {
+fn overall_status(node_ok: bool, any_agent_ok: bool, any_version_issue: bool) -> &'static str {
+    if node_ok && any_agent_ok && !any_version_issue {
         "ok"
     } else if node_ok || any_agent_ok {
         "partial"
@@ -1326,9 +1342,23 @@ mod tests {
             ),
             ("above_floor", ver("1.0.0"), false, false),
             // A pinned bundled copy backs the spawn below the floor
-            // (resolve_agent_command switches to it), so nothing to
-            // report.
+            // only when the SPAWN-side tokenizer can parse the raw
+            // below-floor too (resolve_agent_command switches on its
+            // own strict parse), so nothing to report.
             ("stale_but_bundled", ver("0.37.0"), true, false),
+            // The doctor parser is more lenient than spawn's: it splits
+            // `version=0.37.0` on punctuation while spawn needs a
+            // whitespace token. Spawn keeps the PATH copy, so the
+            // listing must keep flagging despite the bundle.
+            (
+                "lenient_raw_but_bundled",
+                ProbeStatus::Version {
+                    raw: "version=0.37.0".to_string(),
+                    parsed: semver::Version::parse("0.37.0").unwrap(),
+                },
+                true,
+                true,
+            ),
             // Absence is reported by the presence branch either way.
             ("missing_but_bundled", ProbeStatus::Missing, true, false),
             ("absent_unbundled", ProbeStatus::Missing, false, false),
@@ -1413,7 +1443,7 @@ mod tests {
     /// fails its version gate even though its binary exists (#3267).
     #[test]
     fn overall_status_caps_at_partial_on_version_issue() {
-        // (node_ok, any_agent_ok, any_agent_stale, expected)
+        // (node_ok, any_agent_ok, any_version_issue, expected)
         let cases = [
             (true, true, false, "ok"),
             // The #3267 regression row: everything installed but stale

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -239,7 +239,7 @@ struct AgentDoctorEntry {
 
 /// A version-gate finding for one configured agent: the remediation is
 /// the same `install_command` the startup error carries.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 struct AgentVersionIssue {
     reason: String,
     install_command: String,
@@ -310,17 +310,20 @@ fn skip_gate_check(binary: &str, on_path: bool) -> bool {
 
 /// Version-gate finding for one configured agent, the listing-side twin
 /// of `doctor_fix_action`: same verdicts, plus the one distinction the
-/// plain listing needs that `--fix` does not. Only a PATH copy whose
-/// version parses below the floor is backed by a pinned bundled copy,
-/// because that is the only case `path_copy_below_floor` proves at spawn
-/// (see #1017); an unparseable or failed probe keeps the PATH copy at
-/// spawn, so it stays flagged here. Absence with nothing installed stays
-/// the presence check's report; probing cannot sharpen it.
+/// plain listing needs that `--fix` does not. The `bundle_ok` flag
+/// means a pinned bundled copy exists AND provably satisfies the floor
+/// (existence alone is not compliance: a floor bump can strand an older
+/// pin in the data dir). Only a PATH copy whose version parses below
+/// the floor is backed by such a bundle, because that is the only case
+/// `path_copy_below_floor` proves at spawn (see #1017); an unparseable
+/// or failed probe keeps the PATH copy at spawn, so it stays flagged
+/// here. Absence with nothing installed stays the presence check's
+/// report; probing cannot sharpen it.
 #[cfg(feature = "serve")]
 fn doctor_version_issue(
     gate: &crate::acp::agent_compat::VersionGate,
     probe: &crate::acp::version_probe::ProbeStatus,
-    bundle_installed: bool,
+    bundle_ok: bool,
 ) -> Option<AgentVersionIssue> {
     use crate::acp::version_probe::ProbeStatus;
     if matches!(probe, ProbeStatus::Missing) {
@@ -348,7 +351,7 @@ fn doctor_version_issue(
                 // below-floor either, so it keeps the PATH copy.
                 _ => false,
             };
-            if bundle_installed && bundle_backs_spawn {
+            if bundle_ok && bundle_backs_spawn {
                 return None;
             }
             Some(AgentVersionIssue {
@@ -371,9 +374,9 @@ fn bundled_copy_installed(binary: &str) -> bool {
 
 /// Resolve whether `gate`'s adapter would miss its version floor at
 /// spawn time: probe the PATH copy (the one `--fix`'s gate loop checks)
-/// and account for a bundled copy that backs it. Skips the probe
-/// subprocess entirely when nothing usable is installed; the presence
-/// branch already reports that.
+/// and credit the pinned bundle only when its own copy provably meets
+/// the floor. Skips the probe subprocess entirely when nothing usable
+/// is installed; the presence branch already reports that.
 #[cfg(feature = "serve")]
 async fn run_doctor_version_issue(
     gate: &crate::acp::agent_compat::VersionGate,
@@ -384,7 +387,32 @@ async fn run_doctor_version_issue(
         return None;
     }
     let probe = crate::acp::version_probe::probe_binary_version(gate.binary).await;
-    doctor_version_issue(gate, &probe, bundle_installed)
+    let bundle_ok = bundle_installed && bundled_copy_meets_floor(gate).await;
+    doctor_version_issue(gate, &probe, bundle_ok)
+}
+
+/// True when the installed pinned copy's own `--version` parses, on the
+/// strict stdout stream, at or above the floor. A floor bump can strand
+/// an older pin in the data dir; crediting it would reproduce #3267
+/// behind a green doctor, since spawn prefers it whenever the PATH copy
+/// looks stale and validate() then rejects the handshake.
+#[cfg(feature = "serve")]
+async fn bundled_copy_meets_floor(gate: &crate::acp::agent_compat::VersionGate) -> bool {
+    let Some(path) = crate::session::get_app_dir()
+        .ok()
+        .and_then(|app_dir| crate::acp::adapters::bundled_adapter_bin(&app_dir, gate.binary))
+    else {
+        return false;
+    };
+    match crate::acp::version_probe::probe_path_version(&path).await {
+        crate::acp::version_probe::ProbeStatus::Version { stdout_raw, .. } => {
+            semver::Version::parse(gate.min_version).is_ok_and(|min| {
+                crate::acp::version_probe::whitespace_token_semver(stdout_raw.as_str())
+                    .is_some_and(|found| found >= min)
+            })
+        }
+        _ => false,
+    }
 }
 
 #[cfg(feature = "serve")]
@@ -1338,7 +1366,8 @@ mod tests {
             parsed: semver::Version::parse(v).unwrap(),
             stdout_raw: v.to_string(),
         };
-        // (label, probe, bundle_installed, expect_issue)
+        // (label, probe, bundle_ok: a pinned copy exists AND provably
+        // meets the floor, expect_issue)
         let cases: Vec<(&str, ProbeStatus, bool, bool)> = vec![
             // At-floor and above satisfy the gate; no false positive.
             (

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -386,9 +386,54 @@ async fn run_doctor_version_issue(
     if !on_path && !bundle_installed {
         return None;
     }
+
+    // Bundle-only installs are invisible to a PATH probe: which::which
+    // cannot see the data dir, so the pinned copy itself decides. A
+    // floor bump can strand an older pin there, and spawn would run it
+    // unconditionally while validate() rejects its handshake (#3267).
+    if !on_path {
+        let strict = bundled_copy_strict_version(gate.binary).await;
+        let min = semver::Version::parse(gate.min_version);
+        if strict
+            .as_ref()
+            .is_some_and(|found| min.as_ref().is_ok_and(|min| found >= min))
+        {
+            return None;
+        }
+        let reason = match (strict, min) {
+            (Some(found), Ok(min)) => {
+                format!("installed {found} (aoe's pinned copy); requires >={min}")
+            }
+            (_, _) => {
+                format!(
+                    "the bundled copy did not report a usable version; requires >={}",
+                    gate.min_version
+                )
+            }
+        };
+        return Some(AgentVersionIssue {
+            reason,
+            install_command: gate.install_command.to_string(),
+        });
+    }
+
     let probe = crate::acp::version_probe::probe_binary_version(gate.binary).await;
     let bundle_ok = bundle_installed && bundled_copy_meets_floor(gate).await;
     doctor_version_issue(gate, &probe, bundle_ok)
+}
+
+/// Strict stdout semver of the installed pinned copy, probed at its
+/// resolved data-dir path (`which::which` cannot see it there).
+#[cfg(feature = "serve")]
+async fn bundled_copy_strict_version(binary: &str) -> Option<semver::Version> {
+    let app_dir = crate::session::get_app_dir().ok()?;
+    let path = crate::acp::adapters::bundled_adapter_bin(&app_dir, binary)?;
+    match crate::acp::version_probe::probe_path_version(&path).await {
+        crate::acp::version_probe::ProbeStatus::Version { stdout_raw, .. } => {
+            crate::acp::version_probe::whitespace_token_semver(&stdout_raw)
+        }
+        _ => None,
+    }
 }
 
 /// True when the installed pinned copy's own `--version` parses, on the
@@ -1352,10 +1397,11 @@ mod tests {
     }
 
     /// The listing borrows `--fix`'s verdicts verbatim and adds only the
-    /// bundle-awareness the spawn resolver acts on: a pinned bundled
-    /// copy satisfies the floor even when the PATH copy is stale or
-    /// absent, and absence with nothing installed stays the presence
-    /// check's report instead of a second complaint.
+    /// bundle-awareness the spawn resolver acts on: a floor-COMPLIANT
+    /// pinned bundled copy satisfies the gate even when the PATH copy is
+    /// stale, and absence stays the presence check's report instead of a
+    /// second complaint. Bundle-only installs never reach this function:
+    /// the runner judges them from the pinned copy itself.
     #[cfg(feature = "serve")]
     #[test]
     fn doctor_version_issue_verdicts() {
@@ -1409,7 +1455,9 @@ mod tests {
                 true,
                 true,
             ),
-            // Absence is reported by the presence branch either way.
+            // Absence is reported by the presence branch either way;
+            // with a compliant bundle the runner's bundle-only branch
+            // owns that cell, so Missing itself never flags here.
             ("missing_but_bundled", ProbeStatus::Missing, true, false),
             ("absent_unbundled", ProbeStatus::Missing, false, false),
             // Unprobeable copies cannot prove compatibility, with or

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -229,8 +229,10 @@ struct AgentDoctorEntry {
     name: String,
     command_present: bool,
     description: String,
-    /// Set when the copy aoe would spawn misses the adapter's minimum
-    /// version (#3267); the listing must not read `[OK]` then.
+    /// Set when the copy aoe would spawn is not proven compatible with
+    /// the adapter's minimum version (#3267): below-floor, or unprobeable
+    /// so compatibility cannot be proven. The listing must not read
+    /// `[OK]` then.
     #[serde(skip_serializing_if = "Option::is_none")]
     version_issue: Option<AgentVersionIssue>,
 }
@@ -1383,10 +1385,10 @@ mod tests {
         assert_eq!(issue.install_command, opencode.install_command);
     }
 
-    /// The `[!! ]` mark and the overall verdict must react to version
-    /// issues, not only to missing binaries (#3267).
+    /// The `[!! ]` mark must react to version issues, not only to
+    /// missing binaries (#3267).
     #[test]
-    fn doctor_mark_and_overall_demote_on_version_issue() {
+    fn agent_mark_demotes_on_version_issue() {
         let entry = |present: bool, issue: Option<AgentVersionIssue>| AgentDoctorEntry {
             name: "claude".to_string(),
             command_present: present,
@@ -1399,14 +1401,20 @@ mod tests {
         };
         let marks = [
             (entry(true, None), "[OK]"),
-            (entry(true, Some(stale_issue.clone())), "[!! ]"),
+            (entry(true, Some(stale_issue)), "[!! ]"),
             (entry(false, None), "[!! ]"),
         ];
         for (e, mark) in &marks {
             assert_eq!(&agent_mark(e), mark);
         }
+    }
+
+    /// The overall verdict must cap at partial when a configured adapter
+    /// fails its version gate even though its binary exists (#3267).
+    #[test]
+    fn overall_status_caps_at_partial_on_version_issue() {
         // (node_ok, any_agent_ok, any_agent_stale, expected)
-        let overall = [
+        let cases = [
             (true, true, false, "ok"),
             // The #3267 regression row: everything installed but stale
             // must not read as fully green.
@@ -1415,7 +1423,7 @@ mod tests {
             (false, true, false, "partial"),
             (false, false, false, "fail"),
         ];
-        for (node_ok, agents_ok, stale, expected) in overall {
+        for (node_ok, agents_ok, stale, expected) in cases {
             assert_eq!(overall_status(node_ok, agents_ok, stale), expected);
         }
     }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2286,6 +2286,12 @@ fn test_cli_acp_doctor_bundle_only_judged_by_pinned_copy() {
     let cases = [("0.65.0", "[OK] claude"), ("0.44.0", "[!! ] claude")];
     for (bundle_version, expected_mark) in cases {
         let mut h = TuiTestHarness::new("cli_acp_doctor_bundle_only");
+        // The host PATH must not decide this cell: a global adapter
+        // would route the listing through the PATH-present branch.
+        // Scrubbing it leaves only the pinned copy visible, which is
+        // exactly the bundle-only state under test; every invocation
+        // here uses absolute paths, so nothing else needs PATH.
+        h.set_env("PATH", "");
         seed_bundled_fixture(&h, bundle_version);
 
         let out = h.run_cli(&["acp", "doctor"]);

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2273,3 +2273,23 @@ fn test_cli_acp_doctor_stale_bundle_keeps_flagging() {
     assert!(stdout.contains("[!! ] claude"), "{stdout}");
     assert!(!stdout.contains("[OK] claude"), "{stdout}");
 }
+
+/// Bundle-ONLY installs (nothing on PATH) are invisible to the PATH
+/// probe, so the pinned copy itself decides the verdict: compliant
+/// reads `[OK]`, stale reads `[!! ]` naming the bundled version. This
+/// is the stranded-pin cell after a floor bump.
+#[cfg(feature = "serve")]
+#[test]
+#[parallel]
+fn test_cli_acp_doctor_bundle_only_judged_by_pinned_copy() {
+    // (bundled fixture version, expected mark)
+    let cases = [("0.65.0", "[OK] claude"), ("0.44.0", "[!! ] claude")];
+    for (bundle_version, expected_mark) in cases {
+        let mut h = TuiTestHarness::new("cli_acp_doctor_bundle_only");
+        seed_bundled_fixture(&h, bundle_version);
+
+        let out = h.run_cli(&["acp", "doctor"]);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains(expected_mark), "{bundle_version}: {stdout}");
+    }
+}

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2200,3 +2200,76 @@ fn test_cli_acp_doctor_flags_below_floor_adapter() {
     );
     assert!(!stdout.contains("[OK] claude"), "{stdout}");
 }
+
+/// Seed the pinned-bundle location `bundled_adapter_bin` resolves, with
+/// a fixture reporting `version`.
+#[cfg(feature = "serve")]
+fn seed_bundled_fixture(h: &TuiTestHarness, version: &str) {
+    let bin = h.home_path().join(
+        ".config/agent-of-empires-dev/acp-worker/adapters/claude-agent-acp/node_modules/.bin",
+    );
+    std::fs::create_dir_all(&bin).expect("create bundle bin dir");
+    let script = bin.join("claude-agent-acp");
+    std::fs::write(&script, format!("#!/bin/sh\necho {version}\n")).expect("write bundle fixture");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("make bundle fixture executable");
+    }
+}
+
+/// A floor-COMPLIANT pinned bundled copy silences a stale PATH copy,
+/// because spawn switches to the bundle below-floor. This is the only
+/// end-to-end view of `bundled_copy_installed` +
+/// `bundled_copy_meets_floor`: unit tests inject that flag directly.
+#[cfg(feature = "serve")]
+#[test]
+#[parallel]
+fn test_cli_acp_doctor_compliant_bundle_silences_stale_path() {
+    let mut h = TuiTestHarness::new("cli_acp_doctor_bundle_ok");
+    let bin = h.home_path().join("fixture-bin");
+    std::fs::create_dir_all(&bin).expect("create fixture bin dir");
+    let script = bin.join("claude-agent-acp");
+    std::fs::write(&script, "#!/bin/sh\necho 0.37.0\n").expect("write path fixture");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("make path fixture executable");
+    }
+    h.add_path_dir(&bin);
+    seed_bundled_fixture(&h, "0.65.0");
+
+    let out = h.run_cli(&["acp", "doctor"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[OK] claude"), "{stdout}");
+    assert!(!stdout.contains("[!! ] claude"), "{stdout}");
+}
+
+/// The mirror case: an installed but STALE pinned copy (below today's
+/// floor) must not silence the listing, since spawn picks it over the
+/// stale PATH copy and validate() rejects its handshake.
+#[cfg(feature = "serve")]
+#[test]
+#[parallel]
+fn test_cli_acp_doctor_stale_bundle_keeps_flagging() {
+    let mut h = TuiTestHarness::new("cli_acp_doctor_bundle_stale");
+    let bin = h.home_path().join("fixture-bin");
+    std::fs::create_dir_all(&bin).expect("create fixture bin dir");
+    let script = bin.join("claude-agent-acp");
+    std::fs::write(&script, "#!/bin/sh\necho 0.37.0\n").expect("write path fixture");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("make path fixture executable");
+    }
+    h.add_path_dir(&bin);
+    seed_bundled_fixture(&h, "0.44.0");
+
+    let out = h.run_cli(&["acp", "doctor"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[!! ] claude"), "{stdout}");
+    assert!(!stdout.contains("[OK] claude"), "{stdout}");
+}

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2173,6 +2173,7 @@ fn test_cli_session_show_json_reports_archived_and_precedence() {
 /// present but below-floor reads `[!! ]` with remediation instead of
 /// `[OK]`. Deleting the probe call from the listing loop fails here even
 /// though every unit-level decision test stays green.
+#[cfg(feature = "serve")]
 #[test]
 #[parallel]
 fn test_cli_acp_doctor_flags_below_floor_adapter() {

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2167,3 +2167,35 @@ fn test_cli_session_show_json_reports_archived_and_precedence() {
     assert!(both["trashed_at"].is_string());
     assert!(both["archived_at"].is_string());
 }
+
+/// #3267 regression guard at the wiring level: `aoe acp doctor` must run
+/// its version-gate probe on configured agents, so an adapter that is
+/// present but below-floor reads `[!! ]` with remediation instead of
+/// `[OK]`. Deleting the probe call from the listing loop fails here even
+/// though every unit-level decision test stays green.
+#[test]
+#[parallel]
+fn test_cli_acp_doctor_flags_below_floor_adapter() {
+    let mut h = TuiTestHarness::new("cli_acp_doctor_below_floor");
+    let bin = h.home_path().join("fixture-bin");
+    std::fs::create_dir_all(&bin).expect("create fixture bin dir");
+    let script = bin.join("claude-agent-acp");
+    std::fs::write(&script, "#!/bin/sh\necho 0.37.0\n").expect("write fixture script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("make fixture executable");
+    }
+    h.add_path_dir(&bin);
+
+    let out = h.run_cli(&["acp", "doctor"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[!! ] claude"), "{stdout}");
+    assert!(stdout.contains("installed 0.37.0; requires >="), "{stdout}");
+    assert!(
+        stdout.contains("npm install -g @agentclientprotocol/claude-agent-acp@latest"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("[OK] claude"), "{stdout}");
+}

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -417,6 +417,12 @@ last_seen_version = "{}"
         self.extra_env.push((key.to_string(), value.to_string()));
     }
 
+    /// Prepend `dir` to the PATH of every spawned process so a
+    /// test-specific fixture binary shadows anything on the system.
+    pub fn add_path_dir(&mut self, dir: &Path) {
+        self.extra_path_dirs.push(dir.to_path_buf());
+    }
+
     /// Make the fake ACP agent reject `session/fork` (for fork-failure tests).
     /// Must be called BEFORE `install_acp_shim` so the knob is baked into the
     /// shim: the daemon strips arbitrary env before spawning the worker, so a


### PR DESCRIPTION
## Description

`aoe acp doctor` reported `[OK]` for a configured agent whose adapter version is below the floor aoe enforces at session start. A green doctor was followed by structured sessions dying at initialize with `incompatible_agent_version` (#3267): the agent listing consulted binary presence only, while the entire version gate machinery existed behind `--fix`.

Fixes #3267

### RCA

Symptom chain, each step verified on this tree:

1. The plain listing builds entries from `command_present()` alone (`doctor()` entries loop, src/cli/acp.rs), which stats PATH or the bundled install and never runs `<binary> --version`.
2. `[OK]` was rendered if and only if `command_present`.
3. The version gate decision (`doctor_fix_action`, comparing the probed version against `gate.min_version`) had exactly one caller, `run_doctor_fix_action`, invoked only from the `if fix` branch.
4. At session start the same floor applies for real: `resolve_agent_command` (src/acp/acp_client.rs) picks the binary, then post-handshake `agent_compat::validate` rejects below-floor versions with `IncompatibleAgentVersion`, producing exactly the event frames quoted in the issue.

Competing hypothesis, refuted: "[OK] is fine because a bundled pinned copy takes over". In the reported repro there is no bundled copy (`command_present` returned true from PATH alone) and without a bundle the resolver keeps the stale PATH copy, which `validate()` then rejects. Presence is not compatibility.

### Fix

The listing derives an optional per-agent `version_issue` through `doctor_version_issue`, the listing-side twin of `doctor_fix_action`: identical verdicts (one interpretation of the gate), plus one distinction the spawn resolver itself acts on: a pinned bundled copy satisfies the floor even when the PATH copy is stale or absent, so nothing is reported there because sessions start. Flagged entries render `[!! ]` with `installed X; requires >=Y` and the exact `install_command` the startup error carries, and cap `overall` at `partial` (exit code 2).

Required versions still come from the existing single source of truth (`version_gate_for` over `CLAUDE_AGENT_ACP_MIN_VERSION` / `OPENCODE_MIN_VERSION`); no new floor constant anywhere.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no clap help change, so `docs/cli/reference.md` needs no regeneration)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**

- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

`test_cli_acp_doctor_flags_below_floor_adapter` drives the real binary against a 0.37.0 fixture shim and fails if the listing loop stops calling the version gate (the exact #3267 regression). Two companion scenarios pin the bundled-copy decision end to end: only a floor-compliant pinned copy silences a stale PATH copy (`..._compliant_bundle_silences_stale_path`), a stale pinned copy keeps it flagged (`..._stale_bundle_keeps_flagging`). The pure decision matrix stays in unit tables (~ms tier per AGENTS.md cost rules).
  - Before: fixture `claude-agent-acp` printing `0.37.0` on PATH gave `[OK] claude`, `Overall: ok`, exit 0.
  - After: same fixture gives `[!! ] claude`, `installed 0.37.0; requires >=0.55.0`, `install: npm install -g @agentclientprotocol/claude-agent-acp@latest`, `Overall: partial`, exit 2. The `claude-code` alias shares a single probe.

## Risks / notes

- Intentionally breaking for scripts that treated doctor as green: stale setups now yield `overall: partial` and exit code 2. That flip is the requested fix.
- Doctor JSON stays additive: agents gain an optional `version_issue` object (`reason`, `install_command`); existing fields are unchanged.
- Known limitation inherited, not introduced: a gated adapter whose `--version` keeps its stdio pipes open past the 2s probe timeout reports "version probe timed out" (observed with opencode on the dev host while its installed version sits above the floor). `doctor --fix` and the serve boot warnings already emit this exact verdict through the same shared probe; reworking the probe is out of scope here.
- Latency: at most one probe per distinct gated binary (two today) plus one per installed pinned copy when one must be judged, sequential, 2s cap each, skipped entirely when neither PATH nor a bundled copy exists.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** ox-alpha (autonomous session agent)

**Any Additional AI Details you'd like to share:** Full cycle run solo: repro with a fixture binary, RCA, implementation, targeted tests, fmt/clippy, self-review.

- [x] I am an AI Agent filling out this form (check box if true)

### Review cycle additions (3b553832)

- Round 1 finding (fixed): a pinned bundled copy only rescues a *parsed* below-floor PATH copy (`path_copy_below_floor`, src/acp/acp_client.rs); unparseable/failed/timed-out probes stay flagged even with a bundle installed.
- Extracted `bundled_copy_installed` so the `--fix` reporter and the listing share one definition of bundle-installed.
- Follow-up candidates, deliberately not here: mention adapter version floors in the Doctor clap help + module header (requires regenerating docs/cli/reference.md), and consolidating the duplicated reason-string formats across `doctor_fix_action` / `VersionWarning::reason` / `StartupError::user_message`.

### Cycle 2 additions (7e1c603a)

- Adversarial finding fixed: the doctor probe parses more leniently than the spawn-side tokenizer, so a raw like `version=0.37.0` could read green under a bundle while sessions still died. Bundle-backed suppression now requires `whitespace_token_below_floor` agreement; `path_copy_below_floor` delegates to the same predicate so the two probes share one definition.
- Wiring guard added: e2e `test_cli_acp_doctor_flags_below_floor_adapter` drives the real binary against a 0.37.0 fixture shim and fails (reproducing the exact `[OK] claude`) if the listing loop stops calling the version gate.
- Renamed `any_agent_stale` to `any_version_issue`.

### Cycle 2 round 2 additions (89f1bc70)

- ProbeStatus::Version now carries stdout_raw; bundle-backed suppression judges the stream the spawn probe actually reads (stdout only, stderr nulled), so a stderr-only version stays flagged. New stderr_only_but_bundled verdict row.
- The e2e doctor guard is cfg-gated to serve, matching the bare-core CI leg that runs cli:: filtered e2e without the acp subcommand.

### Round 3 from-scratch additions (a205c7d7)

- Foundations pass re-derived cause and fix independently: right fix, right cause; all mutation-audited tests alive.
- doctor_version_issue now degrades on an unparseable floor like every sibling consumer instead of panicking.
- Deleted the unreachable #[cfg(not(feature = "serve"))] fallback arm (module is serve-gated).

### Round 4 from-scratch additions (053ce4d6)

- Ground-truth finding fixed: the pinned bundle was credited on existence only. After a floor bump strands an older pin in the data dir, spawn picks it over a stale PATH copy and validate() rejects its handshake, so the listing now probes the resolved bundled path and credits it only when its strict stdout token parses at or above the floor; two e2e scenarios pin both directions.
- Bundle-only installs (nothing on PATH) are now judged by the pinned copy itself: compliant stays `[OK]`, stale or unprobeable flags with the bundled version named (`a6dcd89b`); e2e `test_cli_acp_doctor_bundle_only_judged_by_pinned_copy` covers both directions.
- The bundle-only e2e scenario scrubs the host PATH entirely (`6d42872b`): a global adapter on the runner would route the listing through the PATH-present branch and decide the verdict instead of the seeded bundle.
- Dropped AgentVersionIssue's unused PartialEq/Eq derives.
- Known limitation, report-only: doctor keys on the registry's default commands; custom wrapper/path command forms (`npx claude-agent-acp`, absolute paths) remain gated at handshake time but the listing probes the bare gate binary. Fixing generally means executing arbitrary wrapper commands; deferred as follow-up.
- Report-only: `--json` shape and the Overall:/exit mapping are asserted unit-side only (overall_status table), not e2e.
