### PR TITLE
fix(test): restore the agent_detect_as registry after mutating tests

### DIFF
--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -2333,8 +2333,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&provisioned);
     }
 
-    #[serial_test::serial]
     #[test]
+    #[serial_test::serial]
     fn build_instance_applies_terminal_fork_seed() {
         use crate::session::ForkSeed;
         let params = InstanceParams {
@@ -2377,8 +2377,8 @@ mod tests {
     }
 
     #[cfg(feature = "serve")]
-    #[serial_test::serial]
     #[test]
+    #[serial_test::serial]
     fn build_instance_applies_structured_fork_seed() {
         use crate::session::ForkSeed;
         let params = InstanceParams {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -2333,6 +2333,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&provisioned);
     }
 
+    #[serial_test::serial]
     #[test]
     fn build_instance_applies_terminal_fork_seed() {
         use crate::session::ForkSeed;
@@ -2376,6 +2377,7 @@ mod tests {
     }
 
     #[cfg(feature = "serve")]
+    #[serial_test::serial]
     #[test]
     fn build_instance_applies_structured_fork_seed() {
         use crate::session::ForkSeed;

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -2192,6 +2192,10 @@ mod tests {
         )
         .unwrap();
         let project = tempfile::tempdir().unwrap();
+        // resolve_config inside build_instance installs this config's
+        // agent_detect_as into the process-global registry; restore the
+        // prior entries afterwards.
+        let _registry = crate::tmux::status_rules::ProfileRegistryGuard::take("default");
 
         let result = build_instance(
             custom_agent_params(project.path(), "remote-claude"),
@@ -2222,6 +2226,7 @@ mod tests {
         )
         .unwrap();
         let project = tempfile::tempdir().unwrap();
+        let _registry = crate::tmux::status_rules::ProfileRegistryGuard::take("default");
 
         let result = build_instance(
             custom_agent_params(project.path(), "remote-opencode"),

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -2337,6 +2337,7 @@ mod tests {
     #[serial_test::serial]
     fn build_instance_applies_terminal_fork_seed() {
         use crate::session::ForkSeed;
+        let _registry = crate::tmux::status_rules::ProfileRegistryGuard::take("default");
         let params = InstanceParams {
             title: "Forked".into(),
             path: "/tmp".into(),
@@ -2381,6 +2382,7 @@ mod tests {
     #[serial_test::serial]
     fn build_instance_applies_structured_fork_seed() {
         use crate::session::ForkSeed;
+        let _registry = crate::tmux::status_rules::ProfileRegistryGuard::take("default");
         let params = InstanceParams {
             title: "Forked".into(),
             path: "/tmp".into(),
@@ -2421,6 +2423,50 @@ mod tests {
             inst.resume_intent,
             crate::session::instance::ResumeIntent::Fork { .. }
         ));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn fork_seed_tests_restore_default_profile_registry() {
+        const ALIAS_AGENT: &str = "fork-seed-registry-alias";
+        const RULE_AGENT: &str = "fork-seed-registry-rule";
+        let cases: &[(&str, fn())] = &[
+            ("terminal", build_instance_applies_terminal_fork_seed),
+            #[cfg(feature = "serve")]
+            ("structured", build_instance_applies_structured_fork_seed),
+        ];
+
+        // serial_test 4's default-key lock is reentrant: the wrapper must call
+        // each serialized test directly to inspect state after its guard drops.
+        for (label, run) in cases {
+            let _cleanup = crate::tmux::status_rules::ProfileRegistryGuard::take("default");
+            let mut sentinels = crate::session::Config::default();
+            sentinels
+                .session
+                .agent_detect_as
+                .insert(ALIAS_AGENT.to_string(), "codex".to_string());
+            sentinels
+                .agents
+                .entry(RULE_AGENT.to_string())
+                .or_default()
+                .status_rules = vec![crate::session::config::StatusRule {
+                status: crate::agents::HookStatus::Running,
+                contains: Some("fork-seed-working".to_string()),
+                regex: None,
+            }];
+            crate::tmux::status_rules::install_from_config("default", &sentinels);
+
+            run();
+
+            let alias = crate::tmux::status_rules::effective_detect_as("default", ALIAS_AGENT, "");
+            let rule =
+                crate::tmux::status_rules::detect("default", RULE_AGENT, "fork-seed-working");
+            assert_eq!(
+                (alias.as_ref(), rule),
+                ("codex", Some(crate::session::Status::Running)),
+                "{label}: fork-seed build must restore the prior alias and compiled rule"
+            );
+        }
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -4639,6 +4639,11 @@ agent_detect_as = { "wrapped-codex" = "codex" }
             container_workdir: None,
         };
         let instance_id = "wrapped-codex-sandbox-hooks-test";
+        // resolve_config_or_warn inside build_container_config installs the
+        // profile overlay's agent_detect_as into the process-global
+        // registry; restore the prior entries afterwards.
+        let _registry =
+            crate::tmux::status_rules::ProfileRegistryGuard::take("sandbox-wrapped-codex");
         let config = build_container_config(
             project_dir.path().to_str().unwrap(),
             &sandbox_info,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -11933,7 +11933,7 @@ mod tests {
         profile: &str,
         aliases: &[(&str, &str)],
     ) -> crate::tmux::status_rules::ProfileRegistryGuard {
-        let restore = crate::tmux::status_rules::ProfileRegistryGuard::take(profile);
+        let guard = crate::tmux::status_rules::ProfileRegistryGuard::take(profile);
         let mut config = crate::session::Config::default();
         for (agent, target) in aliases {
             config
@@ -11942,7 +11942,7 @@ mod tests {
                 .insert(agent.to_string(), target.to_string());
         }
         crate::tmux::status_rules::install_from_config(profile, &config);
-        restore
+        guard
     }
 
     /// A custom-agent row whose stored `detect_as` is empty must still resolve

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -11924,11 +11924,16 @@ mod tests {
         );
     }
 
-    /// Seed the process-global `agent_detect_as` registry for one profile.
-    /// The registry is profile-keyed and `install_from_config` only replaces
-    /// the named profile's entries, so a test-only profile name keeps these
-    /// hermetic without serializing against every other registry writer.
-    fn install_aliases(profile: &str, aliases: &[(&str, &str)]) {
+    /// Seed the process-global `agent_detect_as` registry for one profile
+    /// and return a guard that restores the profile's prior entries on drop:
+    /// `install_from_config` replaces the whole profile's state and the
+    /// registry outlives every test, so the caller must keep the returned
+    /// guard alive for the duration of its reads.
+    fn install_aliases(
+        profile: &str,
+        aliases: &[(&str, &str)],
+    ) -> crate::tmux::status_rules::ProfileRegistryGuard {
+        let restore = crate::tmux::status_rules::ProfileRegistryGuard::take(profile);
         let mut config = crate::session::Config::default();
         for (agent, target) in aliases {
             config
@@ -11937,6 +11942,7 @@ mod tests {
                 .insert(agent.to_string(), target.to_string());
         }
         crate::tmux::status_rules::install_from_config(profile, &config);
+        restore
     }
 
     /// A custom-agent row whose stored `detect_as` is empty must still resolve
@@ -11948,7 +11954,7 @@ mod tests {
     #[test]
     fn empty_detect_as_still_resolves_the_launch_agent() {
         const PROFILE: &str = "detect-as-launch-path-test";
-        install_aliases(PROFILE, &[("claude-personal", "claude")]);
+        let _registry = install_aliases(PROFILE, &[("claude-personal", "claude")]);
 
         let mut inst = Instance::new("orch", "/tmp/x");
         inst.source_profile = PROFILE.to_string();
@@ -11973,7 +11979,7 @@ mod tests {
     #[test]
     fn swap_tool_reresolves_detect_as() {
         const PROFILE: &str = "detect-as-swap-test";
-        install_aliases(
+        let _registry = install_aliases(
             PROFILE,
             &[("claude-personal", "claude"), ("codex-personal", "codex")],
         );

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -272,13 +272,18 @@ impl ProfileRegistryGuard {
     /// resolve would normalize to whatever is configured then, not to this
     /// snapshot's frozen key.
     ///
-    /// The aliases and rules phases each lock their own map, so the guard is
-    /// rollback, not mutual exclusion: a concurrent writer for the same
-    /// profile can interleave and leave a half-swapped pair. The test cohort
-    /// that resolves or installs `default` shares serial_test's default key;
-    /// writers on dedicated profiles may run concurrently because their map
-    /// keys are disjoint. This caller-side exclusion is what makes the two-map
-    /// snapshot coherent. The guard covers exactly these two registries and
+    /// The aliases and rules phases each lock their own map, so this guard is
+    /// rollback, not mutual exclusion: a writer touching the same profile
+    /// between the phases can leave a half-swapped pair standing. Guarding a
+    /// profile nothing else writes therefore needs nothing more, since the
+    /// keys never overlap; guarding a profile other tests write needs those
+    /// writers held off, and a config resolve counts as a write. One known
+    /// case that is not held off: the serve-gated `#[tokio::test]` functions
+    /// in `src/acp/acp_client.rs` reach this registry through
+    /// `resolved_acp_config` and write `default` outside serial_test's default
+    /// key, so a `take("default")` can be raced under `--features serve`.
+    /// Audit the writers of the profile you guard rather than assuming a group
+    /// already covers them. The guard covers exactly these two registries and
     /// only its caller's writes; a future process-global needs its own restore
     /// mechanism.
     pub(crate) fn take(profile: &str) -> Self {

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -266,7 +266,11 @@ pub(crate) struct ProfileRegistryGuard {
 #[cfg(test)]
 impl ProfileRegistryGuard {
     /// Capture `profile`'s current entries. Take the snapshot BEFORE the
-    /// first mutation, or the restore replays the test's own writes.
+    /// first mutation, or the restore replays the test's own writes. Pass
+    /// the same literal profile the guarded section will install under: an
+    /// empty name resolves against config state at call time, and a later
+    /// resolve would normalize to whatever is configured then, not to this
+    /// snapshot's frozen key.
     pub(crate) fn take(profile: &str) -> Self {
         let profile = crate::session::config::effective_profile(profile);
         let aliases = aliases()
@@ -312,6 +316,7 @@ impl Drop for ProfileRegistryGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::sync::Mutex;
 
     /// The registry is process-global; serialize the tests that write to it
@@ -348,6 +353,7 @@ mod tests {
         config
     }
 
+    #[serial]
     #[test]
     fn no_rules_returns_none() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -357,6 +363,7 @@ mod tests {
         assert!(!has_rules("default", "anything"));
     }
 
+    #[serial]
     #[test]
     fn first_match_wins_and_no_match_is_idle() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -383,6 +390,7 @@ mod tests {
         assert_eq!(detect("default", "rules-agent", "$ "), Some(Status::Idle));
     }
 
+    #[serial]
     #[test]
     fn contains_is_case_insensitive_and_regex_is_as_written() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -416,6 +424,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn malformed_rules_are_skipped_and_all_skipped_means_no_entry() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -457,6 +466,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn install_replaces_previous_rules() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -473,6 +483,7 @@ mod tests {
         assert!(!has_rules("default", "rules-agent"));
     }
 
+    #[serial]
     #[test]
     fn install_is_scoped_to_its_profile() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -514,6 +525,7 @@ mod tests {
         assert!(!has_rules("p1", "gjc"));
     }
 
+    #[serial]
     #[test]
     fn detection_tool_prefers_own_rules_over_detect_as() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -539,6 +551,7 @@ mod tests {
     /// persists an empty alias, which used to strand it on the `Status::Idle`
     /// fallback forever. The stored value is a cache, so an empty one defers to
     /// the config the resolve installed.
+    #[serial]
     #[test]
     fn effective_detect_as_falls_back_to_installed_config() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -582,6 +595,7 @@ mod tests {
     /// Own rules outrank the alias whether the alias came from the stored field
     /// or from the config fallback, so the fallback cannot silently take over an
     /// agent the user wrote rules for.
+    #[serial]
     #[test]
     fn own_rules_outrank_the_config_fallback() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -598,6 +612,7 @@ mod tests {
         assert_eq!(detection_tool("default", "rules-agent", ""), "rules-agent");
     }
 
+    #[serial]
     #[test]
     fn rules_dispatch_through_detect_status_from_content_in() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -627,6 +642,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn rules_override_builtin_detector() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -662,6 +678,7 @@ mod tests {
     /// The guard must hand back exactly the snapshotted entries: prior
     /// aliases and rules clobbered by a guarded install come back, and a
     /// profile that had nothing keeps nothing.
+    #[serial]
     #[test]
     fn profile_registry_guard_restores_the_snapshotted_entries_on_drop() {
         let _lock = test_lock().lock().unwrap_or_else(|p| p.into_inner());

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -317,14 +317,6 @@ impl Drop for ProfileRegistryGuard {
 mod tests {
     use super::*;
     use serial_test::serial;
-    use std::sync::Mutex;
-
-    /// The registry is process-global; serialize the tests that write to it
-    /// so parallel test threads can't clobber each other's installs.
-    fn test_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
 
     fn rule(status: HookStatus, contains: Option<&str>, regex: Option<&str>) -> StatusRule {
         StatusRule {
@@ -356,7 +348,6 @@ mod tests {
     #[serial]
     #[test]
     fn no_rules_returns_none() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config("default", &crate::session::Config::default());
         assert_eq!(detect("default", "anything", "some pane text"), None);
@@ -366,7 +357,6 @@ mod tests {
     #[serial]
     #[test]
     fn first_match_wins_and_no_match_is_idle() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
@@ -393,7 +383,6 @@ mod tests {
     #[serial]
     #[test]
     fn contains_is_case_insensitive_and_regex_is_as_written() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
@@ -427,7 +416,6 @@ mod tests {
     #[serial]
     #[test]
     fn malformed_rules_are_skipped_and_all_skipped_means_no_entry() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
@@ -469,7 +457,6 @@ mod tests {
     #[serial]
     #[test]
     fn install_replaces_previous_rules() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
@@ -486,7 +473,6 @@ mod tests {
     #[serial]
     #[test]
     fn install_is_scoped_to_its_profile() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry_p1 = ProfileRegistryGuard::take("p1");
         let _registry_p2 = ProfileRegistryGuard::take("p2");
         // p1's `gjc` maps a marker to Running; p2's `gjc` maps the same marker
@@ -528,7 +514,6 @@ mod tests {
     #[serial]
     #[test]
     fn detection_tool_prefers_own_rules_over_detect_as() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
@@ -554,7 +539,6 @@ mod tests {
     #[serial]
     #[test]
     fn effective_detect_as_falls_back_to_installed_config() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config("default", &config_with_alias("claude-personal", "claude"));
 
@@ -598,7 +582,6 @@ mod tests {
     #[serial]
     #[test]
     fn own_rules_outrank_the_config_fallback() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         let mut config = config_with_alias("rules-agent", "claude");
         config
@@ -615,7 +598,6 @@ mod tests {
     #[serial]
     #[test]
     fn rules_dispatch_through_detect_status_from_content_in() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
@@ -645,7 +627,6 @@ mod tests {
     #[serial]
     #[test]
     fn rules_override_builtin_detector() {
-        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _registry = ProfileRegistryGuard::take("default");
         // "claude" has a built-in pane detector; configured rules outrank it.
         install_from_config(
@@ -681,8 +662,6 @@ mod tests {
     #[serial]
     #[test]
     fn profile_registry_guard_restores_the_snapshotted_entries_on_drop() {
-        let _lock = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-
         // (case label, prior config under the case's profile, alias the
         // sentinel resolves to afterwards, rules present afterwards)
         let cases = [

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -657,20 +657,32 @@ mod tests {
     }
 
     /// The guard must hand back exactly the snapshotted entries: prior
-    /// aliases and rules clobbered by a guarded install come back, and a
-    /// profile that had nothing keeps nothing.
+    /// aliases and rules clobbered by a guarded install come back with
+    /// their original matchers, a rules-only or alias-only prior is
+    /// restored on its own, and a profile that had nothing keeps nothing.
+    /// The outer guard returns each case's profile to the pre-test state
+    /// so the seeded priors themselves do not leak.
     #[serial]
     #[test]
     fn profile_registry_guard_restores_the_snapshotted_entries_on_drop() {
         // (case label, prior config under the case's profile, alias the
-        // sentinel resolves to afterwards, rules present afterwards)
+        // sentinel resolves to afterwards, "spin" detected afterwards)
         let cases = [
-            ("empty", None, "", false),
+            ("empty", None, "", None),
             (
                 "seeded",
                 Some(config_with_alias("sentinel-agent", "codex")),
                 "codex",
-                false,
+                None,
+            ),
+            (
+                "rules-only",
+                Some(config_with_rules(
+                    "rules-agent",
+                    vec![rule(HookStatus::Running, Some("spin"), None)],
+                )),
+                "",
+                Some(Status::Running),
             ),
             (
                 "seeded-with-rules",
@@ -684,11 +696,12 @@ mod tests {
                     config
                 }),
                 "codex",
-                true,
+                Some(Status::Running),
             ),
         ];
-        for (label, prior, want_alias, want_rules) in cases {
+        for (label, prior, want_alias, want_spin) in cases {
             let profile = format!("guard-{label}");
+            let _pre_test = ProfileRegistryGuard::take(&profile);
             if let Some(prior) = prior.as_ref() {
                 install_from_config(&profile, prior);
             }
@@ -710,9 +723,9 @@ mod tests {
                 "{label}: prior alias entry must be restored"
             );
             assert_eq!(
-                has_rules(&profile, "rules-agent"),
-                want_rules,
-                "{label}: prior rules entry must be restored"
+                detect(&profile, "rules-agent", "spin"),
+                want_spin,
+                "{label}: prior rule must be restored with its original matcher"
             );
         }
     }

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -274,11 +274,13 @@ impl ProfileRegistryGuard {
     ///
     /// The aliases and rules phases each lock their own map, so the guard is
     /// rollback, not mutual exclusion: a concurrent writer for the same
-    /// profile can interleave and leave a half-swapped pair. Tests changed by
-    /// this PR are serialized or use disjoint profiles, but other pre-existing
-    /// config-resolving tests still write `default` outside that group. The
-    /// guard covers exactly these two registries and only its caller's writes;
-    /// a future process-global needs its own restore mechanism.
+    /// profile can interleave and leave a half-swapped pair. The test cohort
+    /// that resolves or installs `default` shares serial_test's default key;
+    /// writers on dedicated profiles may run concurrently because their map
+    /// keys are disjoint. This caller-side exclusion is what makes the two-map
+    /// snapshot coherent. The guard covers exactly these two registries and
+    /// only its caller's writes; a future process-global needs its own restore
+    /// mechanism.
     pub(crate) fn take(profile: &str) -> Self {
         let profile = crate::session::config::effective_profile(profile);
         let aliases = aliases()

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -34,11 +34,13 @@ use crate::session::Status;
 
 /// A rule compiled for the poll loop: the matcher is pre-lowered /
 /// pre-compiled so per-tick evaluation is substring or regex work only.
+#[derive(Clone)]
 struct CompiledRule {
     status: Status,
     matcher: Matcher,
 }
 
+#[derive(Clone)]
 enum Matcher {
     /// Case-insensitive substring: stored lowercased, tested against the
     /// lowercased pane text.
@@ -247,6 +249,66 @@ pub fn detection_tool<'a>(profile: &str, tool: &'a str, detect_as: &'a str) -> C
     }
 }
 
+/// Test-only restoration guard over one profile's entries in both
+/// registries. `install_from_config` replaces the whole profile's state and
+/// the registries are process-globals that outlive any single test, so a
+/// test that installs must hand the prior entries back: [`Self::take`]
+/// snapshots what `profile` currently has, and dropping the guard removes
+/// everything the test installed (and reinstates anything it clobbered),
+/// including through an unwinding assertion.
+#[cfg(test)]
+pub(crate) struct ProfileRegistryGuard {
+    profile: String,
+    aliases: Vec<((String, String), String)>,
+    rules: Vec<((String, String), Vec<CompiledRule>)>,
+}
+
+#[cfg(test)]
+impl ProfileRegistryGuard {
+    /// Capture `profile`'s current entries. Take the snapshot BEFORE the
+    /// first mutation, or the restore replays the test's own writes.
+    pub(crate) fn take(profile: &str) -> Self {
+        let profile = crate::session::config::effective_profile(profile);
+        let aliases = aliases()
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .iter()
+            .filter(|((p, _), _)| *p == profile)
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let rules = registry()
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .iter()
+            .filter(|((p, _), _)| *p == profile)
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        Self {
+            profile,
+            aliases,
+            rules,
+        }
+    }
+
+    /// Drop this profile's current entries and reinstall the snapshot.
+    fn restore(&mut self) {
+        let mut map = aliases().write().unwrap_or_else(|p| p.into_inner());
+        map.retain(|(p, _), _| p != &self.profile);
+        map.extend(self.aliases.drain(..));
+        drop(map);
+        let mut reg = registry().write().unwrap_or_else(|p| p.into_inner());
+        reg.retain(|(p, _), _| p != &self.profile);
+        reg.extend(self.rules.drain(..));
+    }
+}
+
+#[cfg(test)]
+impl Drop for ProfileRegistryGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,6 +351,7 @@ mod tests {
     #[test]
     fn no_rules_returns_none() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config("default", &crate::session::Config::default());
         assert_eq!(detect("default", "anything", "some pane text"), None);
         assert!(!has_rules("default", "anything"));
@@ -297,6 +360,7 @@ mod tests {
     #[test]
     fn first_match_wins_and_no_match_is_idle() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
             &config_with_rules(
@@ -317,12 +381,12 @@ mod tests {
             Some(Status::Running)
         );
         assert_eq!(detect("default", "rules-agent", "$ "), Some(Status::Idle));
-        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn contains_is_case_insensitive_and_regex_is_as_written() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
             &config_with_rules(
@@ -350,12 +414,12 @@ mod tests {
             detect("default", "rules-agent", "WAITING FOR 2 APPROVALS"),
             Some(Status::Idle)
         );
-        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn malformed_rules_are_skipped_and_all_skipped_means_no_entry() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
             &config_with_rules(
@@ -391,12 +455,12 @@ mod tests {
             ),
             Some(Status::Error)
         );
-        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn install_replaces_previous_rules() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
             &config_with_rules(
@@ -412,6 +476,8 @@ mod tests {
     #[test]
     fn install_is_scoped_to_its_profile() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry_p1 = ProfileRegistryGuard::take("p1");
+        let _registry_p2 = ProfileRegistryGuard::take("p2");
         // p1's `gjc` maps a marker to Running; p2's `gjc` maps the same marker
         // to Error. Distinct keys, so neither install touches the other.
         install_from_config(
@@ -451,6 +517,7 @@ mod tests {
     #[test]
     fn detection_tool_prefers_own_rules_over_detect_as() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
             &config_with_rules(
@@ -466,7 +533,6 @@ mod tests {
         // No rules: alias applies, and no alias means the tool itself.
         assert_eq!(detection_tool("default", "other-agent", "claude"), "claude");
         assert_eq!(detection_tool("default", "other-agent", ""), "other-agent");
-        install_from_config("default", &crate::session::Config::default());
     }
 
     /// A session built before its tool was added to `[session.agent_detect_as]`
@@ -476,6 +542,7 @@ mod tests {
     #[test]
     fn effective_detect_as_falls_back_to_installed_config() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config("default", &config_with_alias("claude-personal", "claude"));
 
         // (tool, stored detect_as, expected alias, expected detection tool)
@@ -518,6 +585,7 @@ mod tests {
     #[test]
     fn own_rules_outrank_the_config_fallback() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         let mut config = config_with_alias("rules-agent", "claude");
         config
             .agents
@@ -528,13 +596,12 @@ mod tests {
 
         assert_eq!(effective_detect_as("default", "rules-agent", ""), "claude");
         assert_eq!(detection_tool("default", "rules-agent", ""), "rules-agent");
-
-        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn rules_dispatch_through_detect_status_from_content_in() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         install_from_config(
             "default",
             &config_with_rules(
@@ -558,12 +625,12 @@ mod tests {
             ),
             Status::Idle
         );
-        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn rules_override_builtin_detector() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _registry = ProfileRegistryGuard::take("default");
         // "claude" has a built-in pane detector; configured rules outrank it.
         install_from_config(
             "default",
@@ -590,5 +657,67 @@ mod tests {
             ),
             Status::Idle
         );
+    }
+
+    /// The guard must hand back exactly the snapshotted entries: prior
+    /// aliases and rules clobbered by a guarded install come back, and a
+    /// profile that had nothing keeps nothing.
+    #[test]
+    fn profile_registry_guard_restores_the_snapshotted_entries_on_drop() {
+        let _lock = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+        // (case label, prior config under the case's profile, alias the
+        // sentinel resolves to afterwards, rules present afterwards)
+        let cases = [
+            ("empty", None, "", false),
+            (
+                "seeded",
+                Some(config_with_alias("sentinel-agent", "codex")),
+                "codex",
+                false,
+            ),
+            (
+                "seeded-with-rules",
+                Some({
+                    let mut config = config_with_alias("sentinel-agent", "codex");
+                    config
+                        .agents
+                        .entry("rules-agent".to_string())
+                        .or_default()
+                        .status_rules = vec![rule(HookStatus::Running, Some("spin"), None)];
+                    config
+                }),
+                "codex",
+                true,
+            ),
+        ];
+        for (label, prior, want_alias, want_rules) in cases {
+            let profile = format!("guard-{label}");
+            if let Some(prior) = prior.as_ref() {
+                install_from_config(&profile, prior);
+            }
+
+            {
+                let _restore = ProfileRegistryGuard::take(&profile);
+                let mut clobber = config_with_alias("sentinel-agent", "claude");
+                clobber
+                    .agents
+                    .entry("rules-agent".to_string())
+                    .or_default()
+                    .status_rules = vec![rule(HookStatus::Error, Some("boom"), None)];
+                install_from_config(&profile, &clobber);
+            }
+
+            assert_eq!(
+                effective_detect_as(&profile, "sentinel-agent", ""),
+                want_alias,
+                "{label}: prior alias entry must be restored"
+            );
+            assert_eq!(
+                has_rules(&profile, "rules-agent"),
+                want_rules,
+                "{label}: prior rules entry must be restored"
+            );
+        }
     }
 }

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -272,12 +272,13 @@ impl ProfileRegistryGuard {
     /// resolve would normalize to whatever is configured then, not to this
     /// snapshot's frozen key.
     ///
-    /// The aliases and rules phases each lock their own map, so a writer
-    /// touching the same profile between the phases would see or leave a
-    /// half-swapped pair; every same-profile writer therefore sits in the
-    /// default serial group, which excludes them for the whole guard. The
-    /// guard covers exactly these two registries: a future process-global
-    /// needs its own restore mechanism.
+    /// The aliases and rules phases each lock their own map, so the guard is
+    /// rollback, not mutual exclusion: a concurrent writer for the same
+    /// profile can interleave and leave a half-swapped pair. Tests changed by
+    /// this PR are serialized or use disjoint profiles, but other pre-existing
+    /// config-resolving tests still write `default` outside that group. The
+    /// guard covers exactly these two registries and only its caller's writes;
+    /// a future process-global needs its own restore mechanism.
     pub(crate) fn take(profile: &str) -> Self {
         let profile = crate::session::config::effective_profile(profile);
         let aliases = aliases()

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -265,12 +265,19 @@ pub(crate) struct ProfileRegistryGuard {
 
 #[cfg(test)]
 impl ProfileRegistryGuard {
-    /// Capture `profile`'s current entries. Take the snapshot BEFORE the
+    /// Snapshot `profile`'s current entries. Take the snapshot BEFORE the
     /// first mutation, or the restore replays the test's own writes. Pass
     /// the same literal profile the guarded section will install under: an
     /// empty name resolves against config state at call time, and a later
     /// resolve would normalize to whatever is configured then, not to this
     /// snapshot's frozen key.
+    ///
+    /// The aliases and rules phases each lock their own map, so a writer
+    /// touching the same profile between the phases would see or leave a
+    /// half-swapped pair; every same-profile writer therefore sits in the
+    /// default serial group, which excludes them for the whole guard. The
+    /// guard covers exactly these two registries: a future process-global
+    /// needs its own restore mechanism.
     pub(crate) fn take(profile: &str) -> Self {
         let profile = crate::session::config::effective_profile(profile);
         let aliases = aliases()

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -34,13 +34,13 @@ use crate::session::Status;
 
 /// A rule compiled for the poll loop: the matcher is pre-lowered /
 /// pre-compiled so per-tick evaluation is substring or regex work only.
-#[derive(Clone)]
+#[cfg_attr(test, derive(Clone))]
 struct CompiledRule {
     status: Status,
     matcher: Matcher,
 }
 
-#[derive(Clone)]
+#[cfg_attr(test, derive(Clone))]
 enum Matcher {
     /// Case-insensitive substring: stored lowercased, tested against the
     /// lowercased pane text.

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -366,6 +366,7 @@ mod tests {
     /// silently produced a plain new session. Assert the seed is forwarded and
     /// applied (child id pinned, one-shot Fork intent set).
     #[test]
+    #[serial_test::serial]
     fn create_instance_forwards_fork_seed() {
         let request = CreationRequest {
             data: fork_data(ForkSeed::Terminal {

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -614,18 +614,21 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_simple_dialog_focuses_no_button() {
         let dialog = simple_dialog();
         assert_eq!(dialog.focus, FocusElement::NoButton);
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_full_dialog_focuses_first_checkbox() {
         let dialog = full_dialog();
         assert_eq!(dialog.focus, FocusElement::WorktreeCheckbox);
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_full_dialog_respects_config_defaults() {
         let dialog = full_dialog();
         assert!(
@@ -643,6 +646,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_tab_cycles_through_elements() {
         let mut dialog = full_dialog();
         assert_eq!(dialog.focus, FocusElement::WorktreeCheckbox);
@@ -667,6 +671,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_branch_checkbox_toggle() {
         let mut dialog = full_dialog();
         dialog.focus = FocusElement::BranchCheckbox;
@@ -680,6 +685,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_space_toggles_checkbox() {
         let mut dialog = full_dialog();
         let initial = dialog.options.delete_worktree;
@@ -692,6 +698,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_esc_cancels() {
         let mut dialog = full_dialog();
         let result = dialog.handle_key(key(KeyCode::Esc));
@@ -699,6 +706,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_n_cancels() {
         let mut dialog = full_dialog();
         let result = dialog.handle_key(key(KeyCode::Char('n')));
@@ -706,6 +714,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_y_confirms() {
         let mut dialog = full_dialog();
         let result = dialog.handle_key(key(KeyCode::Char('y')));
@@ -713,6 +722,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_enter_on_no_cancels() {
         let mut dialog = simple_dialog();
         let result = dialog.handle_key(key(KeyCode::Enter));
@@ -720,6 +730,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_enter_on_yes_submits() {
         let mut dialog = simple_dialog();
         dialog.focus = FocusElement::YesButton;
@@ -728,6 +739,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_left_focuses_yes() {
         let mut dialog = simple_dialog();
         dialog.handle_key(key(KeyCode::Left));
@@ -735,6 +747,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_right_focuses_no() {
         let mut dialog = simple_dialog();
         dialog.focus = FocusElement::YesButton;
@@ -743,6 +756,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_click_before_render_is_noop() {
         // Both button rects default to Rect::default() (zero-sized) so
         // the contains() check returns false until the dialog has been
@@ -752,6 +766,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_click_on_yes_button_submits() {
         let mut dialog = simple_dialog();
         // Stage the button rects manually since the real coordinates
@@ -764,6 +779,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_click_on_no_button_cancels() {
         let mut dialog = simple_dialog();
         dialog.yes_button_area = Rect::new(10, 8, 5, 1);
@@ -774,6 +790,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_click_between_buttons_misses() {
         let mut dialog = simple_dialog();
         dialog.yes_button_area = Rect::new(10, 8, 5, 1);
@@ -783,6 +800,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_scratch_dialog_focuses_keep_scratch_checkbox() {
         let dialog = scratch_dialog();
         assert_eq!(dialog.focus, FocusElement::KeepScratchCheckbox);
@@ -790,6 +808,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_scratch_dialog_toggles_keep_scratch_on_space() {
         let mut dialog = scratch_dialog();
         dialog.handle_key(key(KeyCode::Char(' ')));
@@ -799,6 +818,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_submit_returns_options() {
         let mut dialog = full_dialog();
         dialog.options.delete_worktree = true;
@@ -848,6 +868,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn hover_highlights_button_without_changing_focus() {
         // Hover drives the visual highlight only; it must leave focus
         // alone, otherwise mouse drift between reading the dialog and
@@ -879,6 +900,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn hover_on_checkbox_row_highlights_without_stealing_focus() {
         let mut dialog = full_dialog();
         stage_rects_for_full(&mut dialog);
@@ -894,6 +916,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn click_on_checkbox_toggles_and_focuses() {
         let mut dialog = full_dialog();
         stage_rects_for_full(&mut dialog);
@@ -907,6 +930,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn click_on_worktree_checkbox_toggles_and_rebuilds_focusables() {
         let mut dialog = full_dialog();
         // Force a known starting state so the test doesn't depend on

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -437,6 +437,7 @@ fn test_backspace_on_empty_field() {
 }
 
 #[test]
+#[serial_test::serial]
 fn test_tool_selection_left_right() {
     let mut dialog = multi_tool_dialog();
     dialog.focused_field = 2; // tool field (single profile: path=0, title=1, tool=2)
@@ -453,6 +454,7 @@ fn test_tool_selection_left_right() {
 }
 
 #[test]
+#[serial_test::serial]
 fn test_tool_selection_left_right_three_tools() {
     let mut dialog = NewSessionDialog::new_with_tools(
         vec!["claude", "opencode", "codex"],
@@ -477,6 +479,7 @@ fn test_tool_selection_left_right_three_tools() {
 }
 
 #[test]
+#[serial_test::serial]
 fn test_tool_selection_space() {
     let mut dialog = multi_tool_dialog();
     dialog.focused_field = 2; // tool field
@@ -507,6 +510,7 @@ fn test_tool_selection_ignored_single_tool() {
 }
 
 #[test]
+#[serial_test::serial]
 fn test_submit_with_selected_tool() {
     let mut dialog = multi_tool_dialog();
     dialog.focused_field = 2; // tool field
@@ -1097,6 +1101,7 @@ fn test_confirm_create_failure_shows_error() {
 // --- Profile picker tests ---
 
 #[test]
+#[serial_test::serial]
 fn test_profile_cycling() {
     let mut dialog = single_tool_dialog();
     dialog.available_profiles = vec![
@@ -1366,6 +1371,7 @@ fn test_env_list_edit_submits_session_override() {
 // --- Sandbox config mode tests ---
 
 #[test]
+#[serial_test::serial]
 fn test_ctrl_p_on_sandbox_enters_config_mode() {
     let mut dialog = multi_tool_dialog();
     dialog.docker_available = true;
@@ -1569,6 +1575,7 @@ fn click_on_path_field_just_moves_focus() {
 }
 
 #[test]
+#[serial_test::serial]
 fn click_on_tool_cycles_when_multi_tool() {
     let mut dialog = multi_tool_dialog();
     // Multi-tool, no-profile layout: path=0, title=1, tool=2.

--- a/src/tui/dialogs/restart.rs
+++ b/src/tui/dialogs/restart.rs
@@ -664,6 +664,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_right_cycles_profile_when_profile_focused() {
         let mut d = dialog("default", "claude");
         d.handle_key(key(KeyCode::Right));
@@ -691,6 +692,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_arrows_cycle_tool_when_tool_focused() {
         let mut d = dialog("default", "claude");
         d.focused_field = 1;
@@ -715,6 +717,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_tool_only_change_submits_tool_some_profile_none() {
         let mut d = dialog("default", "claude");
         d.focused_field = 1;
@@ -729,6 +732,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_tool_override_does_not_snap_profile() {
         let mut d = dialog("default", "claude");
         d.focused_field = 1;
@@ -914,6 +918,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_tool_round_trip_preserves_live_overrides() {
         // Session has custom overrides on its original tool. Cycling the tool
         // away and back must restore the live values (not config defaults),

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10255,8 +10255,8 @@ fn restart_selected_session_tool_swap_resolves_detect_as_for_the_row_profile() {
     // The registries are process-globals and every config resolve in this
     // test (env boot included) rewrites the touched profiles' entries, so
     // snapshot before anything runs and restore on the way out.
-    let _restore_test = crate::tmux::status_rules::ProfileRegistryGuard::take("test");
-    let _restore_other = crate::tmux::status_rules::ProfileRegistryGuard::take("other");
+    let _registry_test = crate::tmux::status_rules::ProfileRegistryGuard::take("test");
+    let _registry_other = crate::tmux::status_rules::ProfileRegistryGuard::take("other");
 
     let mut env = create_test_env_with_sessions(1);
     let id = env.view.instance_at(0).id.clone();
@@ -10306,8 +10306,8 @@ fn tool_swap_test_restores_the_detect_as_registry() {
     ];
     // The probe's own seeds must not leak either: restore the pre-probe
     // entries once the assertion below has run.
-    let _restore_test = crate::tmux::status_rules::ProfileRegistryGuard::take("test");
-    let _restore_other = crate::tmux::status_rules::ProfileRegistryGuard::take("other");
+    let _registry_test = crate::tmux::status_rules::ProfileRegistryGuard::take("test");
+    let _registry_other = crate::tmux::status_rules::ProfileRegistryGuard::take("other");
     for (profile, agent, target) in sentinels {
         let mut seeded = crate::session::Config::default();
         seeded

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10252,6 +10252,12 @@ fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
 #[test]
 #[serial]
 fn restart_selected_session_tool_swap_resolves_detect_as_for_the_row_profile() {
+    // The registries are process-globals and every config resolve in this
+    // test (env boot included) rewrites the touched profiles' entries, so
+    // snapshot before anything runs and restore on the way out.
+    let _restore_test = crate::tmux::status_rules::ProfileRegistryGuard::take("test");
+    let _restore_other = crate::tmux::status_rules::ProfileRegistryGuard::take("other");
+
     let mut env = create_test_env_with_sessions(1);
     let id = env.view.instance_at(0).id.clone();
     env.view.selected_session = Some(id.clone());
@@ -10281,6 +10287,49 @@ fn restart_selected_session_tool_swap_resolves_detect_as_for_the_row_profile() {
     assert_eq!(
         row.detect_as, "claude",
         "the swap must read profile 'test' aliases, not the default profile's"
+    );
+}
+
+/// Repro for the open CodeRabbit thread on #3509: the tool-swap test above
+/// mutates the process-global `agent_detect_as` registry through
+/// `install_from_config` without restoring prior entries, and the registry
+/// outlives the test, so any later reader of those profiles observes state
+/// its config never contained. Sentinel aliases stand in for entries an
+/// earlier test installed; both must survive the swap test unchanged.
+#[test]
+#[serial]
+fn tool_swap_test_restores_the_detect_as_registry() {
+    // (profile, sentinel agent, target)
+    let sentinels = [
+        ("test", "zz-sentinel-test", "codex"),
+        ("other", "zz-sentinel-other", "claude"),
+    ];
+    // The probe's own seeds must not leak either: restore the pre-probe
+    // entries once the assertion below has run.
+    let _restore_test = crate::tmux::status_rules::ProfileRegistryGuard::take("test");
+    let _restore_other = crate::tmux::status_rules::ProfileRegistryGuard::take("other");
+    for (profile, agent, target) in sentinels {
+        let mut seeded = crate::session::Config::default();
+        seeded
+            .session
+            .agent_detect_as
+            .insert(agent.to_string(), target.to_string());
+        crate::tmux::status_rules::install_from_config(profile, &seeded);
+    }
+
+    restart_selected_session_tool_swap_resolves_detect_as_for_the_row_profile();
+
+    for (profile, agent, target) in sentinels {
+        assert_eq!(
+            crate::tmux::status_rules::effective_detect_as(profile, agent, ""),
+            target,
+            "the tool-swap test clobbered pre-existing alias {agent} in profile '{profile}'"
+        );
+    }
+    assert_eq!(
+        crate::tmux::status_rules::effective_detect_as("test", "gjc", ""),
+        "",
+        "the tool-swap test leaked `gjc -> claude` into profile 'test'"
     );
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10317,6 +10317,8 @@ fn tool_swap_test_restores_the_detect_as_registry() {
         crate::tmux::status_rules::install_from_config(profile, &seeded);
     }
 
+    // serial_test 4's default-key lock is reentrant, so this serialized test
+    // can be called directly and observed after its nested guards have dropped.
     restart_selected_session_tool_swap_resolves_detect_as_for_the_row_profile();
 
     for (profile, agent, target) in sentinels {


### PR DESCRIPTION
## Description

Follow-up to the open CodeRabbit thread on #3509 (`Restore the status-rule registry after this test`): the tests that PR added mutate the process-global `agent_detect_as` / status-rules registries through `install_from_config` and never hand the prior state back.

### Root cause

- Both registries are process-globals: `src/tmux/status_rules.rs`, `aliases()` and `registry()` are `&'static RwLock<HashMap<(String, String), _>>`.
- `install_from_config` is their only writer and it replaces a whole profile's entries in both maps (`retain` on each). Production entry points: `resolve_config` (`profile_config.rs:156`) and the `resolve_config_or_warn` fallback (`:177`).
- Three tests installed without restoring:
  - `restart_selected_session_tool_swap_resolves_detect_as_for_the_row_profile` (tui/home/tests.rs) wrote into the real `test` profile and emptied the real `other` profile;
  - `empty_detect_as_still_resolves_the_launch_agent` and `swap_tool_reresolves_detect_as` (session/instance.rs) seeded dedicated profiles via an `install_aliases` helper whose doc comment claimed unique names made them hermetic. They do not: the entries persist for the rest of the process, so any later reader of that profile observes them.
- Why `#[serial]` alone does not refute the finding: serial_test prevents temporal overlap within its key group, it performs no rollback. Order-dependent pollution survives serialization, and writers outside the serial group race it entirely.
- Inside the swap test the leaked `gjc -> claude` alias itself happens to be wiped again mid-test because `restart_selected_session` calls `resolve_config` (`operations.rs:582`), which reinstalls the profile's disk config. The durable damage is destruction of pre-existing entries under `test`/`other`; the alias leak becomes real if that internal resolve ever moves. Same root cause either way: mutation without restoration.

### Fix

A test-only RAII guard in `status_rules.rs`: `ProfileRegistryGuard::take(profile)` snapshots the profile's current entries in both maps, and dropping it removes everything installed since and reinstates exactly the snapshot, unwinding included (Drop). Consumers:

- both profiles guarded in the tui tool-swap test, taken before its first mutation (env boot resolves config too);
- `install_aliases` returns the guard, bound by both instance.rs callers;
- status_rules' own tests converted: trailing cleanup installs dropped, behavioral clear-and-assert sequences kept;
- two build_instance custom-agent mapping tests and both fork-seed tests (`builder.rs`) guard `default`; the sandbox wrapped-codex test (`container_config.rs`) guards `sandbox-wrapped-codex`;
- the complete observed `default` writer cohort shares serial_test's default key: 24 delete-dialog tests, seven new-session tests, five restart-dialog tests, the creation-poller fork test, the builder tests, and the status-rules tests. Dedicated-profile writers remain concurrent because their map keys are disjoint;
- a table-driven contract test pins the restore contract over four prior-state shapes (empty, alias-only, rules-only, alias plus rules), asserting the restored rule still matches its original marker and that each case's profile returns to its pre-test state.
- a second table-driven fork-seed regression calls both serialized tests under alias and compiled-rule sentinels, so either missing guard fails its own labeled row.

A probe test seeds sentinel aliases under the real `test` and `other` profiles, runs the swap test, and asserts both sentinels return with their original targets and no `gjc` alias leaks. Sensitivity was verified by inverse mutation at this HEAD: removing the swap test's guards turns the probe red; short-circuiting only the guard's rules restoration turns the contract test red on its rules-bearing rows; a catch_unwind experiment showed state fully restored through a panic raised while guards were live. The fork-seed regression likewise proves both alias and compiled-rule restoration, including a forced unwind after build_instance. A controlled 600 ms assertion window reproduced the pre-fix race (`None` instead of `Some(Running)`); serializing the 37 actual `default` writers made the same cohort green, and removing the 24 delete-dialog attributes reopened it.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: no behavior change outside unit tests; the registry guard is exercised by unit tests in this diff

## Validation

Broad targeted suites (`tui::home::tests`, `tmux::status_rules`, `session::instance::tests`, `session::builder::tests`, `session::container_config`; 1057 tests) at the pushed commit:

- default parallel threads, repeated runs including three consecutive: all green
- `--test-threads=1`: green
- `--features serve`, exact fork-seed regression: green (covers terminal and structured rows)
- default-writer cohort: 213 passed normally, with `--test-threads=1`, and in five targeted `--test-threads=16` stress runs

Gates: `cargo fmt --all -- --check` clean; the CI invocation `cargo clippy -- -D warnings` clean; locally `cargo clippy --lib --tests -- -D warnings` clean as well (cfg(test) code is outside CI clippy's reach, so the local run covers it).

## Risks

Test-only surface: the guard is `#[cfg(test)]`, so release builds are untouched. The `Clone` derives on `CompiledRule`/`Matcher` are gated behind `#[cfg_attr(test, ...)]`, so even test-profile builds outside `cfg(test)` see no change. Snapshot cost is one HashMap scan per guarded profile per test.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** ox-alpha (Claude Code harness)

**NOTE:** When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a test-only guard to restore profile aliases and status rules.
- Applied the guard to affected session, TUI, builder, container, and status-rule tests.
- Serialized tests that share profile keys.
- Added regression coverage for existing state and panic recovery.
- Kept production behavior unchanged.

## Benefits

- Prevents global registry state from leaking between tests.
- Preserves pre-existing profile configuration.
- Improves reliability in parallel and single-threaded test runs.
- Documents the need for separate synchronization when concurrent writers use the same profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Wall time: 0.52 seconds


Wall time: 0.46 seconds


Wall time: 0.58 seconds