### PR TITLE
fix(hooks): pass the real path as hook bind-mount source so podman machine can see it

### DIFF
--- a/src/hooks/dir_guard.rs
+++ b/src/hooks/dir_guard.rs
@@ -543,27 +543,18 @@ pub(crate) fn unlink_session_id_via_guard(instance_id: &str) -> Result<()> {
 /// against a fixed share set keyed by real paths (podman machine shares
 /// `/private`, never `/tmp`). The lexical base (`/tmp/aoe-hooks-<euid>`) is
 /// therefore canonicalized before it leaves the process; on macOS that turns
-/// `/tmp/...` into the shared `/private/tmp/...` spelling. If resolution
-/// fails (directory removed mid-flight), fall back to the lexical path with
-/// a warning rather than blocking session boot.
+/// `/tmp/...` into the shared `/private/tmp/...` spelling.
 ///
-/// Caller policy on `Err`: skip the bind-mount push, surface a
-/// `tracing::warn!` and let the agent boot without status hooks
-/// (pane-detection fallback).
+/// Resolution errors propagate: a path that no longer resolves on the host
+/// would fail container creation with the same `statfs` error class this
+/// fixes, so callers apply their graceful `Err` policy instead. On
+/// `Err`: skip the bind-mount push, surface a `tracing::warn!` and let the
+/// agent boot without status hooks (pane-detection fallback).
 pub(crate) fn ensure_instance_dir_path(instance_id: &str) -> Result<PathBuf> {
     let _fd = open_instance_dir(instance_id)?;
     let lexical = hook_base_path().join(instance_id);
-    match std::fs::canonicalize(&lexical) {
-        Ok(resolved) => Ok(resolved),
-        Err(e) => {
-            tracing::warn!(target: "hooks.guard",
-                "could not resolve {} to its real path ({e:#}); passing it \
-                 unresolved, VM-backed runtimes may reject it if it crosses a \
-                 symlinked share boundary",
-                lexical.display());
-            Ok(lexical)
-        }
-    }
+    std::fs::canonicalize(&lexical)
+        .with_context(|| format!("canonicalize hook dir {}", lexical.display()))
 }
 
 // Cleanup.

--- a/src/hooks/dir_guard.rs
+++ b/src/hooks/dir_guard.rs
@@ -539,7 +539,7 @@ pub(crate) fn unlink_session_id_via_guard(instance_id: &str) -> Result<()> {
 /// would reject) and the multi-tenant pre-squat + symlink-swap race
 /// against Docker's bind-mount resolution.
 ///
-/// Issue #3240: VM-backed runtimes resolve mount sources inside their VM,
+/// #3240: VM-backed runtimes resolve mount sources inside their VM,
 /// against a fixed share set keyed by real paths (podman machine shares
 /// `/private`, never `/tmp`). The lexical base (`/tmp/aoe-hooks-<euid>`) is
 /// therefore canonicalized before it leaves the process; on macOS that turns

--- a/src/hooks/dir_guard.rs
+++ b/src/hooks/dir_guard.rs
@@ -527,9 +527,9 @@ pub(crate) fn unlink_session_id_via_guard(instance_id: &str) -> Result<()> {
 }
 
 /// Ensure the per-instance hook directory exists with `dir_guard` discipline
-/// and return its host path. Used by callers that hand the path to an
-/// external resolver (Docker bind-mount source, sidecar config writer)
-/// rather than performing in-process I/O directly.
+/// and return its host path, canonically resolved. Used by callers that hand
+/// the path to an external resolver (Docker/Podman bind-mount source, sidecar
+/// config writer) rather than performing in-process I/O directly.
 ///
 /// The function calls `open_instance_dir` to verify-and-create with
 /// `*at`+`O_NOFOLLOW`+`fstat-on-fd`, then drops the fd and returns the
@@ -539,12 +539,31 @@ pub(crate) fn unlink_session_id_via_guard(instance_id: &str) -> Result<()> {
 /// would reject) and the multi-tenant pre-squat + symlink-swap race
 /// against Docker's bind-mount resolution.
 ///
+/// Issue #3240: VM-backed runtimes resolve mount sources inside their VM,
+/// against a fixed share set keyed by real paths (podman machine shares
+/// `/private`, never `/tmp`). The lexical base (`/tmp/aoe-hooks-<euid>`) is
+/// therefore canonicalized before it leaves the process; on macOS that turns
+/// `/tmp/...` into the shared `/private/tmp/...` spelling. If resolution
+/// fails (directory removed mid-flight), fall back to the lexical path with
+/// a warning rather than blocking session boot.
+///
 /// Caller policy on `Err`: skip the bind-mount push, surface a
 /// `tracing::warn!` and let the agent boot without status hooks
 /// (pane-detection fallback).
 pub(crate) fn ensure_instance_dir_path(instance_id: &str) -> Result<PathBuf> {
     let _fd = open_instance_dir(instance_id)?;
-    Ok(hook_base_path().join(instance_id))
+    let lexical = hook_base_path().join(instance_id);
+    match std::fs::canonicalize(&lexical) {
+        Ok(resolved) => Ok(resolved),
+        Err(e) => {
+            tracing::warn!(target: "hooks.guard",
+                "could not resolve {} to its real path ({e:#}); passing it \
+                 unresolved, VM-backed runtimes may reject it if it crosses a \
+                 symlinked share boundary",
+                lexical.display());
+            Ok(lexical)
+        }
+    }
 }
 
 // Cleanup.

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -47,8 +47,8 @@ macro_rules! aoe_hook_marker {
 /// Fixed base path used inside the sandbox image, where the multi-tenant
 /// threat does not apply (per-container, single-tenant). The host bind-mounts
 /// `dir_guard::hook_base_path()/<id>`, canonically resolved since #3240, to
-/// this fixed path inside the container so the sandbox shell can bake a single
-/// canonical string regardless of the host's effective uid.
+/// this fixed path inside the container so the sandbox shell can bake a
+/// single fixed string regardless of the host's effective uid.
 pub(crate) const HOOK_STATUS_BASE_IN_CONTAINER: &str = concat!("/tmp/", aoe_hook_marker!());
 
 /// Marker token embedded by every AoE-emitted hook command in two structurally

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -46,8 +46,8 @@ macro_rules! aoe_hook_marker {
 
 /// Fixed base path used inside the sandbox image, where the multi-tenant
 /// threat does not apply (per-container, single-tenant). The host bind-mounts
-/// `/tmp/aoe-hooks-<euid>/<id>` from `dir_guard::hook_base_path()` to this
-/// fixed path inside the container so the sandbox shell can bake a single
+/// `dir_guard::hook_base_path()/<id>`, canonically resolved since #3240, to
+/// this fixed path inside the container so the sandbox shell can bake a single
 /// canonical string regardless of the host's effective uid.
 pub(crate) const HOOK_STATUS_BASE_IN_CONTAINER: &str = concat!("/tmp/", aoe_hook_marker!());
 
@@ -276,7 +276,8 @@ pub(crate) fn resolve_config_dir_override(var: &str, host_env: &[String]) -> Opt
 ///   `id -u` ownership self-check (defence-in-depth, the Rust-side
 ///   `dir_guard` is the authoritative gate).
 /// - `Sandbox`: bakes `/tmp/aoe-hooks` (fixed inside the container; the
-///   host bind-mounts `/tmp/aoe-hooks-<euid>/<id>` -> `/tmp/aoe-hooks/<id>`)
+///   host bind-mounts `dir_guard::hook_base_path()/<id>`, canonically
+///   resolved since #3240, onto `/tmp/aoe-hooks/<id>`)
 ///   and drops the uid check because the in-container UID is unpredictable
 ///   and the bind-mount source has already been validated host-side.
 ///

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -272,12 +272,9 @@ mod tests {
             } else {
                 real_parent.join("aoe-hooks")
             };
-            dir_guard::override_base_for_test(base.clone());
-            dir_guard::reset_for_test();
+            let _g = BaseGuard::with_base(base.clone());
             let got = crate::hooks::ensure_instance_dir_path("pathres")
                 .expect("instance dir must verify-and-create");
-            dir_guard::clear_base_override_for_test();
-            dir_guard::reset_for_test();
             let want = std::fs::canonicalize(&base).unwrap().join("pathres");
             assert_eq!(got, want, "{label}");
         }

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     #[serial_test::serial(hook_base)]
     fn test_ensure_instance_dir_path_resolves_symlinked_prefix() {
-        // Issue #3240: podman machine shares host paths under their real
+        // #3240: podman machine shares host paths under their real
         // paths (/private, not /tmp) inside the VM, so the bind-mount source
         // handed to the runtime must be canonically resolved.
         use tempfile::TempDir;

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -30,7 +30,7 @@ const ATTENTION_FILE_READ_CAP: usize = 16 * 1024;
 /// `/tmp/aoe-hooks-<euid>` resolved by `dir_guard::hook_base_path()`.
 /// `Err` if `instance_id` fails `validate_instance_id`.
 ///
-/// The path is informational (tests and debug logs); production I/O goes
+/// The path is informational (tests); production I/O goes
 /// through `dir_guard` and never path-joins. The sandbox bind-mount source is
 /// `dir_guard::ensure_instance_dir_path`, canonically resolved since #3240,
 /// so on symlinked prefixes it spells differently from this lexical value.

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -30,8 +30,10 @@ const ATTENTION_FILE_READ_CAP: usize = 16 * 1024;
 /// `/tmp/aoe-hooks-<euid>` resolved by `dir_guard::hook_base_path()`.
 /// `Err` if `instance_id` fails `validate_instance_id`.
 ///
-/// The path is informational (used by the sandbox bind-mount source string and
-/// by debug logs); production I/O goes through `dir_guard` and never path-joins.
+/// The path is informational (tests and debug logs); production I/O goes
+/// through `dir_guard` and never path-joins. The sandbox bind-mount source is
+/// `dir_guard::ensure_instance_dir_path`, canonically resolved since #3240,
+/// so on symlinked prefixes it spells differently from this lexical value.
 pub fn hook_status_dir(instance_id: &str) -> Result<PathBuf> {
     crate::session::validate_instance_id(instance_id)?;
     Ok(dir_guard::hook_base_path().join(instance_id))

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -249,6 +249,42 @@ mod tests {
 
     #[test]
     #[serial_test::serial(hook_base)]
+    fn test_ensure_instance_dir_path_resolves_symlinked_prefix() {
+        // Issue #3240: podman machine shares host paths under their real
+        // paths (/private, not /tmp) inside the VM, so the bind-mount source
+        // handed to the runtime must be canonically resolved.
+        use tempfile::TempDir;
+        let cases = [
+            ("symlinked base prefix resolves to the real path", true),
+            (
+                "already-real base prefix is passed through unchanged",
+                false,
+            ),
+        ];
+        for (label, symlinked) in cases {
+            let tmp = TempDir::new().unwrap();
+            let real_parent = tmp.path().join("real-parent");
+            std::fs::create_dir(&real_parent).unwrap();
+            let base = if symlinked {
+                let link_parent = tmp.path().join("via-symlink");
+                std::os::unix::fs::symlink(&real_parent, &link_parent).unwrap();
+                link_parent.join("aoe-hooks")
+            } else {
+                real_parent.join("aoe-hooks")
+            };
+            dir_guard::override_base_for_test(base.clone());
+            dir_guard::reset_for_test();
+            let got = crate::hooks::ensure_instance_dir_path("pathres")
+                .expect("instance dir must verify-and-create");
+            dir_guard::clear_base_override_for_test();
+            dir_guard::reset_for_test();
+            let want = std::fs::canonicalize(&base).unwrap().join("pathres");
+            assert_eq!(got, want, "{label}");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(hook_base)]
     fn test_cleanup_nonexistent_dir() {
         let (_g, _, _tmp) = BaseGuard::ready();
         cleanup_hook_status_dir("nonexistent_cleanup_test");

--- a/src/hooks/test_support.rs
+++ b/src/hooks/test_support.rs
@@ -38,9 +38,11 @@ impl BaseGuard {
 
     /// As [`Self::fresh`] but with an explicit base path instead of the
     /// default tempdir layout. Use for fixtures whose base must sit under a
-    /// specific parent (symlink chains, shared roots); the caller owns
-    /// creating `base` itself. The override is cleared on drop like the
-    /// other constructors.
+    /// specific parent (symlink chains, shared roots). The helper touches no
+    /// disk state, so pre-create whatever parent chain `base` requires;
+    /// whether `base` itself exists is up to the fixture, since guard entry
+    /// points verify-and-create it when absent. The override is cleared on
+    /// drop like the other constructors.
     pub(crate) fn with_base(base: PathBuf) -> Self {
         super::dir_guard::override_base_for_test(base);
         super::dir_guard::reset_for_test();

--- a/src/hooks/test_support.rs
+++ b/src/hooks/test_support.rs
@@ -35,6 +35,17 @@ impl BaseGuard {
         make_correct_base(&base);
         (g, base, tmp)
     }
+
+    /// As [`Self::fresh`] but with an explicit base path instead of the
+    /// default tempdir layout. Use for fixtures whose base must sit under a
+    /// specific parent (symlink chains, shared roots); the caller owns
+    /// creating `base` itself. The override is cleared on drop like the
+    /// other constructors.
+    pub(crate) fn with_base(base: PathBuf) -> Self {
+        super::dir_guard::override_base_for_test(base);
+        super::dir_guard::reset_for_test();
+        Self
+    }
 }
 
 impl Drop for BaseGuard {

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -3903,7 +3903,15 @@ volume_ignores = ["node_modules"]
     #[test]
     #[serial_test::serial]
     fn test_build_container_config_installs_codex_hooks_files() {
-        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        // Symlinked base prefix: keeps a mount-source assertion sensitive to
+        // the #3240 canonicalization even on Linux, where /tmp is already
+        // real and lexical comparison alone would survive a regression.
+        let tmp_base = TempDir::new().unwrap();
+        let real_parent = tmp_base.path().join("real-parent");
+        std::fs::create_dir(&real_parent).unwrap();
+        let link_parent = tmp_base.path().join("via-symlink");
+        std::os::unix::fs::symlink(&real_parent, &link_parent).unwrap();
+        let _hg = BaseGuard::with_base(link_parent.join("aoe-hooks"));
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -3953,6 +3953,9 @@ volume_ignores = ["node_modules"]
 
         let hook_dir =
             crate::hooks::hook_status_dir(instance_id).expect("test id must be allowlist-safe");
+        // Canonicalize for comparison (handles /var -> /private/var on macOS);
+        // the mount source is the resolved real path since #3240.
+        let hook_dir = hook_dir.canonicalize().unwrap();
         let expected_container_path = format!(
             "{}/{instance_id}",
             crate::hooks::HOOK_STATUS_BASE_IN_CONTAINER
@@ -4334,6 +4337,9 @@ trust_level = "trusted"
 
             let hook_dir = crate::hooks::hook_status_dir(&instance_id)
                 .expect("test id must be allowlist-safe");
+            // Canonicalize for comparison (handles /var -> /private/var on
+            // macOS); the mount source is the resolved real path since #3240.
+            let hook_dir = hook_dir.canonicalize().unwrap();
             assert!(
                 config
                     .volumes
@@ -4575,6 +4581,8 @@ trust_level = "trusted"
 
         let hook_dir =
             crate::hooks::hook_status_dir(instance_id).expect("test id must be allowlist-safe");
+        // Lexical is correct here: hooks are disabled, the instance dir is
+        // never created, so canonicalize would fail and no mount can match.
         assert!(
             !config
                 .volumes
@@ -4652,6 +4660,9 @@ agent_detect_as = { "wrapped-codex" = "codex" }
 
         let hook_dir =
             crate::hooks::hook_status_dir(instance_id).expect("test id must be allowlist-safe");
+        // Canonicalize for comparison (handles /var -> /private/var on macOS);
+        // the mount source is the resolved real path since #3240.
+        let hook_dir = hook_dir.canonicalize().unwrap();
         assert!(
             config
                 .volumes


### PR DESCRIPTION
## Description

Under the Podman runtime on macOS, sandbox container creation always failed:

```
Failed to create container: Error: statfs /tmp/aoe-hooks-501/<id>: no such file or directory
```

The hooks directory is created on the host at `/tmp/aoe-hooks-<euid>/<id>` (`src/hooks/dir_guard.rs`) and that lexical path is handed to the runtime as the bind-mount source (`src/session/container_config.rs`). Podman runs in a VM and resolves mount sources inside it, against a fixed share set keyed by real paths: `podman machine init` shares `/private` (never `/tmp`), and on macOS `/tmp` is a symlink to `/private/tmp`. The host directory is therefore already visible inside the VM under `/private/tmp/...`; only the unresolved spelling AoE passes is not.

### Change

`ensure_instance_dir_path` (the single boundary where the verified hooks path is handed to an external resolver) now canonicalizes the path via `std::fs::canonicalize` before returning it, so runtimes receive `/private/tmp/aoe-hooks-<uid>/<id>`. Resolution errors propagate so callers apply their graceful `Err` policy (skip the mount and boot without status hooks): a path that no longer resolves on the host would fail container creation with exactly the `statfs` error class this fixes, never a silent regression to the bug spelling. Linux behavior is unchanged: for non-symlinked prefixes canonicalize is the identity.

Option 2 from the issue (moving the directory under $HOME) was deliberately not taken: it changes an on-disk location other tooling may reference, historically requires a data migration (see v017), and is unnecessary because option 1 alone makes the path resolvable with no user configuration.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## Verification limits

End-to-end verification requires macOS with a running `podman machine`, which CI cannot exercise. The issue documents a VM-level workaround proving the mechanism (a symlink inside the VM, `podman machine ssh "sudo ln -sfn /private/tmp/aoe-hooks-$(id -u) /tmp/aoe-hooks-$(id -u)"`, makes today's binary work), and the same one-liners show `/private/tmp/...` mounts succeed while `/tmp/...` fails with the exact statfs error above. Here this is covered by a regression unit test that reproduces the defect at the path-construction boundary: with a symlinked base prefix, `ensure_instance_dir_path` must return the real path; red before the fix, green after (`hooks::status_file::tests::test_ensure_instance_dir_path_resolves_symlinked_prefix`).

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: reproducing the failure end to end needs macOS plus a live podman machine, which e2e CI does not have; the bug lives entirely in the pure host-side path construction, which the new unit test pins.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** ox-alpha (coding agent)

**Any Additional AI Details you'd like share:** RCA, fix and tests authored by the agent.

- [x] I am an AI Agent filling out this form (check box if true)
