### PR TITLE
fix(web): keep the sidebar long-press menu open on Android

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1307,28 +1307,34 @@ export const SessionRow = memo(function SessionRow({
   useEffect(() => {
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
-    const onDocClick = (e: MouseEvent) => {
-      // Clicks inside the menu should be handled by item onClick
-      // handlers, not by this dismiss listener.
+    // One handler for both dismissers, so the click and contextmenu paths
+    // cannot drift apart again. An unguarded contextmenu listener here made
+    // Android's long-press menu open and instantly vanish (#3460).
+    const dismissIfOutside = (e: MouseEvent) => {
+      // Events inside the menu should be handled by item onClick handlers,
+      // not by this dismiss listener. The menu is a portal placed at the
+      // touch point, so on Android it is the topmost element under the
+      // finger when the native contextmenu lands.
       if (menuRef.current?.contains(e.target as Node)) return;
-      // On mobile, lifting the finger after a long-press dispatches a
-      // synthetic click even when touchend called preventDefault().
-      // Ignore clicks that arrive shortly after a touch-triggered open.
+      // Android's long-press emits a synthetic click even when touchend
+      // called preventDefault(), plus a native contextmenu, both after our
+      // timer already opened the menu. Ignore either one when it arrives
+      // shortly after a touch-triggered open.
       if (Date.now() - touchOpenedAt.current < 500) return;
       close();
     };
     // Defer so the event that opened the menu finishes bubbling first
     const id = requestAnimationFrame(() => {
-      document.addEventListener("click", onDocClick);
-      document.addEventListener("contextmenu", close);
+      document.addEventListener("click", dismissIfOutside);
+      document.addEventListener("contextmenu", dismissIfOutside);
     });
     // Listen for the "close" broadcast from any sibling SessionRow
     // that is opening its own menu.
     menuBus.addEventListener("close", close);
     return () => {
       cancelAnimationFrame(id);
-      document.removeEventListener("click", onDocClick);
-      document.removeEventListener("contextmenu", close);
+      document.removeEventListener("click", dismissIfOutside);
+      document.removeEventListener("contextmenu", dismissIfOutside);
       menuBus.removeEventListener("close", close);
     };
   }, [contextMenu]);

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1307,9 +1307,14 @@ export const SessionRow = memo(function SessionRow({
   useEffect(() => {
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
-    // One handler for both dismissers, so the click and contextmenu paths
-    // cannot drift apart again. An unguarded contextmenu listener here made
-    // Android's long-press menu open and instantly vanish (#3460).
+    // One handler for both of this row's dismissers, so the click and
+    // contextmenu paths cannot drift apart again. An unguarded contextmenu
+    // listener here made Android's long-press menu open and instantly
+    // vanish (#3460). SidebarGroupHeader, ProjectsSection and
+    // CopyPathContextMenu still carry the two-listener shape; none of them
+    // has a long-press timer, so their menu is only ever opened by a
+    // contextmenu whose dispatch the requestAnimationFrame below defers
+    // past, and this sequence is unreachable there.
     const dismissIfOutside = (e: MouseEvent) => {
       // Events inside the menu should be handled by item onClick handlers,
       // not by this dismiss listener. The menu is a portal placed at the

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1307,6 +1307,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.longpress-menu-persists",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/sidebar-longpress-menu-persists.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.longpress-slop",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/sidebar-longpress-menu-persists.spec.ts
+++ b/web/tests/sidebar-longpress-menu-persists.spec.ts
@@ -105,8 +105,27 @@ test("a native contextmenu after the long-press does not dismiss the row menu", 
   await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 
   // The guard is a window, not a latch: once it lapses a tap outside still
-  // dismisses the menu.
+  // dismisses the menu. A tap rather than a mouse click, since touch is the
+  // path the bug lived on. The point is derived from the menu box and clears
+  // it HORIZONTALLY on purpose: the menu is capped at `100dvh - 16px` and on
+  // a phone it is nearly full height, so there is no reliable gap above or
+  // below it, and Chromium's touch adjustment snaps a near-miss back onto the
+  // menu. The side margin is the only dependable outside.
   await page.waitForTimeout(LONG_PRESS_MS + 100);
-  await page.mouse.click(5, 5);
+  const outside = await menu.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const gapLeft = r.left;
+    const gapRight = window.innerWidth - r.right;
+    if (Math.max(gapLeft, gapRight) < 12) throw new Error("no horizontal gap beside the menu");
+    return {
+      x: Math.round(gapLeft >= gapRight ? gapLeft / 2 : (r.right + window.innerWidth) / 2),
+      y: Math.round(r.top + r.height / 2),
+    };
+  });
+  const urlBefore = page.url();
+  await page.touchscreen.tap(outside.x, outside.y);
   await expect(menu).toBeHidden();
+  // The dismissal has to come from the document listener, not from the tap
+  // landing on a row and navigating away, which would hide the menu too.
+  expect(page.url()).toBe(urlBefore);
 });

--- a/web/tests/sidebar-longpress-menu-persists.spec.ts
+++ b/web/tests/sidebar-longpress-menu-persists.spec.ts
@@ -1,0 +1,112 @@
+// A native `contextmenu` event arriving after the long-press timer already
+// opened the session-row menu must NOT dismiss it (#3460).
+//
+// On Android the long-press gesture emits a native `contextmenu` a moment
+// after our own 500ms timer has opened and painted the menu. The document
+// dismiss listener used to be the bare `close`, with neither the inside-menu
+// guard nor the recency guard the sibling `click` listener already had, so the
+// menu opened and instantly vanished. Delete, Rename and Stop were then
+// unreachable for every touch user.
+//
+// Chromium does not emit `contextmenu` on a touch hold, so the test drives a
+// real CDP touch hold to arm the app timer and then synthesizes the one event
+// the engine will not produce. That is the whole point of the repro: the
+// ordering (touchstart, timer opens menu, document listener installed, THEN
+// contextmenu) is what breaks, and it is not reachable any other way here.
+//
+// The menu is a portal rendered `position: fixed` at the touch coordinates, so
+// it sits directly under the finger. Which element Android targets is not
+// guaranteed, so both plausible targets are exercised: the topmost element at
+// the press point (asserted to be inside the menu) and the row itself.
+
+import { devices } from "@playwright/test";
+import { test, expect } from "./helpers/mockedTest";
+import { installSidebarMocks, threeSessionsInOneRepo } from "./helpers/sidebarMocks";
+import { openMobileSidebar } from "./helpers/sidebar";
+
+test.use({ ...devices["iPhone 13"] });
+
+const LONG_PRESS_MS = 500;
+
+test("a native contextmenu after the long-press does not dismiss the row menu", async ({ page }) => {
+  await installSidebarMocks(page, { sessions: threeSessionsInOneRepo() });
+
+  await page.goto("/");
+  // Blocks until the slide-in settles the row box inside the viewport, so the
+  // synthesized touch lands on the row rather than off-screen.
+  await openMobileSidebar(page);
+
+  const row = page.getByTestId("sidebar-session-row").first();
+  await expect(row).toBeVisible();
+  const box = await row.boundingBox();
+  if (!box) throw new Error("session row has no bounding box");
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+
+  const menu = page.getByTestId("sidebar-context-menu");
+  const cdp = await page.context().newCDPSession(page);
+
+  // Hold past the 500ms long-press threshold so the app timer opens the menu
+  // and the effect installs its document listeners.
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y, id: 1 }] });
+  await page.waitForTimeout(LONG_PRESS_MS + 100);
+  await expect(menu).toBeVisible();
+
+  // The portal is placed at the press point, so it should now be the topmost
+  // element there. Pin that, since it is what makes the inside-menu guard the
+  // load-bearing half of the fix.
+  const topmostIsMenu = await page.evaluate(
+    ({ px, py }) => {
+      const target = document.elementFromPoint(px, py);
+      const el = document.querySelector('[data-testid="sidebar-context-menu"]');
+      return !!target && !!el && el.contains(target);
+    },
+    { px: x, py: y },
+  );
+  expect(topmostIsMenu).toBe(true);
+
+  // Target 1: the topmost element under the finger, which is inside the menu.
+  await page.evaluate(
+    ({ px, py }) => {
+      document.elementFromPoint(px, py)?.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          button: 2,
+          clientX: px,
+          clientY: py,
+        }),
+      );
+    },
+    { px: x, py: y },
+  );
+  await expect(menu).toBeVisible();
+
+  // Target 2: the row itself, in case the engine reuses the touchstart target
+  // instead of hit-testing at dispatch time.
+  await row.evaluate(
+    (el, point) => {
+      el.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          button: 2,
+          clientX: point.px,
+          clientY: point.py,
+        }),
+      );
+    },
+    { px: x, py: y },
+  );
+  await expect(menu).toBeVisible();
+
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+
+  // The guard is a window, not a latch: once it lapses a tap outside still
+  // dismisses the menu.
+  await page.waitForTimeout(LONG_PRESS_MS + 100);
+  await page.mouse.click(5, 5);
+  await expect(menu).toBeHidden();
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On Android, long-pressing a session row in the web sidebar opened the context menu and then instantly dismissed it. The menu visibly blinked and was gone, which left Delete, Rename, Stop and Archive unreachable for every touch user; `aoe rm` was the only workaround.

The dismiss effect in `SessionRow` registered two document listeners when the menu opened. The `click` listener was guarded twice, ignoring events inside the menu and events within 500ms of a touch-triggered open. The `contextmenu` listener was the bare `close`, with neither guard. Android's long-press gesture emits a native `contextmenu` after our own 500ms timer has already opened the menu and installed those listeners, so the event bubbled to `document` and closed the menu immediately. `[-webkit-touch-callout:none]` suppresses the iOS callout but does not stop Android from emitting `contextmenu`, and the `preventDefault()` in `onTouchEnd` runs after that event has already been dispatched.

Both listeners now point at one guarded handler, so the two paths cannot drift apart again. The inside-menu guard turns out to be the load-bearing half rather than a nicety: the menu is a `createPortal` rendered `position: fixed` at the touch coordinates, so it is the topmost element under the finger when the native event lands. The regression test asserts that directly via `elementFromPoint` before dispatching, and on the pre-fix tree it is that portal-targeted dispatch which fails. A fix that keyed off the row's own handler instead would not have worked, because React portals propagate along the React tree and the portal is a sibling of the row, not a child, so the row handler never runs for that event.

Verified red before green: the new spec was run against a detached worktree at the parent of the fix commit and fails there on the portal dispatch, then passes on this branch.

Deliberately left alone:

- `ProjectsSection.tsx` and `diff/CopyPathContextMenu.tsx` carry the same unguarded document `contextmenu` listener, but neither has a long-press timer, so their menu is only ever opened *by* a `contextmenu` event whose dispatch the `requestAnimationFrame` defers past. This sequence is not reachable there, so widening the fix would be churn.
- Pre-existing and unchanged by this PR: right-clicking inside the open menu lets the browser's own context menu appear over it, since the portal has no `onContextMenu` `preventDefault()` the way `CopyPathContextMenu.tsx:84` does. Before this change our menu also closed underneath it; now it stays. Worth a separate one-line fix, not this one.

Closes #3460

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On an Android phone, open the dashboard over LAN and long-press a session row in the sidebar. The context menu opens and stays open instead of blinking away.
- [ ] From that menu, confirm Rename, Delete and Stop are all reachable and act on the right session.
- [ ] With the menu open, tap somewhere outside it. The menu dismisses, so the guard is a window and not a latch that never closes.
- [ ] Long-press a different session row while the first menu is open. The first closes and the second opens, one menu at a time.
- [ ] On desktop, right-click a session row. The menu opens as before, and right-clicking a different row moves it to that row.
- [ ] On iOS Safari, long-press a session row and confirm the menu still opens with no native link-preview sheet.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

`web/tests/sidebar-longpress-menu-persists.spec.ts`, plus a new `sidebar.longpress-menu-persists` surface in the matrix. It drives a real CDP touch hold to arm the long-press timer, then synthesizes the native `contextmenu` that Chromium will not emit on a touch hold, dispatching on both plausible targets.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill), with a Gemini 3.1 Pro and GPT-5.6 debate round on the fix shape

**Any Additional AI Details you'd like to share:**

Investigation, plan and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit. The fix shape was pressure-tested against two other models, both of which opened with a different approach (`stopPropagation` in the row handler, and an exact-native-event-identity ref) and both of which conceded once the portal behavior was established, since neither approach runs at all when the event targets the portal.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed an Android issue where long-pressing a session caused its context menu to close immediately.
- Added safeguards for events inside the menu and events received shortly after a touch-triggered opening.
- Added Playwright coverage for long-press behavior, menu persistence, and outside dismissal.
- Updated the test coverage matrix.

## Benefits

Touch users can reliably access session actions such as Delete, Rename, Stop, and Archive.

## Technical notes

The shared dismissal handler covers document `click` and `contextmenu` events. It ignores protected events for 500 ms after a touch-triggered menu opening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->