### PR TITLE
perf(tmux): take one liveness snapshot per pass, not per instance

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6041,10 +6041,14 @@ async fn drain_session_id_updates_in_state(state: &Arc<AppState>) {
         // just made durable.
         let outcome =
             crate::session::sync::drain_and_persist_session_ids(&mut snapshot, &file_watch);
+        // One observation for the whole repair walk, as on the TUI side: this
+        // visits every instance, so a per-item `list-sessions` fork scales with
+        // the store.
+        let live = crate::tmux::LiveSessionSnapshot::take();
         let repaired: std::collections::HashSet<String> = snapshot
             .iter_mut()
             .filter_map(|inst| {
-                inst.repair_session_id_poller_if_needed()
+                inst.repair_session_id_poller_if_needed(&live)
                     .then(|| inst.id.clone())
             })
             .collect();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6044,7 +6044,7 @@ async fn drain_session_id_updates_in_state(state: &Arc<AppState>) {
         // One observation for the whole repair walk, as on the TUI side: this
         // visits every instance, so a per-item `list-sessions` fork scales with
         // the store.
-        let live = crate::tmux::LiveSessionSnapshot::take();
+        let live = crate::tmux::LiveSessionSnapshot::new();
         let repaired: std::collections::HashSet<String> = snapshot
             .iter_mut()
             .filter_map(|inst| {

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -976,7 +976,22 @@ pub(crate) fn compose_exclusion(
     current_instance_id: &str,
     extra: &HashSet<String>,
 ) -> HashSet<String> {
-    let mut set = build_exclusion_set(current_instance_id);
+    compose_exclusion_in(
+        current_instance_id,
+        extra,
+        &crate::tmux::LiveSessionSnapshot::new(),
+    )
+}
+
+/// [`compose_exclusion`] against a snapshot the caller already holds, so a
+/// pass that also probes per-instance liveness observes tmux once instead of
+/// twice.
+fn compose_exclusion_in(
+    current_instance_id: &str,
+    extra: &HashSet<String>,
+    live: &crate::tmux::LiveSessionSnapshot,
+) -> HashSet<String> {
+    let mut set = build_exclusion_set(current_instance_id, live);
     set.extend(extra.iter().cloned());
     set
 }
@@ -1009,7 +1024,16 @@ pub(crate) fn compose_exclusion_with_persisted_peers(
     profile: &str,
     retroactive_capture_excludes: &HashSet<String>,
 ) -> HashSet<String> {
-    let mut set = compose_exclusion(current_instance_id, retroactive_capture_excludes);
+    // One observation for the whole pass. Both halves consult tmux: the
+    // cross-instance scan needs the live session names, and the walk below
+    // visits every stored session sharing the project path, trashed ones
+    // included, so a per-instance liveness probe costs a fork each. A store of
+    // a few hundred sessions made that the dominant cost of the pass.
+    // `names() == None` (server unreachable) reads as "no live pane" here,
+    // which is what the per-item probe already did when its own
+    // `list-sessions` failed, and this pass re-runs.
+    let live = crate::tmux::LiveSessionSnapshot::new();
+    let mut set = compose_exclusion_in(current_instance_id, retroactive_capture_excludes, &live);
     let Ok(storage) = crate::session::storage::Storage::new_unwatched(profile) else {
         return set;
     };
@@ -1022,13 +1046,6 @@ pub(crate) fn compose_exclusion_with_persisted_peers(
     // silently drops them from this exclusion even though they share the
     // directory — re-opening the #2355 steal for exactly those peers (#2858).
     let canonical_current = canonicalize_or_raw(current_project_path);
-    // One observation for the whole walk. This loop visits every stored session
-    // sharing the project path, trashed ones included, so a per-instance
-    // liveness probe costs a fork each; a store of a few hundred sessions made
-    // that the dominant cost of the pass. `names() == None` (server
-    // unreachable) reads as "no live pane", which is what the per-item probe
-    // already did when its `list-sessions` failed.
-    let live = crate::tmux::LiveSessionSnapshot::take();
     for inst in instances {
         if inst.id == current_instance_id {
             continue;
@@ -1076,18 +1093,17 @@ pub(crate) fn compose_exclusion_with_persisted_peers(
 /// the resume-fallback cascade's just-crashed sid) should use
 /// [`compose_exclusion`] instead, which composes this function with the
 /// per-instance exclusion list.
-fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
-    let output = match crate::tmux::tmux_command()
-        .args(["list-sessions", "-F", "#{session_name}"])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return HashSet::new(),
+fn build_exclusion_set(
+    current_instance_id: &str,
+    live: &crate::tmux::LiveSessionSnapshot,
+) -> HashSet<String> {
+    let Some(names) = live.names() else {
+        return HashSet::new();
     };
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let aoe_sessions: Vec<&str> = stdout
-        .lines()
+    let aoe_sessions: Vec<&str> = names
+        .iter()
+        .map(String::as_str)
         .filter(|name| {
             name.starts_with(crate::tmux::SESSION_PREFIX)
                 && !name.starts_with(crate::tmux::TOOL_PREFIX)
@@ -4656,7 +4672,10 @@ mod tests {
 
     #[test]
     fn test_build_exclusion_set_empty() {
-        let result = build_exclusion_set("nonexistent-instance-id-12345");
+        let result = build_exclusion_set(
+            "nonexistent-instance-id-12345",
+            &crate::tmux::LiveSessionSnapshot::new(),
+        );
         // The exclusion set should never contain our own instance ID
         // (it collects OTHER instances' captured session IDs).
         // On a machine with active AoE tmux sessions, the set may be

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -1022,6 +1022,13 @@ pub(crate) fn compose_exclusion_with_persisted_peers(
     // silently drops them from this exclusion even though they share the
     // directory — re-opening the #2355 steal for exactly those peers (#2858).
     let canonical_current = canonicalize_or_raw(current_project_path);
+    // One observation for the whole walk. This loop visits every stored session
+    // sharing the project path, trashed ones included, so a per-instance
+    // liveness probe costs a fork each; a store of a few hundred sessions made
+    // that the dominant cost of the pass. `names() == None` (server
+    // unreachable) reads as "no live pane", which is what the per-item probe
+    // already did when its `list-sessions` failed.
+    let live = crate::tmux::LiveSessionSnapshot::take();
     for inst in instances {
         if inst.id == current_instance_id {
             continue;
@@ -1046,7 +1053,7 @@ pub(crate) fn compose_exclusion_with_persisted_peers(
         }
         let should_exclude = matches!(inst.status, crate::session::Status::Stopped)
             || inst.is_archived()
-            || !inst.has_live_tmux_pane();
+            || !inst.has_live_tmux_pane_in(&live);
         if !should_exclude {
             continue;
         }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5928,14 +5928,17 @@ impl Instance {
     ///
     /// OMP pollers reload pane metadata on every tick, so a replacement binds
     /// to the durable generation that won any concurrent restart race.
-    pub(crate) fn repair_session_id_poller_if_needed(&mut self) -> bool {
+    pub(crate) fn repair_session_id_poller_if_needed(
+        &mut self,
+        snapshot: &crate::tmux::LiveSessionSnapshot,
+    ) -> bool {
         // Structured sessions have ACP workers rather than tmux panes. Their
         // lifecycle is reconciled by the daemon, so probing tmux here can only
         // fail and is especially costly from the native TUI's refresh loop.
         if self.is_structured()
             || !self.supports_session_poller()
             || self.session_id_poller_is_running()
-            || !self.has_live_tmux_pane()
+            || !self.has_live_tmux_pane_in(snapshot)
         {
             return false;
         }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1512,16 +1512,16 @@ fn override_if_distinct(stored: Option<&str>, fresh: String) -> Option<String> {
     }
 }
 
+/// Reads the shared session-name cache rather than forking its own
+/// `list-sessions`. [`Instance::has_live_tmux_pane`] sits on top of this and is
+/// called once per instance by several passes (the peer-exclusion scan walks
+/// every stored session sharing the project path, trashed ones included), so a
+/// fork here is multiplied by the size of the whole session store. Every
+/// lifecycle operation that can change tmux session existence already calls
+/// `refresh_session_cache`, so the snapshot is stale only within its TTL.
 fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
-    let output = crate::tmux::tmux_command()
-        .args(["list-sessions", "-F", "#{session_name}"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    crate::tmux::live_any_kind_name_for_id(stdout.lines(), instance_id)
+    let names = crate::tmux::cached_session_names();
+    crate::tmux::live_any_kind_name_for_id(names.iter().map(String::as_str), instance_id)
 }
 
 /// A passively-detected status transition, queued for a batched disk write.
@@ -16125,6 +16125,13 @@ mod tests {
                     .status()
                     .expect("failed to spawn tmux");
                 assert!(status.success(), "tmux new-session failed for {}", name);
+                // Production creation refreshes the shared session cache (see
+                // `Session::create_with_size_env_inner` and
+                // `PairedTerminal::create_with_size`); liveness reads that
+                // cache, so a helper that spawns tmux directly has to do the
+                // same or the session stays invisible for the snapshot's TTL.
+                // Mirrors the same helper in `tui/home/tests.rs`.
+                crate::tmux::refresh_session_cache();
                 Self(name)
             }
 
@@ -16138,6 +16145,7 @@ mod tests {
                 let _ = crate::tmux::tmux_command()
                     .args(["kill-session", "-t", &self.0])
                     .output();
+                crate::tmux::refresh_session_cache();
             }
         }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3776,6 +3776,15 @@ impl Instance {
         self.tmux_env_session_name().is_some()
     }
 
+    /// [`Self::tmux_env_session_name`] answered from a snapshot the caller
+    /// already took, for passes that ask once per stored session.
+    pub(crate) fn tmux_env_session_name_in(
+        &self,
+        snapshot: &crate::tmux::LiveSessionSnapshot,
+    ) -> Option<String> {
+        crate::tmux::live_any_kind_name_for_id_in(snapshot, &self.id)
+    }
+
     /// [`Self::has_live_tmux_pane`] answered from a snapshot the caller already
     /// took, for passes that ask once per stored session. Same decision and the
     /// same freshness — one live observation shared by the batch instead of a
@@ -3784,7 +3793,7 @@ impl Instance {
         &self,
         snapshot: &crate::tmux::LiveSessionSnapshot,
     ) -> bool {
-        crate::tmux::live_any_kind_name_for_id_in(snapshot, &self.id).is_some()
+        self.tmux_env_session_name_in(snapshot).is_some()
     }
 
     pub fn start_container_terminal_with_size(&mut self, size: Option<(u16, u16)>) -> Result<()> {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1512,16 +1512,16 @@ fn override_if_distinct(stored: Option<&str>, fresh: String) -> Option<String> {
     }
 }
 
-/// Reads the shared session-name cache rather than forking its own
-/// `list-sessions`. [`Instance::has_live_tmux_pane`] sits on top of this and is
-/// called once per instance by several passes (the peer-exclusion scan walks
-/// every stored session sharing the project path, trashed ones included), so a
-/// fork here is multiplied by the size of the whole session store. Every
-/// lifecycle operation that can change tmux session existence already calls
-/// `refresh_session_cache`, so the snapshot is stale only within its TTL.
 fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
-    let names = crate::tmux::cached_session_names();
-    crate::tmux::live_any_kind_name_for_id(names.iter().map(String::as_str), instance_id)
+    let output = crate::tmux::tmux_command()
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    crate::tmux::live_any_kind_name_for_id(stdout.lines(), instance_id)
 }
 
 /// A passively-detected status transition, queued for a batched disk write.
@@ -3774,6 +3774,17 @@ impl Instance {
     /// has died. Used by recovery, status polling, and TUI reload.
     pub fn has_live_tmux_pane(&self) -> bool {
         self.tmux_env_session_name().is_some()
+    }
+
+    /// [`Self::has_live_tmux_pane`] answered from a snapshot the caller already
+    /// took, for passes that ask once per stored session. Same decision and the
+    /// same freshness — one live observation shared by the batch instead of a
+    /// `list-sessions` fork per instance.
+    pub(crate) fn has_live_tmux_pane_in(
+        &self,
+        snapshot: &crate::tmux::LiveSessionSnapshot,
+    ) -> bool {
+        crate::tmux::live_any_kind_name_for_id_in(snapshot, &self.id).is_some()
     }
 
     pub fn start_container_terminal_with_size(&mut self, size: Option<(u16, u16)>) -> Result<()> {
@@ -16125,13 +16136,6 @@ mod tests {
                     .status()
                     .expect("failed to spawn tmux");
                 assert!(status.success(), "tmux new-session failed for {}", name);
-                // Production creation refreshes the shared session cache (see
-                // `Session::create_with_size_env_inner` and
-                // `PairedTerminal::create_with_size`); liveness reads that
-                // cache, so a helper that spawns tmux directly has to do the
-                // same or the session stays invisible for the snapshot's TTL.
-                // Mirrors the same helper in `tui/home/tests.rs`.
-                crate::tmux::refresh_session_cache();
                 Self(name)
             }
 
@@ -16145,7 +16149,6 @@ mod tests {
                 let _ = crate::tmux::tmux_command()
                     .args(["kill-session", "-t", &self.0])
                     .output();
-                crate::tmux::refresh_session_cache();
             }
         }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3770,14 +3770,8 @@ impl Instance {
             .unwrap_or(false)
     }
 
-    /// `exists()` alone is insufficient: a pane can exist while its agent
-    /// has died. Used by recovery, status polling, and TUI reload.
-    pub fn has_live_tmux_pane(&self) -> bool {
-        self.tmux_env_session_name().is_some()
-    }
-
     /// [`Self::tmux_env_session_name`] answered from a snapshot the caller
-    /// already took, for passes that ask once per stored session.
+    /// already holds, for passes that ask once per stored session.
     pub(crate) fn tmux_env_session_name_in(
         &self,
         snapshot: &crate::tmux::LiveSessionSnapshot,
@@ -3785,10 +3779,31 @@ impl Instance {
         crate::tmux::live_any_kind_name_for_id_in(snapshot, &self.id)
     }
 
-    /// [`Self::has_live_tmux_pane`] answered from a snapshot the caller already
-    /// took, for passes that ask once per stored session. Same decision and the
-    /// same freshness — one live observation shared by the batch instead of a
-    /// `list-sessions` fork per instance.
+    /// [`Self::tmux_env_session_name_in`] for a one-shot pass that cannot
+    /// retry: an unreachable tmux server is Unknown, not "no live pane", so
+    /// fall back to a fresh per-item probe rather than dropping the row.
+    ///
+    /// The startup hidden-env publication in `HomeView::new` is such a pass.
+    /// Nothing re-runs it on reload and a poller does not re-emit an unchanged
+    /// sid, so a row skipped there stays unpublished until an unrelated sid
+    /// change or a relaunch, weakening the ownership attribution
+    /// `build_exclusion_set` reads. Startup recovery treats the same
+    /// distinction the other way, skipping its whole pass on a failed probe
+    /// rather than reading it as "every pane is dead".
+    pub(crate) fn tmux_env_session_name_in_or_probe(
+        &self,
+        snapshot: &crate::tmux::LiveSessionSnapshot,
+    ) -> Option<String> {
+        match snapshot.names() {
+            Some(_) => self.tmux_env_session_name_in(snapshot),
+            None => self.tmux_env_session_name(),
+        }
+    }
+
+    /// Whether this instance has a live tmux pane, answered from a snapshot
+    /// the caller already holds. `exists()` alone is insufficient: a pane can
+    /// exist while its agent has died. Used by peer exclusion, poller repair,
+    /// and TUI reload.
     pub(crate) fn has_live_tmux_pane_in(
         &self,
         snapshot: &crate::tmux::LiveSessionSnapshot,
@@ -7858,6 +7873,54 @@ mod tests {
             !contended.contains(&("opencode".to_string(), canon)),
             "a dead id-less peer must not force the live session to abstain"
         );
+    }
+
+    /// A one-shot pass must not read an unreachable snapshot as "no live
+    /// pane". The startup hidden-env publication is batched behind one
+    /// `LiveSessionSnapshot`, and nothing re-runs it, so collapsing Unknown
+    /// into Absent there would leave every row's `AOE_INSTANCE_ID` and
+    /// `AOE_CAPTURED_SESSION_ID` unpublished until an unrelated sid change or
+    /// a relaunch, and peer exclusion reads exactly those variables.
+    #[test]
+    #[serial_test::serial]
+    #[cfg(unix)]
+    fn one_shot_name_probes_when_the_snapshot_missed_tmux() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let inst = Instance::new("Refactor billing", "/tmp/aoe-test-one-shot-probe");
+        let live_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+
+        // A `tmux` that answers with one live session name, standing in for the
+        // probe that succeeds after the snapshot's own `list-sessions` failed.
+        // The pane-liveness check reads the same output and parses it as "not
+        // dead", which is what the real probe does for any answer but `1`.
+        let shim = temp.path().join("tmux");
+        std::fs::write(&shim, format!("#!/bin/sh\necho '{live_name}'\n")).unwrap();
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = format!(
+            "{}:{}",
+            temp.path().display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let _guard = EnvGuard::set(&[("PATH", path)]);
+
+        let missed = crate::tmux::LiveSessionSnapshot::from_parts(None, None);
+        assert_eq!(
+            inst.tmux_env_session_name_in(&missed),
+            None,
+            "the snapshot alone has nothing to answer an unreachable server with"
+        );
+        assert_eq!(
+            inst.tmux_env_session_name_in_or_probe(&missed).as_deref(),
+            Some(live_name.as_str()),
+            "a one-shot caller falls back to the per-item probe"
+        );
+
+        // A snapshot that did reach the server is authoritative: absent from
+        // its list means absent, with no probe behind it.
+        let observed = crate::tmux::LiveSessionSnapshot::from_parts(Some(Vec::new()), None);
+        assert_eq!(inst.tmux_env_session_name_in_or_probe(&observed), None);
     }
 
     /// Force the tmux session cache into a fresh "server reachable, but this
@@ -14565,7 +14628,7 @@ mod tests {
 
             // Companion to the above: same setup but the peer carries the
             // default `Status::Idle` and is not archived, exercising the
-            // `!inst.has_live_tmux_pane()` branch on its own. The peer has
+            // `!inst.has_live_tmux_pane_in()` branch on its own. The peer has
             // never spawned a tmux pane in the test, so it counts as
             // pane-less even though its Status field does not flag it.
             #[test]
@@ -14601,7 +14664,7 @@ mod tests {
                 peer_inst.agent_session_id = Some(peer.to_string());
                 assert!(!peer_inst.is_archived());
                 assert!(matches!(peer_inst.status, Status::Idle));
-                assert!(!peer_inst.has_live_tmux_pane());
+                assert!(!peer_inst.has_live_tmux_pane_in(&crate::tmux::LiveSessionSnapshot::new()));
 
                 super::seed_disk_for_sidecar_test(profile, &peer_inst);
 

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -112,8 +112,8 @@ fn recovery_lock_path() -> Result<PathBuf> {
 /// cascade? Excludes structured view-mode sessions (handled by `acp_reconciler`),
 /// sessions whose agent has `ResumeStrategy::Unsupported`, sessions without
 /// a valid `agent_session_id`, and sunk rows (archived, currently snoozed, or
-/// explicitly stopped). Live tmux panes are filtered separately by the caller
-/// using `Instance::has_live_tmux_pane()`.
+/// explicitly stopped). Live tmux panes are filtered separately by the caller,
+/// from one batched tmux observation.
 ///
 /// Archive, snooze, and stop are explicit "leave this session alone" signals;
 /// each of them kills the tmux pane, so without this guard the next TUI
@@ -197,7 +197,7 @@ pub fn orphaned_agents_alive(insts: &[Instance]) -> Vec<bool> {
 /// this process can no longer see: on a mid-crash `/tmp` wipe (WSL2) the
 /// server's socket file is unlinked, orphaning the still-running server, and a
 /// later pass resolving a fresh default socket observes the session as
-/// "missing" (`has_live_tmux_pane()` is false) and would recreate it,
+/// "missing" (no live pane carries its id) and would recreate it,
 /// orphaning the first batch's agent processes. After a socket loss the OS
 /// process table is the *only* source of truth that survives (the socket file,
 /// and therefore any `tmux` query, is gone), and it is host-local, so unlike a

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -564,6 +564,110 @@ pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
     NameShape::agent(&id_suffix(session_id)).matches(tmux_name)
 }
 
+/// One tmux observation shared by a batch of per-instance liveness lookups.
+///
+/// A pass that asks "is this instance's pane live?" once per stored session
+/// otherwise pays a `list-sessions` fork per instance, plus a `pane_dead`
+/// fork per match. `compose_exclusion_with_persisted_peers` walks every
+/// session sharing the project path — trashed ones included — so on a store
+/// of a few hundred that is a few hundred `fork`+`exec` round-trips per pass,
+/// on the thread that also serves input.
+///
+/// This is a *fresh* observation taken once per pass, not a cached one: the
+/// session cache's answers are asymmetric (a hit proves existence, a miss only
+/// means "not seen at the last scan"), and liveness here decides both
+/// exclusion and env publication, where a false negative and a false positive
+/// are each harmful. Taking one live snapshot keeps the decision exactly as
+/// authoritative as the per-item probe it replaces.
+///
+/// Server-unreachable is preserved rather than collapsed into "absent":
+/// [`Self::names`] returns `None`, so a caller that needs Unknown distinct
+/// from Absent can still tell them apart.
+pub(crate) struct LiveSessionSnapshot {
+    names: Option<Vec<String>>,
+    panes: Option<HashMap<String, PaneMetadata>>,
+}
+
+impl LiveSessionSnapshot {
+    /// Take one fresh snapshot: a single `list-sessions` plus a single
+    /// `list-panes -a`, regardless of how many instances are then looked up.
+    pub(crate) fn take() -> Self {
+        let names = tmux_query_command()
+            .args(["list-sessions", "-F", "#{session_name}"])
+            .output()
+            .ok()
+            .filter(|out| out.status.success())
+            .map(|out| {
+                String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .map(str::trim)
+                    .filter(|l| !l.is_empty())
+                    .map(String::from)
+                    .collect()
+            });
+        Self {
+            names,
+            panes: batch_pane_metadata().ok(),
+        }
+    }
+
+    /// Build a snapshot from already-known parts, for tests that must not
+    /// depend on a live tmux server.
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        names: Option<Vec<String>>,
+        panes: Option<HashMap<String, PaneMetadata>>,
+    ) -> Self {
+        Self { names, panes }
+    }
+
+    /// Live session names, or `None` when the tmux server could not be reached.
+    pub(crate) fn names(&self) -> Option<&[String]> {
+        self.names.as_deref()
+    }
+
+    /// Whether `name`'s first pane is dead, mirroring `utils::is_pane_dead`
+    /// but read from the batched metadata. An absent entry is reported alive,
+    /// matching the per-item probe's `unwrap_or(false)` on a failed query.
+    pub(crate) fn pane_dead(&self, name: &str) -> bool {
+        self.panes
+            .as_ref()
+            .and_then(|panes| panes.get(name))
+            .map(|meta| meta.pane_dead)
+            .unwrap_or(false)
+    }
+}
+
+/// [`live_any_kind_name_for_id`] against an already-taken snapshot, so a batch
+/// of lookups costs one observation instead of one per instance.
+pub(crate) fn live_any_kind_name_for_id_in(
+    snapshot: &LiveSessionSnapshot,
+    session_id: &str,
+) -> Option<String> {
+    let names = snapshot.names()?;
+    let suffix = id_suffix(session_id);
+    let agent = NameShape::agent(&suffix);
+    let terminal = NameShape::terminal(&suffix);
+    let container = NameShape::container(&suffix);
+    let (mut agent_hit, mut terminal_hit, mut container_hit) = (None, None, None);
+    for name in names {
+        let name = name.as_str();
+        let bucket = if agent.matches(name) {
+            &mut agent_hit
+        } else if terminal.matches(name) {
+            &mut terminal_hit
+        } else if container.matches(name) {
+            &mut container_hit
+        } else {
+            continue;
+        };
+        if bucket.is_none() && !snapshot.pane_dead(name) {
+            *bucket = Some(name.to_string());
+        }
+    }
+    agent_hit.or(terminal_hit).or(container_hit)
+}
+
 /// The live tmux session name carrying `session_id`'s `_<id8>` tail, preferring
 /// the agent pane, then a paired terminal, then a container terminal, skipping
 /// dead panes (tool sub-sessions never match any of these shapes). Unlike
@@ -997,47 +1101,6 @@ impl Drop for SessionCacheGuard {
 /// force a fresh `refresh_session_cache()` call.
 const CACHE_TTL: Duration = Duration::from_secs(2);
 
-/// Live tmux session names from the shared [`SESSION_CACHE`], refreshing the
-/// snapshot only when it is older than [`CACHE_TTL`].
-///
-/// Any caller that needs the name list *per instance* must use this rather than
-/// its own `list-sessions`. A store with N sessions turns one such caller into N
-/// forks per pass, and a fork+exec round-trip is ~5ms on macOS, so a few hundred
-/// sessions is enough to keep a thread blocked for a large fraction of every
-/// second — including the thread serving keystrokes.
-///
-/// An empty list is returned both for "no sessions" and for "the last refresh
-/// could not reach the server". That matches what the per-caller
-/// `list-sessions` did on failure, and deliberately does not re-probe: during a
-/// real outage the retry fails the same way and just burns a fork per lookup.
-pub fn cached_session_names() -> Vec<String> {
-    if let Some(names) = session_names_from_cache() {
-        return names;
-    }
-    refresh_session_cache();
-    session_names_from_cache().unwrap_or_default()
-}
-
-/// Names from the current snapshot, or `None` when it is stale (older than
-/// [`CACHE_TTL`]) or the lock is poisoned, meaning the caller must refresh.
-fn session_names_from_cache() -> Option<Vec<String>> {
-    let cache = SESSION_CACHE.read().ok()?;
-    let fresh = cache
-        .time
-        .map(|t| t.elapsed() <= CACHE_TTL)
-        .unwrap_or(false);
-    if !fresh {
-        return None;
-    }
-    Some(
-        cache
-            .data
-            .as_ref()
-            .map(|m| m.keys().cloned().collect())
-            .unwrap_or_default(),
-    )
-}
-
 pub fn session_exists_from_cache(name: &str) -> Option<bool> {
     let cache = SESSION_CACHE.read().ok()?;
 
@@ -1453,32 +1516,6 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn cached_session_names_serves_a_fresh_snapshot() {
-        let guard = SessionCacheGuard::capture();
-        let a = format!("{P}cached_names_one_abc12345");
-        let b = format!("{P}cached_names_two_abc12345");
-        guard.force_present(&[&a, &b]);
-        let mut got = cached_session_names();
-        got.sort();
-        let mut want = vec![a, b];
-        want.sort();
-        assert_eq!(got, want);
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn cached_session_names_is_empty_when_server_unreachable() {
-        let guard = SessionCacheGuard::capture();
-        // Fresh snapshot, no data: the last `list-sessions` failed. Callers
-        // treated that as "no live sessions" when they forked it themselves, so
-        // it stays that way — and must not re-probe, which during an outage
-        // would burn one fork per lookup.
-        guard.force_unreachable();
-        assert!(cached_session_names().is_empty());
-    }
-
-    #[test]
-    #[serial_test::serial]
     fn probe_session_existence_returns_unknown_when_server_unreachable() {
         let guard = SessionCacheGuard::capture();
         let name = format!("{P}probe_unknown_abc12345");
@@ -1676,6 +1713,47 @@ mod tests {
             ID
         ));
         assert!(!agent_session_belongs_to("vim", ID));
+    }
+
+    fn dead_pane_meta(dead: bool) -> PaneMetadata {
+        PaneMetadata {
+            pane_dead: dead,
+            pane_current_command: None,
+            pane_start_command_is_protected: false,
+        }
+    }
+
+    #[test]
+    fn snapshot_lookup_matches_the_per_item_probe() {
+        let agent = format!("{P}Refactor_{ID8}");
+        let snapshot = LiveSessionSnapshot::from_parts(
+            Some(vec![agent.clone()]),
+            Some(HashMap::from([(agent.clone(), dead_pane_meta(false))])),
+        );
+        assert_eq!(
+            live_any_kind_name_for_id_in(&snapshot, ID).as_deref(),
+            Some(agent.as_str())
+        );
+    }
+
+    #[test]
+    fn snapshot_lookup_skips_a_dead_pane() {
+        let agent = format!("{P}Refactor_{ID8}");
+        let snapshot = LiveSessionSnapshot::from_parts(
+            Some(vec![agent.clone()]),
+            Some(HashMap::from([(agent.clone(), dead_pane_meta(true))])),
+        );
+        assert_eq!(live_any_kind_name_for_id_in(&snapshot, ID), None);
+    }
+
+    #[test]
+    fn snapshot_lookup_reports_not_live_when_server_unreachable() {
+        // `names() == None` is Unknown, preserved on the snapshot so a caller
+        // can distinguish it; the exclusion walk collapses it to "not live",
+        // which is what the per-item probe did when its `list-sessions` failed.
+        let snapshot = LiveSessionSnapshot::from_parts(None, None);
+        assert!(snapshot.names().is_none());
+        assert_eq!(live_any_kind_name_for_id_in(&snapshot, ID), None);
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -569,46 +569,37 @@ pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
 /// A pass that asks "is this instance's pane live?" once per stored session
 /// otherwise pays a `list-sessions` fork per instance, plus a `pane_dead`
 /// fork per match. `compose_exclusion_with_persisted_peers` walks every
-/// session sharing the project path — trashed ones included — so on a store
-/// of a few hundred that is a few hundred `fork`+`exec` round-trips per pass,
-/// on the thread that also serves input.
+/// session sharing the project path, trashed ones included, so on a store of
+/// a few hundred that is a few hundred `fork`+`exec` round-trips per pass, on
+/// the thread that also serves input.
 ///
-/// This is a *fresh* observation taken once per pass, not a cached one: the
-/// session cache's answers are asymmetric (a hit proves existence, a miss only
-/// means "not seen at the last scan"), and liveness here decides both
-/// exclusion and env publication, where a false negative and a false positive
-/// are each harmful. Taking one live snapshot keeps the decision exactly as
-/// authoritative as the per-item probe it replaces.
+/// The observations are *fresh*, not cached: the session cache's answers are
+/// asymmetric (a hit proves existence, a miss only means "not seen at the last
+/// scan"), and liveness here decides both peer exclusion and env publication,
+/// where a false negative and a false positive are each harmful. One live
+/// observation per pass leaves the decision exactly as authoritative as the
+/// per-item probe it replaces.
 ///
-/// Server-unreachable is preserved rather than collapsed into "absent":
-/// [`Self::names`] returns `None`, so a caller that needs Unknown distinct
-/// from Absent can still tell them apart.
+/// Each observation is taken on first use, and only if used: a pass that ends
+/// up asking nothing, because no stored peer shares the project path or every
+/// row short-circuits before the liveness clause, forks nothing, and a caller
+/// that only needs session names never forks `list-panes`.
+///
+/// An unreachable server is preserved rather than collapsed into "absent":
+/// [`Self::names`] returns `None`, so a one-shot caller that cannot retry can
+/// tell Unknown from Absent and probe per row instead (see
+/// `Instance::tmux_env_session_name_in_or_probe`).
+#[derive(Default)]
 pub(crate) struct LiveSessionSnapshot {
-    names: Option<Vec<String>>,
-    panes: Option<HashMap<String, PaneMetadata>>,
+    names: OnceLock<Option<Vec<String>>>,
+    panes: OnceLock<Option<HashMap<String, PaneMetadata>>>,
 }
 
 impl LiveSessionSnapshot {
-    /// Take one fresh snapshot: a single `list-sessions` plus a single
-    /// `list-panes -a`, regardless of how many instances are then looked up.
-    pub(crate) fn take() -> Self {
-        let names = tmux_query_command()
-            .args(["list-sessions", "-F", "#{session_name}"])
-            .output()
-            .ok()
-            .filter(|out| out.status.success())
-            .map(|out| {
-                String::from_utf8_lossy(&out.stdout)
-                    .lines()
-                    .map(str::trim)
-                    .filter(|l| !l.is_empty())
-                    .map(String::from)
-                    .collect()
-            });
-        Self {
-            names,
-            panes: batch_pane_metadata().ok(),
-        }
+    /// A snapshot for one pass: at most one `list-sessions` and at most one
+    /// `list-panes -a`, however many instances are then looked up.
+    pub(crate) fn new() -> Self {
+        Self::default()
     }
 
     /// Build a snapshot from already-known parts, for tests that must not
@@ -618,19 +609,42 @@ impl LiveSessionSnapshot {
         names: Option<Vec<String>>,
         panes: Option<HashMap<String, PaneMetadata>>,
     ) -> Self {
-        Self { names, panes }
+        let snapshot = Self::new();
+        let _ = snapshot.names.set(names);
+        let _ = snapshot.panes.set(panes);
+        snapshot
     }
 
     /// Live session names, or `None` when the tmux server could not be reached.
     pub(crate) fn names(&self) -> Option<&[String]> {
-        self.names.as_deref()
+        self.names
+            .get_or_init(|| {
+                tmux_query_command()
+                    .args(["list-sessions", "-F", "#{session_name}"])
+                    .output()
+                    .ok()
+                    .filter(|out| out.status.success())
+                    .map(|out| {
+                        String::from_utf8_lossy(&out.stdout)
+                            .lines()
+                            .map(str::trim)
+                            .filter(|l| !l.is_empty())
+                            .map(String::from)
+                            .collect()
+                    })
+            })
+            .as_deref()
     }
 
     /// Whether `name`'s first pane is dead, mirroring `utils::is_pane_dead`
     /// but read from the batched metadata. An absent entry is reported alive,
     /// matching the per-item probe's `unwrap_or(false)` on a failed query.
+    ///
+    /// Only reachable once [`Self::names`] has produced a candidate, so an
+    /// unreachable server never pays for this observation.
     pub(crate) fn pane_dead(&self, name: &str) -> bool {
         self.panes
+            .get_or_init(|| batch_pane_metadata().ok())
             .as_ref()
             .and_then(|panes| panes.get(name))
             .map(|meta| meta.pane_dead)
@@ -1726,33 +1740,28 @@ mod tests {
     #[test]
     fn snapshot_lookup_matches_the_per_item_probe() {
         let agent = format!("{P}Refactor_{ID8}");
-        let snapshot = LiveSessionSnapshot::from_parts(
-            Some(vec![agent.clone()]),
-            Some(HashMap::from([(agent.clone(), dead_pane_meta(false))])),
-        );
-        assert_eq!(
-            live_any_kind_name_for_id_in(&snapshot, ID).as_deref(),
-            Some(agent.as_str())
-        );
-    }
-
-    #[test]
-    fn snapshot_lookup_skips_a_dead_pane() {
-        let agent = format!("{P}Refactor_{ID8}");
-        let snapshot = LiveSessionSnapshot::from_parts(
-            Some(vec![agent.clone()]),
-            Some(HashMap::from([(agent.clone(), dead_pane_meta(true))])),
-        );
-        assert_eq!(live_any_kind_name_for_id_in(&snapshot, ID), None);
+        let cases = [(false, Some(agent.as_str())), (true, None)];
+        for (pane_dead, expected) in cases {
+            let snapshot = LiveSessionSnapshot::from_parts(
+                Some(vec![agent.clone()]),
+                Some(HashMap::from([(agent.clone(), dead_pane_meta(pane_dead))])),
+            );
+            assert_eq!(
+                live_any_kind_name_for_id_in(&snapshot, ID).as_deref(),
+                expected,
+                "pane_dead = {pane_dead}"
+            );
+        }
     }
 
     #[test]
     fn snapshot_lookup_reports_not_live_when_server_unreachable() {
-        // `names() == None` is Unknown, preserved on the snapshot so a caller
-        // can distinguish it; the exclusion walk collapses it to "not live",
-        // which is what the per-item probe did when its `list-sessions` failed.
+        // Unknown collapses to "not live" for the exclusion walk, which is what
+        // the per-item probe did when its own `list-sessions` failed, and the
+        // walk re-runs. A one-shot caller must not collapse it; that rule is
+        // covered by
+        // `instance::tests::one_shot_name_probes_when_the_snapshot_missed_tmux`.
         let snapshot = LiveSessionSnapshot::from_parts(None, None);
-        assert!(snapshot.names().is_none());
         assert_eq!(live_any_kind_name_for_id_in(&snapshot, ID), None);
     }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -997,6 +997,47 @@ impl Drop for SessionCacheGuard {
 /// force a fresh `refresh_session_cache()` call.
 const CACHE_TTL: Duration = Duration::from_secs(2);
 
+/// Live tmux session names from the shared [`SESSION_CACHE`], refreshing the
+/// snapshot only when it is older than [`CACHE_TTL`].
+///
+/// Any caller that needs the name list *per instance* must use this rather than
+/// its own `list-sessions`. A store with N sessions turns one such caller into N
+/// forks per pass, and a fork+exec round-trip is ~5ms on macOS, so a few hundred
+/// sessions is enough to keep a thread blocked for a large fraction of every
+/// second — including the thread serving keystrokes.
+///
+/// An empty list is returned both for "no sessions" and for "the last refresh
+/// could not reach the server". That matches what the per-caller
+/// `list-sessions` did on failure, and deliberately does not re-probe: during a
+/// real outage the retry fails the same way and just burns a fork per lookup.
+pub fn cached_session_names() -> Vec<String> {
+    if let Some(names) = session_names_from_cache() {
+        return names;
+    }
+    refresh_session_cache();
+    session_names_from_cache().unwrap_or_default()
+}
+
+/// Names from the current snapshot, or `None` when it is stale (older than
+/// [`CACHE_TTL`]) or the lock is poisoned, meaning the caller must refresh.
+fn session_names_from_cache() -> Option<Vec<String>> {
+    let cache = SESSION_CACHE.read().ok()?;
+    let fresh = cache
+        .time
+        .map(|t| t.elapsed() <= CACHE_TTL)
+        .unwrap_or(false);
+    if !fresh {
+        return None;
+    }
+    Some(
+        cache
+            .data
+            .as_ref()
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default(),
+    )
+}
+
 pub fn session_exists_from_cache(name: &str) -> Option<bool> {
     let cache = SESSION_CACHE.read().ok()?;
 
@@ -1408,6 +1449,32 @@ mod tests {
         // confirmed this session is not in its list.
         guard.force_present(&[&format!("{P}some_other_session")]);
         assert_eq!(probe_session_existence(&name), SessionExistence::Absent);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cached_session_names_serves_a_fresh_snapshot() {
+        let guard = SessionCacheGuard::capture();
+        let a = format!("{P}cached_names_one_abc12345");
+        let b = format!("{P}cached_names_two_abc12345");
+        guard.force_present(&[&a, &b]);
+        let mut got = cached_session_names();
+        got.sort();
+        let mut want = vec![a, b];
+        want.sort();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cached_session_names_is_empty_when_server_unreachable() {
+        let guard = SessionCacheGuard::capture();
+        // Fresh snapshot, no data: the last `list-sessions` failed. Callers
+        // treated that as "no live sessions" when they forked it themselves, so
+        // it stays that way — and must not re-probe, which during an outage
+        // would burn one fork per lookup.
+        guard.force_unreachable();
+        assert!(cached_session_names().is_empty());
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2519,7 +2519,7 @@ impl HomeView {
                 continue;
             }
 
-            inst.repair_session_id_poller_if_needed();
+            inst.repair_session_id_poller_if_needed(&live);
         }
 
         // Startup auto-recovery: kick off a worker pool to restart any
@@ -3648,8 +3648,14 @@ impl HomeView {
     /// [`Self::apply_session_id_updates`], which runs on every input/render
     /// wake while live views are open.
     pub fn repair_session_id_pollers(&mut self) {
+        // One observation for the whole walk. This runs on the `App::run` tick
+        // over every instance, so a per-item `list-sessions` fork scales with
+        // the store and lands on the thread that also serves keystrokes —
+        // profiling a store of a few hundred sessions put this path at the top
+        // of the main thread.
+        let live = crate::tmux::LiveSessionSnapshot::take();
         for instance in self.instances.values_mut() {
-            instance.repair_session_id_poller_if_needed();
+            instance.repair_session_id_poller_if_needed(&live);
         }
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2463,14 +2463,19 @@ impl HomeView {
         // so that build_exclusion_set() on other AoE instances can see them.
         // One observation for both per-instance walks below. They visit every
         // instance in the view, so a per-item `list-sessions` fork scales with
-        // the whole store — measured as the dominant tmux cost of this pass on
+        // the whole store, measured as the dominant tmux cost of this pass on
         // a store of a few hundred sessions.
-        let live = crate::tmux::LiveSessionSnapshot::take();
+        let live = crate::tmux::LiveSessionSnapshot::new();
         {
             let mut set_batch: Vec<(String, String, String)> = Vec::new();
             let mut unset_batch: Vec<(String, String)> = Vec::new();
             for inst in view.instances.values() {
-                let Some(tmux_name) = inst.tmux_env_session_name_in(&live) else {
+                // This publication is one-shot: no reload re-runs it and a
+                // poller does not re-emit an unchanged sid, so a row dropped
+                // here stays unpublished until an unrelated sid change or a
+                // relaunch. A snapshot that could not reach the server is
+                // therefore probed per row rather than read as "no live pane".
+                let Some(tmux_name) = inst.tmux_env_session_name_in_or_probe(&live) else {
                     continue;
                 };
 
@@ -3650,10 +3655,10 @@ impl HomeView {
     pub fn repair_session_id_pollers(&mut self) {
         // One observation for the whole walk. This runs on the `App::run` tick
         // over every instance, so a per-item `list-sessions` fork scales with
-        // the store and lands on the thread that also serves keystrokes —
-        // profiling a store of a few hundred sessions put this path at the top
+        // the store and lands on the thread that also serves keystrokes.
+        // Profiling a store of a few hundred sessions put this path at the top
         // of the main thread.
-        let live = crate::tmux::LiveSessionSnapshot::take();
+        let live = crate::tmux::LiveSessionSnapshot::new();
         for instance in self.instances.values_mut() {
             instance.repair_session_id_poller_if_needed(&live);
         }
@@ -3968,11 +3973,11 @@ impl HomeView {
         };
 
         let mut candidates: Vec<crate::session::Instance> = Vec::new();
-        // Single fallible tmux probe instead of per-instance
-        // `inst.has_live_tmux_pane()` calls. On Err: skip recovery this
-        // launch (a transient tmux glitch must NOT collapse to "all panes
-        // dead" and trigger phantom cascades). Bonus: one subprocess call
-        // regardless of instance count (was 1-2 per instance).
+        // Single fallible tmux probe instead of a per-instance liveness
+        // lookup. On Err: skip recovery this launch (a transient tmux glitch
+        // must NOT collapse to "all panes dead" and trigger phantom
+        // cascades). Bonus: one subprocess call regardless of instance count
+        // (was 1-2 per instance).
         let pane_meta = match crate::tmux::batch_pane_metadata() {
             Ok(map) => map,
             Err(e) => {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2461,11 +2461,16 @@ impl HomeView {
 
         // Batch-sync instance IDs and captured session IDs to tmux hidden env
         // so that build_exclusion_set() on other AoE instances can see them.
+        // One observation for both per-instance walks below. They visit every
+        // instance in the view, so a per-item `list-sessions` fork scales with
+        // the whole store — measured as the dominant tmux cost of this pass on
+        // a store of a few hundred sessions.
+        let live = crate::tmux::LiveSessionSnapshot::take();
         {
             let mut set_batch: Vec<(String, String, String)> = Vec::new();
             let mut unset_batch: Vec<(String, String)> = Vec::new();
             for inst in view.instances.values() {
-                let Some(tmux_name) = inst.tmux_env_session_name() else {
+                let Some(tmux_name) = inst.tmux_env_session_name_in(&live) else {
                     continue;
                 };
 
@@ -2509,7 +2514,7 @@ impl HomeView {
 
         // Recover session IDs for pre-existing sessions via pollers.
         for inst in view.instances.values_mut() {
-            let has_live_tmux = inst.has_live_tmux_pane();
+            let has_live_tmux = inst.has_live_tmux_pane_in(&live);
             if !has_live_tmux {
                 continue;
             }


### PR DESCRIPTION
## AI-generated patch and review status

**This implementation and pull request were created with Claude Code. The code has not been line-reviewed by a human.**

It is the local patch we are currently running. Please treat it as a measured candidate fix rather than an assertion that this is the right final implementation.

## Description

`Instance::has_live_tmux_pane()` forks a full `tmux list-sessions` on every call, via `tmux_env_session_name_for_instance_id`. Several passes call it once per instance — notably `compose_exclusion_with_persisted_peers`, which walks **every stored session sharing the project path, trashed ones included**. On a store with a few hundred sessions that turns one pass into a few hundred `fork`+`exec` round-trips.

This is visible as input lag in the TUI: keystrokes land on a thread that is blocked waiting on those subprocesses.

Measured on macOS with 169 stored sessions (11 live, 158 trashed) on one project path, by shimming `tmux` to log its argv:

```
568 tmux invocations in 6s — of which 520 were the identical
    list-sessions -F '#{session_name}'
```

One such call costs 4.99 ms here (mean of 100), so ≈ 87 calls/s ≈ **470 ms of subprocess round-trip per wall-clock second**. `sample` on the TUI agrees independently: the main thread sits in `poll` on a child pipe for 45% of samples. The idle TUI drew 9.5% CPU.

**Reshaped after review** (@njbrake, @jerome-benoit). The first attempt made `has_live_tmux_pane()` itself cache-backed. That was wrong: it trusted a cached *miss*, which this module's own doctrine on `session_exists()` rejects ("a HIT proves the session existed as of the last scan, but a MISS is unreliable"). The decision drives both peer exclusion and tmux env publication, so a false negative and a false positive are each harmful, and one consumer (`instance.rs:5173`) is a one-shot cleanup that does not self-heal. My safety argument — "both creation paths already refresh the cache" — also only held in-process: the TUI, the daemon and each CLI invocation carry separate caches.

The current shape takes **one fresh, fallible observation per pass** and threads it through the per-item lookups, as @njbrake proposed. Four passes share one snapshot: the peer-exclusion walk, the two `HomeView::new` walks, poller repair, and the daemon's equivalent behind `serve`. The per-item probe underneath (`tmux_env_session_name`) is untouched and still live at the two correctness-sensitive sites @jerome-benoit named, the post-CAS env publication in `sync.rs` and the one-shot holder cleanup in `instance.rs`. "Server unreachable" stays distinguishable on the snapshot (`names() == None`) instead of collapsing into "absent": the exclusion walk maps it to "not live", which is exactly what the per-item probe did when its own `list-sessions` failed, and that walk re-runs.

**Third round** (@njbrake at `10ea6a0a`, @jerome-benoit at `10ea6a0a`), three items, one commit:

- **Unknown must not read as Absent in a one-shot pass.** `HomeView::new`'s hidden-env publication is not retried: no reload re-runs it, and a poller does not re-emit an unchanged sid. A single transient `list-sessions` failure at startup therefore skipped every row and left `AOE_INSTANCE_ID` / `AOE_CAPTURED_SESSION_ID` missing or stale until an unrelated sid change or a relaunch — which is exactly what peer exclusion reads. That caller now falls back to a fresh per-item probe when the snapshot could not reach the server. Startup recovery in the same file already draws this distinction the other way (skip the whole pass rather than read it as "all panes dead"), so the rule is not new to the file, only to this pass.
- **The snapshot is lazy, which closes the "adds forks to passes it does not fix" finding.** `LiveSessionSnapshot` now observes on first use rather than at construction, and observes `list-sessions` and `list-panes -a` independently. `build_exclusion_set` also reads the pass's snapshot instead of forking its own `list-sessions`, so the duplicate call @njbrake and CodeRabbit both flagged is gone as well. Measured with a `tmux` argv shim, against `10ea6a0a`:

  | | before | after |
  |---|---|---|
  | snapshot taken but never queried | 2 forks | **0** |
  | pass with no live same-tool peer | 3 forks | **1** |

  The one remaining fork is `build_exclusion_set`'s own `list-sessions`, which is what `main` pays for that pass too. So no pass is now more expensive than it was before this PR, which was the substance of the finding.
- **`has_live_tmux_pane()` is deleted.** Once every production pass takes a snapshot it had no callers left, surviving only in one test assert and in two `recovery.rs` doc comments. It is `pub fn`, so nothing warned. Its rationale moved to `has_live_tmux_pane_in`; the doc comments are reworded.

**On the numbers.** The reshape initially did not work, and only re-measuring caught it. Batching `compose_exclusion_with_persisted_peers` alone left the fork rate unchanged, because that is not the hot caller — I had inferred it from reading the code. Profiling an unstripped build named the real one:

```
App::run
  -> HomeView::repair_session_id_pollers          4389 of ~4700 main-thread samples
    -> Instance::repair_session_id_poller_if_needed
      -> has_live_tmux_pane -> tmux_env_session_name -> Command::output
```

Poller repair walks every instance on the `App::run` tick, on the thread that also serves keystrokes. @njbrake reproduced this independently and sized it larger still: 338 forks per `HomeView::new` and 169 per repair pass on a 169-instance store, against 2 each after.

End-to-end numbers, measured on the same machine and store (182 sessions, 9 live), 8-second windows, `tmux` shimmed to log argv with per-pid attribution so two TUIs cannot contaminate each other. **These were taken at `10ea6a0a`**, before the laziness commit, which only reduces the counts further; I have not re-run the 8-second windows since, and the per-pass shim numbers above are what covers that commit:

| | `list-sessions` / 8s | total tmux calls / 8s | idle TUI CPU |
|---|---|---|---|
| before | ~693 | ~760 | 9.5% |
| at `10ea6a0a` | **32** | **209** | **3.7%** |

For reference, the rejected cache-the-accessor version measured 16 and 182 on the same store. The batched version makes more calls than the cache and matches it on CPU — that is the intended trade: a fresh observation per pass instead of a possibly-`CACHE_TTL`-stale one.

One caveat on the totals: `capture-pane` volume depends on whether the previewed pane is streaming, so only the `list-sessions` row is a clean like-for-like. Separately, and unrelated to this PR: previewing a session that is *not* in the session cache forks a `has-session` per rendered frame (~22/s) via `refresh_preview_cache_if_needed` -> `Session::exists`. That is pre-existing on `main`; happy to file it separately if useful.

Also addressed from review: `cached_session_names()` is gone, so the rustdoc failure @jerome-benoit found (`public documentation ... links to private item`) goes with it — I verified `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features serve` is clean. The per-call `Vec<String>` clone he and @njbrake both flagged is gone too. The test helper I had "fixed" is restored to its original form: @njbrake is right that its failing assertion *was* the out-of-band-creation coverage, so refreshing inside the helper deleted the signal rather than fixing it. The four em dashes in added comments are gone; I left the ones in surrounding pre-existing prose alone.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (4,666 library tests pass; one unrelated pre-existing failure, see below)
- [x] Documentation was updated where necessary (rationale documented on the new accessor and at the call sites)
- [x] For UI changes: N/A, no UI changes

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped an e2e test, because: this is a subprocess-count change behind an existing accessor with no behavioural difference to assert end-to-end. The observable effect is a fork rate, measured above with a `tmux` argv shim; the correctness-relevant edges (fresh snapshot, unreachable server, one-shot fallback) are covered by unit tests.

Added:

- `tmux::tests::snapshot_lookup_matches_the_per_item_probe` — a live name resolves from the snapshot, and a dead pane does not.
- `tmux::tests::snapshot_lookup_reports_not_live_when_server_unreachable` — pins the "server unreachable" behaviour for the re-running walks to what the per-caller `list-sessions` did on failure.
- `instance::tests::one_shot_name_probes_when_the_snapshot_missed_tmux` — the regression @jerome-benoit asked for: with a shimmed `tmux` on `PATH`, an unreachable snapshot must still resolve the row through a per-item probe, while a snapshot that did reach the server stays authoritative. I checked it fails with the fallback removed, so it is pinning the behaviour rather than passing vacuously.

Commands run on this branch (based on `9e970918`):

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings` (the CI form)
- `cargo clippy --lib --tests -- -D warnings`
- `cargo check --features serve` (a released binary is built with it; CI's plain `cargo clippy` does not cover the `server/mod.rs` call site)
- `cargo test --lib` — 4,666 passed, 1 failed (below), 2 ignored
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features serve` — clean

Two notes on running these locally, neither caused by this PR:

- `rust-toolchain.toml` pins `channel = "stable"`, and since #3499 the dev-dependency `serial_test 4.0.1` requires rustc 1.93.1, so any `stable` older than that cannot build the test targets at all. I ran the above on 1.95.0.
- `cargo clippy --features serve -- -D warnings` on 1.95.0 reports two `collapsible_match` errors, in `src/acp/event_store.rs:1275` and `src/process/runner.rs:1779`. Neither file is in this diff; this is a newer clippy than the one CI currently runs.

`git::worktree::tests::worktree_move_observation_canonicalizes_symlinked_parents` fails on this machine, and fails identically on an unmodified checkout of the same commit — it compares `/var/...` against macOS's `/private/var/...`. Unrelated to this change.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus)

**Any Additional AI Details you'd like to share:**

Claude profiled the running TUI (`sample`), identified the fork storm by shimming `tmux` to log argv, traced it to the accessor and its per-instance callers, wrote the patch, and re-ran the same measurement to confirm the drop. The before/after numbers above are from that instrumentation, not estimates; where a number predates the current head, the body says so rather than restating it as current.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added one lazy, fresh `tmux` snapshot for each liveness scan.
- Reused the snapshot across session checks, exclusions, TUI updates, and poller repairs.
- Added fallback probing when `tmux` is temporarily unreachable.
- Removed the obsolete liveness accessor.
- Updated documentation and tests for snapshot freshness, unreachable servers, and pane visibility.

## Benefits

- Reduces repeated `tmux` process calls and idle CPU usage.
- Prevents cached misses from hiding live sessions.
- Preserves correct behavior when `tmux` is unreachable.
- Keeps session and poller state more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->