### PR TITLE
fix(tmux): read abbreviated Claude token counters as Running

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2686,7 +2686,7 @@ enter to select · esc to cancel";
             ("plain integer", "(4s · ↓ 88 tokens)", true),
             ("multi-digit", "(12s · ↓ 1234 tokens)", true),
             ("decimal with k", "(53s · ↓ 7.0k tokens)", true),
-            ("decimal without suffix", "(4s · ↓ 44.7 tokens)", true),
+            ("plain decimal", "(4s · ↓ 44.7 tokens)", true),
             ("integer with k", "(4s · ↓ 512k tokens)", true),
             ("decimal with m", "(4s · ↓ 1.2m tokens)", true),
             ("integer with g", "(4s · ↓ 3g tokens)", true),

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -260,73 +260,102 @@ fn claude_pane_has_running_signal(
 /// rule rejected those and left long turns reading Idle (#3440).
 fn has_claude_live_token_counter(content: &str) -> bool {
     let bytes = content.as_bytes();
-    for (pos, _) in content.match_indices("s · ↓") {
-        // The anchor tail alone would match prose like `summary: 4s · ↓ 88
-        // tokens)`; the live counter always opens with `(` right before the
-        // duration. Walk back over that duration (`22m 8`) and require the
-        // opening paren; anything else (punctuation, prose letters, a
-        // closing paren, start of content) rejects this anchor occurrence,
-        // and the scan moves on to the next one.
-        let mut i = pos;
-        while i > 0 {
-            let c = bytes[i - 1];
-            if c == b'(' {
-                break;
+    // Two anchor shapes: the full `s · ↓` tail, and `s` + newline + `↓`
+    // when a narrow pane wraps right after the duration group
+    // (`(22m 8s` + newline + `↓ 44.7k tokens)`).
+    for pattern in ["s · ↓", "s\n↓"] {
+        for (pos, _) in content.match_indices(pattern) {
+            // The live counter always opens with `(` right before its
+            // duration, and that duration ends in a digit: `(22m 8s`,
+            // never `(s · ↓` or `(22m s · ↓`. Walk back over the duration
+            // (newlines included: narrow panes wrap mid-token, splitting
+            // `8s` across lines) and require the opening paren; anything
+            // else rejects this occurrence and the scan moves on to the
+            // next one. The digit itself may sit across the wrapping
+            // newline (`22m 8` + newline + `s · ↓`).
+            let mut j = pos;
+            while j > 0 && matches!(bytes[j - 1], b'\n') {
+                j -= 1;
             }
-            if !(c.is_ascii_digit() || matches!(c, b'm' | b's' | b'h' | b' ' | b'\t')) {
-                break;
+            if j == 0 || !bytes[j - 1].is_ascii_digit() {
+                continue;
             }
-            i -= 1;
-        }
-        if i == 0 || bytes[i - 1] != b'(' {
-            continue;
-        }
-        let after = content[pos + "s · ↓".len()..].trim_start();
-        let count_bytes = after.as_bytes();
-        let mut count_end = count_bytes
-            .iter()
-            .position(|b| !b.is_ascii_digit())
-            .unwrap_or(count_bytes.len());
-        if count_end > 0 {
-            // Optional single fractional part (`44.7`), consumed only when a
-            // digit follows the dot so `44.tokens` does not half-parse.
-            if count_bytes.get(count_end) == Some(&b'.')
-                && count_bytes
-                    .get(count_end + 1)
-                    .is_some_and(|b| b.is_ascii_digit())
-            {
-                count_end += 1;
-                count_end += count_bytes[count_end..]
-                    .iter()
-                    .position(|b| !b.is_ascii_digit())
-                    .unwrap_or(count_bytes.len() - count_end);
+            let mut i = pos;
+            while i > 0 {
+                let c = bytes[i - 1];
+                if c == b'(' {
+                    break;
+                }
+                if !(c.is_ascii_digit() || matches!(c, b'm' | b's' | b'h' | b' ' | b'\t' | b'\n')) {
+                    break;
+                }
+                i -= 1;
             }
-            // Optional magnitude suffix (`512k`, `1.2m`, `3g`), lowercase
-            // only: every captured rendering is lowercase, and prose echoes
-            // more readily carry an uppercase unit.
-            if matches!(count_bytes.get(count_end), Some(b'k' | b'm' | b'g')) {
-                count_end += 1;
+            if i == 0 || bytes[i - 1] != b'(' {
+                continue;
             }
-            let tail = after[count_end..].trim_start();
-            if let Some(after_tokens) = tail.strip_prefix("tokens") {
-                // The live counter ends the spinner line, so its closing
-                // paren must close a whitespace-only line. Quoted literals
-                // (this repo's own test rows, docs) carry punctuation or
-                // prose right after it; rejecting those keeps them from
-                // pinning a parked pane on Running. A newline itself is
-                // fine: narrow panes wrap the counter across lines, and a
-                // bare `)` opening the next line still completes the shape
-                // (pinned by the wrapped-before-paren row below).
-                let accepted = after_tokens
-                    .trim_start()
-                    .strip_prefix(')')
-                    .is_some_and(|rest| {
-                        rest.lines()
-                            .next()
-                            .is_none_or(|line| line.trim().is_empty())
-                    });
-                if accepted {
-                    return true;
+            let mut i = pos;
+            while i > 0 {
+                let c = bytes[i - 1];
+                if c == b'(' {
+                    break;
+                }
+                if !(c.is_ascii_digit() || matches!(c, b'm' | b's' | b'h' | b' ' | b'\t' | b'\n')) {
+                    break;
+                }
+                i -= 1;
+            }
+            if i == 0 || bytes[i - 1] != b'(' {
+                continue;
+            }
+            let after = content[pos + pattern.len()..].trim_start();
+            let count_bytes = after.as_bytes();
+            let mut count_end = count_bytes
+                .iter()
+                .position(|b| !b.is_ascii_digit())
+                .unwrap_or(count_bytes.len());
+            if count_end > 0 {
+                // Optional single fractional part (`44.7`), consumed only when a
+                // digit follows the dot so `44.tokens` does not half-parse.
+                if count_bytes.get(count_end) == Some(&b'.')
+                    && count_bytes
+                        .get(count_end + 1)
+                        .is_some_and(|b| b.is_ascii_digit())
+                {
+                    count_end += 1;
+                    count_end += count_bytes[count_end..]
+                        .iter()
+                        .position(|b| !b.is_ascii_digit())
+                        .unwrap_or(count_bytes.len() - count_end);
+                }
+                // Optional magnitude suffix (`512k`, `1.2m`, `3g`), lowercase
+                // only: every captured rendering is lowercase, and prose echoes
+                // more readily carry an uppercase unit.
+                if matches!(count_bytes.get(count_end), Some(b'k' | b'm' | b'g')) {
+                    count_end += 1;
+                }
+                let tail = after[count_end..].trim_start();
+                if let Some(after_tokens) = tail.strip_prefix("tokens") {
+                    // The live counter ends the spinner line, so its closing
+                    // paren must close a whitespace-only line. Quoted literals
+                    // (this repo's own test rows, docs) carry punctuation or
+                    // prose right after it; rejecting those keeps them from
+                    // pinning a parked pane on Running. A newline itself is
+                    // fine: narrow panes wrap the counter across lines, and a
+                    // bare `)` opening the next line still completes the shape
+                    // (pinned by the wrapped-before-paren row below).
+                    let accepted =
+                        after_tokens
+                            .trim_start()
+                            .strip_prefix(')')
+                            .is_some_and(|rest| {
+                                rest.lines()
+                                    .next()
+                                    .is_none_or(|line| line.trim().is_empty())
+                            });
+                    if accepted {
+                        return true;
+                    }
                 }
             }
         }
@@ -2720,6 +2749,13 @@ enter to select · esc to cancel";
                 "integer k, no decimal",
                 "✶ Summarizing the findings… (4s · ↓ 512k tokens)",
             ),
+            (
+                "wrap between duration and arrow",
+                "(22m 8s\n↓ 44.7k tokens)",
+            ),
+            // Narrow panes wrap mid-token: the joined capture carries the
+            // newline inside what was `8s`.
+            ("wrap inside seconds", "(22m 8\ns · ↓ 44.7k tokens)"),
         ];
         for (name, pane) in cases {
             assert_eq!(detect_claude_status(pane), Status::Running, "{name}");
@@ -2750,17 +2786,22 @@ enter to select · esc to cancel";
                 "✻ Judging #3413 feedback… (4s · ↓ 88 tokens\n)",
                 true,
             ),
-            // A narrow pane wraps the counter across lines; the scan hops
-            // the newline before `tokens`.
+            // Transcript prose may follow on the next physical line; only
+            // the paren's own line must stay blank.
+            (
+                "prose on the following line",
+                "(4s · ↓ 88 tokens)\nRan 2 shell commands",
+                true,
+            ),
             (
                 "wrapped across lines",
                 "✶ Summarizing the findings… (22m 8s · ↓ 44.7k\ntokens)",
                 true,
             ),
-            // The frozen strip's counters end the line without a closing
-            // paren; that is what keeps them excluded.
-            ("strip integer, no paren", "19s · ↓ 728 tokens", false),
-            ("strip k, no paren", "1m 14s · ↓ 40.4k tokens", false),
+            // Duration segments without their own digits are malformed
+            // pane text, not a counter.
+            ("empty duration", "(s · ↓ 88 tokens)", false),
+            ("unit without own digits", "(22m s · ↓ 88 tokens)", false),
             ("no count", "(4s · ↓ tokens)", false),
             ("comma separator", "(4s · ↓ 12,345 tokens)", false),
             ("uppercase suffix", "(4s · ↓ 44.7K tokens)", false),

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -252,36 +252,59 @@ fn claude_pane_has_running_signal(
 /// counters (`1m 14s · ↓ 40.4k tokens`) and stays on screen, frozen at its
 /// final values, after the agent completes and the session is fully idle.
 /// Matching it would pin a parked session on Running (the bug #2909 fixed),
-/// so the count must be numeric and `tokens` must be followed by the
-/// counter's closing paren, which strip rows never have. The paren is the
-/// requirement that excludes the strip, so the count itself may take
+/// so three structural requirements hold: an opening paren right before the
+/// duration (`(22m 8s · ↓`), a numeric count, and `tokens` followed by the
+/// counter's closing paren, which strip rows never have. The closing paren
+/// is the requirement that excludes the strip, so the count itself may take
 /// Claude's abbreviated forms (`44.7k`, `1.2m`); the earlier plain-integer
 /// rule rejected those and left long turns reading Idle (#3440).
 fn has_claude_live_token_counter(content: &str) -> bool {
-    let mut search = content;
-    while let Some(pos) = search.find("s · ↓") {
-        let after = search[pos + "s · ↓".len()..].trim_start();
-        let bytes = after.as_bytes();
-        let mut count_end = bytes
+    let bytes = content.as_bytes();
+    for (pos, _) in content.match_indices("s · ↓") {
+        // The anchor tail alone would match prose like `summary: 4s · ↓ 88
+        // tokens)`; the live counter always opens with `(` right before the
+        // duration. Walk back over that duration (`22m 8`) and require the
+        // opening paren; anything else (punctuation, prose letters, a
+        // closing paren, start of content) rejects this anchor occurrence,
+        // and the scan moves on to the next one.
+        let mut i = pos;
+        while i > 0 {
+            let c = bytes[i - 1];
+            if c == b'(' {
+                break;
+            }
+            if !(c.is_ascii_digit() || matches!(c, b'm' | b's' | b'h' | b' ' | b'\t')) {
+                break;
+            }
+            i -= 1;
+        }
+        if i == 0 || bytes[i - 1] != b'(' {
+            continue;
+        }
+        let after = content[pos + "s · ↓".len()..].trim_start();
+        let count_bytes = after.as_bytes();
+        let mut count_end = count_bytes
             .iter()
             .position(|b| !b.is_ascii_digit())
-            .unwrap_or(bytes.len());
+            .unwrap_or(count_bytes.len());
         if count_end > 0 {
             // Optional single fractional part (`44.7`), consumed only when a
             // digit follows the dot so `44.tokens` does not half-parse.
-            if bytes.get(count_end) == Some(&b'.')
-                && bytes.get(count_end + 1).is_some_and(|b| b.is_ascii_digit())
+            if count_bytes.get(count_end) == Some(&b'.')
+                && count_bytes
+                    .get(count_end + 1)
+                    .is_some_and(|b| b.is_ascii_digit())
             {
                 count_end += 1;
-                count_end += bytes[count_end..]
+                count_end += count_bytes[count_end..]
                     .iter()
                     .position(|b| !b.is_ascii_digit())
-                    .unwrap_or(bytes.len() - count_end);
+                    .unwrap_or(count_bytes.len() - count_end);
             }
             // Optional magnitude suffix (`512k`, `1.2m`, `3g`), lowercase
             // only: every captured rendering is lowercase, and prose echoes
             // more readily carry an uppercase unit.
-            if matches!(bytes.get(count_end), Some(b'k' | b'm' | b'g')) {
+            if matches!(count_bytes.get(count_end), Some(b'k' | b'm' | b'g')) {
                 count_end += 1;
             }
             let tail = after[count_end..].trim_start();
@@ -307,8 +330,6 @@ fn has_claude_live_token_counter(content: &str) -> bool {
                 }
             }
         }
-        // Advance past this match so we don't loop on the same position.
-        search = &search[pos + "s · ↓".len()..];
     }
     false
 }
@@ -2744,6 +2765,15 @@ enter to select · esc to cancel";
             ("comma separator", "(4s · ↓ 12,345 tokens)", false),
             ("uppercase suffix", "(4s · ↓ 44.7K tokens)", false),
             ("non-digit count", "(4s · ↓ many tokens)", false),
+            // The duration must sit inside an opening paren; an anchor tail
+            // loose in prose is not a live counter (review finding on
+            // #3488).
+            ("no opening paren", "summary: 4s · ↓ 88 tokens)", false),
+            (
+                "prose before the duration",
+                "see issue s · ↓ 88 tokens)",
+                false,
+            ),
             ("double dot", "(4s · ↓ 44..7k tokens)", false),
             // A dot with no digit after it must not be eaten as a fraction,
             // or `44.tokens)` would half-parse into a live counter.

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -252,23 +252,39 @@ fn claude_pane_has_running_signal(
 /// counters (`1m 14s · ↓ 40.4k tokens`) and stays on screen, frozen at its
 /// final values, after the agent completes and the session is fully idle.
 /// Matching it would pin a parked session on Running (the bug #2909 fixed),
-/// so two structural requirements exclude it: the count must be a plain
-/// integer (no `40.4k` decimal/suffix forms) and `tokens` must be followed by
-/// the counter's closing paren, which strip rows never have.
+/// so the count must be numeric and `tokens` must be followed by the
+/// counter's closing paren, which strip rows never have. The paren is the
+/// requirement that excludes the strip, so the count itself may take
+/// Claude's abbreviated forms (`44.7k`, `1.2m`); the earlier plain-integer
+/// rule rejected those and left long turns reading Idle (#3440).
 fn has_claude_live_token_counter(content: &str) -> bool {
     let mut search = content;
     while let Some(pos) = search.find("s · ↓") {
         let after = search[pos + "s · ↓".len()..].trim_start();
-        let mut digits_end = 0;
-        for (i, c) in after.char_indices() {
-            if c.is_ascii_digit() {
-                digits_end = i + c.len_utf8();
-            } else {
-                break;
+        let bytes = after.as_bytes();
+        let mut count_end = bytes
+            .iter()
+            .position(|b| !b.is_ascii_digit())
+            .unwrap_or(bytes.len());
+        if count_end > 0 {
+            // Optional single fractional part (`44.7`), consumed only when a
+            // digit follows the dot so `44.tokens` does not half-parse.
+            if bytes.get(count_end) == Some(&b'.')
+                && bytes.get(count_end + 1).is_some_and(|b| b.is_ascii_digit())
+            {
+                count_end += 1;
+                count_end += bytes[count_end..]
+                    .iter()
+                    .position(|b| !b.is_ascii_digit())
+                    .unwrap_or(bytes.len() - count_end);
             }
-        }
-        if digits_end > 0 {
-            let tail = after[digits_end..].trim_start();
+            // Optional magnitude suffix (`512k`, `1.2m`, `3g`), lowercase
+            // only: every captured rendering is lowercase, and prose echoes
+            // more readily carry an uppercase unit.
+            if matches!(bytes.get(count_end), Some(b'k' | b'm' | b'g')) {
+                count_end += 1;
+            }
+            let tail = after[count_end..].trim_start();
             if let Some(after_tokens) = tail.strip_prefix("tokens") {
                 if after_tokens.trim_start().starts_with(')') {
                     return true;
@@ -2633,6 +2649,59 @@ enter to select · esc to cancel";
             detect_claude_status("● Cooking… (12s · ↓ 1234 tokens)"),
             Status::Running
         );
+    }
+
+    #[test]
+    fn test_detect_claude_status_running_on_abbreviated_token_counter() {
+        // Claude abbreviates the live count once a turn runs long
+        // (`↓ 44.7k tokens`); the spinner line's ellipsis can sit past the
+        // second word, so the counter is that pane's only running signal.
+        // Captured from #3440.
+        let long_turn_pane = "\
+● Clippy clean on both; waiting on the base-commit control.\n\
+  Ran 2 shell commands\n\
+✻ Judging #3413 feedback… (22m 8s · ↓ 44.7k tokens)\n\
+┌─────\n\
+❯\n\
+└─────\n\
+  ⏵⏵ auto mode on";
+        let cases = [
+            ("issue pane", long_turn_pane),
+            ("k suffix", "✶ Working… (53s · ↓ 7.0k tokens)"),
+            ("m suffix", "✶ Working… (4s · ↓ 1.2m tokens)"),
+            ("g suffix", "✶ Working… (4s · ↓ 3g tokens)"),
+            ("integer k, no decimal", "✶ Working… (4s · ↓ 512k tokens)"),
+        ];
+        for (name, pane) in cases {
+            assert_eq!(detect_claude_status(pane), Status::Running, "{name}");
+        }
+    }
+
+    #[test]
+    fn test_has_claude_live_token_counter_variants() {
+        // Accepts every count form Claude renders inside the parenthesized
+        // live counter; rejects the unparenthesized frozen agents-strip
+        // counters (#2909) and malformed echoes.
+        let cases = [
+            ("plain integer", "(4s · ↓ 88 tokens)", true),
+            ("multi-digit", "(12s · ↓ 1234 tokens)", true),
+            ("decimal with k", "(53s · ↓ 7.0k tokens)", true),
+            ("integer with k", "(4s · ↓ 512k tokens)", true),
+            ("decimal with m", "(4s · ↓ 1.2m tokens)", true),
+            ("integer with g", "(4s · ↓ 3g tokens)", true),
+            // The frozen strip's counters end the line without a closing
+            // paren; that is what keeps them excluded.
+            ("strip integer, no paren", "19s · ↓ 728 tokens", false),
+            ("strip k, no paren", "1m 14s · ↓ 40.4k tokens", false),
+            ("no count", "(4s · ↓ tokens)", false),
+            ("comma separator", "(4s · ↓ 12,345 tokens)", false),
+            ("uppercase suffix", "(4s · ↓ 44.7K tokens)", false),
+            ("non-digit count", "(4s · ↓ many tokens)", false),
+            ("double dot", "(4s · ↓ 44..7k tokens)", false),
+        ];
+        for (name, content, expected) in cases {
+            assert_eq!(has_claude_live_token_counter(content), expected, "{name}");
+        }
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -273,6 +273,15 @@ fn has_claude_live_token_counter(content: &str) -> bool {
             // else rejects this occurrence and the scan moves on to the
             // next one. The digit itself may sit across the wrapping
             // newline (`22m 8` + newline + `s · ↓`).
+            //
+            // Wrapping is covered only where these two anchors reach: a
+            // break before the duration's last digit, one splitting that
+            // digit from its `s`, or one right after the `s`. A break
+            // inside `· ↓` matches neither anchor, and a split `8s` is
+            // walked only when the continuation starts flush, because the
+            // hop below crosses newlines but not the indentation a boxed
+            // pane puts after one. Both read Idle until the next capture,
+            // the harmless direction.
             let mut j = pos;
             while j > 0 && matches!(bytes[j - 1], b'\n') {
                 j -= 1;

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -286,15 +286,22 @@ fn has_claude_live_token_counter(content: &str) -> bool {
             }
             let tail = after[count_end..].trim_start();
             if let Some(after_tokens) = tail.strip_prefix("tokens") {
-                // The live counter ends the spinner line, so only
-                // whitespace may follow the closing paren. Quoted literals
+                // The live counter ends the spinner line, so its closing
+                // paren must close a whitespace-only line. Quoted literals
                 // (this repo's own test rows, docs) carry punctuation or
-                // quotes right after it; rejecting those keeps an echoed
-                // row from pinning a parked pane on Running.
+                // prose right after it, and a following physical line
+                // starting with `)` cannot complete an echoed anchor tail;
+                // rejecting both keeps them from pinning a parked pane on
+                // Running. A newline itself is fine: narrow panes wrap the
+                // counter across lines.
                 let accepted = after_tokens
                     .trim_start()
                     .strip_prefix(')')
-                    .is_some_and(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace));
+                    .is_some_and(|rest| {
+                        rest.lines()
+                            .next()
+                            .is_none_or(|line| line.trim().is_empty())
+                    });
                 if accepted {
                     return true;
                 }
@@ -2746,6 +2753,23 @@ enter to select · esc to cancel";
             // The anchor needs the duration's `s`; a bare arrow in prose is
             // not a counter.
             ("bare arrow in prose", "watch the ↓ 88 tokens) chart", false),
+            // Text after the closing paren on its own line means the shape
+            // is quoted prose, not a live counter.
+            ("prose after paren", "(4s · ↓ 88 tokens) renders", false),
+            // A following physical line starting with `)` must not supply
+            // the paren to a prose line ending in the anchor tail.
+            (
+                "next line completes shape",
+                "● The helper reads s · ↓ 42 tokens\n) -> Status {",
+                false,
+            ),
+            // Relaxing the anchor to a bare middle-dot arrow would let
+            // ordinary prose through; the duration's `s` is load-bearing.
+            (
+                "middle dot arrow without duration",
+                "chart · ↓ 88 tokens)",
+                false,
+            ),
             // Unobserved magnitude units stay out of the alphabet.
             ("b suffix", "(4s · ↓ 512b tokens)", false),
         ];

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2686,6 +2686,7 @@ enter to select · esc to cancel";
             ("plain integer", "(4s · ↓ 88 tokens)", true),
             ("multi-digit", "(12s · ↓ 1234 tokens)", true),
             ("decimal with k", "(53s · ↓ 7.0k tokens)", true),
+            ("decimal without suffix", "(4s · ↓ 44.7 tokens)", true),
             ("integer with k", "(4s · ↓ 512k tokens)", true),
             ("decimal with m", "(4s · ↓ 1.2m tokens)", true),
             ("integer with g", "(4s · ↓ 3g tokens)", true),

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2665,12 +2665,24 @@ enter to select · esc to cancel";
 ❯\n\
 └─────\n\
   ⏵⏵ auto mode on";
+        // The synthetic rows put the ellipsis on the third word, like the
+        // captured pane: `claude_line_is_active_spinner` then rejects the
+        // line and the counter is the only running signal being pinned.
         let cases = [
             ("issue pane", long_turn_pane),
-            ("k suffix", "✶ Working… (53s · ↓ 7.0k tokens)"),
-            ("m suffix", "✶ Working… (4s · ↓ 1.2m tokens)"),
-            ("g suffix", "✶ Working… (4s · ↓ 3g tokens)"),
-            ("integer k, no decimal", "✶ Working… (4s · ↓ 512k tokens)"),
+            (
+                "k suffix",
+                "✶ Summarizing the findings… (53s · ↓ 7.0k tokens)",
+            ),
+            (
+                "m suffix",
+                "✶ Summarizing the findings… (4s · ↓ 1.2m tokens)",
+            ),
+            ("g suffix", "✶ Summarizing the findings… (4s · ↓ 3g tokens)"),
+            (
+                "integer k, no decimal",
+                "✶ Summarizing the findings… (4s · ↓ 512k tokens)",
+            ),
         ];
         for (name, pane) in cases {
             assert_eq!(detect_claude_status(pane), Status::Running, "{name}");
@@ -2699,6 +2711,9 @@ enter to select · esc to cancel";
             ("uppercase suffix", "(4s · ↓ 44.7K tokens)", false),
             ("non-digit count", "(4s · ↓ many tokens)", false),
             ("double dot", "(4s · ↓ 44..7k tokens)", false),
+            // A dot with no digit after it must not be eaten as a fraction,
+            // or `44.tokens)` would half-parse into a live counter.
+            ("no digit after dot", "(4s · ↓ 44.tokens)", false),
         ];
         for (name, content, expected) in cases {
             assert_eq!(has_claude_live_token_counter(content), expected, "{name}");

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -286,7 +286,16 @@ fn has_claude_live_token_counter(content: &str) -> bool {
             }
             let tail = after[count_end..].trim_start();
             if let Some(after_tokens) = tail.strip_prefix("tokens") {
-                if after_tokens.trim_start().starts_with(')') {
+                // The live counter ends the spinner line, so only
+                // whitespace may follow the closing paren. Quoted literals
+                // (this repo's own test rows, docs) carry punctuation or
+                // quotes right after it; rejecting those keeps an echoed
+                // row from pinning a parked pane on Running.
+                let accepted = after_tokens
+                    .trim_start()
+                    .strip_prefix(')')
+                    .is_some_and(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace));
+                if accepted {
                     return true;
                 }
             }
@@ -2702,6 +2711,14 @@ enter to select · esc to cancel";
             ("integer with k", "(4s · ↓ 512k tokens)", true),
             ("decimal with m", "(4s · ↓ 1.2m tokens)", true),
             ("integer with g", "(4s · ↓ 3g tokens)", true),
+            ("two-digit fraction", "(4s · ↓ 1.23m tokens)", true),
+            // A narrow pane wraps the counter across lines; the scan hops
+            // the newline before `tokens`.
+            (
+                "wrapped across lines",
+                "✶ Summarizing the findings… (22m 8s · ↓ 44.7k\ntokens)",
+                true,
+            ),
             // The frozen strip's counters end the line without a closing
             // paren; that is what keeps them excluded.
             ("strip integer, no paren", "19s · ↓ 728 tokens", false),
@@ -2714,6 +2731,23 @@ enter to select · esc to cancel";
             // A dot with no digit after it must not be eaten as a fraction,
             // or `44.tokens)` would half-parse into a live counter.
             ("no digit after dot", "(4s · ↓ 44.tokens)", false),
+            // Only whitespace may follow the closing paren: a quoted
+            // literal row carries punctuation there and must stay
+            // rejected, echo or not.
+            ("punctuation after paren", "(4s · ↓ 7.0k tokens),", false),
+            ("quote after paren", "(4s · ↓ 88 tokens)\",", false),
+            // A decoy anchor inside footer text must not stop the scan
+            // from finding the real counter later in the window.
+            (
+                "decoy anchor then real counter",
+                "  ⏵⏵ bypass permissions on · ← for agents · ↓ to manage\n(4s · ↓ 88 tokens)",
+                true,
+            ),
+            // The anchor needs the duration's `s`; a bare arrow in prose is
+            // not a counter.
+            ("bare arrow in prose", "watch the ↓ 88 tokens) chart", false),
+            // Unobserved magnitude units stay out of the alphabet.
+            ("b suffix", "(4s · ↓ 512b tokens)", false),
         ];
         for (name, content, expected) in cases {
             assert_eq!(has_claude_live_token_counter(content), expected, "{name}");

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -289,11 +289,11 @@ fn has_claude_live_token_counter(content: &str) -> bool {
                 // The live counter ends the spinner line, so its closing
                 // paren must close a whitespace-only line. Quoted literals
                 // (this repo's own test rows, docs) carry punctuation or
-                // prose right after it, and a following physical line
-                // starting with `)` cannot complete an echoed anchor tail;
-                // rejecting both keeps them from pinning a parked pane on
-                // Running. A newline itself is fine: narrow panes wrap the
-                // counter across lines.
+                // prose right after it; rejecting those keeps them from
+                // pinning a parked pane on Running. A newline itself is
+                // fine: narrow panes wrap the counter across lines, and a
+                // bare `)` opening the next line still completes the shape
+                // (pinned by the wrapped-before-paren row below).
                 let accepted = after_tokens
                     .trim_start()
                     .strip_prefix(')')
@@ -2708,8 +2708,10 @@ enter to select · esc to cancel";
     #[test]
     fn test_has_claude_live_token_counter_variants() {
         // Accepts every count form Claude renders inside the parenthesized
-        // live counter; rejects the unparenthesized frozen agents-strip
-        // counters (#2909) and malformed echoes.
+        // live counter plus the regular extensions of that shape (m, g and
+        // bare decimals are extrapolations, not captures); rejects the
+        // unparenthesized frozen agents-strip counters (#2909) and
+        // malformed echoes.
         let cases = [
             ("plain integer", "(4s · ↓ 88 tokens)", true),
             ("multi-digit", "(12s · ↓ 1234 tokens)", true),
@@ -2719,6 +2721,14 @@ enter to select · esc to cancel";
             ("decimal with m", "(4s · ↓ 1.2m tokens)", true),
             ("integer with g", "(4s · ↓ 3g tokens)", true),
             ("two-digit fraction", "(4s · ↓ 1.23m tokens)", true),
+            // A bare `)` opening the next line still completes a wrapped
+            // counter; pinning it so a future tightening knows what it
+            // changes.
+            (
+                "wrapped before paren",
+                "✻ Judging #3413 feedback… (4s · ↓ 88 tokens\n)",
+                true,
+            ),
             // A narrow pane wraps the counter across lines; the scan hops
             // the newline before `tokens`.
             (

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -294,20 +294,6 @@ fn has_claude_live_token_counter(content: &str) -> bool {
             if i == 0 || bytes[i - 1] != b'(' {
                 continue;
             }
-            let mut i = pos;
-            while i > 0 {
-                let c = bytes[i - 1];
-                if c == b'(' {
-                    break;
-                }
-                if !(c.is_ascii_digit() || matches!(c, b'm' | b's' | b'h' | b' ' | b'\t' | b'\n')) {
-                    break;
-                }
-                i -= 1;
-            }
-            if i == 0 || bytes[i - 1] != b'(' {
-                continue;
-            }
             let after = content[pos + pattern.len()..].trim_start();
             let count_bytes = after.as_bytes();
             let mut count_end = count_bytes


### PR DESCRIPTION
## Description

Fixes bug 1 of #3440. Bug 2 stays open, see "Out of scope" below.

`has_claude_live_token_counter` (`src/tmux/status_detection.rs`, pre-fix lines 258 to 282) accepted only a plain ASCII integer between its `s · ↓` anchor and `tokens`, then required the closing paren. Claude abbreviates the live count once a turn runs long, so a pane mid-generation on a long turn renders `✻ Judging #3413 feedback… (22m 8s · ↓ 44.7k tokens)` and reads `Idle`.

### Root cause chain (each step verified on HEAD `74813729`)

- `detect_claude_status` (`src/tmux/status_detection.rs:154`) finds no blocking prompt and consults `claude_pane_has_running_signal` (`:223`).
- That calls `has_claude_live_token_counter(recent_joined)` (`:238`). The digit walk consumed `44` and stopped at `.`, so `strip_prefix("tokens")` failed on `.7k tokens)` and the counter returned false.
- The spinner matcher could not rescue the reported pane: the ellipsis sits on the third word (`Judging #3413 feedback…`), outside the deliberate first-or-second-word window of `claude_line_is_active_spinner` (`:291`). Widening that window was tried and withdrawn upstream: `● Running the full suite… (1m 52s)` is indistinguishable from a spinner by shape and pins a parked pane on Running with no recovery (#2909 direction). The token counter is the structurally safe signal for that pane, which is why the fix lands there and nowhere else.

### Fix

The count now accepts every count form Claude renders inside the parenthesized live counter plus the regular extensions of that shape: ASCII digits, one optional fractional part, one optional lowercase `k`/`m`/`g` suffix. Observed in captures: plain integers and decimal-plus-k (`88`, `1234`, `44.7k`); regular extensions kept for grammar symmetry and pinned by tests though no capture shows them yet (`44.7`, `512k`, `1.2m`, `3g`, two-digit fractions). Guards kept strict:

- The closing-paren requirement is untouched and is what excludes the frozen background-agents strip (its counters terminate at end of line, never `)`), so every #2915 fixture still passes.
- Comma separators (`12,345`), uppercase units (`44.7K`), fractions without a following digit (`44.`), double dots, and echoed or truncated counts without the exact live-counter context are still rejected.
- The closing paren must be followed only by whitespace (round-3 red-team hardening): the live counter ends the spinner line, while quoted literals (source rows, docs) carry punctuation right after the paren and stay rejected. Live probe on a parked pane quoting this repo's own test row: Running before, Idle after. This guard is also the direct answer to the objection recorded in the issue thread (#3147): the reporter had built this same relaxation and abstained because, on its own, it widens the echo path from short turns to every turn, and spinner-framed anchoring does not save it. Closing the shape on a whitespace-only line plus the quoted-literal and splice rejection rows keep that path shut without the ruled-out anchoring.
- The duration must sit inside an opening paren and must end in a digit: each anchor occurrence walks back over `22m 8` and requires `(` right behind it, so `summary: 4s · ↓ 88 tokens)` is no longer a counter and the malformed `(s · ↓` / `(22m s · ↓` shapes are rejected, with the scan moving on to the next anchor (review findings on this PR; pinned by the `no opening paren`, `prose before the duration`, `empty duration` and `unit without own digits` rows).
- Narrow panes wrap the counter, so the anchor set carries a second shape (`s` + newline + `↓`) and the backward walk crosses newlines: `(22m 8s` + newline + `↓ 44.7k tokens)` and `(22m 8` + newline + `s · ↓ 44.7k tokens)` both read Running, where a same-line-only walk read Idle. The cover is the breaks that reach an anchor, not every one: a break inside `· ↓`, or one splitting `8s` whose continuation is indented, still reads Idle until the next capture, which is the false-negative direction; the guard comment names which is which.
- The spinner path (`CLAUDE_SPINNER_CHARS`, `claude_line_is_active_spinner`) is untouched: relaxing the counter cannot reintroduce fake Running through spinner glyphs, because the shape still requires the literal `s · ↓ <count> tokens)` context.

### Out of scope (follow-up)

Bug 2 of #3440 is deliberately NOT addressed here: `claude_has_approval_prompt` matches a question phrase plus any `N.` line independently, so ordinary prose with a numbered list reads Waiting. Its proposed fix (requiring the `❯` selection cursor) needs maintainer arbitration: the cursor glyph may be theme-dependent (the Gemini detector documents another agent's default is `›`), narrowing detection carries a #1913-shaped risk if a real prompt ever renders without it, and `tests/e2e/permission_response_e2e.rs` renders a cursorless `1. Yes` that would rot silently. Tracked in the issue for that decision.

## Tests

- New `test_detect_claude_status_running_on_abbreviated_token_counter`: red before the fix on the issue's exact pane fixture (got Idle, expected Running), green after.
- New table `test_has_claude_live_token_counter_variants`: accepts plain, decimal, suffixed forms; rejects unparenthesized strip counters and malformed shapes.
- Full `tmux::status_detection` module: 173 passed, including every #2915 background-agents-strip fixture.
- `cargo fmt --all -- --check` clean.

### Accepted residual risks (documented)

- A quoted counter literal alone on its own line inside an otherwise parked pane still reads Running until it scrolls out of the 30-line window (end-to-end via `detect_claude_status`): the parenthesized shape is byte-identical to a real counter, so substring matching cannot separate them. Related: a prose line containing `s · ↓ N tokens)` matches when what follows the paren is punctuation-free whitespace, since any word ending in `s` before ` · ↓` works as the duration's tail. Inherent to substring anchoring, pre-existing for plain integers; a full fix would need line-anchored matching with its own false-negative cost. The closing-paren side is hardened instead: the paren must close a whitespace-only line, which rejects same-line prose after the counter and cross-line splices like a following `) -> Status {` line.
- The anchor `s · ↓ ... tokens)` is capture-derived, so an upstream reword of the counter format would silently reintroduce the long-turn blindness this PR fixes, in the false-negative direction (back toward Idle). The `token_counter` marker in the `status_change` fingerprint log is the signal that would reveal it: long turns logging transitions without that marker mean the anchor needs another capture.

## CI note

The CI job that ran red earlier on this PR (`test_export_exec_compound_command_passes_env`) is the known bare-core tmux timing flake, unrelated to this branch: verified green 3x locally at HEAD, main runs green, and the rerun on this branch is green. Tracked in #3513.

## Known baseline failures (not from this PR)

Under stable clippy 1.97.0, HEAD already fails `cargo clippy --all-targets -- -D warnings` with 6 errors in files this PR does not touch: `src/tui/home/mod.rs:6044` (items after test module) and `src/session/groups.rs:2353, 2378, 2394, 2415, 2569` (`clippy::useless_vec`). Verified by stashing this PR's diff and rerunning clippy (same errors). Left out of scope to keep the diff focused.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the changed surface is pane-text parsing, already pinned by deterministic unit fixtures over captured panes; an e2e would need a live Claude turn long enough to abbreviate its counter, which cannot be reproduced deterministically.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** ox-alpha

**Any Additional AI Details you'd like to share:** Autonomous end-to-end fix session for #3440 bug 1 (repro, RCA, design, implementation, validation, adversarial self-review).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved Claude pane status detection for long-running turns with abbreviated token counts, such as `44.7k tokens`.
- Added support for counters that wrap across lines, including breaks within durations and before token markers.
- Rejected malformed counters, quoted text, prose echoes, and incomplete formats.
- Added tests for valid, invalid, quoted, prose, and wrapped counters.
- Preserved spinner detection and background-agent behavior.

## Benefits

Claude panes now report active turns more accurately in narrow terminals. The status-detection module passes 173 tests, and formatting checks remain clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

