### PR TITLE
fix(session): resolve the detect_as alias at launch, and re-resolve it on tool swap

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2036,6 +2036,18 @@ impl Instance {
                 .insert(self.tool.clone(), outgoing);
         }
         self.tool = new_tool.to_string();
+        // The alias is resolved per-tool, so the outgoing tool's answer cannot
+        // survive: kept, it points `resolved_agent` at the wrong built-in
+        // outright (a `codex-personal` -> `claude-personal` swap would keep
+        // detecting as codex); cleared, the row lands in the same
+        // empty-`detect_as` state a session built before its tool joined
+        // `[session.agent_detect_as]` does. Re-resolve against the same
+        // process-global registry `effective_detect_as` reads, so this stays a
+        // lookup rather than a config load, and the row ends up exactly as if
+        // it had been built on the new tool.
+        self.detect_as =
+            tmux::status_rules::effective_detect_as(&self.source_profile, new_tool, "")
+                .into_owned();
         // Consumed, not copied: the row owns exactly one live conversation per
         // agent, and leaving the entry behind would let a later swap restore an
         // id this session has since replaced.
@@ -2609,6 +2621,32 @@ impl Instance {
     /// when `source_profile` was never populated (e.g. legacy callers).
     pub fn effective_profile(&self) -> String {
         super::config::effective_profile(&self.source_profile)
+    }
+
+    /// The `agent_detect_as` alias that actually applies to this session.
+    ///
+    /// `detect_as` is resolved once at session build and persisted, so it is
+    /// empty on a row created before its tool gained an
+    /// `[session.agent_detect_as]` entry. Treat the stored field as a cache
+    /// and let [`tmux::status_rules::effective_detect_as`] consult the live
+    /// registry when it is empty, the same way the pane detector, hook
+    /// reconciliation, and the status-change log line already do (#3398).
+    fn effective_detect_as(&self) -> std::borrow::Cow<'_, str> {
+        tmux::status_rules::effective_detect_as(&self.source_profile, &self.tool, &self.detect_as)
+    }
+
+    /// The built-in agent backing this session: its own tool when that names
+    /// one, else the agent its `agent_detect_as` alias points at.
+    ///
+    /// Every launch-time consumer resolves through here rather than reading
+    /// `detect_as` raw, because a miss is silent and permanent. `None` drops
+    /// the `AOE_PROFILE`/`AOE_INSTANCE_ID` prefix from the launch line
+    /// ([`status_hook_env_prefix`]) and skips hook install, so every hook the
+    /// agent does have bails on `[ -n "$AOE_INSTANCE_ID" ]` and the session
+    /// reports Idle forever with nothing logged.
+    fn resolved_agent(&self) -> Option<&'static crate::agents::AgentDef> {
+        crate::agents::get_agent(&self.tool)
+            .or_else(|| crate::agents::get_agent(&self.effective_detect_as()))
     }
 
     /// Resolve the effective `environment` list for this session's profile,
@@ -3750,9 +3788,10 @@ impl Instance {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("sandbox_info missing for sandboxed session"))?;
 
+        let detect_as = self.effective_detect_as().into_owned();
         let managed_codex_home = container_config::managed_codex_home(
             &self.tool,
-            Some(&self.detect_as),
+            Some(detect_as.as_str()),
             &self.source_profile,
             &self.id,
         )?;
@@ -4321,8 +4360,7 @@ impl Instance {
         if self.tool == "omp" && !self.has_command_override() {
             reject_omp_secret_args(&super::config::quote_model_value_in_args(&self.extra_args))?;
         }
-        let agent = crate::agents::get_agent(&self.tool)
-            .or_else(|| crate::agents::get_agent(&self.detect_as));
+        let agent = self.resolved_agent();
         self.install_agent_status_hooks(agent);
         self.propagate_managed_skills();
 
@@ -4381,8 +4419,8 @@ impl Instance {
         if self.tool == "omp" && !self.has_command_override() {
             reject_omp_secret_args(&super::config::quote_model_value_in_args(&self.extra_args))?;
         }
-        let agent = crate::agents::get_agent(&self.tool)
-            .or_else(|| crate::agents::get_agent(&self.detect_as));
+        let agent = self.resolved_agent();
+        let detect_as = self.effective_detect_as().into_owned();
 
         let (cmd, is_existing, omp_capture_plan, launch_env) = if self.is_sandboxed() {
             let image = self
@@ -4453,7 +4491,7 @@ impl Instance {
                 .ok_or_else(|| anyhow::anyhow!("sandbox_info missing for sandboxed instance"))?;
             let managed_codex_home = container_config::managed_codex_home(
                 &self.tool,
-                Some(&self.detect_as),
+                Some(detect_as.as_str()),
                 &self.source_profile,
                 &self.id,
             )?;
@@ -5308,6 +5346,7 @@ impl Instance {
     }
 
     pub fn get_container_for_instance(&mut self) -> Result<containers::DockerContainer> {
+        let detect_as = self.effective_detect_as().into_owned();
         let image = self
             .sandbox_info
             .as_ref()
@@ -5329,13 +5368,13 @@ impl Instance {
                 &self.effective_profile(),
                 &self.id,
                 &self.tool,
-                Some(&self.detect_as),
+                Some(detect_as.as_str()),
             );
             self.backfill_container_workdir(&container);
             if self.is_yolo_mode() {
                 container_config::ensure_yolo_trust_config_for_active_agent(
                     &self.tool,
-                    Some(&self.detect_as),
+                    Some(detect_as.as_str()),
                     &self.source_profile,
                     &self.id,
                     &self.container_workdir(),
@@ -5352,14 +5391,14 @@ impl Instance {
                 &self.effective_profile(),
                 &self.id,
                 &self.tool,
-                Some(&self.detect_as),
+                Some(detect_as.as_str()),
             );
             container.start()?;
             self.backfill_container_workdir(&container);
             if self.is_yolo_mode() {
                 container_config::ensure_yolo_trust_config_for_active_agent(
                     &self.tool,
-                    Some(&self.detect_as),
+                    Some(detect_as.as_str()),
                     &self.source_profile,
                     &self.id,
                     &self.container_workdir(),
@@ -5442,6 +5481,7 @@ impl Instance {
     }
 
     fn build_container_config(&self) -> Result<crate::containers::ContainerConfig> {
+        let detect_as = self.effective_detect_as();
         let sandbox = self
             .sandbox_info
             .as_ref()
@@ -5458,8 +5498,7 @@ impl Instance {
             // Mirror the host path's agent resolution (a custom wrapper detected
             // as kiro carries kiro's sidecar via detect_as), and the sandbox's
             // own `resolve_active_agent`, which also falls back to detect_as.
-            crate::agents::get_agent(&self.tool)
-                .or_else(|| crate::agents::get_agent(&self.detect_as))
+            self.resolved_agent()
                 .and_then(|a| a.sidecar_hooks.as_ref())
                 .and_then(|s| s.selected_agent_hooks.as_ref())
                 .and_then(|sel| {
@@ -5471,7 +5510,7 @@ impl Instance {
         container_config::build_container_config(
             &self.project_path,
             sandbox,
-            container_config::ContainerAgentSelection::new(&self.tool, Some(&self.detect_as))
+            container_config::ContainerAgentSelection::new(&self.tool, Some(&detect_as))
                 .with_selected_agent(selected_agent.as_deref()),
             self.is_yolo_mode(),
             &self.id,
@@ -11781,6 +11820,81 @@ mod tests {
             status_hook_env_prefix("work", "abc123", crate::agents::get_agent("kimi")),
             "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
+    }
+
+    /// Seed the process-global `agent_detect_as` registry for one profile.
+    /// The registry is profile-keyed and `install_from_config` only replaces
+    /// the named profile's entries, so a test-only profile name keeps these
+    /// hermetic without serializing against every other registry writer.
+    fn install_aliases(profile: &str, aliases: &[(&str, &str)]) {
+        let mut config = crate::session::Config::default();
+        for (agent, target) in aliases {
+            config
+                .session
+                .agent_detect_as
+                .insert(agent.to_string(), target.to_string());
+        }
+        crate::tmux::status_rules::install_from_config(profile, &config);
+    }
+
+    /// A custom-agent row whose stored `detect_as` is empty must still resolve
+    /// its built-in agent at launch. Without it `status_hook_env_prefix` drops
+    /// `AOE_INSTANCE_ID`, every hook in the agent's settings file bails on
+    /// `[ -n "$AOE_INSTANCE_ID" ]`, and the session reports Idle forever with
+    /// nothing logged. #3398 taught the read sites to consult the live
+    /// registry; this is the launch site.
+    #[test]
+    fn empty_detect_as_still_resolves_the_launch_agent() {
+        const PROFILE: &str = "detect-as-launch-path-test";
+        install_aliases(PROFILE, &[("claude-personal", "claude")]);
+
+        let mut inst = Instance::new("orch", "/tmp/x");
+        inst.source_profile = PROFILE.to_string();
+        inst.tool = "claude-personal".to_string();
+        inst.command = "claude-personal".to_string();
+        inst.detect_as = String::new();
+
+        assert_eq!(
+            inst.resolved_agent().map(|a| a.name),
+            Some("claude"),
+            "empty detect_as must fall back to the live agent_detect_as registry"
+        );
+        assert_eq!(
+            status_hook_env_prefix(&inst.effective_profile(), "abc123", inst.resolved_agent()),
+            format!("AOE_PROFILE='{PROFILE}' AOE_INSTANCE_ID='abc123' "),
+        );
+    }
+
+    /// `swap_tool` re-resolves the alias for the incoming tool. The alias is
+    /// per-tool, so carrying the outgoing tool's value forward aims every
+    /// launch-time reader at the wrong built-in.
+    #[test]
+    fn swap_tool_reresolves_detect_as() {
+        const PROFILE: &str = "detect-as-swap-test";
+        install_aliases(
+            PROFILE,
+            &[("claude-personal", "claude"), ("codex-personal", "codex")],
+        );
+
+        // (starting tool, stored alias, tool swapped to, expected alias)
+        let cases = [
+            // The reported row: created on a built-in (no alias to store),
+            // then swapped onto a custom agent.
+            ("claude", "", "claude-personal", "claude"),
+            // Custom to custom: the outgoing alias is actively wrong, not
+            // merely stale, so it cannot survive.
+            ("codex-personal", "codex", "claude-personal", "claude"),
+            // Custom back to a built-in: nothing to pin.
+            ("claude-personal", "claude", "codex", ""),
+        ];
+        for (tool, detect_as, new_tool, expected) in cases {
+            let mut inst = Instance::new("t", "/tmp/x");
+            inst.source_profile = PROFILE.to_string();
+            inst.tool = tool.to_string();
+            inst.detect_as = detect_as.to_string();
+            inst.swap_tool(new_tool);
+            assert_eq!(inst.detect_as, expected, "{tool} -> {new_tool}");
+        }
     }
 
     #[test]

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -625,8 +625,18 @@ impl HomeView {
         };
         let id_owned = id.to_string();
         let new_tool = new_tool.to_string();
+        let row_profile = profile.clone();
         if let Err(e) = storage.update(|instances, _groups| {
             if let Some(disk) = instances.iter_mut().find(|i| i.id == id_owned) {
+                // `source_profile` is `skip_serializing`, so a storage-loaded
+                // row always comes back blank and would resolve the incoming
+                // tool's `agent_detect_as` alias against the default profile.
+                // A tool name aliased differently per profile would then be
+                // pinned to the wrong built-in on disk, and `detect_as` is not
+                // in `reconcile_from_disk`'s carry set, so the next launch
+                // reads that value rather than the in-memory one. Restore it
+                // the same way `reconcile_from_disk` does before the swap.
+                disk.source_profile = row_profile.clone();
                 disk.swap_tool(&new_tool);
             }
             Ok(())

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10244,6 +10244,46 @@ fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
     assert_eq!(parked.acp_session_id.as_deref(), Some("acp-sess-1"));
 }
 
+/// The disk row a tool swap writes must resolve `agent_detect_as` against the
+/// session's own profile. `source_profile` is `skip_serializing`, so a
+/// storage-loaded row comes back blank and would key the default profile's
+/// aliases instead; `detect_as` is not in `reconcile_from_disk`'s carry set,
+/// so that wrong value is what the next launch reads.
+#[test]
+#[serial]
+fn restart_selected_session_tool_swap_resolves_detect_as_for_the_row_profile() {
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    // Pin the resolved default profile to something other than the row's own
+    // profile, so a blank `source_profile` is observably the wrong key.
+    let app_dir = crate::session::get_app_dir().expect("app dir");
+    std::fs::create_dir_all(app_dir.join("profiles").join("other")).expect("other profile");
+    std::fs::write(app_dir.join("config.toml"), "default_profile = \"other\"\n")
+        .expect("global config");
+
+    let mut config = crate::session::Config::default();
+    config
+        .session
+        .agent_detect_as
+        .insert("gjc".to_string(), "claude".to_string());
+    crate::tmux::status_rules::install_from_config("test", &config);
+    crate::tmux::status_rules::install_from_config("other", &crate::session::Config::default());
+
+    env.view
+        .restart_selected_session(None, Some("gjc"), None, None)
+        .unwrap();
+
+    let disk = Storage::new_unwatched("test").unwrap().load().unwrap();
+    let row = disk.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(row.tool, "gjc");
+    assert_eq!(
+        row.detect_as, "claude",
+        "the swap must read profile 'test' aliases, not the default profile's"
+    );
+}
+
 #[test]
 #[serial]
 fn restart_selected_session_surfaces_resume_failed_after_async_restart() {


### PR DESCRIPTION
## Description

A non-sandboxed session running a custom agent (`[session.custom_agents]` + `[session.agent_detect_as]`) could launch with **no `AOE_PROFILE`/`AOE_INSTANCE_ID` on its command line**. Every status hook aoe installs opens with `[ -n "$AOE_INSTANCE_ID" ] || exit 0`, so all of them silently no-op: `/tmp/aoe-hooks-<euid>/<id>/status` is never written, the session reports **Idle forever**, and nothing is logged.

Found on a live session that had been frozen at Idle for four days. Its agent process carried neither variable, while every other session's did; its hook sidecar's mtime predated the pane it was supposed to belong to.

### Root cause

Both symptoms come from reading `Instance::detect_as` raw. #3398 established that the persisted field is a *cache* rather than the authority and routed three read sites through `status_rules::effective_detect_as` — but the launch path kept resolving by hand:

```rust
let agent = get_agent(&self.tool).or_else(|| get_agent(&self.detect_as));
```

With an empty alias that yields `None`, and `status_hook_env_prefix` emits nothing for `None`. The sandbox branch appends `-e AOE_PROFILE -e AOE_INSTANCE_ID` unconditionally, which is why only host sessions could hit this — 1 of ~24 custom-agent sessions on the reporting machine.

The sidecar is also where a custom-agent session's `agent_session_id` comes from (`aoe __extract-session-id`), so a row in this state loses track of its conversation as well — the reported row's `agent_session_id` was absent and the id of its live 5.9 MB transcript was known only to Claude Code.

`swap_tool` is how the row got an empty alias in the first place: it reassigns `self.tool` and carefully migrates `agent_session_id`, `acp_session_id`, `resume_intent`, `acp_effort` and `agent_model`, but left `detect_as` untouched. That is not merely stale — a `codex-personal` -> `claude-personal` swap kept aiming `resolved_agent` at codex. The reported row was created on plain `claude` (nothing to store) and swapped onto `claude-personal` two days *after* v024 backfilled every existing row, so the migration could not have covered it.

### Changes

- `Instance::resolved_agent` / `Instance::effective_detect_as` resolve through the live registry, and every launch-time reader now goes through them: hook install, the launch-command build, container agent selection, managed `CODEX_HOME`, the container config refresh, and yolo trust config. Per v024's own note, leaving the field wrong on disk means every future reader has to know to distrust it, so this converts the remaining hand-rolled readers rather than fixing only the one that was reported.
- `swap_tool` re-resolves `detect_as` for the incoming tool, off the same process-global registry `effective_detect_as` reads (a lookup, not a config load), so the row ends up exactly as if it had been built on the new tool.

The fallback is a strict no-regression: it only fires when the stored field is empty, which today is already the broken state.

### Deliberately not fixed here

`apply_session_flags` -> `append_resume_flags` -> `build_resume_flags` key on the raw `self.tool` rather than the alias, and `get_agent` only searches the static `AGENTS` table. So **no custom-agent session ever emits `--session-id`/`--resume`**, and `aoe session set-session-id` is accepted and then silently dropped at launch. Same class of raw read, but a wider behavior change — it would start splicing resume subcommands into wrapper command lines (`codex resume <sid> --profile ...`) — so it wants its own PR rather than riding along here.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --all-targets` (no new warnings), `cargo test` — 4651 passed. Two pre-existing failures are unrelated and reproduce on the parent commit: `tui::dialogs::hooks_install::tests::test_content_shows_settings_path` fails whenever `CLAUDE_CONFIG_DIR` is set in the environment (passes under `env -u CLAUDE_CONFIG_DIR`), and `git::worktree::tests::worktree_move_observation_canonicalizes_symlinked_parents` fails on this symlinked checkout.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: an e2e test would have to stand up a custom-agent wrapper on `PATH`, launch it non-sandboxed, and assert on the launched process's environment — roughly 10-28s of the serial e2e budget for a defect that is fully determined by pure resolution logic. Two unit tests pin it instead, both of which fail on the parent commit:

- `empty_detect_as_still_resolves_the_launch_agent` — a custom-agent row with an empty stored alias must resolve its built-in agent and keep the `AOE_PROFILE`/`AOE_INSTANCE_ID` launch prefix. Fails on `main` with `resolved_agent()` returning `None`, exactly as the reported session did.
- `swap_tool_reresolves_detect_as` — table over built-in -> custom (the reported row), custom -> custom (the actively-wrong pin), and custom -> built-in.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any Additional AI Details you'd like to share:**

Used to diagnose the live frozen session (agent process env vs. hook sidecar mtimes vs. `session.status_change` history) and to write the fix and tests. Diagnosis and patch reviewed by me before pushing.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Resolve session agent aliases from the active profile registry during launch, status hooks, container setup, managed `CODEX_HOME` configuration, and status detection.
- Re-resolve aliases when tools change to prevent stale agent mappings.
- Restore the session profile before tool swaps so profile-specific aliases resolve correctly.
- Add regression tests for empty aliases, tool swaps, and profile-specific session restarts.

These changes prevent custom-agent sessions from remaining idle because required launch environment variables are missing.

## Potential enhancement

- Add resume flag support for custom agents in a separate change, as planned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->