### PR TITLE
fix(web): enforce per-cell width in live terminal rows so fallback glyphs cannot shift columns

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -3,7 +3,6 @@ import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
 import {
   LineParseCache,
-  cellWidth,
   clusterSpanAt,
   findCursorCharIndex,
   splitCellRuns,
@@ -397,12 +396,13 @@ export const Row = memo(function Row({
       if (idx != null) {
         placed = true;
         const chars = [...run.text];
-        // Slice at cluster boundaries: a fixed run is a coalesced stretch
-        // of whole graphemes, and the cursor cell must take exactly the
-        // cluster under the cursor (base plus its marks/tails, a flag pair,
-        // or whatever a ZWJ joins) so no composition tail is stranded in a
-        // zero-width sibling where browsers draw dotted circles.
-        const [clusterStart, clusterEnd] = run.fixed ? clusterSpanAt(run.text, idx) : [idx, idx + 1];
+        // Slice at cluster boundaries for BOTH run kinds: a fixed run is a
+        // coalesced stretch of whole graphemes, and flow runs can carry
+        // glued marks too (NFD input). The cursor cell must take exactly
+        // the cluster under the cursor (base plus its marks/tails, a flag
+        // pair, or whatever a ZWJ joins) so no composition tail is
+        // stranded in a zero-width sibling where browsers draw circles.
+        const [clusterStart, clusterEnd] = clusterSpanAt(run.text, idx);
         if (clusterStart > 0) {
           const pre = chars.slice(0, clusterStart).join("");
           out.push(
@@ -418,7 +418,7 @@ export const Row = memo(function Row({
             data-live-cursor
             className={focused ? "animate-term-cursor-blink" : undefined}
             style={{
-              ...fixedBoxStyle(run.fixed ? textWidth(cursorText) : cellWidth(cursorText), base),
+              ...fixedBoxStyle(textWidth(cursorText), base),
               ...cursorStyle,
             }}
           >

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1,7 +1,16 @@
 import { Fragment, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
-import { LineParseCache, findCursorCharIndex, splitUrls, textWidth, wrapLine } from "../lib/liveTermLines";
+import {
+  LineParseCache,
+  cellWidth,
+  findCursorCharIndex,
+  splitCellRuns,
+  splitUrls,
+  textWidth,
+  wrapLine,
+  type CellRun,
+} from "../lib/liveTermLines";
 import { wheelNotches } from "../lib/liveMouse";
 import { registerMobileKeyboardProxyReceiver, type MobileKeyboardProxyInput } from "../lib/mobileKeyboardProxy";
 import { writeClipboard } from "../lib/clipboard";
@@ -181,6 +190,27 @@ function segStyle(style: AnsiStyle): CSSProperties | undefined {
   if (style.underline) css.textDecoration = "underline";
   return Object.keys(css).length ? css : undefined;
 }
+// Explicit-width box for one isolated run (#3342): an inline-block of
+// exactly `cells` cells, sized by the term-cell CSS variable set on the
+// scroller, absorbs any fallback font's advance error so a glyph missing
+// from the configured font shifts nothing after it. The 1em fallback in
+// the calc only covers standalone renders (unit tests) with no scroller.
+function fixedBoxStyle(cells: number, base: CSSProperties | undefined): CSSProperties {
+  return { ...base, display: "inline-block", width: `calc(var(--term-cell, 1em) * ${cells})` };
+}
+
+/** One styled run of a row: flowing text renders bare; fixed clusters get
+ *  the explicit box while remaining ordinary selectable/copyable spans.
+ *  Linkification applies per run (#2685); URLs are ASCII, so they live in
+ *  flow runs and keep their exact href and text. */
+function cellRunSpan(run: CellRun, style: AnsiStyle, key: string): ReactNode {
+  const base = segStyle(style);
+  return (
+    <span key={key} style={run.fixed ? fixedBoxStyle(run.cells, base) : base}>
+      {linkify(run.text)}
+    </span>
+  );
+}
 
 // Diagnostic overlay for cursor-alignment field reports: open the dashboard
 // with `?livedebug=1` and the live view shows the geometry the overlay math
@@ -338,73 +368,87 @@ export const Row = memo(function Row({
     if (segs.length === 0) return <div> </div>; // keep empty rows at full height
     return (
       <div>
-        {segs.map((seg, i) => (
-          <span key={i} style={segStyle(seg.style)}>
-            {linkify(seg.text)}
-          </span>
-        ))}
+        {segs.map((seg, i) => splitCellRuns(seg.text).map((run, j) => cellRunSpan(run, seg.style, `${i}-${j}`)))}
       </div>
     );
   }
   // The cursor row (live input line) keeps the delicate cell-split logic below
   // and is not linkified; agent-output URLs live in the cursorCol == null rows.
-  // Render the row with the single cell at `cursorCol` boxed. Walk segments by
-  // terminal cell width, not UTF-16 code units, since `cursorCol` is a real
-  // cell count from tmux and CJK/wide glyphs take two cells but one code
-  // unit (#2665); split the segment that straddles the cursor.
+  // Walk the row by terminal cell width, not UTF-16 code units, since
+  // `cursorCol` is a real cell count from tmux and CJK/wide glyphs take two
+  // cells but one code unit (#2665). Runs from splitCellRuns carry explicit
+  // widths (#3342), so splitting the run that straddles the cursor re-derives
+  // each piece's box and the boxed cell lands exactly on its column even when
+  // earlier glyphs fell back to another font.
   const out: ReactNode[] = [];
   let col = 0;
   let placed = false;
   let key = 0;
   for (const seg of segs) {
-    const t = seg.text;
-    const idx = placed ? null : findCursorCharIndex(t, cursorCol - col);
-    if (idx != null) {
-      const chars = [...t];
-      if (idx > 0) {
+    for (const run of splitCellRuns(seg.text)) {
+      const end = col + run.cells;
+      const base = segStyle(seg.style);
+      const idx = placed
+        ? null
+        : cursorCol >= col && cursorCol < end
+          ? findCursorCharIndex(run.text, cursorCol - col)
+          : null;
+      if (idx != null) {
+        placed = true;
+        const chars = [...run.text];
+        if (idx > 0) {
+          const pre = chars.slice(0, idx).join("");
+          out.push(
+            <span key={key++} style={run.fixed ? fixedBoxStyle(textWidth(pre), base) : base}>
+              {pre}
+            </span>,
+          );
+        }
         out.push(
-          <span key={key++} style={segStyle(seg.style)}>
-            {chars.slice(0, idx).join("")}
+          <span
+            key={key++}
+            data-live-cursor
+            className={focused ? "animate-term-cursor-blink" : undefined}
+            style={{ ...fixedBoxStyle(cellWidth(chars[idx]!), base), ...cursorStyle }}
+          >
+            {chars[idx]}
+          </span>,
+        );
+        if (idx + 1 < chars.length) {
+          const post = chars.slice(idx + 1).join("");
+          out.push(
+            <span key={key++} style={run.fixed ? fixedBoxStyle(textWidth(post), base) : base}>
+              {post}
+            </span>,
+          );
+        }
+      } else {
+        out.push(
+          <span key={key++} style={run.fixed ? fixedBoxStyle(run.cells, base) : base}>
+            {run.text}
           </span>,
         );
       }
-      out.push(
-        <span
-          key={key++}
-          data-live-cursor
-          className={focused ? "animate-term-cursor-blink" : undefined}
-          style={{ ...segStyle(seg.style), ...cursorStyle }}
-        >
-          {chars[idx]}
-        </span>,
-      );
-      if (idx + 1 < chars.length) {
-        out.push(
-          <span key={key++} style={segStyle(seg.style)}>
-            {chars.slice(idx + 1).join("")}
-          </span>,
-        );
-      }
-      placed = true;
-    } else {
-      out.push(
-        <span key={key++} style={segStyle(seg.style)}>
-          {t}
-        </span>,
-      );
+      col = end;
     }
-    col += textWidth(t);
   }
   if (!placed) {
     // Cursor sits past the row's text (blank input cell): pad to the column
-    // and box a space.
-    if (cursorCol > col) out.push(<span key="pad">{" ".repeat(cursorCol - col)}</span>);
+    // and box a space. The pad is an explicit box too; a fallback font's
+    // space advance must not move the cursor either.
+    if (cursorCol > col) {
+      out.push(
+        <span key="pad" style={fixedBoxStyle(cursorCol - col, undefined)}>
+          {" ".repeat(cursorCol - col)}
+        </span>,
+      );
+    }
     out.push(
       <span
         key="cursor"
         data-live-cursor
         className={focused ? "animate-term-cursor-blink" : undefined}
-        style={cursorStyle}
+        style={{ ...fixedBoxStyle(1, undefined), ...cursorStyle }}
       >
         {" "}
       </span>,
@@ -1756,44 +1800,51 @@ export function MobileLiveTerminal({
         className={`absolute inset-x-0 top-0 bottom-[8px] font-mono flex flex-col ${
           forwardMode ? "overflow-hidden" : "overflow-y-auto overflow-x-clip"
         }`}
-        style={{
-          fontSize: `${fontSize}px`,
-          // Undefined leaves the `font-mono` class to supply the default family.
-          fontFamily,
-          lineHeight: `${lineH}px`,
-          background: "var(--term-bg, #1c1c1f)",
-          color: "var(--term-fg, #e4e4e7)",
-          // A terminal is a fixed grid: never ligate or substitute contextual
-          // glyphs (e.g. `->`, `!=`, `==`), which would merge cells and read as
-          // fuzz. Inherited by the row spans below.
-          fontVariantLigatures: "none",
-          fontFeatureSettings: '"liga" 0, "calt" 0',
-          overscrollBehavior: "contain",
-          // Forward mode has no native scrolling (overflow hidden): a drag
-          // becomes forwarded wheel notches in onTouchMove. Suppressing the
-          // browser's own pan must happen HERE, declaratively: React
-          // registers its delegated touchstart/touchmove/wheel listeners as
-          // passive, so a preventDefault inside onTouchMove never reaches
-          // the browser. Without this the pan falls through the
-          // non-scrollable terminal to the page, and whenever the layout
-          // viewport is taller than the visual one (soft keyboard open,
-          // Safari URL bar) iOS pans the whole page while the forwarded
-          // wheel scrolls the app, the double-scroll clunk. touch-action:
-          // none stops the browser from starting any pan or zoom for
-          // touches on the terminal; JS still receives every touch event.
-          touchAction: forwardMode ? "none" : undefined,
-          // Do NOT set `-webkit-overflow-scrolling: touch` here. It promotes
-          // this opaque scroll region to a composited layer that macOS/iOS
-          // Safari rasterizes at 1x, making the DOM terminal text look
-          // pixelated/low-res. It is deprecated and a no-op on iOS 13+
-          // (momentum scrolling is always on), so omitting it costs nothing.
-          // The spacer model keeps above-viewport pixels invariant by
-          // construction, so a preserved scrollTop is always correct.
-          // The browser's own scroll anchoring doesn't know that: when
-          // the full-history frame replaces the spacer it re-anchors and
-          // teleports scrollTop. Ours is the only anchoring allowed.
-          overflowAnchor: "none",
-        }}
+        style={
+          {
+            fontSize: `${fontSize}px`,
+            // Undefined leaves the `font-mono` class to supply the default family.
+            fontFamily,
+            lineHeight: `${lineH}px`,
+            // The measured cell advance the row boxes multiply (#3342). A CSS
+            // variable rather than per-span pixel widths so a re-measure (webfont
+            // load, font-size change) restyles every mounted row without
+            // re-rendering them.
+            "--term-cell": `${charW}px`,
+            background: "var(--term-bg, #1c1c1f)",
+            color: "var(--term-fg, #e4e4e7)",
+            // A terminal is a fixed grid: never ligate or substitute contextual
+            // glyphs (e.g. `->`, `!=`, `==`), which would merge cells and read as
+            // fuzz. Inherited by the row spans below.
+            fontVariantLigatures: "none",
+            fontFeatureSettings: '"liga" 0, "calt" 0',
+            overscrollBehavior: "contain",
+            // Forward mode has no native scrolling (overflow hidden): a drag
+            // becomes forwarded wheel notches in onTouchMove. Suppressing the
+            // browser's own pan must happen HERE, declaratively: React
+            // registers its delegated touchstart/touchmove/wheel listeners as
+            // passive, so a preventDefault inside onTouchMove never reaches
+            // the browser. Without this the pan falls through the
+            // non-scrollable terminal to the page, and whenever the layout
+            // viewport is taller than the visual one (soft keyboard open,
+            // Safari URL bar) iOS pans the whole page while the forwarded
+            // wheel scrolls the app, the double-scroll clunk. touch-action:
+            // none stops the browser from starting any pan or zoom for
+            // touches on the terminal; JS still receives every touch event.
+            touchAction: forwardMode ? "none" : undefined,
+            // Do NOT set `-webkit-overflow-scrolling: touch` here. It promotes
+            // this opaque scroll region to a composited layer that macOS/iOS
+            // Safari rasterizes at 1x, making the DOM terminal text look
+            // pixelated/low-res. It is deprecated and a no-op on iOS 13+
+            // (momentum scrolling is always on), so omitting it costs nothing.
+            // The spacer model keeps above-viewport pixels invariant by
+            // construction, so a preserved scrollTop is always correct.
+            // The browser's own scroll anchoring doesn't know that: when
+            // the full-history frame replaces the spacer it re-anchors and
+            // teleports scrollTop. Ours is the only anchoring allowed.
+            overflowAnchor: "none",
+          } as CSSProperties
+        }
       >
         <span
           ref={measureRef}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -396,6 +396,11 @@ export const Row = memo(function Row({
       if (idx != null) {
         placed = true;
         const chars = [...run.text];
+        // A fixed run is exactly one cluster (base plus its own trailing
+        // zero-width marks): box the WHOLE cluster as the cursor cell, or
+        // the marks would land in a zero-width sibling where they can no
+        // longer shape with their base and browsers draw a dotted circle.
+        const curEnd = run.fixed ? chars.length : idx + 1;
         if (idx > 0) {
           const pre = chars.slice(0, idx).join("");
           out.push(
@@ -409,13 +414,16 @@ export const Row = memo(function Row({
             key={key++}
             data-live-cursor
             className={focused ? "animate-term-cursor-blink" : undefined}
-            style={{ ...fixedBoxStyle(cellWidth(chars[idx]!), base), ...cursorStyle }}
+            style={{
+              ...fixedBoxStyle(run.fixed ? run.cells : cellWidth(chars[idx]!), base),
+              ...cursorStyle,
+            }}
           >
-            {chars[idx]}
+            {chars.slice(idx, curEnd).join("")}
           </span>,
         );
-        if (idx + 1 < chars.length) {
-          const post = chars.slice(idx + 1).join("");
+        if (curEnd < chars.length) {
+          const post = chars.slice(curEnd).join("");
           out.push(
             <span key={key++} style={run.fixed ? fixedBoxStyle(textWidth(post), base) : base}>
               {post}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -201,8 +201,8 @@ function fixedBoxStyle(cells: number, base: CSSProperties | undefined): CSSPrope
 
 /** One styled run of a row: flowing text renders bare; fixed clusters get
  *  the explicit box while remaining ordinary selectable/copyable spans.
- *  Linkification applies per run (#2685); URLs are ASCII, so they live in
- *  flow runs and keep their exact href and text. */
+ *  Linkification applies per run (#2685); the URL regex is bounded to
+ *  printable ASCII, so an anchor never crosses into a fixed run. */
 function cellRunSpan(run: CellRun, style: AnsiStyle, key: string): ReactNode {
   const base = segStyle(style);
   return (

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -201,13 +201,14 @@ function fixedBoxStyle(cells: number, base: CSSProperties | undefined): CSSPrope
 
 /** One styled run of a row: flowing text renders bare; fixed clusters get
  *  the explicit box while remaining ordinary selectable/copyable spans.
- *  Linkification applies per run (#2685); the URL regex is bounded to
- *  printable ASCII, so an anchor never crosses into a fixed run. */
+ *  Anchoring happens one level up, per URL part over the whole segment,
+ *  so a href keeps its glued non-ASCII glyphs even though the runs split
+ *  there (#3342). */
 function cellRunSpan(run: CellRun, style: AnsiStyle, key: string): ReactNode {
   const base = segStyle(style);
   return (
     <span key={key} style={run.fixed ? fixedBoxStyle(run.cells, base) : base}>
-      {linkify(run.text)}
+      {run.text}
     </span>
   );
 }
@@ -337,23 +338,6 @@ function specialKeySequence(e: TerminalKeyLike): string | null {
   }
 }
 
-// Wrap http(s) URLs in a segment's text as clickable anchors, so agent output
-// (PR links, localhost dev servers, docs) opens in one tap instead of a
-// manual select-copy-paste (#2685). Plain text returns as-is.
-function linkify(text: string): ReactNode {
-  const parts = splitUrls(text);
-  if (parts.length === 1 && parts[0]!.url == null) return text;
-  return parts.map((p, i) =>
-    p.url ? (
-      <a key={i} href={p.url} target="_blank" rel="noopener noreferrer" className="underline cursor-pointer">
-        {p.text}
-      </a>
-    ) : (
-      p.text
-    ),
-  );
-}
-
 export const Row = memo(function Row({
   segs,
   cursorCol,
@@ -368,7 +352,26 @@ export const Row = memo(function Row({
     if (segs.length === 0) return <div> </div>; // keep empty rows at full height
     return (
       <div>
-        {segs.map((seg, i) => splitCellRuns(seg.text).map((run, j) => cellRunSpan(run, seg.style, `${i}-${j}`)))}
+        {segs.map((seg, i) =>
+          splitUrls(seg.text).map((part, j) => {
+            const runs = splitCellRuns(part.text).map((run, k) => cellRunSpan(run, seg.style, `${i}-${j}-${k}`));
+            // Whole-part anchors: a URL that runs into glued non-ASCII
+            // keeps those glyphs in its href and inside the clickable
+            // span, with each run still boxed cell-exact.
+            if (!part.url) return <Fragment key={`${i}-${j}`}>{runs}</Fragment>;
+            return (
+              <a
+                key={`${i}-${j}`}
+                href={part.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline cursor-pointer"
+              >
+                {runs}
+              </a>
+            );
+          }),
+        )}
       </div>
     );
   }

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -4,6 +4,7 @@ import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
 import {
   LineParseCache,
   cellWidth,
+  clusterSpanAt,
   findCursorCharIndex,
   splitCellRuns,
   splitUrls,
@@ -396,34 +397,36 @@ export const Row = memo(function Row({
       if (idx != null) {
         placed = true;
         const chars = [...run.text];
-        // A fixed run is exactly one cluster (base plus its own trailing
-        // zero-width marks): box the WHOLE cluster as the cursor cell, or
-        // the marks would land in a zero-width sibling where they can no
-        // longer shape with their base and browsers draw a dotted circle.
-        const curEnd = run.fixed ? chars.length : idx + 1;
-        if (idx > 0) {
-          const pre = chars.slice(0, idx).join("");
+        // Slice at cluster boundaries: a fixed run is a coalesced stretch
+        // of whole graphemes, and the cursor cell must take exactly the
+        // cluster under the cursor (base plus its marks/tails, a flag pair,
+        // or whatever a ZWJ joins) so no composition tail is stranded in a
+        // zero-width sibling where browsers draw dotted circles.
+        const [clusterStart, clusterEnd] = run.fixed ? clusterSpanAt(run.text, idx) : [idx, idx + 1];
+        if (clusterStart > 0) {
+          const pre = chars.slice(0, clusterStart).join("");
           out.push(
             <span key={key++} style={run.fixed ? fixedBoxStyle(textWidth(pre), base) : base}>
               {pre}
             </span>,
           );
         }
+        const cursorText = chars.slice(clusterStart, clusterEnd).join("");
         out.push(
           <span
             key={key++}
             data-live-cursor
             className={focused ? "animate-term-cursor-blink" : undefined}
             style={{
-              ...fixedBoxStyle(run.fixed ? run.cells : cellWidth(chars[idx]!), base),
+              ...fixedBoxStyle(run.fixed ? textWidth(cursorText) : cellWidth(cursorText), base),
               ...cursorStyle,
             }}
           >
-            {chars.slice(idx, curEnd).join("")}
+            {cursorText}
           </span>,
         );
-        if (curEnd < chars.length) {
-          const post = chars.slice(curEnd).join("");
+        if (clusterEnd < chars.length) {
+          const post = chars.slice(clusterEnd).join("");
           out.push(
             <span key={key++} style={run.fixed ? fixedBoxStyle(textWidth(post), base) : base}>
               {post}

--- a/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
@@ -28,22 +28,28 @@ describe("Row cursor placement with CJK (wide) characters", () => {
     const { container } = render(<Row segs={[seg(text)]} cursorCol={17} />);
     const cell = cursorCell(container);
     expect(cell).not.toBeNull();
-    // Per-cell runs (#3342): each CJK glyph gets its own fixed box, the
-    // ASCII digits flow together. No pad span of spaces may appear before
-    // the cursor; drift shows up as exactly that.
+    // The CJK stretch coalesces into ONE fixed box (#3342 follow-up):
+    // atomic-inline boundaries inside the stretch would break bidi,
+    // complex-script shaping and emoji composition. The box pins the
+    // flow/fixed boundary at exactly 14 cells; no pad span of spaces may
+    // appear before the cursor.
     const spans = [...container.querySelectorAll("span")];
-    expect(spans.map((s) => s.textContent)).toEqual([..."한글정렬테스트", "123", " "]);
+    expect(spans.map((s) => s.textContent)).toEqual(["한글정렬테스트", "123", " "]);
+    expect(spans[0].style.width).toBe("calc(var(--term-cell, 1em) * 14)");
     expect(cell!.previousSibling!.textContent).toBe("123");
     expect(cell!.textContent).toBe(" ");
-    // Fixed boxes carry explicit widths; the cursor cell (a space) is one
-    // of them. Each Hangul glyph is one code point in a two-cell box.
-    const fixed = spans.filter((s) => s.style.display === "inline-block");
-    expect(fixed).toHaveLength(8);
-    for (const box of fixed) {
-      expect(box.style.width).toBe(`calc(var(--term-cell, 1em) * ${cellWidth([...box.textContent!][0]!)})`);
-    }
+    expect(cell!.style.width).toBe("calc(var(--term-cell, 1em) * 1)");
   });
 
+  it("slices a coalesced stretch at cluster boundaries under the cursor", () => {
+    // Cursor on the second glyph of a CJK word: pre and cursor pieces are
+    // separately boxed at their exact cell widths, nothing drifts.
+    const { container } = render(<Row segs={[seg("한글")]} cursorCol={2} />);
+    const spans = [...container.querySelectorAll("span")];
+    expect(spans.map((s) => s.textContent)).toEqual(["한", "글"]);
+    expect(spans[0].style.width).toBe("calc(var(--term-cell, 1em) * 2)");
+    expect(cursorCell(container)!.textContent).toBe("글");
+  });
 
   it("keeps trailing combining marks inside the boxed cursor cell", () => {
     // A fixed run IS one cluster; splitting the base from its marks would

--- a/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
@@ -7,6 +7,7 @@
 // under-counts and the boxed cell drifts right of the actual cursor.
 
 import { describe, expect, it } from "vitest";
+import { cellWidth } from "../../lib/liveTermLines";
 import { render } from "@testing-library/react";
 import { Row } from "../MobileLiveTerminal";
 import type { AnsiSegment } from "../../lib/ansi";
@@ -27,11 +28,20 @@ describe("Row cursor placement with CJK (wide) characters", () => {
     const { container } = render(<Row segs={[seg(text)]} cursorCol={17} />);
     const cell = cursorCell(container);
     expect(cell).not.toBeNull();
-    // The row is [text span, cursor span]. No pad span should be inserted
-    // between them; drift shows up as a pad span full of spaces.
-    expect(container.querySelectorAll("span")).toHaveLength(2);
-    expect(cell!.previousSibling!.textContent).toBe(text);
+    // Per-cell runs (#3342): each CJK glyph gets its own fixed box, the
+    // ASCII digits flow together. No pad span of spaces may appear before
+    // the cursor; drift shows up as exactly that.
+    const spans = [...container.querySelectorAll("span")];
+    expect(spans.map((s) => s.textContent)).toEqual([..."한글정렬테스트", "123", " "]);
+    expect(cell!.previousSibling!.textContent).toBe("123");
     expect(cell!.textContent).toBe(" ");
+    // Fixed boxes carry explicit widths; the cursor cell (a space) is one
+    // of them. Each Hangul glyph is one code point in a two-cell box.
+    const fixed = spans.filter((s) => s.style.display === "inline-block");
+    expect(fixed).toHaveLength(8);
+    for (const box of fixed) {
+      expect(box.style.width).toBe(`calc(var(--term-cell, 1em) * ${cellWidth([...box.textContent!][0]!)})`);
+    }
   });
 
   it("boxes the correct character in a mixed ASCII+CJK line", () => {

--- a/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
@@ -44,6 +44,18 @@ describe("Row cursor placement with CJK (wide) characters", () => {
     }
   });
 
+
+  it("keeps trailing combining marks inside the boxed cursor cell", () => {
+    // A fixed run IS one cluster; splitting the base from its marks would
+    // strand them in a zero-width sibling and browsers draw dotted circles.
+    const text = "\u6F22\u0301"; // CJK base + combining acute
+    const { container } = render(<Row segs={[seg(text)]} cursorCol={0} />);
+    const cell = cursorCell(container);
+    expect(cell!.textContent).toBe(text);
+    expect(cell!.style.width).toBe(`calc(var(--term-cell, 1em) * ${cellWidth("\u6F22")})`);
+    // No sibling spans: the whole row lives in the cursor cell.
+    expect(container.querySelectorAll("span")).toHaveLength(1);
+  });
   it("boxes the correct character in a mixed ASCII+CJK line", () => {
     // "hello " is 6 cells; then CJK chars are 2 cells each: 한(6-8) 글(8-10)
     // 정(10-12) 렬(12-14). Column 8 must land on "글", not "정".

--- a/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
@@ -52,8 +52,9 @@ describe("Row cursor placement with CJK (wide) characters", () => {
   });
 
   it("keeps trailing combining marks inside the boxed cursor cell", () => {
-    // A fixed run IS one cluster; splitting the base from its marks would
-    // strand them in a zero-width sibling and browsers draw dotted circles.
+    // clusterSpanAt must take the WHOLE cluster (base plus marks): slicing
+    // the base alone would strand its marks in a zero-width sibling and
+    // browsers draw dotted circles.
     const text = "\u6F22\u0301"; // CJK base + combining acute
     const { container } = render(<Row segs={[seg(text)]} cursorCol={0} />);
     const cell = cursorCell(container);

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
@@ -58,6 +58,17 @@ describe("Row cursor fill state", () => {
     expect(cell!.className).toContain("animate-term-cursor-blink");
   });
 
+  it("keeps a glued mark inside the cursor cell on a flow run (NFD input)", () => {
+    // Flow runs can carry zero-width marks too (NFD text typed into the
+    // live input); slicing must stay cluster-aware so the mark is not
+    // stranded outside the highlight.
+    const { container } = render(<Row segs={[seg("cafe\u0301")]} cursorCol={3} />);
+    const cell = cursorCell(container);
+    expect(cell!.textContent).toBe("e\u0301");
+    expect(cell!.style.width).toBe("calc(var(--term-cell, 1em) * 1)");
+    expect(cell!.previousSibling!.textContent).toBe("caf");
+  });
+
   it("boxes the cursor on a completely empty row (no segments)", () => {
     // A blank live-input line carries no segments; the pad + blank-cell
     // path must still run or the cursor vanishes from an empty prompt.

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
@@ -57,4 +57,14 @@ describe("Row cursor fill state", () => {
     expect(cell!.style.outline).toBe("");
     expect(cell!.className).toContain("animate-term-cursor-blink");
   });
+
+  it("boxes the cursor on a completely empty row (no segments)", () => {
+    // A blank live-input line carries no segments; the pad + blank-cell
+    // path must still run or the cursor vanishes from an empty prompt.
+    const { container } = render(<Row segs={[]} cursorCol={3} />);
+    const cell = cursorCell(container);
+    expect(cell).not.toBeNull();
+    expect(cell!.textContent).toBe(" ");
+    expect(cell!.previousSibling!.textContent).toBe("   ");
+  });
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
@@ -61,10 +61,15 @@ describe("Row cursor fill state", () => {
   it("boxes the cursor on a completely empty row (no segments)", () => {
     // A blank live-input line carries no segments; the pad + blank-cell
     // path must still run or the cursor vanishes from an empty prompt.
+    // The pad is an explicit box so a fallback font's space advance
+    // cannot push the cursor off its column either.
     const { container } = render(<Row segs={[]} cursorCol={3} />);
     const cell = cursorCell(container);
     expect(cell).not.toBeNull();
     expect(cell!.textContent).toBe(" ");
-    expect(cell!.previousSibling!.textContent).toBe("   ");
+    expect(cell!.style.width).toBe("calc(var(--term-cell, 1em) * 1)");
+    const pad = cell!.previousSibling!;
+    expect(pad.textContent).toBe("   ");
+    expect((pad as HTMLElement).style.width).toBe("calc(var(--term-cell, 1em) * 3)");
   });
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.linkify.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.linkify.test.tsx
@@ -34,4 +34,14 @@ describe("Row URL linkification", () => {
     const { container } = render(<Row segs={[seg("https://example.com")]} cursorCol={0} />);
     expect(container.querySelector("a")).toBeNull();
   });
+
+  it("keeps the anchor out of a CJK glyph glued to the URL", () => {
+    // The flow run ends at the first non-ASCII code point (#3342); the
+    // href and anchor text must stop there instead of swallowing the glue.
+    const { container } = render(<Row segs={[seg("voir https://github.com/o/r를 suite")]} cursorCol={null} />);
+    const a = container.querySelector("a");
+    expect(a!.getAttribute("href")).toBe("https://github.com/o/r");
+    expect(a!.textContent).toBe("https://github.com/o/r");
+    expect(container.textContent).toBe("voir https://github.com/o/r를 suite");
+  });
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.linkify.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.linkify.test.tsx
@@ -35,13 +35,17 @@ describe("Row URL linkification", () => {
     expect(container.querySelector("a")).toBeNull();
   });
 
-  it("keeps the anchor out of a CJK glyph glued to the URL", () => {
-    // The flow run ends at the first non-ASCII code point (#3342); the
-    // href and anchor text must stop there instead of swallowing the glue.
+  it("anchors glued non-ASCII glyphs while keeping their cell boxes", () => {
+    // Whole-part anchoring (#3342): the href follows the URL match
+    // including the glued glyph, the glyph keeps its own fixed box inside
+    // the anchor, and the row text is unchanged.
     const { container } = render(<Row segs={[seg("voir https://github.com/o/r를 suite")]} cursorCol={null} />);
     const a = container.querySelector("a");
-    expect(a!.getAttribute("href")).toBe("https://github.com/o/r");
-    expect(a!.textContent).toBe("https://github.com/o/r");
+    expect(a).not.toBeNull();
+    expect(a!.getAttribute("href")).toBe("https://github.com/o/r를");
+    expect(a!.textContent).toBe("https://github.com/o/r를");
+    const boxed = a!.querySelector("span[style*='inline-block']");
+    expect(boxed!.textContent).toBe("를");
     expect(container.textContent).toBe("voir https://github.com/o/r를 suite");
   });
 });

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -159,12 +159,12 @@ describe("splitUrls", () => {
     ]);
   });
 
-  it("stops the href at a non-ASCII glyph glued to the URL", () => {
-    // Cell runs (#3342) start a fixed stretch at the first non-ASCII code
-    // point; the anchor must claim no more than the ASCII prefix.
+  it("claims glued non-ASCII glyphs into the URL part", () => {
+    // The regex owns part boundaries; Row anchors whole parts, so the
+    // href follows the match including glued glyphs.
     expect(splitUrls("https://github.com/o/r를 확인")).toEqual([
-      { text: "https://github.com/o/r", url: "https://github.com/o/r" },
-      { text: "를 확인", url: null },
+      { text: "https://github.com/o/r를", url: "https://github.com/o/r를" },
+      { text: " 확인", url: null },
     ]);
   });
 
@@ -260,15 +260,39 @@ describe("splitCellRuns", () => {
     expect(splitCellRuns("سلام")).toEqual([{ text: "سلام", cells: 4, fixed: true }]);
   });
 
+  it("matches tmux cell widths per grapheme cluster", () => {
+    // Measured against real tmux 3.6a cursor_x deltas (round 5 probe):
+    // VS16-forced emoji = 2, flag pair = 2, ZWJ chain = 2, lone RI = 1,
+    // skin-tone tail adds nothing to its wide base.
+    const cases: Array<[string, number]> = [
+      ["\u26A0\uFE0F", 2],
+      ["\u2714\uFE0F", 2],
+      ["\u2139\uFE0F", 2],
+      ["\u270F\uFE0F", 2],
+      ["\u2764\uFE0F", 2],
+      ["\u{1F1FA}\u{1F1F8}", 2],
+      ["\u{1F468}\u200D\u{1F469}\u200D\u{1F467}", 2],
+      ["\u{1F468}\u200D\u{1F469}\u200D\u{1F466}", 2],
+      ["\u{1F44D}\u{1F3FB}", 2],
+      ["\u{1F600}", 2],
+      ["\u{1F1EB}", 1],
+      ["\uD55C", 2],
+      ["\u280B", 1],
+      ["\u{E0B0}", 1],
+      ["e\u0301", 1],
+    ];
+    for (const [input, expected] of cases) {
+      expect(textWidth(input)).toBe(expected, input);
+    }
+  });
+
   it("keeps composed emoji sequences whole at their terminal width", () => {
-    // Flag pair, skin-tone tail, ZWJ join: each stays one fixed run.
-    // Widths follow the file's own wcwidth convention: regional
-    // indicators and pictographs are Emoji_Presentation, so a flag is
-    // 2 x 2 cells and a three-person ZWJ chain is 3 x 2.
-    expect(splitCellRuns("\u{1F1FA}\u{1F1F8}")).toEqual([{ text: "\u{1F1FA}\u{1F1F8}", cells: 4, fixed: true }]);
+    // Flag pair, skin-tone tail, ZWJ join: one fixed run at the tmux
+    // cluster width.
+    expect(splitCellRuns("\u{1F1FA}\u{1F1F8}")).toEqual([{ text: "\u{1F1FA}\u{1F1F8}", cells: 2, fixed: true }]);
     expect(splitCellRuns("\u{1F44D}\u{1F3FB}")).toEqual([{ text: "\u{1F44D}\u{1F3FB}", cells: 2, fixed: true }]);
     expect(splitCellRuns("\u{1F9D1}\u200D\u{1F4BB}")).toEqual([
-      { text: "\u{1F9D1}\u200D\u{1F4BB}", cells: 4, fixed: true },
+      { text: "\u{1F9D1}\u200D\u{1F4BB}", cells: 2, fixed: true },
     ]);
   });
 
@@ -283,6 +307,7 @@ describe("splitCellRuns", () => {
       "tone \u{1F44D}\u{1F3FB}",
       "dev \u{1F9D1}\u200D\u{1F4BB} ops",
       "arabic \u6F22\u0301 glue",
+      "warn \u26A0\uFE0F end",
     ];
     for (const line of cases) {
       const runs = splitCellRuns(line);
@@ -291,14 +316,28 @@ describe("splitCellRuns", () => {
     }
   });
 
-  it("glues zero-width marks onto the preceding run, not into new boxes", () => {
-    // Combining acute on 'e' stays in the flow run; a ZWJ after a wide
-    // char joins that char's stretch and widens no cell.
-    expect(splitCellRuns("cafe\u0301")).toEqual([{ text: "cafe\u0301", cells: 4, fixed: false }]);
-    expect(splitCellRuns("한\u200dB")).toEqual([
-      { text: "한\u200d", cells: 2, fixed: true },
-      { text: "B", cells: 1, fixed: false },
-    ]);
+  it("resolves cursor columns onto whole tmux clusters", () => {
+    // Flag occupies columns 0-1: both land on its single code point span;
+    // column 2 is past it. ZWJ chain spans columns 0-1 likewise.
+    expect(findCursorCharIndex("\u{1F1FA}\u{1F1F8}", 0)).toBe(0);
+    expect(findCursorCharIndex("\u{1F1FA}\u{1F1F8}", 1)).toBe(0);
+    expect(findCursorCharIndex("\u{1F1FA}\u{1F1F8}", 2)).toBeNull();
+    expect(findCursorCharIndex("\u{1F468}\u200D\u{1F469}\u200D\u{1F467}", 0)).toBe(0);
+    expect(findCursorCharIndex("\u{1F468}\u200D\u{1F469}\u200D\u{1F467}", 1)).toBe(0);
+    expect(findCursorCharIndex("\u{1F468}\u200D\u{1F469}\u200D\u{1F467}", 2)).toBeNull();
+  });
+
+  it("never splits a cluster when wrapping", () => {
+    const line = [{ text: "\u{1F9D1}\u200D\u{1F4BB}\u{1F44D}", style: {} }];
+    for (const cols of [2, 3, 4]) {
+      const rows = wrapLine(line, cols);
+      expect(
+        rows
+          .flat()
+          .map((s) => s.text)
+          .join(""),
+      ).toBe("\u{1F9D1}\u200D\u{1F4BB}\u{1F44D}");
+    }
   });
 
   it("counts emoji tails as zero-width cells", () => {

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -158,6 +158,15 @@ describe("splitUrls", () => {
     ]);
   });
 
+  it("stops the href at a non-ASCII glyph glued to the URL", () => {
+    // Per-cell runs (#3342) end the flow run at the first non-ASCII code
+    // point; the anchor must claim no more than the ASCII prefix.
+    expect(splitUrls("https://github.com/o/r를 확인")).toEqual([
+      { text: "https://github.com/o/r", url: "https://github.com/o/r" },
+      { text: "를 확인", url: null },
+    ]);
+  });
+
   it("handles multiple URLs on one line", () => {
     const parts = splitUrls("https://a.com and https://b.com");
     expect(parts.filter((p) => p.url).map((p) => p.url)).toEqual(["https://a.com", "https://b.com"]);

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -340,6 +340,21 @@ describe("splitCellRuns", () => {
     }
   });
 
+  it("counts keycap sequences as two-cell clusters", () => {
+    // tmux-measured: base + VS16 + U+20E3 advances cursor_x by exactly 2
+    // even when the base is printable ASCII; rendering keeps the whole
+    // sequence in one flow node so the font composes it.
+    const cases: Array<[string, number]> = [
+      ["#\uFE0F\u20E3", 2],
+      ["1\uFE0F\u20E3", 2],
+      ["*\uFE0F\u20E3", 2],
+    ];
+    for (const [input, expected] of cases) {
+      expect(textWidth(input)).toBe(expected, input);
+    }
+    expect(splitCellRuns("#\uFE0F\u20E3")).toEqual([{ text: "#\uFE0F\u20E3", cells: 2, fixed: false }]);
+  });
+
   it("counts emoji tails as zero-width cells", () => {
     expect(textWidth("\uFE0F")).toBe(0);
     expect(textWidth("\u{1F3FB}")).toBe(0);

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { LineParseCache, ansiToLines, findCursorCharIndex, lineText, splitUrls, wrapLine } from "./liveTermLines";
+import {
+  LineParseCache,
+  ansiToLines,
+  findCursorCharIndex,
+  lineText,
+  splitCellRuns,
+  splitUrls,
+  textWidth,
+  wrapLine,
+} from "./liveTermLines";
 
 describe("ansiToLines", () => {
   it("splits plain text into lines and drops the capture trailing terminator", () => {
@@ -217,5 +226,38 @@ describe("LineParseCache", () => {
     // Re-parsed after eviction: equal content, fresh identity.
     expect(b[0]).toEqual(a[0]);
     expect(b[0]).not.toBe(a[0]);
+  });
+});
+
+describe("splitCellRuns", () => {
+  it("keeps printable ASCII as flowing runs and isolates risky glyphs as fixed boxes", () => {
+    // The #3342 fixture: ASCII prompt, CJK, braille spinner, powerline PUA.
+    const runs = splitCellRuns("$ ok 한글 ⠋⠙ \u{E0B0}");
+    expect(runs.map((r) => r.fixed)).toEqual([false, true, true, false, true, true, false, true]);
+    expect(runs.filter((r) => r.fixed).map((r) => r.text)).toEqual(["한", "글", "⠋", "⠙", "\u{E0B0}"]);
+    expect(runs.filter((r) => r.fixed).map((r) => r.cells)).toEqual([2, 2, 1, 1, 1]);
+  });
+
+  it("returns a single flowing run for pure-ASCII text", () => {
+    expect(splitCellRuns("$ ls --color")).toEqual([{ text: "$ ls --color", cells: 12, fixed: false }]);
+  });
+
+  it("preserves the row invariant sum(cells) == textWidth on mixed lines", () => {
+    const cases = ["$ ready", "가각ᅟ⠋⠙", "\u{E0B0}\u{E0B2} powerline", "e\u0301glue", "emoji \u{1F600} done"];
+    for (const line of cases) {
+      const runs = splitCellRuns(line);
+      expect(runs.reduce((n, r) => n + r.cells, 0)).toBe(textWidth(line), line);
+      expect(runs.map((r) => r.text).join("")).toBe(line);
+    }
+  });
+
+  it("glues zero-width marks onto the preceding cluster, not into new boxes", () => {
+    // Combining acute on 'e' stays in the flow run; a ZWJ after a wide char
+    // widens no cell.
+    expect(splitCellRuns("cafe\u0301")).toEqual([{ text: "cafe\u0301", cells: 4, fixed: false }]);
+    expect(splitCellRuns("한\u200dB")).toEqual([
+      { text: "한\u200d", cells: 2, fixed: true },
+      { text: "B", cells: 1, fixed: false },
+    ]);
   });
 });

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -160,7 +160,7 @@ describe("splitUrls", () => {
   });
 
   it("stops the href at a non-ASCII glyph glued to the URL", () => {
-    // Per-cell runs (#3342) end the flow run at the first non-ASCII code
+    // Cell runs (#3342) start a fixed stretch at the first non-ASCII code
     // point; the anchor must claim no more than the ASCII prefix.
     expect(splitUrls("https://github.com/o/r를 확인")).toEqual([
       { text: "https://github.com/o/r", url: "https://github.com/o/r" },

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -317,6 +317,10 @@ describe("clusterSpanAt", () => {
   it("spans both regional indicators from either half of a flag", () => {
     expect(clusterSpanAt("\u{1F1FA}\u{1F1F8}", 0)).toEqual([0, 2]);
     expect(clusterSpanAt("\u{1F1FA}\u{1F1F8}", 1)).toEqual([0, 2]);
+    // A tone tail glued behind the completed pair stays inside the span
+    // from either RI half; stranding it outside would detach the swatch.
+    expect(clusterSpanAt("\u{1F1E9}\u{1F1EA}\u{1F3FB}", 0)).toEqual([0, 3]);
+    expect(clusterSpanAt("\u{1F1E9}\u{1F1EA}\u{1F3FB}", 1)).toEqual([0, 3]);
   });
 
   it("keeps tone tails and ZWJ chains inside the span", () => {

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -239,6 +239,8 @@ describe("LineParseCache", () => {
   });
 });
 
+const ZWJ = "\u200D";
+
 describe("splitCellRuns", () => {
   it("keeps printable ASCII as flow and coalesces non-ASCII stretches", () => {
     // The #3342 fixture: ASCII prompt, CJK, braille spinner, powerline PUA.
@@ -263,7 +265,7 @@ describe("splitCellRuns", () => {
   it("matches tmux cell widths per grapheme cluster", () => {
     // Measured against real tmux 3.6a cursor_x deltas (round 5 probe):
     // VS16-forced emoji = 2, flag pair = 2, ZWJ chain = 2, lone RI = 1,
-    // skin-tone tail adds nothing to its wide base.
+    // skin-tone tail adds nothing to a base that takes a modifier.
     const cases: Array<[string, number]> = [
       ["\u26A0\uFE0F", 2],
       ["\u2714\uFE0F", 2],
@@ -280,6 +282,21 @@ describe("splitCellRuns", () => {
       ["\u280B", 1],
       ["\u{E0B0}", 1],
       ["e\u0301", 1],
+      // A skin-tone swatch folds in only behind a base that takes a
+      // modifier. U+1F600 does not, so tmux gives the swatch its own two
+      // columns, as it does after CJK or after nothing at all.
+      ["\u{1F600}\u{1F3FB}", 4],
+      ["\u6F22\u{1F3FB}", 4],
+      ["\u280B\u{1F3FB}", 3],
+      ["a\u{1F3FB}", 3],
+      ["\u{1F3FB}", 2],
+      // An orphan ZWJ or enclosing keycap has no base to modify, so it is
+      // an ordinary zero-width mark rather than the two-cell composition
+      // its presence inside a cluster would imply.
+      [ZWJ, 0],
+      [`a${ZWJ}b`, 2],
+      ["\u20E3", 0],
+      ["1\u20E3", 1],
     ];
     for (const [input, expected] of cases) {
       expect(textWidth(input)).toBe(expected, input);
@@ -357,8 +374,10 @@ describe("splitCellRuns", () => {
 
   it("counts emoji tails as zero-width cells", () => {
     expect(textWidth("\uFE0F")).toBe(0);
-    expect(textWidth("\u{1F3FB}")).toBe(0);
+    // A swatch behind a modifier base folds in; standing alone it keeps
+    // its own two columns, matching tmux.
     expect(textWidth("\u{1F44D}\u{1F3FB}")).toBe(2);
+    expect(textWidth("\u{1F3FB}")).toBe(2);
   });
 });
 
@@ -371,10 +390,11 @@ describe("clusterSpanAt", () => {
   it("spans both regional indicators from either half of a flag", () => {
     expect(clusterSpanAt("\u{1F1FA}\u{1F1F8}", 0)).toEqual([0, 2]);
     expect(clusterSpanAt("\u{1F1FA}\u{1F1F8}", 1)).toEqual([0, 2]);
-    // A tone tail glued behind the completed pair stays inside the span
-    // from either RI half; stranding it outside would detach the swatch.
-    expect(clusterSpanAt("\u{1F1E9}\u{1F1EA}\u{1F3FB}", 0)).toEqual([0, 3]);
-    expect(clusterSpanAt("\u{1F1E9}\u{1F1EA}\u{1F3FB}", 1)).toEqual([0, 3]);
+    // A regional indicator takes no skin-tone modifier, so a swatch after
+    // a completed pair is its own cell (tmux measures flag + tone at 4
+    // columns) and the span stops at the pair.
+    expect(clusterSpanAt("\u{1F1E9}\u{1F1EA}\u{1F3FB}", 0)).toEqual([0, 2]);
+    expect(clusterSpanAt("\u{1F1E9}\u{1F1EA}\u{1F3FB}", 1)).toEqual([0, 2]);
   });
 
   it("keeps tone tails and ZWJ chains inside the span", () => {

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   LineParseCache,
   ansiToLines,
+  clusterSpanAt,
   findCursorCharIndex,
   lineText,
   splitCellRuns,
@@ -239,20 +240,50 @@ describe("LineParseCache", () => {
 });
 
 describe("splitCellRuns", () => {
-  it("keeps printable ASCII as flowing runs and isolates risky glyphs as fixed boxes", () => {
+  it("keeps printable ASCII as flow and coalesces non-ASCII stretches", () => {
     // The #3342 fixture: ASCII prompt, CJK, braille spinner, powerline PUA.
     const runs = splitCellRuns("$ ok 한글 ⠋⠙ \u{E0B0}");
-    expect(runs.map((r) => r.fixed)).toEqual([false, true, true, false, true, true, false, true]);
-    expect(runs.filter((r) => r.fixed).map((r) => r.text)).toEqual(["한", "글", "⠋", "⠙", "\u{E0B0}"]);
-    expect(runs.filter((r) => r.fixed).map((r) => r.cells)).toEqual([2, 2, 1, 1, 1]);
+    expect(runs.map((r) => r.fixed)).toEqual([false, true, false, true, false, true]);
+    expect(runs.filter((r) => r.fixed).map((r) => r.text)).toEqual(["한글", "⠋⠙", "\u{E0B0}"]);
+    // Contiguous CJK coalesces into one box whose cells sum.
+    expect(runs.filter((r) => r.fixed).map((r) => r.cells)).toEqual([4, 2, 1]);
   });
 
   it("returns a single flowing run for pure-ASCII text", () => {
     expect(splitCellRuns("$ ls --color")).toEqual([{ text: "$ ls --color", cells: 12, fixed: false }]);
   });
 
+  it("coalesces a whole script stretch so bidi and shaping survive", () => {
+    // Per-character boxes would reverse RTL order and cut complex-script
+    // shaping; one box per stretch keeps the text node whole while its
+    // edges stay cell-exact.
+    expect(splitCellRuns("سلام")).toEqual([{ text: "سلام", cells: 4, fixed: true }]);
+  });
+
+  it("keeps composed emoji sequences whole at their terminal width", () => {
+    // Flag pair, skin-tone tail, ZWJ join: each stays one fixed run.
+    // Widths follow the file's own wcwidth convention: regional
+    // indicators and pictographs are Emoji_Presentation, so a flag is
+    // 2 x 2 cells and a three-person ZWJ chain is 3 x 2.
+    expect(splitCellRuns("\u{1F1FA}\u{1F1F8}")).toEqual([{ text: "\u{1F1FA}\u{1F1F8}", cells: 4, fixed: true }]);
+    expect(splitCellRuns("\u{1F44D}\u{1F3FB}")).toEqual([{ text: "\u{1F44D}\u{1F3FB}", cells: 2, fixed: true }]);
+    expect(splitCellRuns("\u{1F9D1}\u200D\u{1F4BB}")).toEqual([
+      { text: "\u{1F9D1}\u200D\u{1F4BB}", cells: 4, fixed: true },
+    ]);
+  });
+
   it("preserves the row invariant sum(cells) == textWidth on mixed lines", () => {
-    const cases = ["$ ready", "가각ᅟ⠋⠙", "\u{E0B0}\u{E0B2} powerline", "e\u0301glue", "emoji \u{1F600} done"];
+    const cases = [
+      "$ ready",
+      "가각ᅟ⠋⠙",
+      "\u{E0B0}\u{E0B2} powerline",
+      "e\u0301glue",
+      "emoji \u{1F600} done",
+      "\u{1F1FA}\u{1F1F8} flag",
+      "tone \u{1F44D}\u{1F3FB}",
+      "dev \u{1F9D1}\u200D\u{1F4BB} ops",
+      "arabic \u6F22\u0301 glue",
+    ];
     for (const line of cases) {
       const runs = splitCellRuns(line);
       expect(runs.reduce((n, r) => n + r.cells, 0)).toBe(textWidth(line), line);
@@ -260,13 +291,38 @@ describe("splitCellRuns", () => {
     }
   });
 
-  it("glues zero-width marks onto the preceding cluster, not into new boxes", () => {
-    // Combining acute on 'e' stays in the flow run; a ZWJ after a wide char
-    // widens no cell.
+  it("glues zero-width marks onto the preceding run, not into new boxes", () => {
+    // Combining acute on 'e' stays in the flow run; a ZWJ after a wide
+    // char joins that char's stretch and widens no cell.
     expect(splitCellRuns("cafe\u0301")).toEqual([{ text: "cafe\u0301", cells: 4, fixed: false }]);
     expect(splitCellRuns("한\u200dB")).toEqual([
       { text: "한\u200d", cells: 2, fixed: true },
       { text: "B", cells: 1, fixed: false },
     ]);
+  });
+
+  it("counts emoji tails as zero-width cells", () => {
+    expect(textWidth("\uFE0F")).toBe(0);
+    expect(textWidth("\u{1F3FB}")).toBe(0);
+    expect(textWidth("\u{1F44D}\u{1F3FB}")).toBe(2);
+  });
+});
+
+describe("clusterSpanAt", () => {
+  it("covers one CJK glyph per column", () => {
+    expect(clusterSpanAt("한글", 0)).toEqual([0, 1]);
+    expect(clusterSpanAt("한글", 1)).toEqual([1, 2]);
+  });
+
+  it("spans both regional indicators from either half of a flag", () => {
+    expect(clusterSpanAt("\u{1F1FA}\u{1F1F8}", 0)).toEqual([0, 2]);
+    expect(clusterSpanAt("\u{1F1FA}\u{1F1F8}", 1)).toEqual([0, 2]);
+  });
+
+  it("keeps tone tails and ZWJ chains inside the span", () => {
+    expect(clusterSpanAt("\u{1F44D}\u{1F3FB}", 0)).toEqual([0, 2]);
+    // a=0, man=1, ZWJ=2, woman=3, ZWJ=4, boy=5, b=6.
+    expect(clusterSpanAt("a\u{1F468}\u200D\u{1F469}\u200D\u{1F466}b", 1)).toEqual([1, 6]);
+    expect(clusterSpanAt("a\u{1F468}\u200D\u{1F469}\u200D\u{1F466}b", 6)).toEqual([6, 7]);
   });
 });

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -326,7 +326,18 @@ describe("clusterSpanAt", () => {
   it("keeps tone tails and ZWJ chains inside the span", () => {
     expect(clusterSpanAt("\u{1F44D}\u{1F3FB}", 0)).toEqual([0, 2]);
     // a=0, man=1, ZWJ=2, woman=3, ZWJ=4, boy=5, b=6.
+
     expect(clusterSpanAt("a\u{1F468}\u200D\u{1F469}\u200D\u{1F466}b", 1)).toEqual([1, 6]);
     expect(clusterSpanAt("a\u{1F468}\u200D\u{1F469}\u200D\u{1F466}b", 6)).toEqual([6, 7]);
+  });
+
+  it("pairs adjacent flags on parity without crossing the boundary", () => {
+    // US DE: cursor on the leading half of the second flag must pair
+    // forward within its own flag, not backward across the pair boundary.
+    const twoFlags = "\u{1F1FA}\u{1F1F8}\u{1F1E9}\u{1F1EA}";
+    expect(clusterSpanAt(twoFlags, 0)).toEqual([0, 2]);
+    expect(clusterSpanAt(twoFlags, 1)).toEqual([0, 2]);
+    expect(clusterSpanAt(twoFlags, 2)).toEqual([2, 4]);
+    expect(clusterSpanAt(twoFlags, 3)).toEqual([2, 4]);
   });
 });

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -99,7 +99,10 @@ export function lineText(line: AnsiSegment[]): string {
 // ponytail: plain per-line regex, no OSC 8 / reflow tracking (there is no
 // xterm here). A URL split across wrapped visual rows linkifies only its
 // first part; upgrade to reflow-aware matching only if that proves painful.
-const URL_RE = /https?:\/\/\S+/g;
+// Bounded to printable ASCII: a URL glued to CJK text must not claim the
+// glued glyphs into its href, and per-cell runs (#3342) end the flow run at
+// the first non-ASCII code point, so the anchor must stop there too.
+const URL_RE = /https?:\/\/[!-~]+/g;
 // Trailing punctuation that is usually sentence/wrapping syntax, not the URL
 // (e.g. `see https://x.com/a).`). Stripped from the match; re-emitted as text.
 const URL_TRAILING = /[.,;:!?)\]}'">]+$/;
@@ -189,8 +192,6 @@ export interface CellRun {
   fixed: boolean;
 }
 
-const ASCII_CHAR = /^[\x20-\x7E]$/;
-
 /** Split one line's text into runs of like rendering risk. Zero-width
  *  characters glue onto the preceding run (marks must stay with their base
  *  or browsers draw a dotted-circle placeholder); a run opening the line
@@ -209,7 +210,7 @@ export function splitCellRuns(text: string): CellRun[] {
   let i = 0;
   while (i < chars.length) {
     const ch = chars[i]!;
-    if (ASCII_CHAR.test(ch)) {
+    if (ASCII_PRINTABLE_ONLY.test(ch)) {
       flow += ch;
     } else if (ZERO_WIDTH.test(ch)) {
       const last = runs[runs.length - 1];

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -143,7 +143,7 @@ const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]|\p{M}/u;
 // Emoji composition tails: they modify the preceding pictographic glyph
 // and occupy no column of their own (skin-tone swatches, text/color
 // variation selectors).
-const EMOJI_TAIL = /[\uFE0E\uFE0F\u{1F3FB}-\u{1F3FF}]/u;
+const EMOJI_TAIL = /^(?:[\uFE0E\uFE0F]|[\u{1F3FB}-\u{1F3FF}])$/u;
 // Regional indicator pairs compose flag glyphs. Each RI carries
 // Emoji_Presentation, so the wide classifier counts two cells per RI and
 // a flag renders as four cells in this grid's convention.

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -173,6 +173,61 @@ export function findCursorCharIndex(text: string, col: number): number | null {
   return null;
 }
 
+/** One renderable piece of a row. Consecutive printable ASCII flows
+ *  naturally (`fixed: false`, the configured monospace font is trusted for
+ *  the only range where every plausible fallback agrees), everything else
+ *  becomes its own explicitly sized box: CJK, braille, powerline PUA, emoji,
+ *  box drawing, combining clusters. A glyph missing from the configured font
+ *  falls back to a font whose advance is not 1 cell, and without the box
+ *  every later column on the row shifts (#3342); with it, a row of N cells
+ *  lays out N x cellWidth regardless of which font supplied each glyph. */
+export interface CellRun {
+  text: string;
+  /** Terminal cells this run occupies (zero-width marks add none). */
+  cells: number;
+  /** Render inside an explicit `cells x cellWidth` box. */
+  fixed: boolean;
+}
+
+const ASCII_CHAR = /^[\x20-\x7E]$/;
+
+/** Split one line's text into runs of like rendering risk. Zero-width
+ *  characters glue onto the preceding run (marks must stay with their base
+ *  or browsers draw a dotted-circle placeholder); a run opening the line
+ *  holds them until a base arrives. Each non-ASCII cluster is isolated so
+ *  exactly one box absorbs any fallback-advance error. */
+export function splitCellRuns(text: string): CellRun[] {
+  const runs: CellRun[] = [];
+  let flow = "";
+  const flushFlow = () => {
+    if (flow) {
+      runs.push({ text: flow, cells: textWidth(flow), fixed: false });
+      flow = "";
+    }
+  };
+  const chars = [...text];
+  let i = 0;
+  while (i < chars.length) {
+    const ch = chars[i]!;
+    if (ASCII_CHAR.test(ch)) {
+      flow += ch;
+    } else if (ZERO_WIDTH.test(ch)) {
+      const last = runs[runs.length - 1];
+      if (last && !flow) last.text += ch;
+      else flow += ch;
+    } else {
+      flushFlow();
+      // Base glyph plus its own trailing zero-width marks form one cluster.
+      let cluster = ch;
+      while (i + 1 < chars.length && ZERO_WIDTH.test(chars[i + 1]!)) cluster += chars[++i]!;
+      runs.push({ text: cluster, cells: cellWidth(ch), fixed: true });
+    }
+    i++;
+  }
+  flushFlow();
+  return runs;
+}
+
 /** Hard-wrap one styled line at `cols` terminal cells, preserving
  *  segment styles across the breaks. Lines at or under the limit return
  *  a single visual row (the normal case: the pane is sized to the

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -200,6 +200,9 @@ export function findCursorCharIndex(text: string, col: number): number | null {
  *  back to a font whose advance is not 1 cell; the box pins every
  *  flow/fixed boundary to its exact column (#3342), so a row of N cells
  *  lays out N x cellWidth regardless of which font supplied each glyph.
+ *  cellWidth is measured at regular weight; on systems where the
+ *  configured font has no true bold face, synthesized bold can advance
+ *  slightly wider and bold runs may drift inside their boxes.
  *  Whole stretches stay in a single text node because atomic inline
  *  boundaries would otherwise break Unicode bidi reordering, complex
  *  script shaping and emoji composition inside the stretch. */

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -172,7 +172,13 @@ export function splitGraphemes(text: string): string[] {
   let i = 0;
   while (i < chars.length) {
     let cluster = chars[i]!;
-    if (REGIONAL_INDICATOR.test(cluster)) {
+    if (chars[i + 1] === "\uFE0F" && chars[i + 2] === "\u20E3") {
+      // Keycap sequence (base + VS16 + enclosing keycap): one two-cell
+      // cluster even when the base is printable ASCII like #, * or a
+      // digit.
+      cluster += chars[++i]!;
+      cluster += chars[++i]!;
+    } else if (REGIONAL_INDICATOR.test(cluster)) {
       // Pair on parity within the maximal RI run.
       let runStart = i;
       while (runStart > 0 && REGIONAL_INDICATOR.test(chars[runStart - 1]!)) runStart--;
@@ -208,10 +214,10 @@ export function splitGraphemes(text: string): string[] {
   return clusters;
 }
 
-/** Terminal cells occupied by one grapheme cluster (see splitGraphemes). */
 export function graphemeWidth(cluster: string): number {
   const cps = [...cluster];
   const riCount = cps.filter((c) => REGIONAL_INDICATOR.test(c)).length;
+  if (cps.some((c) => c === "\u20E3")) return 2;
   if (riCount >= 2) return 2;
   if (riCount === 1 && cps.length === 1) return 1;
   if (cps.some((c) => c === ZWJ)) return 2;

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -100,8 +100,8 @@ export function lineText(line: AnsiSegment[]): string {
 // xterm here). A URL split across wrapped visual rows linkifies only its
 // first part; upgrade to reflow-aware matching only if that proves painful.
 // Bounded to printable ASCII: a URL glued to CJK text must not claim the
-// glued glyphs into its href, and per-cell runs (#3342) end the flow run at
-// the first non-ASCII code point, so the anchor must stop there too.
+// glued glyphs into its href, and cell runs (#3342) start a fixed stretch
+// at the first non-ASCII code point, so the anchor must stop there too.
 const URL_RE = /https?:\/\/[!-~]+/g;
 // Trailing punctuation that is usually sentence/wrapping syntax, not the URL
 // (e.g. `see https://x.com/a).`). Stripped from the match; re-emitted as text.

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -134,18 +134,31 @@ export function splitUrls(text: string): UrlPart[] {
   return parts;
 }
 
-// Terminal cell widths, wcwidth-style: combining marks and zero-width
-// joiners take no cell; East Asian Wide/Fullwidth and emoji take two.
-// tmux wraps by cells, so wrapping (and the cursor math built on it)
-// must count the same way, not in UTF-16 code units.
+// Terminal cell widths, wcwidth-style: combining marks, zero-width
+// joiners, variation selectors and emoji modifiers take no cell; East
+// Asian Wide/Fullwidth and emoji take two. tmux wraps by cells, so
+// wrapping (and the cursor math built on it) must count the same way,
+// not in UTF-16 code units.
 const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]|\p{M}/u;
+// Emoji composition tails: they modify the preceding pictographic glyph
+// and occupy no column of their own (skin-tone swatches, text/color
+// variation selectors).
+const EMOJI_TAIL = /[\uFE0E\uFE0F\u{1F3FB}-\u{1F3FF}]/u;
+// Regional indicator pairs compose flag glyphs; a lone RI is one cell.
+const REGIONAL_INDICATOR = /[\u{1F1E6}-\u{1F1FF}]/u;
 const WIDE =
   /[\u1100-\u115F\u2E80-\u303E\u3041-\u33FF\u3400-\u4DBF\u4E00-\u9FFF\uA000-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE4F\uFF00-\uFF60\uFFE0-\uFFE6\u{1F300}-\u{1FAFF}]|\p{Emoji_Presentation}/u;
 const ASCII_PRINTABLE_ONLY = /^[\x20-\x7E]*$/;
 
 export function cellWidth(codePoint: string): number {
-  if (ZERO_WIDTH.test(codePoint)) return 0;
+  if (ZERO_WIDTH.test(codePoint) || EMOJI_TAIL.test(codePoint)) return 0;
   return WIDE.test(codePoint) ? 2 : 1;
+}
+
+/** Last code point of a string, surrogate-pair aware (`slice(-1)` would
+ *  return a lone low surrogate for astral glyphs like flags). */
+function lastCodePoint(s: string): string {
+  return [...s].slice(-1)[0] ?? "";
 }
 
 export function textWidth(text: string): number {
@@ -178,12 +191,16 @@ export function findCursorCharIndex(text: string, col: number): number | null {
 
 /** One renderable piece of a row. Consecutive printable ASCII flows
  *  naturally (`fixed: false`, the configured monospace font is trusted for
- *  the only range where every plausible fallback agrees), everything else
- *  becomes its own explicitly sized box: CJK, braille, powerline PUA, emoji,
- *  box drawing, combining clusters. A glyph missing from the configured font
- *  falls back to a font whose advance is not 1 cell, and without the box
- *  every later column on the row shifts (#3342); with it, a row of N cells
- *  lays out N x cellWidth regardless of which font supplied each glyph. */
+ *  the only range where every plausible fallback agrees); each contiguous
+ *  stretch of everything else (CJK, braille, powerline PUA, emoji, box
+ *  drawing, RTL or joining scripts) becomes ONE explicitly sized box of
+ *  `cells x cellWidth`. A glyph missing from the configured font falls
+ *  back to a font whose advance is not 1 cell; the box pins every
+ *  flow/fixed boundary to its exact column (#3342), so a row of N cells
+ *  lays out N x cellWidth regardless of which font supplied each glyph.
+ *  Whole stretches stay in a single text node because atomic inline
+ *  boundaries would otherwise break Unicode bidi reordering, complex
+ *  script shaping and emoji composition inside the stretch. */
 export interface CellRun {
   text: string;
   /** Terminal cells this run occupies (zero-width marks add none). */
@@ -193,17 +210,26 @@ export interface CellRun {
 }
 
 /** Split one line's text into runs of like rendering risk. Zero-width
- *  characters glue onto the preceding run (marks must stay with their base
- *  or browsers draw a dotted-circle placeholder); a run opening the line
- *  holds them until a base arrives. Each non-ASCII cluster is isolated so
- *  exactly one box absorbs any fallback-advance error. */
+ *  characters and emoji tails glue onto the preceding run (marks must
+ *  shape with their base or browsers draw dotted-circle placeholders);
+ *  leading marks with no base open their own zero-cell flow run. A fixed
+ *  stretch absorbs clusters while they continue the current grapheme:
+ *  trailing marks and tails, a ZWJ plus whatever it joins, or a second
+ *  regional indicator completing one flag. */
 export function splitCellRuns(text: string): CellRun[] {
   const runs: CellRun[] = [];
   let flow = "";
+  let fixedStretch = "";
   const flushFlow = () => {
     if (flow) {
       runs.push({ text: flow, cells: textWidth(flow), fixed: false });
       flow = "";
+    }
+  };
+  const flushFixed = () => {
+    if (fixedStretch) {
+      runs.push({ text: fixedStretch, cells: textWidth(fixedStretch), fixed: true });
+      fixedStretch = "";
     }
   };
   const chars = [...text];
@@ -211,22 +237,73 @@ export function splitCellRuns(text: string): CellRun[] {
   while (i < chars.length) {
     const ch = chars[i]!;
     if (ASCII_PRINTABLE_ONLY.test(ch)) {
+      flushFixed();
       flow += ch;
     } else if (ZERO_WIDTH.test(ch)) {
-      const last = runs[runs.length - 1];
-      if (last && !flow) last.text += ch;
+      // Glue backward: onto the pending fixed stretch, else onto the flow
+      // run (a line opening with a mark opens a zero-width flow run).
+      if (fixedStretch) fixedStretch += ch;
+      else flow += ch;
+    } else if (
+      EMOJI_TAIL.test(ch) ||
+      (REGIONAL_INDICATOR.test(ch) && REGIONAL_INDICATOR.test(lastCodePoint(fixedStretch)))
+    ) {
+      // Composition tail of the previous glyph, or the second half of a
+      // flag pair: no new box, no new cells beyond what textWidth counts.
+      if (fixedStretch) fixedStretch += ch;
       else flow += ch;
     } else {
       flushFlow();
-      // Base glyph plus its own trailing zero-width marks form one cluster.
-      let cluster = ch;
-      while (i + 1 < chars.length && ZERO_WIDTH.test(chars[i + 1]!)) cluster += chars[++i]!;
-      runs.push({ text: cluster, cells: cellWidth(ch), fixed: true });
+      fixedStretch += ch;
+      // Absorb what continues this grapheme: trailing marks and tails, a
+      // second regional indicator completing exactly one flag pair, then
+      // whatever non-ASCII glyph a ZWJ joins into the same glyph.
+      let ris = REGIONAL_INDICATOR.test(ch) ? 1 : 0;
+      let joiner = false;
+      for (;;) {
+        const next = chars[i + 1];
+        if (next === undefined) break;
+        const joins = joiner
+          ? !ASCII_PRINTABLE_ONLY.test(next)
+          : ZERO_WIDTH.test(next) || EMOJI_TAIL.test(next) || (ris === 1 && REGIONAL_INDICATOR.test(next));
+        if (!joins) break;
+        fixedStretch += next;
+        i++;
+        if (REGIONAL_INDICATOR.test(next)) ris = Math.min(ris + 1, 2);
+        joiner = next === "\u200D";
+      }
     }
     i++;
   }
   flushFlow();
+  flushFixed();
   return runs;
+}
+
+/** Code-point range `[start, end)` of the grapheme cluster containing
+ *  `charIndex`: its base plus trailing zero-width marks and emoji tails,
+ *  extended over a completing regional-indicator pair and across a ZWJ
+ *  join, mirroring splitCellRuns' absorption rules so the cursor cell can
+ *  slice a coalesced fixed stretch without stranding a composition tail
+ *  outside the highlight. */
+export function clusterSpanAt(text: string, charIndex: number): [number, number] {
+  const chars = [...text];
+  let start = charIndex;
+  let end = charIndex + 1;
+  const glueAt = (k: number) =>
+    k >= 0 && k < chars.length && (ZERO_WIDTH.test(chars[k]!) || EMOJI_TAIL.test(chars[k]!));
+  while (glueAt(end)) end++;
+  if (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start + 1] ?? "")) {
+    end = Math.max(end, start + 2);
+  } else if (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start - 1] ?? "")) {
+    start--;
+    end = Math.max(end, start + 2);
+  }
+  while (chars[end - 1] === "\u200D") {
+    end++;
+    while (glueAt(end)) end++;
+  }
+  return [Math.max(start, 0), Math.min(end, chars.length)];
 }
 
 /** Hard-wrap one styled line at `cols` terminal cells, preserving

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -281,16 +281,16 @@ export function clusterSpanAt(text: string, charIndex: number): [number, number]
   const glueAt = (k: number) =>
     k >= 0 && k < chars.length && (ZERO_WIDTH.test(chars[k]!) || EMOJI_TAIL.test(chars[k]!));
   while (glueAt(end)) end++;
-  const extendRi =
-    (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start + 1] ?? "")) ||
-    (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start - 1] ?? ""));
-  if (extendRi) {
-    if (!REGIONAL_INDICATOR.test(chars[start - 1] ?? "")) {
-      end = Math.max(end, start + 2);
-    } else {
-      start--;
-      end = Math.max(end, start + 2);
-    }
+  // Regional indicators pair on parity within their maximal run, so a
+  // cursor between two adjacent flags pairs with its own flag's half
+  // instead of straddling the boundary.
+  let runStart = start;
+  while (runStart > 0 && REGIONAL_INDICATOR.test(chars[runStart - 1] ?? "")) runStart--;
+  const onRi = REGIONAL_INDICATOR.test(chars[start] ?? "");
+  const oddInRun = (start - runStart) % 2 === 1;
+  if (onRi && (oddInRun || REGIONAL_INDICATOR.test(chars[start + 1] ?? ""))) {
+    if (oddInRun) start--;
+    end = Math.max(end, start + 2);
     // The pair may itself be followed by composition tails.
     while (glueAt(end)) end++;
   }

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -135,15 +135,27 @@ export function splitUrls(text: string): UrlPart[] {
 
 // Terminal cell widths, tmux-aligned and counted PER GRAPHEME CLUSTER,
 // not per code point (measured against tmux 3.6a cursor_x deltas):
-// combining marks, zero-width joiners, variation selectors and emoji
-// modifiers take no column of their own; a VS16-forced emoji, a flag
-// pair and a ZWJ chain each take exactly two columns; a lone regional
-// indicator takes one; East Asian Wide/Fullwidth and emoji take two.
+// combining marks, zero-width joiners and variation selectors take no
+// column of their own, and neither does a skin-tone swatch that has a
+// modifier base in front of it; a VS16-forced emoji, a flag pair and a
+// ZWJ chain each take exactly two columns; a lone regional indicator
+// takes one; East Asian Wide/Fullwidth and emoji take two. An orphan
+// mark with no base to attach to keeps whatever width it has on its own.
 const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]|\p{M}/u;
 // Emoji composition tails: they modify the preceding pictographic glyph
-// and occupy no column of their own (skin-tone swatches, text/color
-// variation selectors).
-const EMOJI_TAIL = /^(?:[\uFE0E\uFE0F]|[\u{1F3FB}-\u{1F3FF}])$/u;
+// and occupy no column of their own (text/color variation selectors).
+const EMOJI_TAIL = /^[\uFE0E\uFE0F]$/u;
+// Skin-tone swatches fold into the preceding glyph only when that glyph
+// takes a modifier; after anything else the swatch keeps its own two
+// columns (measured: thumbs-up + tone = 2 cells, grinning face + tone =
+// 4, since U+1F600 takes no modifier). tmux 3.6a decides this from a
+// hand-maintained list of ~70 base code points in utf8_should_combine()
+// rather than from Unicode's Emoji_Modifier_Base property, so a base in
+// the property but missing from that list (U+270B, U+1F91D, U+1F3C3)
+// still measures 2 here against tmux's 4. The property is the closest
+// stable approximation and errs only on that gap.
+const SKIN_TONE = /^[\u{1F3FB}-\u{1F3FF}]$/u;
+const MODIFIER_BASE = /\p{Emoji_Modifier_Base}/u;
 // Regional indicator pairs compose flag glyphs.
 const REGIONAL_INDICATOR = /[\u{1F1E6}-\u{1F1FF}]/u;
 const WIDE =
@@ -156,22 +168,26 @@ export function cellWidth(codePoint: string): number {
   return WIDE.test(codePoint) ? 2 : 1;
 }
 
-/** Last code point of a string, surrogate-pair aware (`slice(-1)` would
- *  return a lone low surrogate for astral glyphs like flags). */
-function lastCodePoint(s: string): string {
-  return [...s].slice(-1)[0] ?? "";
+/** True when `next` composes onto a cluster based on `base` instead of
+ *  opening a column of its own. Shared by splitGraphemes (which decides
+ *  cluster widths) and clusterSpanAt (which decides how much text the
+ *  boxed cursor cell takes), so the two cannot drift apart. */
+function composesOnto(base: string, next: string): boolean {
+  if (SKIN_TONE.test(next)) return MODIFIER_BASE.test(base);
+  return ZERO_WIDTH.test(next) || EMOJI_TAIL.test(next);
 }
 
 /** Split text into extended grapheme clusters: a base glyph plus its
  *  zero-width marks and emoji tails; consecutive regional indicators
  *  pair up on parity into flags; a ZWJ joins the next non-ASCII glyph
  *  into the same cluster. Mirrors clusterSpanAt's absorption rules. */
-export function splitGraphemes(text: string): string[] {
+function splitGraphemes(text: string): string[] {
   const clusters: string[] = [];
   const chars = [...text];
   let i = 0;
   while (i < chars.length) {
-    let cluster = chars[i]!;
+    const base = chars[i]!;
+    let cluster = base;
     if (chars[i + 1] === "\uFE0F" && chars[i + 2] === "\u20E3") {
       // Keycap sequence (base + VS16 + enclosing keycap): one two-cell
       // cluster even when the base is printable ASCII like #, * or a
@@ -200,7 +216,7 @@ export function splitGraphemes(text: string): string[] {
           i++;
           continue;
         }
-        if (ZERO_WIDTH.test(next) || EMOJI_TAIL.test(next)) {
+        if (composesOnto(base, next)) {
           cluster += next;
           i++;
           continue;
@@ -214,13 +230,16 @@ export function splitGraphemes(text: string): string[] {
   return clusters;
 }
 
-export function graphemeWidth(cluster: string): number {
+function graphemeWidth(cluster: string): number {
   const cps = [...cluster];
   const riCount = cps.filter((c) => REGIONAL_INDICATOR.test(c)).length;
-  if (cps.some((c) => c === "\u20E3")) return 2;
+  // The keycap and ZWJ rules need a base to apply to: an orphan U+20E3 or
+  // U+200D with nothing in front of it is an ordinary zero-width mark, so
+  // both guards require more than one code point in the cluster.
+  if (cps.length > 1 && cps.some((c) => c === "\u20E3")) return 2;
   if (riCount >= 2) return 2;
   if (riCount === 1 && cps.length === 1) return 1;
-  if (cps.some((c) => c === ZWJ)) return 2;
+  if (cps.length > 1 && cps.some((c) => c === ZWJ)) return 2;
   if (cps.length > 1 && cps[cps.length - 1] === "\uFE0F") return 2;
   return cellWidth(cps[0]!);
 }
@@ -307,12 +326,9 @@ export function splitCellRuns(text: string): CellRun[] {
       // run (a line opening with a mark opens a zero-width flow run).
       if (fixedStretch) fixedStretch += ch;
       else flow += ch;
-    } else if (
-      EMOJI_TAIL.test(ch) ||
-      (REGIONAL_INDICATOR.test(ch) && REGIONAL_INDICATOR.test(lastCodePoint(fixedStretch)))
-    ) {
-      // Composition tail of the previous glyph, or the second half of a
-      // flag pair: no new box, no new cells beyond what textWidth counts.
+    } else if (EMOJI_TAIL.test(ch)) {
+      // Composition tail of the previous glyph: no new box, no new cells
+      // beyond what textWidth counts.
       if (fixedStretch) fixedStretch += ch;
       else flow += ch;
     } else {
@@ -339,8 +355,7 @@ export function clusterSpanAt(text: string, charIndex: number): [number, number]
   const chars = [...text];
   let start = charIndex;
   let end = charIndex + 1;
-  const glueAt = (k: number) =>
-    k >= 0 && k < chars.length && (ZERO_WIDTH.test(chars[k]!) || EMOJI_TAIL.test(chars[k]!));
+  const glueAt = (k: number) => k >= 0 && k < chars.length && composesOnto(chars[start] ?? "", chars[k]!);
   while (glueAt(end)) end++;
   // Regional indicators pair on parity within their maximal run, so a
   // cursor between two adjacent flags pairs with its own flag's half

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -144,7 +144,9 @@ const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]|\p{M}/u;
 // and occupy no column of their own (skin-tone swatches, text/color
 // variation selectors).
 const EMOJI_TAIL = /[\uFE0E\uFE0F\u{1F3FB}-\u{1F3FF}]/u;
-// Regional indicator pairs compose flag glyphs; a lone RI is one cell.
+// Regional indicator pairs compose flag glyphs. Each RI carries
+// Emoji_Presentation, so the wide classifier counts two cells per RI and
+// a flag renders as four cells in this grid's convention.
 const REGIONAL_INDICATOR = /[\u{1F1E6}-\u{1F1FF}]/u;
 const WIDE =
   /[\u1100-\u115F\u2E80-\u303E\u3041-\u33FF\u3400-\u4DBF\u4E00-\u9FFF\uA000-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE4F\uFF00-\uFF60\uFFE0-\uFFE6\u{1F300}-\u{1FAFF}]|\p{Emoji_Presentation}/u;
@@ -213,9 +215,9 @@ export interface CellRun {
  *  characters and emoji tails glue onto the preceding run (marks must
  *  shape with their base or browsers draw dotted-circle placeholders);
  *  leading marks with no base open their own zero-cell flow run. A fixed
- *  stretch absorbs clusters while they continue the current grapheme:
- *  trailing marks and tails, a ZWJ plus whatever it joins, or a second
- *  regional indicator completing one flag. */
+ *  stretch swallows every contiguous non-ASCII code point, so composed
+ *  glyphs (flag pairs, skin tones, ZWJ chains) and script shaping stay
+ *  whole inside one text node. */
 export function splitCellRuns(text: string): CellRun[] {
   const runs: CellRun[] = [];
   let flow = "";
@@ -254,24 +256,10 @@ export function splitCellRuns(text: string): CellRun[] {
       else flow += ch;
     } else {
       flushFlow();
+      // Contiguous non-ASCII coalesces: every following code point that is
+      // not printable ASCII lands here too (marks, tails, joined glyphs),
+      // keeping the whole stretch in one text node.
       fixedStretch += ch;
-      // Absorb what continues this grapheme: trailing marks and tails, a
-      // second regional indicator completing exactly one flag pair, then
-      // whatever non-ASCII glyph a ZWJ joins into the same glyph.
-      let ris = REGIONAL_INDICATOR.test(ch) ? 1 : 0;
-      let joiner = false;
-      for (;;) {
-        const next = chars[i + 1];
-        if (next === undefined) break;
-        const joins = joiner
-          ? !ASCII_PRINTABLE_ONLY.test(next)
-          : ZERO_WIDTH.test(next) || EMOJI_TAIL.test(next) || (ris === 1 && REGIONAL_INDICATOR.test(next));
-        if (!joins) break;
-        fixedStretch += next;
-        i++;
-        if (REGIONAL_INDICATOR.test(next)) ris = Math.min(ris + 1, 2);
-        joiner = next === "\u200D";
-      }
     }
     i++;
   }
@@ -293,11 +281,18 @@ export function clusterSpanAt(text: string, charIndex: number): [number, number]
   const glueAt = (k: number) =>
     k >= 0 && k < chars.length && (ZERO_WIDTH.test(chars[k]!) || EMOJI_TAIL.test(chars[k]!));
   while (glueAt(end)) end++;
-  if (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start + 1] ?? "")) {
-    end = Math.max(end, start + 2);
-  } else if (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start - 1] ?? "")) {
-    start--;
-    end = Math.max(end, start + 2);
+  const extendRi =
+    (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start + 1] ?? "")) ||
+    (REGIONAL_INDICATOR.test(chars[start] ?? "") && REGIONAL_INDICATOR.test(chars[start - 1] ?? ""));
+  if (extendRi) {
+    if (!REGIONAL_INDICATOR.test(chars[start - 1] ?? "")) {
+      end = Math.max(end, start + 2);
+    } else {
+      start--;
+      end = Math.max(end, start + 2);
+    }
+    // The pair may itself be followed by composition tails.
+    while (glueAt(end)) end++;
   }
   while (chars[end - 1] === "\u200D") {
     end++;

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -99,10 +99,9 @@ export function lineText(line: AnsiSegment[]): string {
 // ponytail: plain per-line regex, no OSC 8 / reflow tracking (there is no
 // xterm here). A URL split across wrapped visual rows linkifies only its
 // first part; upgrade to reflow-aware matching only if that proves painful.
-// Bounded to printable ASCII: a URL glued to CJK text must not claim the
-// glued glyphs into its href, and cell runs (#3342) start a fixed stretch
-// at the first non-ASCII code point, so the anchor must stop there too.
-const URL_RE = /https?:\/\/[!-~]+/g;
+// The match may run into glued non-ASCII glyphs; Row anchors whole parts,
+// so the href follows whatever this regex claims.
+const URL_RE = /https?:\/\/\S+/g;
 // Trailing punctuation that is usually sentence/wrapping syntax, not the URL
 // (e.g. `see https://x.com/a).`). Stripped from the match; re-emitted as text.
 const URL_TRAILING = /[.,;:!?)\]}'">]+$/;
@@ -134,23 +133,23 @@ export function splitUrls(text: string): UrlPart[] {
   return parts;
 }
 
-// Terminal cell widths, wcwidth-style: combining marks, zero-width
-// joiners, variation selectors and emoji modifiers take no cell; East
-// Asian Wide/Fullwidth and emoji take two. tmux wraps by cells, so
-// wrapping (and the cursor math built on it) must count the same way,
-// not in UTF-16 code units.
+// Terminal cell widths, tmux-aligned and counted PER GRAPHEME CLUSTER,
+// not per code point (measured against tmux 3.6a cursor_x deltas):
+// combining marks, zero-width joiners, variation selectors and emoji
+// modifiers take no column of their own; a VS16-forced emoji, a flag
+// pair and a ZWJ chain each take exactly two columns; a lone regional
+// indicator takes one; East Asian Wide/Fullwidth and emoji take two.
 const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]|\p{M}/u;
 // Emoji composition tails: they modify the preceding pictographic glyph
 // and occupy no column of their own (skin-tone swatches, text/color
 // variation selectors).
 const EMOJI_TAIL = /^(?:[\uFE0E\uFE0F]|[\u{1F3FB}-\u{1F3FF}])$/u;
-// Regional indicator pairs compose flag glyphs. Each RI carries
-// Emoji_Presentation, so the wide classifier counts two cells per RI and
-// a flag renders as four cells in this grid's convention.
+// Regional indicator pairs compose flag glyphs.
 const REGIONAL_INDICATOR = /[\u{1F1E6}-\u{1F1FF}]/u;
 const WIDE =
   /[\u1100-\u115F\u2E80-\u303E\u3041-\u33FF\u3400-\u4DBF\u4E00-\u9FFF\uA000-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE4F\uFF00-\uFF60\uFFE0-\uFFE6\u{1F300}-\u{1FAFF}]|\p{Emoji_Presentation}/u;
 const ASCII_PRINTABLE_ONLY = /^[\x20-\x7E]*$/;
+const ZWJ = "\u200D";
 
 export function cellWidth(codePoint: string): number {
   if (ZERO_WIDTH.test(codePoint) || EMOJI_TAIL.test(codePoint)) return 0;
@@ -163,30 +162,83 @@ function lastCodePoint(s: string): string {
   return [...s].slice(-1)[0] ?? "";
 }
 
-export function textWidth(text: string): number {
-  if (ASCII_PRINTABLE_ONLY.test(text)) return text.length;
-  let width = 0;
-  for (const ch of text) width += cellWidth(ch);
-  return width;
+/** Split text into extended grapheme clusters: a base glyph plus its
+ *  zero-width marks and emoji tails; consecutive regional indicators
+ *  pair up on parity into flags; a ZWJ joins the next non-ASCII glyph
+ *  into the same cluster. Mirrors clusterSpanAt's absorption rules. */
+export function splitGraphemes(text: string): string[] {
+  const clusters: string[] = [];
+  const chars = [...text];
+  let i = 0;
+  while (i < chars.length) {
+    let cluster = chars[i]!;
+    if (REGIONAL_INDICATOR.test(cluster)) {
+      // Pair on parity within the maximal RI run.
+      let runStart = i;
+      while (runStart > 0 && REGIONAL_INDICATOR.test(chars[runStart - 1]!)) runStart--;
+      if ((i - runStart) % 2 === 0 && REGIONAL_INDICATOR.test(chars[i + 1] ?? "")) {
+        cluster += chars[++i]!;
+      }
+    } else if (!ASCII_PRINTABLE_ONLY.test(cluster)) {
+      // Non-ASCII base: absorb trailing marks, emoji tails and whatever
+      // non-ASCII glyph a ZWJ joins into the same cluster.
+      for (;;) {
+        const next = chars[i + 1];
+        if (next === undefined) break;
+        if (next === ZWJ) {
+          cluster += next;
+          i++;
+          const joined = chars[i + 1];
+          if (joined === undefined || ASCII_PRINTABLE_ONLY.test(joined)) break;
+          cluster += joined;
+          i++;
+          continue;
+        }
+        if (ZERO_WIDTH.test(next) || EMOJI_TAIL.test(next)) {
+          cluster += next;
+          i++;
+          continue;
+        }
+        break;
+      }
+    }
+    clusters.push(cluster);
+    i++;
+  }
+  return clusters;
 }
 
-/** Find the code point in `text` whose terminal cell range contains `col`
- *  (cell units from the start of `text`), or null if `col` falls at or
- *  past the end. Iterates code points (an emoji's surrogate pair never
- *  splits) and counts cells the same way `textWidth`/`wrapLine` do, so a
- *  cursor column from tmux (already cell-based) lands on the right glyph
- *  even when wide CJK or zero-width characters precede it. */
+/** Terminal cells occupied by one grapheme cluster (see splitGraphemes). */
+export function graphemeWidth(cluster: string): number {
+  const cps = [...cluster];
+  const riCount = cps.filter((c) => REGIONAL_INDICATOR.test(c)).length;
+  if (riCount >= 2) return 2;
+  if (riCount === 1 && cps.length === 1) return 1;
+  if (cps.some((c) => c === ZWJ)) return 2;
+  if (cps.length > 1 && cps[cps.length - 1] === "\uFE0F") return 2;
+  return cellWidth(cps[0]!);
+}
+
+/** Terminal cells occupied by a whole line: the sum of its grapheme
+ *  clusters' widths, matching how tmux counts columns. */
+export function textWidth(text: string): number {
+  if (ASCII_PRINTABLE_ONLY.test(text)) return text.length;
+  return splitGraphemes(text).reduce((n, c) => n + graphemeWidth(c), 0);
+}
+
+/** Find the code point that starts the grapheme cluster whose terminal
+ *  cell range contains `col`, or null if `col` falls at or past the end.
+ *  Counts cells per cluster (a flag, ZWJ chain or VS16-forced emoji is
+ *  one stop of width 2), so a cursor column from tmux lands on the right
+ *  glyph even when wide CJK or zero-width characters precede it. */
 export function findCursorCharIndex(text: string, col: number): number | null {
-  if (ASCII_PRINTABLE_ONLY.test(text)) {
-    return col >= 0 && col < text.length ? col : null;
-  }
   let c = 0;
-  let i = 0;
-  for (const ch of text) {
-    const w = cellWidth(ch);
-    if (col >= c && col < c + w) return i;
+  let pos = 0;
+  for (const cluster of splitGraphemes(text)) {
+    const w = graphemeWidth(cluster);
+    if (col >= c && col < c + w) return pos;
     c += w;
-    i++;
+    pos += [...cluster].length;
   }
   return null;
 }
@@ -310,8 +362,8 @@ export function clusterSpanAt(text: string, charIndex: number): [number, number]
  *  viewer's grid, so this is the identity). Wider lines appear when
  *  another writer resized the tmux window out from under the viewer;
  *  wrapping keeps them readable until the server re-asserts the grid.
- *  Iterates code points (an emoji's surrogate pair never splits) and
- *  counts cells, so CJK and emoji wrap where tmux would wrap them. */
+ *  Iterates grapheme clusters and counts cells, so CJK, flags, ZWJ
+ *  chains and emoji wrap where tmux would wrap them. */
 export function wrapLine(line: AnsiSegment[], cols: number): AnsiSegment[][] {
   if (!Number.isFinite(cols) || cols <= 0) return [line];
   const total = line.reduce((n, s) => n + textWidth(s.text), 0);
@@ -327,17 +379,17 @@ export function wrapLine(line: AnsiSegment[], cols: number): AnsiSegment[][] {
         chunk = "";
       }
     };
-    for (const ch of seg.text) {
-      const w = cellWidth(ch);
-      // A wide char that doesn't fit wraps whole (terminals leave the
-      // last cell empty); zero-width marks stay with their base char.
+    for (const cluster of splitGraphemes(seg.text)) {
+      const w = graphemeWidth(cluster);
+      // A cluster that doesn't fit wraps whole (terminals leave the last
+      // cell empty); zero-width members never separate from their base.
       if (used + w > cols && used > 0) {
         flushChunk();
         rows.push(current);
         current = [];
         used = 0;
       }
-      chunk += ch;
+      chunk += cluster;
       used += w;
     }
     flushChunk();

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -170,6 +170,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx"]
     },
     {
+      "id": "terminal.live-glyph-cell-width",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/live-glyph-columns.spec.ts", "src/lib/liveTermLines.test.ts"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
       "id": "terminal.live-cursor-focus-fill",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live-glyph-columns.spec.ts
+++ b/web/tests/live-glyph-columns.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "./helpers/mockedTest";
+import { mockTerminalApis } from "./helpers/terminal-mocks";
+import { clickSidebarSession } from "./helpers/sidebar";
+
+// #3342: rows rendered as one `white-space: pre` run take their column
+// positions from whatever font supplied each glyph. A glyph missing from the
+// configured font (CJK under Geist Mono, braille under D2Coding NF) falls
+// back to a font whose advance is not 1 cell and every later column on that
+// row shifts. The renderer must enforce per-cell width so a row of N terminal
+// cells always lays out N x cellWidth pixels, regardless of fallback fonts.
+
+const ASCII_ROW = "AAAAAAAAAAAAAAAAAAAA"; // exactly 20 cells
+const MIXED_ROW = "\uD55C\uAE00\uD14C\uC2A4\uD2B8" + "AAAA" + "\u280B\u280D" + "AAAA"; // 5x2 CJK + 4 + 2 braille + 4 = 20 cells
+
+test.describe("Live terminal glyph cell-width enforcement", () => {
+  test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
+  test("a row with glyphs missing from the terminal font is exactly cells x cellWidth wide", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    const term = page.locator("[data-live-terminal]").first();
+    await term.waitFor({ state: "visible", timeout: 10_000 });
+    // Let the mount settle: webfonts load, the component re-measures charW,
+    // and its final resize lands. The mocked live-ws answers every resize
+    // with a fresh default frame, so pushing before that settle races the
+    // overwrite.
+    await page.waitForFunction(() => document.fonts.status === "loaded", undefined, { timeout: 10_000 });
+    await term.locator("[data-live-content]").innerText(); // default frame rendered
+    await page.waitForTimeout(250);
+
+    // Two lines with the SAME terminal cell count (20): one pure ASCII, one
+    // mixing CJK + braille that no default stack covers. Pre-fix the mixed
+    // line renders narrower because each missing glyph falls back to a
+    // non-1-cell advance.
+    handle.pushLiveFrame({
+      content: [ASCII_ROW, MIXED_ROW, ""].join("\n"),
+      rows: 6,
+      history: 0,
+      cursor: null,
+    });
+    const content = term.locator("[data-live-content]");
+    await expect.poll(() => content.innerText()).toContain("테스트");
+
+    const metrics = await page.evaluate(() => {
+      const grid = document.querySelector<HTMLElement>("[data-live-content]")!;
+      // Mirror the component's own cell measure: a 20-char M run in the same
+      // styles, inside the grid so it inherits font family and size.
+      const probe = document.createElement("span");
+      probe.textContent = "M".repeat(20);
+      probe.setAttribute("aria-hidden", "true");
+      probe.style.whiteSpace = "pre";
+      probe.style.position = "absolute";
+      probe.style.visibility = "hidden";
+      grid.appendChild(probe);
+      const cellW = probe.getBoundingClientRect().width / 20;
+      probe.remove();
+      // Row divs are full-width blocks; their INLINE content extent is the
+      // laid-out text width, which is what the grid invariant constrains.
+      const inlineWidth = (el: HTMLElement) => {
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        return range.getBoundingClientRect().width;
+      };
+      const rows = [...grid.children]
+        .filter((el): el is HTMLElement => el instanceof HTMLElement && el.tagName === "DIV")
+        .map((el) => ({ text: el.textContent ?? "", width: inlineWidth(el) }));
+      return { cellW, rows };
+    });
+
+    const ascii = metrics.rows.find((r) => r.text.startsWith(ASCII_ROW.slice(0, 10)));
+    const mixed = metrics.rows.find((r) => r.text.includes("테스트"));
+    expect(ascii).toBeDefined();
+    expect(mixed).toBeDefined();
+    expect(metrics.cellW).toBeGreaterThan(0);
+    const expected = 20 * metrics.cellW;
+    // Pure-ASCII line already honors the grid; it anchors the measurement.
+    expect(Math.abs(ascii!.width - expected)).toBeLessThan(0.75);
+    // The mixed line must be exactly as wide as its cell count demands.
+    expect(Math.abs(mixed!.width - expected)).toBeLessThan(0.75);
+  });
+});


### PR DESCRIPTION
# Fix(web): enforce per-cell width in the live terminal so fallback glyphs cannot shift columns

## Description

**What:** the web terminal renderer (`MobileLiveTerminal` `Row`) now splits each row's text into *cell runs* and renders every non-ASCII cluster inside an explicit `inline-block` box of exactly `cells × cellWidth` pixels (via a new `--term-cell` CSS variable fed by the already-measured `charW`). Printable-ASCII runs keep flowing naturally, so typical agent output gains zero extra DOM nodes.

**Why (#3342):** rows rendered as one `white-space: pre` run take their column positions from whatever font supplied each glyph. When a glyph is missing from the configured font, the browser falls back to another font whose advance is not 1 cell and every later column on that row shifts: Hangul measures 1.533 cells under the default Geist Mono stack, braille spinners measure 1.464 under D2Coding NF (fallback DejaVu Sans braille advance 0.732em vs the font's 0.500em cell), powerline 0.833. Damage is per-line, so the right edge of the terminal "wobbles" between lines.

### RCA

- Symptom → cause chain:
  - `web/src/components/MobileLiveTerminal.tsx`, `Row`: every ANSI segment was emitted as a bare `<span>` inside the `whitespace-pre` container; no element constrained glyph positions to a cell grid.
  - The cell width was already known and measured (hidden 20×`M` span → `charW`, same component) and used for the `cols` shipped to tmux and for pointer→cell mapping, but never imposed on text layout.
  - CSS font fallback substitutes a per-character missing glyph using **the fallback font's own advance**, which no CSS property can renormalize to the primary font's cell.
- Competing hypothesis considered and refuted: a "magic" font-stack cannot fix this. The issue measured all 17 locally-installed fonts containing U+280B; none has a 0.500em advance (narrowest 0.659em), and CJK would still need an exact 2.000-cell advance from whatever fallback the viewer's device picks. Bundling one full-coverage webfont (option 2) was explicitly out of scope and does not protect user-configured fonts anyway.

### Design

Options weighed:

1. Per-cell box for *every* character: uniform, but multiplies DOM nodes ~50× on ASCII-heavy output for no additional correctness (the bug class is missing-glyph fallback, which overwhelmingly affects non-Latin ranges).
2. Fixed width per ANSI segment only: rejected without measurement; tmux commonly emits whole lines as one segment, and intra-segment shifts are exactly the reported symptom.
3. **Chosen: hybrid per-stretch runs** (`splitCellRuns` in `web/src/lib/liveTermLines.ts`). ASCII flows; each contiguous non-ASCII stretch gets ONE explicit-width box of `textWidth(stretch) × charW`, pinning every flow/fixed boundary cell-exact. Whole stretches stay in a single text node because per-character atomic boxes break Unicode bidi reordering (RTL words reversed), complex-script shaping and emoji composition; caught by the round-2 from-scratch review. Widths are counted PER GRAPHEME CLUSTER, tmux-aligned (maintainer review): VS16-forced emoji, flag pairs and ZWJ chains = 2 cells, lone regional indicators = 1, skin-tone tails zero-width; splitGraphemes/graphemeWidth feed textWidth, cursor math and wrapping alike. Guarantees `rowWidth == textWidth(line) × charW` whenever the configured font is monospace for ASCII.

Measured tradeoffs:

- Geometry before/after (mocked Playwright, headless Chromium, 20-cell rows at `charW = 8px`, expected 160px): pure-ASCII line correct both ways; mixed CJK+braille line laid out **15px short (~9%)** before the fix, exact after.
- Worst case perf (all-CJK wall, ~190 columns × 62 rows): virtualization keeps the mounted window at 81 rows / ~3,000 boxed spans; forced layout < 0.1ms. Pure-ASCII lines add zero boxes.
- Selection/copy unaffected: boxes remain inline text spans. Linkification is line-level: splitUrls runs on the whole segment and Row wraps each URL part's runs in a single anchor, so hrefs are never truncated at cell-run boundaries (the interim printable-ASCII narrowing of URL_RE was reverted as redundant).

Note: this also hardens the #2665 cursor path for free: the cursor cell is now itself an explicit-width box, so it lands exactly on its column even when earlier glyphs on the input line fell back to another font. #2665 stays closed; no behavior change intended there beyond this shared-mechanism coverage.

Out of scope (as arbitrated): bundling a full-coverage font, xterm.js v6 (#1010). The Font family help-text note (option 3) can ride along later if wanted; it is not required with structural enforcement in place.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-doc surface changed; settings help text untouched)
- [ ] For UI changes: included screenshot or recording

*(Visual change is corrective alignment of terminal rows; the mocked Playwright spec asserts the geometric invariant directly rather than via screenshot.)*

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
  - New mocked spec `web/tests/live-glyph-columns.spec.ts` (matrix entry `terminal.live-glyph-cell-width`, risk high): pushes a frame mixing ASCII and CJK+braille rows of equal cell count and asserts, in real Chromium layout, that both rows span exactly `cells × cellWidth`. Tier justified: the assertion needs real text shaping with genuine font fallback, which jsdom cannot do.
  - Vitest: `splitCellRuns` unit tests (run classification, zero-width gluing, invariant) plus updated `MobileLiveTerminal.cjkCursor` assertions covering the cursor cell as an explicit box.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## Tests executed

- `cd web && npx vitest run`: 3711 tests, 3711 passing, 0 failing; `tsc` clean. (An earlier revision of this section claimed 3 pre-existing locale-sensitive failures in `Composer.usageHint.test.tsx`; that does not reproduce, the suite is green under `en_US.UTF-8` as well as `LC_ALL=C`.)
- `cd web && npx playwright test` (full mocked suite): 420 passed, 3 skipped, 0 failed.
- `cd web && npm run format:check` (oxfmt): green. `npm run lint` (ESLint): green. `tsc -b`: green.
- `node tests/validate-coverage-matrix.mjs`: green.
- Rust pipeline untouched (web-only change); `cargo clippy` ran via pre-commit hook on commit.

## Risks

- Devices whose configured font lacks basic Latin punctuation could still see flow-run drift inside pure-ASCII stretches; no realistic installed font lacks those glyphs, and the boxed ranges cover everything where fallback actually varies (measured in the issue).
- cellWidth is measured at regular weight; on systems where the configured font has no true bold face, synthesized bold can advance slightly wider and bold runs may drift inside their boxes (documented in the CellRun docs).
- Pathological single-line output: contiguous non-ASCII coalesces into ONE box per stretch (not per cluster), so node counts stay bounded by row virtualization and memoized rows (measured above).
- The box constrains the advance, not the glyph: `fixedBoxStyle` sets a width and no `overflow`, so a 1-cell box does not shrink a fallback glyph that draws wider than one cell. Braille under D2Coding NF is the measured case at 1.46 cells. The trade is deliberate: the spinner row stops shifting every column after it, and instead the oversized glyph overlaps its neighbour by roughly 25-45% of a cell. Stable columns with a little overlap read better than a right edge that wobbles line to line, and clipping the overflow would cut the glyph instead.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** ox-alpha (coding agent)

**Any Additional AI Details you'd like to share:** Full cycle executed by the agent (repro → RCA → design → implementation → validation); human review still requested before ready-for-review.

- [x] I am an AI Agent filling out this form (check box if true)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed live terminal alignment for CJK, braille, emoji, powerline, and other fallback glyphs.
- Improved grapheme-aware width calculations for cursor placement and line wrapping.
- Preserved glued non-ASCII characters inside URL links.
- Added unit and Playwright tests for glyph widths, cursor behavior, wrapping, URLs, and empty rows.
- Benefits include stable columns, accurate cursor placement, and more reliable Unicode rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

