### PR TITLE
chore: fix clippy --all-targets lints in test code

### DIFF
--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -2350,7 +2350,7 @@ mod tests {
         let mut new_plain = Instance::new("new_plain", "/tmp/np");
         new_plain.created_at = chrono::Utc::now();
 
-        let instances = vec![old_fav, new_plain];
+        let instances = [old_fav, new_plain];
 
         // Feature off: plain newest-first, unchanged behavior.
         let mut refs: Vec<&Instance> = instances.iter().collect();
@@ -2375,7 +2375,7 @@ mod tests {
         fav_new.favorite();
         let plain = Instance::new("plain", "/tmp/p");
 
-        let instances = vec![fav_old, fav_new, plain];
+        let instances = [fav_old, fav_new, plain];
         let mut refs: Vec<&Instance> = instances.iter().collect();
         sort_sessions_inner(&mut refs, SortOrder::Newest, true);
 
@@ -2391,7 +2391,7 @@ mod tests {
         z_fav.favorite();
         let a_plain = Instance::new("apple", "/tmp/a");
 
-        let instances = vec![z_fav, a_plain];
+        let instances = [z_fav, a_plain];
 
         let mut refs: Vec<&Instance> = instances.iter().collect();
         sort_sessions_inner(&mut refs, SortOrder::AZ, true);
@@ -2412,7 +2412,7 @@ mod tests {
         let mut new_plain = Instance::new("new_plain", "/tmp/np");
         new_plain.created_at = chrono::Utc::now();
 
-        let instances = vec![snoozed_fav, new_plain];
+        let instances = [snoozed_fav, new_plain];
         let mut refs: Vec<&Instance> = instances.iter().collect();
         sort_sessions_inner(&mut refs, SortOrder::Newest, true);
 
@@ -2566,7 +2566,7 @@ mod tests {
         let mut plain_waiting = Instance::new("plain_waiting", "/tmp/pw");
         plain_waiting.status = crate::session::Status::Waiting;
 
-        let instances = vec![fav_idle, plain_waiting];
+        let instances = [fav_idle, plain_waiting];
 
         let mut on: Vec<&Instance> = instances.iter().collect();
         sort_sessions_inner(&mut on, SortOrder::Attention, true);

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -6040,47 +6040,6 @@ fn permission_response_tokens(
     }
 }
 
-#[cfg(test)]
-mod permission_response_tokens_tests {
-    use super::*;
-    use crate::agents::{KeyToken, PermissionResponse};
-    use crate::tui::dialogs::PermissionResponseChoice;
-
-    #[test]
-    fn maps_each_choice_to_its_own_field() {
-        let response = PermissionResponse {
-            allow: &[KeyToken::Literal("1")],
-            allow_always: Some(&[KeyToken::Literal("2")]),
-            deny: &[KeyToken::Literal("3")],
-        };
-        assert_eq!(
-            permission_response_tokens(&response, PermissionResponseChoice::Allow),
-            Some(response.allow)
-        );
-        assert_eq!(
-            permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
-            response.allow_always
-        );
-        assert_eq!(
-            permission_response_tokens(&response, PermissionResponseChoice::Deny),
-            Some(response.deny)
-        );
-    }
-
-    #[test]
-    fn allow_always_none_maps_to_none() {
-        let response = PermissionResponse {
-            allow: &[KeyToken::Named("Enter")],
-            allow_always: None,
-            deny: &[KeyToken::Named("Down"), KeyToken::Named("Enter")],
-        };
-        assert_eq!(
-            permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
-            None
-        );
-    }
-}
-
 impl HomeView {
     /// Whether the agent row is in a live status with its tmux pane up, so a
     /// revive cascade (`ensure_pane_ready` / `prepare_live_send`) is expected
@@ -7813,5 +7772,45 @@ impl HomeView {
     ) -> anyhow::Result<()> {
         self.try_mutate_instance(id, |inst| inst.start_container_terminal_with_size(size))
             .map(|_| ())
+    }
+}
+#[cfg(test)]
+mod permission_response_tokens_tests {
+    use super::*;
+    use crate::agents::{KeyToken, PermissionResponse};
+    use crate::tui::dialogs::PermissionResponseChoice;
+
+    #[test]
+    fn maps_each_choice_to_its_own_field() {
+        let response = PermissionResponse {
+            allow: &[KeyToken::Literal("1")],
+            allow_always: Some(&[KeyToken::Literal("2")]),
+            deny: &[KeyToken::Literal("3")],
+        };
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::Allow),
+            Some(response.allow)
+        );
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
+            response.allow_always
+        );
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::Deny),
+            Some(response.deny)
+        );
+    }
+
+    #[test]
+    fn allow_always_none_maps_to_none() {
+        let response = PermissionResponse {
+            allow: &[KeyToken::Named("Enter")],
+            allow_always: None,
+            deny: &[KeyToken::Named("Down"), KeyToken::Named("Enter")],
+        };
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Description

Carries the content of commit `d0bc6568` ("chore: fix clippy lints surfaced by rust 1.97") as its own standalone PR, per the maintainer review on #3485 requesting it be moved out of that change.

Fixes the two lints that fire under `cargo clippy --all-targets -- -D warnings`:

- `useless_vec` (5 sites): test fixtures in `src/session/groups.rs` build an immutable binding consumed only via `.iter()`, so `vec![a, b]` becomes `[a, b]`.
- `items_after_test_module` (1 site): `mod permission_response_tokens_tests` sat mid-file in `src/tui/home/mod.rs` with a later `impl HomeView` block after it; the module moved verbatim to the end of the file.

All changed code is `cfg(test)`; zero runtime behavior change. Before/after proof on clean checkouts of `origin/main` and this branch (rustc/clippy 1.97.1): before exits 101 with exactly those 6 errors, after exits 0. Targeted suites green: `session::groups` 78/78, `permission_response_tokens_tests` 2/2 (relocated), `tui::home` 796/796.

**Why a separate PR:** the GitHub Actions checks do not exercise these lints (`ci.yml` runs bare `cargo clippy -- -D warnings`; `tests.yml` uses `cargo check --all-targets`, which runs no clippy lints). The repo's own Nix gate does: `checks.aoe-clippy` (flake.nix) runs clippy with `--all-targets` and deny-warnings and is currently red on main; this change repairs its session/TUI portion. The remaining macOS-only `items_after_test_module` at `src/process/macos.rs:266` is pre-existing and intentionally out of scope here.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the change relocates test code and converts test fixtures; no observable contract is added. Both files' unit suites are re-run green above instead.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** ox-alpha (OpenRouter), driven via omp

**Any Additional AI Details you'd like to share:** Cherry-pick of `d0bc6568` authored by Jérôme Benoit onto fresh `origin/main`; the applied diff is verified byte-identical to the original commit's diff.
