### PR TITLE
feat(web): search box for the new-session wizard's project picker

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1610,6 +1610,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1627,6 +1630,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1644,6 +1650,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1661,6 +1670,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1678,6 +1690,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1695,6 +1710,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1712,6 +1730,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1729,6 +1750,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1610,9 +1610,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1630,9 +1627,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1650,9 +1644,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,9 +1661,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1690,9 +1678,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1710,9 +1695,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1730,9 +1712,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1750,9 +1729,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2245,7 +2245,14 @@ export function AddProjectModal({
   // letting Escape close the modal mid-request would throw away the result,
   // the warnings, and the "the agent did not restart" notice this component
   // exists to surface.
-  useEffect(() => {
+  //
+  // The subscription closes over `busy`, so it has to be re-established in a
+  // layout effect, not a passive one. A keydown on `document` never reaches
+  // React's root listener, so nothing flushes pending passive effects before
+  // this handler runs. As a passive effect it left a window right after the
+  // response landed where the DOM already showed the result but the listener
+  // still held `busy === true`, and Escape was silently swallowed.
+  useLayoutEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape" && !busy) onCancel();
     };

--- a/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
@@ -175,15 +175,17 @@ describe("ProjectStep saved-projects render (#2140)", () => {
     expect(queryByText("Recent", asHeader)).toBeNull();
   });
 
-  it("narrows the Saved projects section to entries matching the path filter", async () => {
+  it("narrows the Saved projects section to entries matching the search query", async () => {
     vi.mocked(fetchProjects).mockResolvedValue([
       savedProject({ name: "alpha", path: "/repo/alpha" }),
       savedProject({ name: "zeta", path: "/repo/zeta" }),
     ]);
     vi.mocked(fetchSessions).mockResolvedValue({ sessions: [], workspace_ordering: [] });
 
-    // data.path acts as the filter query against both sections.
-    const { findByText, queryByText } = renderStep("zeta");
+    // The search box drives the filter over both sections (#3461); before it
+    // existed the query came from the already-selected data.path.
+    const { findByLabelText, findByText, queryByText } = renderStep();
+    fireEvent.change(await findByLabelText("Search projects"), { target: { value: "zeta" } });
     expect(await findByText("/repo/zeta")).toBeTruthy();
     expect(queryByText("/repo/alpha")).toBeNull();
   });

--- a/web/src/components/session-wizard/__tests__/ProjectStep.search.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.search.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// #3461: the Recent tab has a search box that filters across the whole
+// saved + recent list. With an empty query the recents stay capped at
+// RECENT_CAP (6) so the tab reads as a short "jump back in" list; typing
+// searches the full merged list, so a project below the cap is reachable
+// without falling back to the Browse tab.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { ProjectStep } from "../steps/ProjectStep";
+import { initialData } from "../wizardReducer";
+import type { ProjectInfo } from "../../../lib/types";
+import type { RecentProjectEntry } from "../../../lib/api";
+
+vi.mock("../../../lib/api", () => ({
+  fetchSessions: vi.fn().mockResolvedValue({ sessions: [], workspace_ordering: [] }),
+  fetchRecentProjects: vi.fn(),
+  fetchProjects: vi.fn(),
+  cloneRepo: vi.fn(),
+}));
+
+import { fetchRecentProjects, fetchProjects } from "../../../lib/api";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Eight recents, newest first, so `zebra` lands at index 7 and is below the
+// six-row cap. Names are distinct enough that a substring hits exactly one.
+const NAMES = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "zebra"];
+
+function recents(): RecentProjectEntry[] {
+  return NAMES.map((name, i) => ({
+    path: `/repo/${name}`,
+    display_name: name,
+    tool: "claude",
+    // Descending timestamps keep the array order after the merge sort.
+    last_used_at: `2025-09-${String(20 - i).padStart(2, "0")}T00:00:00+00:00`,
+  }));
+}
+
+function savedProject(): ProjectInfo {
+  return { name: "saved-yankee", path: "/repo/saved-yankee", scope: "global" } as ProjectInfo;
+}
+
+function renderStep() {
+  return render(
+    <ProjectStep data={{ ...initialData, path: "", extraRepoPaths: [], scratch: false }} onChange={vi.fn()} />,
+  );
+}
+
+describe("ProjectStep project search (#3461)", () => {
+  it("caps recents with an empty query and finds a below-the-cap project by typing", async () => {
+    vi.mocked(fetchRecentProjects).mockResolvedValue({ projects: recents() });
+    vi.mocked(fetchProjects).mockResolvedValue([]);
+
+    renderStep();
+    const box = await screen.findByLabelText("Search projects");
+
+    // Only the first six recents render before any query.
+    expect(await screen.findByText("alpha")).toBeTruthy();
+    expect(screen.getByText("foxtrot")).toBeTruthy();
+    expect(screen.queryByText("golf")).toBeNull();
+    expect(screen.queryByText("zebra")).toBeNull();
+
+    // Typing reaches past the cap.
+    fireEvent.change(box, { target: { value: "zeb" } });
+    expect(await screen.findByText("zebra")).toBeTruthy();
+    expect(screen.queryByText("alpha")).toBeNull();
+
+    // Clearing restores the capped list.
+    fireEvent.change(box, { target: { value: "" } });
+    expect(await screen.findByText("alpha")).toBeTruthy();
+    expect(screen.queryByText("zebra")).toBeNull();
+  });
+
+  it("matches on path as well as display name", async () => {
+    vi.mocked(fetchRecentProjects).mockResolvedValue({ projects: recents() });
+    vi.mocked(fetchProjects).mockResolvedValue([]);
+
+    renderStep();
+    const box = await screen.findByLabelText("Search projects");
+
+    fireEvent.change(box, { target: { value: "/repo/golf" } });
+    expect(await screen.findByText("golf")).toBeTruthy();
+    expect(screen.queryByText("alpha")).toBeNull();
+  });
+
+  it("filters saved projects too", async () => {
+    vi.mocked(fetchRecentProjects).mockResolvedValue({ projects: recents() });
+    vi.mocked(fetchProjects).mockResolvedValue([savedProject()]);
+
+    renderStep();
+    const box = await screen.findByLabelText("Search projects");
+    expect(await screen.findByText("saved-yankee")).toBeTruthy();
+
+    fireEvent.change(box, { target: { value: "yank" } });
+    expect(screen.getByText("saved-yankee")).toBeTruthy();
+    expect(screen.queryByText("alpha")).toBeNull();
+
+    fireEvent.change(box, { target: { value: "alpha" } });
+    expect(await screen.findByText("alpha")).toBeTruthy();
+    expect(screen.queryByText("saved-yankee")).toBeNull();
+  });
+
+  it("shows an empty state when nothing matches", async () => {
+    vi.mocked(fetchRecentProjects).mockResolvedValue({ projects: recents() });
+    vi.mocked(fetchProjects).mockResolvedValue([]);
+
+    renderStep();
+    const box = await screen.findByLabelText("Search projects");
+
+    fireEvent.change(box, { target: { value: "nothing-here" } });
+    expect(await screen.findByText(/No projects match that search/)).toBeTruthy();
+    expect(screen.queryByText("alpha")).toBeNull();
+  });
+});

--- a/web/src/components/session-wizard/steps/ExtraReposPicker.tsx
+++ b/web/src/components/session-wizard/steps/ExtraReposPicker.tsx
@@ -144,7 +144,7 @@ export function ExtraReposPicker({
   };
 
   return (
-    <div>
+    <div data-testid="extra-repos-picker">
       <div className="flex items-center justify-between mb-2">
         <h3 className="text-sm font-medium text-text-primary">Extra repos (optional)</h3>
         <span className="text-[11px] text-text-dim">

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -54,6 +54,10 @@ function Toggle({
 
 type Tab = "recent" | "browse" | "clone" | "import";
 
+/** How many recents render when the search box is empty. The search itself is
+ *  not capped; see the filteredRecent memo. */
+const RECENT_CAP = 6;
+
 interface Props {
   data: WizardData;
   onChange: (field: string, value: unknown) => void;
@@ -169,6 +173,7 @@ export function ProjectStep({ data, onChange, initialTab, agents = [] }: Props) 
   const [saved, setSaved] = useState<ProjectInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<Tab>(initialTab ?? "recent");
+  const [query, setQuery] = useState("");
 
   // Clone state
   const [cloneUrl, setCloneUrl] = useState("");
@@ -183,7 +188,7 @@ export function ProjectStep({ data, onChange, initialTab, agents = [] }: Props) 
     Promise.all([fetchSessions(), fetchRecentProjects(), fetchProjects()]).then(
       ([envelope, recentEnvelope, savedProjects]) => {
         const sessionDerived = envelope ? collectRecentProjects(envelope.sessions) : [];
-        const merged = mergeRecentProjects(sessionDerived, recentEnvelope?.projects ?? []).slice(0, 6);
+        const merged = mergeRecentProjects(sessionDerived, recentEnvelope?.projects ?? []);
         const split = splitSavedAndRecent(savedProjects, merged);
         setSaved(split.saved);
         setRecent(split.recent);
@@ -198,17 +203,20 @@ export function ProjectStep({ data, onChange, initialTab, agents = [] }: Props) 
     );
   }, [initialTab]);
 
+  // #3461: with no query, recents stay capped so the tab reads as a short
+  // "jump back in" list. A query searches the whole merged list instead, so a
+  // project sitting below the cap is still reachable by typing.
   const filteredRecent = useMemo(() => {
-    if (!data.path) return recent;
-    const q = data.path.toLowerCase();
+    const q = query.trim().toLowerCase();
+    if (!q) return recent.slice(0, RECENT_CAP);
     return recent.filter((r) => r.path.toLowerCase().includes(q) || r.displayName.toLowerCase().includes(q));
-  }, [recent, data.path]);
+  }, [recent, query]);
 
   const filteredSaved = useMemo(() => {
-    if (!data.path) return saved;
-    const q = data.path.toLowerCase();
+    const q = query.trim().toLowerCase();
+    if (!q) return saved;
     return saved.filter((s) => s.path.toLowerCase().includes(q) || s.name.toLowerCase().includes(q));
-  }, [saved, data.path]);
+  }, [saved, query]);
 
   const hasPicks = recent.length > 0 || saved.length > 0;
 
@@ -355,6 +363,22 @@ export function ProjectStep({ data, onChange, initialTab, agents = [] }: Props) 
               session-derived and persisted recents below. */}
           {!loading && activeTab === "recent" && hasPicks && (
             <div className="flex flex-col gap-4">
+              {/* #3461: type-to-filter over the whole saved + recent list, so
+                  a project below RECENT_CAP is reachable without falling back
+                  to Browse. */}
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search projects by name or path"
+                aria-label="Search projects"
+                className="w-full px-3 py-2.5 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600"
+              />
+
+              {filteredSaved.length === 0 && filteredRecent.length === 0 && (
+                <p className="text-sm text-text-dim">No projects match that search. Try the Browse tab.</p>
+              )}
+
               {filteredSaved.length > 0 && (
                 <div className="flex flex-col gap-1.5">
                   <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim">Saved projects</p>

--- a/web/tests/live/mobile-live-no-flutter.spec.ts
+++ b/web/tests/live/mobile-live-no-flutter.spec.ts
@@ -82,16 +82,19 @@ done
     // still catches it; a slow CI reflow settles within the cap. A plain loop
     // (not expect.poll) avoids recording a spurious assertion failure on the
     // regression path.
-    const settled = async () => {
-      const a = await headerTop();
-      await page.waitForTimeout(80);
-      const b = await headerTop();
-      return a != null && a === b;
-    };
+    // A single equal pair was too weak a settle signal. The spinner toggles
+    // every 120ms, so two samples can coincide while the bottom-align is still
+    // converging; sampling then started mid-move and read a ~2 row jitter.
+    // Require a run of consecutive equal samples instead.
+    const STABLE_RUN = 4;
     const settleDeadline = 5_000;
-    for (let waited = 0; waited < settleDeadline; waited += 180) {
-      if (await settled()) break;
-      await page.waitForTimeout(100);
+    let last = await headerTop();
+    let run = 1;
+    for (let waited = 0; waited < settleDeadline && run < STABLE_RUN; waited += 90) {
+      await page.waitForTimeout(90);
+      const y = await headerTop();
+      run = y != null && y === last ? run + 1 : 1;
+      last = y;
     }
 
     const ys: number[] = [];

--- a/web/tests/wizard-extra-repos.spec.ts
+++ b/web/tests/wizard-extra-repos.spec.ts
@@ -89,16 +89,17 @@ test.describe("Wizard extra repos picker (#1219)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openProjectStepWithPath(page);
-    // Scope to the wizard: the same registered projects also render in the
-    // sidebar Projects section now (#2212), so page-wide button locators are
+    // Scope to the picker itself: the same registered projects also render in
+    // the sidebar Projects section (#2212) and in the step's own Saved
+    // projects list (#3461), so page-wide or wizard-wide button locators are
     // ambiguous.
-    const wizard = page.getByTestId("session-wizard");
-    await expect(wizard.getByText("Registered projects")).toBeVisible();
+    const picker = page.getByTestId("extra-repos-picker");
+    await expect(picker.getByText("Registered projects")).toBeVisible();
     // The primary entry (matching /tmp/example) is hidden from the picker
     // so users can't accidentally duplicate it.
-    await expect(wizard.getByRole("button").filter({ hasText: /^primary$/ })).toHaveCount(0);
-    await expect(wizard.getByRole("button").filter({ hasText: /^shared-lib/ })).toBeVisible();
-    await expect(wizard.getByRole("button").filter({ hasText: /^docs/ })).toBeVisible();
+    await expect(picker.getByRole("button").filter({ hasText: /^primary/ })).toHaveCount(0);
+    await expect(picker.getByRole("button").filter({ hasText: /^shared-lib/ })).toBeVisible();
+    await expect(picker.getByRole("button").filter({ hasText: /^docs/ })).toBeVisible();
   });
 
   test("clicking a registered project chip toggles selection", async ({ page }) => {
@@ -106,9 +107,10 @@ test.describe("Wizard extra repos picker (#1219)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openProjectStepWithPath(page);
-    // Scope to the wizard; the sidebar Projects section also lists shared-lib.
+    // Scope to the picker; the sidebar Projects section and the step's own
+    // Saved projects list also render a shared-lib row.
     const sharedLib = page
-      .getByTestId("session-wizard")
+      .getByTestId("extra-repos-picker")
       .getByRole("button")
       .filter({ hasText: /^shared-lib/ })
       .first();


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The new-session wizard's Recent tab capped its recents at 6 rows and had no way to type a filter. With more than a handful of checkouts, a project either scrolled past that cap or never rendered at all, so picking a less-recently-used one meant re-walking the filesystem in the Browse tab.

`ProjectStep.tsx` already had `filteredRecent` / `filteredSaved` memos, but they matched against `data.path`, the path the user had *already selected*. Nothing ever fed a query into them, so the only visible effect was that clicking a project silently collapsed the list down to rows matching it. This repoints both memos at a real `query` state driven by a new search input, keeps the full merged recents list in component state instead of slicing it at fetch time, and applies the 6-row cap only when the query is empty. A search therefore reaches every project the dashboard knows about, saved registry entries and session-derived plus persisted recents alike, while an untouched tab still reads as a short "jump back in" list.

Two consequences worth calling out for review. First, selecting a project no longer collapses the list, so you can change your mind without clearing the field; that is the behavior the old `data.path` filter was accidentally preventing. Second, because the cap now applies after `splitSavedAndRecent` dedupes saved paths out of recents, a saved project no longer eats a recent slot, so you may see 6 recents where you previously saw 5.

Scoped deliberately: plain case-insensitive substring matching over name and path, matching the memos that were already there. No fuzzy ranking, no keyboard navigation, and no reach into the filesystem browser for paths unknown to both lists. The issue floats that last one as a "consider whether"; it needs a debounced backend search and the Browse tab already covers genuinely unknown paths, so it is left out.

## Also in this branch: two unrelated CI fixes

CI was red on this branch for reasons that have nothing to do with the search box, so two pre-existing flakes on `main` are fixed here as drive-bys. `WorkspaceSidebar.tsx` swaps a `useEffect` for a `useLayoutEffect` so the Escape-key listener re-subscribes in the same commit that paints the result, closing a window where RTL's `waitFor` returned before the passive-effect flush and the keypress was swallowed (`AddProjectAction.test.tsx:339`). `web/tests/live/mobile-live-no-flutter.spec.ts` tightens its settle gate from one equal sample pair at 80ms to four consecutive equal samples at 90ms, so it no longer starts sampling before the layout has converged. The 5000ms budget and the `jitter < 3` assertion are both untouched, so the gate only got stricter.

One test edit in `web/tests/wizard-extra-repos.spec.ts:99` looks like a loosened assertion and is the opposite: the picker chip concatenates name and scope with no separator, so `/^primary$/` matched nothing and its `toHaveCount(0)` was passing vacuously. Dropping the anchor to `/^primary/` gives that assertion teeth for the first time.

Closes #3461

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the dashboard with more than 6 known projects, press `n`, and confirm the Recent tab shows a "Search projects by name or path" box above the lists.
- [ ] With the box empty, confirm at most 6 recent rows render (plus any Saved projects section), same as before.
- [ ] Type part of the name of a project you know sits below the 6-row cap; confirm it appears.
- [ ] Type part of a *path* rather than a name (for example `/repo/`), confirm matching rows render.
- [ ] Confirm the query also narrows the Saved projects section.
- [ ] Type something that matches nothing; confirm "No projects match that search. Try the Browse tab." instead of a blank tab.
- [ ] Clear the box; confirm the capped list comes back.
- [ ] Click a project row, then confirm the other rows stay visible so you can pick a different one, and that launching the session still uses the clicked path.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

New Vitest spec `web/src/components/session-wizard/__tests__/ProjectStep.search.test.tsx` covers the cap-with-empty-query, reaching past the cap by typing, path matching, saved-section filtering, and the no-match empty state. `ProjectStep.saved-projects.test.tsx` had a case pinning the old `data.path`-as-query behavior; it now drives the search box instead. `web/tests/wizard-extra-repos.spec.ts` needed its two ambiguous locators scoped to a new `data-testid="extra-repos-picker"`, because the project list no longer collapses on selection and the same project names now render in both places. `ProjectStep.tsx` and `ExtraReposPicker.tsx` were already mapped by the existing `wizard` entry in `coverage-matrix.json`, so no matrix edit was needed and `validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No docs change: the search box is discoverable UI, so there is nothing a user cannot work out by opening the wizard.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (substring over fuzzy, no filesystem reach, cap only when the query is empty), reviewed each commit, and will run the manual test steps above before marking this ready.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added project search to the Recent project picker.
- Search matches saved and recent projects by name or path.
- The six-project limit applies only when the search field is empty.
- Added an empty-results message.
- Expanded test coverage and improved project-picker locator scoping.
- Added a test ID for the extra repositories picker.
- Improved Escape-key handling and mobile viewport settling.

## Benefits

Users can find projects beyond the visible recent-project limit. Saved projects and recent projects now share one search experience.

## Potential enhancement

Filesystem search for paths unknown to the dashboard remains outside this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
