### PR TITLE
fix(tmux): idle omp sessions read Idle instead of Waiting (yellow) at rest

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1899,19 +1899,22 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
 
 /// Oh My Pi status detection via its live pane output.
 ///
-/// OMP keeps a bordered prompt visible both while running and while idle.
+/// OMP keeps a bordered composer visible both while running and while idle.
 /// Status is decided by the lowest pane signal, where position 1 is the
 /// bottom non-empty line: the live loader (`Working… ⟦esc⟧`), the retry
 /// countdown (`Retrying (N/M) in Ns…`), the pinned error banner (matched by
 /// its anchor line "Dismissed when you send your next message."), the
 /// terminal retry lines (`Error: Retry budget exhausted` / `Error: Retry
 /// failed after`), sub-agent retry labels (`retrying N/M …`, the rule-repair
-/// `Attempt N/M ·`), the approval prompt (`Allow tool: …`), and the
-/// `╭── π`/`╰─` prompt box. Each signal has a freshness window; beyond it the
-/// signal is ignored, so a completed turn's loader or a dismissed banner in
-/// scrollback cannot pin the session. The heuristic cannot see structured
-/// turn events; the structured error/retry path (herdr-style extension) is
-/// tracked in #3380.
+/// `Attempt N/M ·`), and the approval prompt (`Allow tool: …`). Each signal
+/// has a freshness window; beyond it the signal is ignored, so a completed
+/// turn's loader or a dismissed banner in scrollback cannot pin the session.
+/// When no signal matched, the frame reads as healthy idle rather than
+/// Waiting. In practice it is parked on the always-visible `╭── π`/`╰─`
+/// composer box, though the fallback itself does not require the box to be
+/// present.
+/// The heuristic cannot see structured turn events; the structured
+/// error/retry path (herdr-style extension) is tracked in #3380.
 pub fn detect_omp_status(raw_content: &str) -> Status {
     let clean = strip_ansi(raw_content);
     let non_empty_lines: Vec<&str> = clean
@@ -2031,17 +2034,9 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         };
     }
 
-    // Fallback: parked at the prompt.
-    let has_header = footer
-        .iter()
-        .any(|line| line.trim_start().starts_with("╭── π"));
-    let has_input = footer
-        .iter()
-        .any(|line| line.trim_start().starts_with("╰─"));
-    if has_header && has_input {
-        return Status::Waiting;
-    }
-
+    // No live signal matched. omp parks every healthy frame on its
+    // always-visible composer box, so an unsignaled frame is idle at the
+    // composer, not waiting for the user.
     Status::Idle
 }
 
@@ -5149,31 +5144,69 @@ You can monitor progress with aoe session logs.\n\
     }
 
     #[test]
-    fn test_detect_omp_status_waiting() {
-        let pane = "OK\n\
-                    ╭── π  > GPT-5.6 Sol ─╮\n\
-                    ╰─                   ─╯";
-        assert_eq!(detect_omp_status(pane), Status::Waiting);
+    fn test_detect_omp_status_waiting_on_approval_prompt() {
+        // A live `Allow tool:` prompt is the only user-attention state at
+        // rest; the composer box alone must not read as Waiting.
+        // Case-insensitive on entry: the gate lowercases the window before
+        // matching, so an all-caps render still reads as a live approval.
+        assert_eq!(
+            detect_omp_status("ALLOW TOOL: BASH\nAPPROVE\nDENY"),
+            Status::Waiting
+        );
         assert_eq!(
             detect_omp_status("Allow tool: bash\nApprove\nDeny"),
             Status::Waiting
         );
     }
 
+    /// The two-line composer box omp renders at rest, shared by the
+    /// fixture-based tests below.
+    const MINIMAL_COMPOSER_BOX: &str = "╭── π  > GPT-5.6 Sol ─╮\n╰─                   ─╯";
+
+    /// Archived repro for the "idle omp sessions render yellow forever"
+    /// bug: tail of a live pane captured after returning to the session
+    /// panel. omp parks every healthy frame on its always-visible composer
+    /// box, so box-only frames are the at-rest shape, not a Waiting signal.
+    const OMP_PARKED_AT_COMPOSER_REPRO: &str = "\
+ ※ recap: Goal was a simple probe: replied OK and ran echo, which returned rca-probe-42 successfully.
+
+╭── π  > ⬢ Ox Alpha · ◉ max > 🗑 …of-empires-dev/scratch/4d9eb39378df4f4e ▶───2%───────────────────┃──────────1M─◀ Reply with OK ──╮
+╰─                                                                                                                                                                                      ─╯";
+
     #[test]
-    fn test_detect_omp_status_ignores_stale_loader() {
-        let pane = "⠋ Working… ⟦esc⟧\n\
-                    Completed response.\n\
-                    Additional output.\n\
-                    OK\n\
-                    ╭── π  > GPT-5.6 Sol ─╮\n\
-                    ╰─                   ─╯";
-        assert_eq!(detect_omp_status(pane), Status::Waiting);
+    fn test_detect_omp_status_idle_at_composer_box() {
+        let cases = [
+            ("bare box", MINIMAL_COMPOSER_BOX.to_string()),
+            // Completed turn above the box (the pre-fix contract said
+            // Waiting here, which painted every idle omp session yellow).
+            ("turn finished", format!("OK\n{MINIMAL_COMPOSER_BOX}")),
+            // Stale loader from the previous turn buried in scrollback.
+            (
+                "stale loader ignored",
+                format!("⠋ Working… ⟦esc⟧\nCompleted response.\nAdditional output.\nOK\n{MINIMAL_COMPOSER_BOX}"),
+            ),
+            // Live loader pushed one line past the 3-line footer window:
+            // the miss now reads Idle where pre-fix it read Waiting.
+            (
+                "loader pushed past footer",
+                format!("⠋ Working… ⟦esc⟧\nOK\n{MINIMAL_COMPOSER_BOX}"),
+            ),
+            // Full archived repro snapshot (see the const doc).
+            ("repro snapshot", OMP_PARKED_AT_COMPOSER_REPRO.to_string()),
+        ];
+        for (name, pane) in &cases {
+            assert_eq!(detect_omp_status(pane), Status::Idle, "case: {name}");
+        }
     }
 
     #[test]
     fn test_detect_omp_status_idle_without_prompt() {
-        assert_eq!(detect_omp_status("plain command output"), Status::Idle);
+        // Empty and whitespace-only panes must stay Idle without panicking:
+        // every window is empty and the unsignaled fallback applies.
+        let panes = ["plain command output", "", " \n\t\n"];
+        for pane in panes {
+            assert_eq!(detect_omp_status(pane), Status::Idle, "case: {pane:?}");
+        }
     }
 
     #[test]
@@ -5183,7 +5216,7 @@ You can monitor progress with aoe session logs.\n\
         // its dismissal footer) or the terminal retry lines; retries read
         // Running via the countdown and the sub-agent labels. Positions are
         // 1-based from the bottom; the lowest signal wins.
-        let prompt_box = "╭── π  > GPT-5.6 Sol ─╮\n╰─                   ─╯";
+        let prompt_box = MINIMAL_COMPOSER_BOX;
         let br = "─".repeat(24);
         let banner = |msg: &str| {
             format!(
@@ -5266,7 +5299,7 @@ You can monitor progress with aoe session logs.\n\
                 Status::Error,
             ),
             // Anchor at the window bound (pos 6) -> Error; past it (pos 7)
-            // the fallback prompt box wins.
+            // only the parked-composer fallback remains, which reads Idle.
             (
                 "anchor pos 6 bound",
                 format!(
@@ -5279,7 +5312,17 @@ You can monitor progress with aoe session logs.\n\
                 format!(
                     " Dismissed when you send your next message.\n l1\n l2\n l3\n l4\n{prompt_box}"
                 ),
+                Status::Idle,
+            ),
+            (
+                "approval pos 8 bound",
+                format!("Allow tool: bash\nApprove\nDeny\n l1\n l2\n l3\n{prompt_box}"),
                 Status::Waiting,
+            ),
+            (
+                "approval pos 9 out",
+                format!("Allow tool: bash\nApprove\nDeny\n l1\n l2\n l3\n l4\n{prompt_box}"),
+                Status::Idle,
             ),
             // US2: retry in progress -> Running.
             (
@@ -5411,71 +5454,73 @@ You can monitor progress with aoe session logs.\n\
                 ),
                 Status::Error,
             ),
-            // US3: ordinary tool output never pins a healthy session.
+            // US3: ordinary tool output never pins a healthy session. These
+            // rows pre-fix expected Waiting only because the composer-box
+            // fallback returned Waiting; they are pure Idle cases.
             (
                 "curl timed out",
                 format!(
                     "curl: (28) Operation timed out after 30000 milliseconds\n{prompt_box}"
                 ),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "ssh refused",
                 format!(
                     "ssh: connect to host 10.0.0.1 port 22: Connection refused\n{prompt_box}"
                 ),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "terminated by user",
                 format!("The agent was terminated by the user.\n{prompt_box}"),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "retry-after header",
                 format!("Retry-After: 30\n{prompt_box}"),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "attempt prose",
                 format!("I will attempt 2/3 of the cases\n{prompt_box}"),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "retrying prose",
                 format!(
                     "The tool kept retrying 2/3 of the files before giving up.\n{prompt_box}"
                 ),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "retrying next batch",
                 format!("I will be retrying 2/3 in the next batch\n{prompt_box}"),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "stop retrying intervals",
                 format!("Stop retrying (2/3) in 5s intervals!\n{prompt_box}"),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "retry failed no prefix",
                 format!(
                     "The tool reported retry failed after 3 attempts\n{prompt_box}"
                 ),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "retrying my tests",
                 format!("I keep retrying 2/3 in my tests: still failing\n{prompt_box}"),
-                Status::Waiting,
+                Status::Idle,
             ),
             (
                 "sub agent gave up",
                 format!(
                     "auto-retry gave up after 3 attempts: 429 Too Many Requests (rate limited).\n{prompt_box}"
                 ),
-                Status::Waiting,
+                Status::Idle,
             ),
             // Accepted: prose indistinguishable from the real label render
             // (family R3, bounded) reads Running by design.
@@ -5483,6 +5528,20 @@ You can monitor progress with aoe session logs.\n\
                 "label prose accepted",
                 format!("I'm retrying 2/3 now: the API timed out.\n{prompt_box}"),
                 Status::Running,
+            ),
+            (
+                "label pos 12 bound",
+                format!(
+                    "retrying 2/3 now: 429 Too Many Requests (rate limited).\n f1\n f2\n f3\n f4\n f5\n f6\n f7\n f8\n f9\n{prompt_box}"
+                ),
+                Status::Running,
+            ),
+            (
+                "label pos 13 out",
+                format!(
+                    "retrying 2/3 now: 429 Too Many Requests (rate limited).\n f1\n f2\n f3\n f4\n f5\n f6\n f7\n f8\n f9\n f10\n{prompt_box}"
+                ),
+                Status::Idle,
             ),
             // Precedences: the lowest signal wins.
             (
@@ -5555,7 +5614,7 @@ You can monitor progress with aoe session logs.\n\
                 format!(
                     " Error: Retry failed after 10 attempts: …\n OK\n Done.\n Next\n Final\n{prompt_box}"
                 ),
-                Status::Waiting,
+                Status::Idle,
             ),
         ];
         for (name, pane, expected) in cases {


### PR DESCRIPTION
## Description

omp sessions in the TUI never read as Idle: every resting session rendered
yellow (`Status::Waiting` via `theme.waiting`), with a pulsing
`spinner_waiting` glyph, both in the home list and in `aoe ps --json`
(`"state":"waiting"`). The operator-visible trigger was "come back to the
panel and the omp row is yellow", but the yellow state was in fact the
steady state of every parked omp pane.

Root cause (RCA below): `detect_omp_status` mapped omp's always-visible
composer box to `Status::Waiting`. omp draws the `╭── π ... ╮` /
`╰─ ─╯` bordered composer in every healthy frame, running or idle, so the
box-only fallback fired on every parked session, leaving no live frame
eligible for Idle.
Other detectors that map their rest prompt to Waiting (pi's `pi>`,
gemini's bare `>`, qwen's `qwen>`) can do so because their prompt only
shows while parked; omp is different in kind: its composer box renders in
every healthy frame including running turns, so it cannot distinguish
rest from anything else and must not carry a status by itself.
The change: with no live signal present, a frame that shows only the
composer box reads `Status::Idle`, the same resting contract as claude,
codex and hermes. Genuine user-attention states are unchanged and still
come from the ranked signals above the fallback:

- approval prompt (`Allow tool:` + approve/deny) → Waiting
- pinned error banner anchor / terminal retry lines → Error
- loader (`Working… ⟦esc⟧`), retry countdown, sub-agent labels → Running

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## RCA

Reported symptom (operator): omp rows do not stay Idle; they turn yellow,
especially after returning from a session to the panel; entering an omp
pane also re-scrolls the whole transcript from the beginning.

Scripted reproduction (deterministic, against a throwaway scratch session
on an isolated app dir and tmux socket):

1. Fresh `aoe add --scratch --tool omp --launch`, never attached from any
   client. After boot, three polls 6s apart over 18s all reported
   `"state":"waiting"` while the captured pane showed only the boot text
   plus the composer box. No repaint had ever happened at this point.
2. One trivial turn: `waiting → running → waiting`; never `idle`.
3. A tool-running turn behaved the same (no approval prompt appears for
   auto-approved tools).
4. TUI toggle (enter session view, return to panel): pane resized by the
   embedded view (80x24 → 181/220 x 43/49), omp redrew its full transcript
   including the splash banner, and the status stayed `waiting`.

Hypotheses ruled out:

- H1 stale scrollback signal (approval/banner) captured during repaint:
  refuted as necessary cause by step 1, where the yellow steady state
  occurs before any attach/repaint and the archived snapshot contains no
  approval, banner, countdown or loader line anywhere in the pane. The
  only Waiting-shaped content was the composer box itself.
- H2 transient repaint frames misread as signals: refuted by step 1/4;
  the reading was stable across minutes and identical before and after a
  full redraw.
- H3 persistent AoE-side state not re-evaluated: refuted by observing
  live transitions (`running` during turns) while never opening the
  panel view; the poller continuously re-derives the status, it just
  deterministically re-derived `Waiting`.
- H4 pure omp-side cause: partially confirmed but not exculpatory. The
  full-rescroll on entry is omp redrawing on SIGWINCH (resize triggered
  by the embed); that part is upstream behavior we do not patch. The
  yellow-at-rest mapping, however, is AoE's own heuristic choice
  introduced in #3073 and kept through #3383; no product rationale for
  Waiting-at-rest is documented there.

Faulty snapshot (archived in the regression test as
`OMP_PARKED_AT_COMPOSER_REPRO`, tail of the live pane after returning to
the panel):

```
 ※ recap: Goal was a simple probe: replied OK and ran echo, which returned rca-probe-42 successfully.

╭── π  > ⬢ Ox Alpha · ◉ max > 🗑 …of-empires-dev/scratch/<id> ▶───2%──────┃──────1M─◀ Reply with OK ──╮
╰─                                                                                                    ─╯
```

No signal of any kind in the window; pre-fix this returned Waiting.

## Fix

`src/tmux/status_detection.rs`: the bare-composer fallback now returns
`Status::Idle`. Doc comment updated to state the contract: box-only
frames are healthy idle; user-attention states come exclusively from the
live signals above the fallback.

## Tests

- New `test_detect_omp_status_idle_at_composer_box`: table-driven, five
  cases (bare box, finished turn above box, stale loader buried in
  scrollback, live loader pushed one line past the footer window,
  archived repro snapshot), asserting Idle. Red before the fix (FAILED
  against main behavior), green after.
- Window-boundary rows added to the #3383 table so every freshness
  window edge stays locked: approval `Allow tool:` at pos 8 (Waiting)
  vs pos 9 (Idle), retrying label at pos 12 (Running) vs pos 13 (Idle),
  alongside the existing anchor pos 6/7 and countdown pos 6 rows.
- `test_detect_omp_status_idle_without_prompt` now also covers empty
  and whitespace-only panes; `waiting_on_approval_prompt` covers an
  all-caps approval render (gate lowercases its window).
- `test_detect_omp_status_waiting` reshaped into
  `test_detect_omp_status_waiting_on_approval_prompt`: only the genuine
  `Allow tool:` prompt asserts Waiting now.
- The #3383 table rows whose expectation came from the old fallback
  (ordinary tool output, out-of-window anchor/terminal lines) flipped
  Waiting → Idle with updated comments; every row backed by a real
  signal (approval, banner, countdown, labels) keeps its expectation.
- `cargo test` full default suite green (4660 lib + integration targets),
  `cargo fmt --all -- --check` clean, `cargo clippy -- -D warnings`
  clean.
- Scripted repro replayed against the fixed binary end-to-end: idle at
  rest before any attach, running during the turn, idle at rest after
  entering and leaving the session view, stable across repeated polls.

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary (code comment contract only)
- [x] For UI changes: included screenshot or recording (status color change verified via scripted tmux/TUI run; snapshots inline above)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the changed surface is the pure pane-text
  detector, covered by deterministic unit tests including a live-captured
  fixture; the end-to-end flow was exercised manually with the scripted
  tmux reproduction described in the RCA.

## Risks

- Polling tier: resting omp rows move from Hot (Waiting) to Warm (Idle)
  cadence (~5 ticks at ~500ms). An approval prompt that appears while
  parked is picked up within ~2.5s instead of ~0.5s, same tradeoff as
  every other agent.
- Unread dots can now paint on finished omp turns (resting rows include
  Idle), consistent with claude/codex behavior.
- A mid-turn frame whose loader left the 3-line footer would briefly read
  Idle instead of briefly Waiting; bounded by the next poll tick and
  identical to the flapping exposure other agents already accept.
- Residual, adjudicated in review and left unchanged here: if a live
  approval prompt renders with its command preview wrapping tall enough
  to push `Allow tool:` beyond the 8-line window while Approve/Deny stay
  inside it, the gate fails and the frame reads Idle (pre-fix it read
  Waiting only by accident of the box fallback; without the box visible
  it already read Idle pre-fix). Hardening the gate means re-tuning the
  #3383 windows without a live corpus of wrapped omp approvals, so it is
  deferred to the structured path tracked in #3380 rather than guessed
  at here.
- Opted-in idle auto-stop (`session.auto_stop_idle_secs`, default 0 =
  off) now treats resting omp sessions as reaping-eligible once their
  threshold passes, identical to claude/codex parked-at-prompt sessions;
  attached or recently-touched sessions remain spared.
- Transition consumers observe Idle instead of Waiting when omp parks:
  sounds fire `on_idle` rather than `on_waiting`, web push users relying
  on `notify_on_waiting` need `notify_on_idle` for parked omp, and
  webhook/plugin payloads label the rest transition `idle` instead of
  `waiting`. All match the other agents' resting contract.

## AI Usage

- [ ] No AI used
- [x] AI was used

**AI Model/Tool used:** Oh My Pi (ox-alpha)

**Any Additional AI Details you'd like to share:** RCA performed by the agent; scripted reproduction, fix, tests and validation runs executed end-to-end by the agent.

- [x] I am an AI Agent filling out this form (check box if true)
