### PR TITLE
fix(tui): stop forking tmux per row in Terminal and Tool views

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -252,6 +252,19 @@ struct SessionCache {
     data: Option<HashMap<String, i64>>,
     time: Option<Instant>,
 }
+
+/// Shared `tmux list-panes -a` snapshot behind [`pane_dead_for_display`],
+/// mirroring [`SESSION_CACHE`]'s TTL and its `data: None` "the server could
+/// not answer" state.
+static PANE_META_CACHE: RwLock<PaneMetaCache> = RwLock::new(PaneMetaCache {
+    data: None,
+    time: None,
+});
+
+struct PaneMetaCache {
+    data: Option<HashMap<String, PaneMetadata>>,
+    time: Option<Instant>,
+}
 const TMUX_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn run_tmux_command_with_timeout_inner(
@@ -1104,6 +1117,79 @@ pub fn session_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Session liveness for a **render path**, answered from the shared snapshot
+/// and never from a per-name probe.
+///
+/// [`session_exists`] falls through to a live `has-session` on a cache miss so
+/// teardown and drift decisions can't act on a cached false negative. A row
+/// glyph is neither of those, and that fallback costs one fork per call: the
+/// Terminal-view list called it once per visible row per frame, which measured
+/// 52ms/frame at 30 rows (1.7ms/row) against 47us for the agent view, whose
+/// rows read `Instance.status` straight from the poller's batched snapshot.
+///
+/// The trade is that a session created since the last scan reads as absent for
+/// up to [`CACHE_TTL`]. Call sites that start or kill a pane already force a
+/// [`refresh_session_cache`], so the glyph flips immediately there; the TTL
+/// only covers panes created behind this process's back.
+///
+/// An unreachable tmux server resolves to `false` (nothing to draw as live)
+/// without re-forking per row, because [`probe_session_existence`] treats a
+/// fresh "server did not answer" snapshot as an answer.
+pub fn session_exists_for_display(name: &str) -> bool {
+    matches!(probe_session_existence(name), SessionExistence::Present)
+}
+
+/// Pane-dead state for a **render path**, from a shared `list-panes -a`
+/// snapshot refreshed at most once per [`CACHE_TTL`].
+///
+/// The per-name [`utils::is_pane_dead`] forks a `display-message` on every
+/// call, so the Tool view paid two forks per row per frame (this plus
+/// existence). See [`session_exists_for_display`] for the measurement and the
+/// staleness trade.
+///
+/// Returns `false` ("not known to be dead") for a session missing from the
+/// snapshot and whenever the snapshot could not be produced, matching
+/// [`batch_pane_metadata`]'s contract that an `Err` means "don't know" rather
+/// than "everything is dead". Callers gate on existence first, so a missing
+/// key is an absent session rather than a live pane.
+pub fn pane_dead_for_display(name: &str) -> bool {
+    if let Some(dead) = pane_dead_from_cache(name) {
+        return dead;
+    }
+    refresh_pane_meta_cache();
+    pane_dead_from_cache(name).unwrap_or(false)
+}
+
+/// Resolve from the current pane snapshot without spawning. `None` only when
+/// the snapshot is stale or the lock is poisoned, so the caller knows a
+/// refresh could still change the answer. A fresh snapshot with no data is an
+/// answer (`Some(false)`, "can't tell, don't claim dead"), not a stale one, or
+/// every row would re-refresh into the same failure.
+fn pane_dead_from_cache(name: &str) -> Option<bool> {
+    let cache = PANE_META_CACHE.read().ok()?;
+    if cache.time.map(|t| t.elapsed() > CACHE_TTL).unwrap_or(true) {
+        return None;
+    }
+    Some(
+        cache
+            .data
+            .as_ref()
+            .and_then(|map| map.get(name))
+            .is_some_and(|meta| meta.pane_dead),
+    )
+}
+
+/// Repopulate [`PANE_META_CACHE`]. The timestamp is stamped even when the
+/// query fails, so a tmux outage costs one fork per [`CACHE_TTL`] instead of
+/// one per row per frame.
+fn refresh_pane_meta_cache() {
+    let data = batch_pane_metadata().ok();
+    if let Ok(mut cache) = PANE_META_CACHE.write() {
+        cache.data = data;
+        cache.time = Some(Instant::now());
+    }
+}
+
 pub fn get_current_session_name() -> Option<String> {
     let output = tmux_command()
         .args(["display-message", "-p", "#{session_name}"])
@@ -1897,6 +1983,47 @@ mod tests {
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn display_liveness_answers_from_the_snapshot_instead_of_probing_per_name() {
+        // The render path's contract: `session_exists_for_display` reads the
+        // shared snapshot, where `session_exists` falls through to a live
+        // `has-session` on a miss. Only a snapshot that DISAGREES with tmux
+        // separates them, so force one that says "server reachable, zero
+        // sessions" while a real pane is live. Getting this wrong costs one
+        // fork per row per frame (~1.7ms each), which is what stalled the
+        // Terminal-view list at ~19fps.
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = SessionCacheGuard::capture();
+        let session = test_helpers::TmuxTestSession::new(&format!("{SESSION_PREFIX}display_probe"));
+        let created = tmux_command()
+            .args(["new-session", "-d", "-s", session.name(), "sleep 60"])
+            .output()
+            .expect("tmux new-session");
+        assert!(created.status.success());
+
+        // No fork between forcing the snapshot and reading it, so the TTL
+        // cannot expire out from under the assertions.
+        guard.force_present(&[]);
+        assert!(
+            !session_exists_for_display(session.name()),
+            "display path must answer from the snapshot, not probe tmux"
+        );
+        assert!(
+            session_exists(session.name()),
+            "the probing path must see the live pane the snapshot missed; \
+             without this the test would pass on a broken snapshot too"
+        );
+
+        // And a snapshot that lists the session resolves live without tmux
+        // being consulted at all.
+        guard.force_present(&[session.name()]);
+        assert!(session_exists_for_display(session.name()));
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1006,6 +1006,45 @@ impl Drop for SessionCacheGuard {
     }
 }
 
+/// [`SessionCacheGuard`] for [`PANE_META_CACHE`]: captures the prior snapshot
+/// and restores it on `Drop` so a mid-test panic cannot leak a forced state
+/// into a later test. Pair with `#[serial_test::serial]`.
+#[cfg(test)]
+pub(crate) struct PaneMetaCacheGuard {
+    prev_data: Option<HashMap<String, PaneMetadata>>,
+    prev_time: Option<Instant>,
+}
+
+#[cfg(test)]
+impl PaneMetaCacheGuard {
+    pub(crate) fn capture() -> Self {
+        let cache = PANE_META_CACHE.read().expect("pane meta cache lock");
+        Self {
+            prev_data: cache.data.clone(),
+            prev_time: cache.time,
+        }
+    }
+
+    /// Force a fresh snapshot that carries no data: what `refresh_pane_meta_cache`
+    /// writes when `batch_pane_metadata` fails.
+    pub(crate) fn force_failed_refresh(&self) {
+        if let Ok(mut cache) = PANE_META_CACHE.write() {
+            cache.data = None;
+            cache.time = Some(Instant::now());
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for PaneMetaCacheGuard {
+    fn drop(&mut self) {
+        if let Ok(mut cache) = PANE_META_CACHE.write() {
+            cache.data = self.prev_data.take();
+            cache.time = self.prev_time;
+        }
+    }
+}
+
 /// How long a [`SESSION_CACHE`] snapshot is trusted before a lookup must
 /// force a fresh `refresh_session_cache()` call.
 const CACHE_TTL: Duration = Duration::from_secs(2);
@@ -1128,7 +1167,7 @@ pub fn session_exists(name: &str) -> bool {
 /// rows read `Instance.status` straight from the poller's batched snapshot.
 ///
 /// The trade is that a session created since the last scan reads as absent for
-/// up to [`CACHE_TTL`]. Call sites that start or kill a pane already force a
+/// up to `CACHE_TTL`. Call sites that start or kill a pane already force a
 /// [`refresh_session_cache`], so the glyph flips immediately there; the TTL
 /// only covers panes created behind this process's back.
 ///
@@ -1140,9 +1179,9 @@ pub fn session_exists_for_display(name: &str) -> bool {
 }
 
 /// Pane-dead state for a **render path**, from a shared `list-panes -a`
-/// snapshot refreshed at most once per [`CACHE_TTL`].
+/// snapshot refreshed at most once per `CACHE_TTL`.
 ///
-/// The per-name [`utils::is_pane_dead`] forks a `display-message` on every
+/// The per-name `utils::is_pane_dead` forks a `display-message` on every
 /// call, so the Tool view paid two forks per row per frame (this plus
 /// existence). See [`session_exists_for_display`] for the measurement and the
 /// staleness trade.
@@ -1983,6 +2022,30 @@ mod tests {
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn a_failed_pane_snapshot_is_an_answer_so_rows_do_not_re_fork() {
+        // `refresh_pane_meta_cache` stamps `time` even when `batch_pane_metadata`
+        // fails, and `pane_dead_from_cache` gates on `time` alone. That pairing is
+        // what bounds a tmux outage to one fork per CACHE_TTL instead of one per
+        // row per frame: if a fresh-but-empty snapshot resolved to `None`, every
+        // Tool row would drive another doomed refresh, which is the per-row fork
+        // this whole change removes.
+        let guard = PaneMetaCacheGuard::capture();
+        guard.force_failed_refresh();
+
+        assert_eq!(
+            pane_dead_from_cache("aoe_tool_absent_00000000"),
+            Some(false),
+            "a fresh snapshot with no data must answer \"can't tell, not dead\", \
+             not report itself stale"
+        );
+        assert!(
+            !pane_dead_for_display("aoe_tool_absent_00000000"),
+            "and the display helper must not claim a pane it cannot see is dead"
+        );
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -396,6 +396,100 @@ pub(crate) fn agent_row_icon(inst: &crate::session::Instance) -> &'static str {
     }
 }
 
+/// A view mode's contribution to a session row: the glyph, color, and any
+/// modifier describing the state of *its own* backing pane. Structured seeds
+/// from the poller-maintained `Instance.status`, Terminal from the paired
+/// terminal's liveness, Tool from the tool pane's. Everything layered on top
+/// is mode-independent and lives in [`decorate_row`].
+struct RowSeed {
+    icon: &'static str,
+    color: Color,
+    modifier: ratatui::style::Modifier,
+}
+
+/// The archive/trash, snooze, urgent, and favorite overlays every view mode
+/// paints on top of its [`RowSeed`], plus the title prefix that goes with them.
+///
+/// This was three copies: the Structured and Terminal arms of
+/// `render_item_line` carried byte-identical title blocks and near-identical
+/// style blocks, and the Tool arm had silently dropped all of it, so an
+/// archived or snoozed session in Tool view kept painting its running glyph
+/// with no `z ` / `! ` prefix.
+///
+/// `sunk_icon` is the glyph a sunk row (archived / trashed / snoozed) falls
+/// back to: [`agent_row_icon`] for Structured, [`ICON_STOPPED`] for the pane
+/// views, which have no richer resting state to show.
+fn decorate_row(
+    inst: &crate::session::Instance,
+    in_attention: bool,
+    show_favorite: bool,
+    seed: RowSeed,
+    sunk_icon: &'static str,
+    theme: &Theme,
+) -> (&'static str, std::borrow::Cow<'static, str>, Style) {
+    use ratatui::style::Modifier;
+    use std::borrow::Cow;
+
+    let mut icon = seed.icon;
+    let mut style = Style::default().fg(seed.color).add_modifier(seed.modifier);
+
+    // Error and Deleting are live delete-op states this TUI set (a failed or
+    // in-flight permanent delete), not stale persisted pane statuses, so they
+    // punch through the sunk-row mask; swallowing them left a failed Empty
+    // Trash indistinguishable from a healthy trash row. `agent_row_icon`
+    // applies the same exception to the glyph.
+    let live_delete_op = matches!(inst.status, Status::Error | Status::Deleting);
+    if (inst.is_archived() || inst.is_trashed()) && !live_delete_op {
+        // Archived and trashed rows render with one uniform muted glyph
+        // regardless of underlying pane status. The pane is dead, so painting
+        // the persisted status would be misleading. The Archived section
+        // header is the sole textual cue, so no italic/dim modifier here; just
+        // a dim color.
+        icon = sunk_icon;
+        style = Style::default().fg(theme.dimmed);
+    } else if in_attention && inst.is_snoozed() {
+        // Snooze decoration is Attention-only. Outside Attention the row
+        // paints its real state (the timer keeps running; the visual
+        // treatment just doesn't surface).
+        icon = sunk_icon;
+        style = Style::default()
+            .fg(theme.dimmed)
+            .add_modifier(Modifier::ITALIC)
+            .add_modifier(Modifier::DIM);
+    } else if in_attention && inst.is_urgent() {
+        // Urgent decoration is Attention-only. The flag still persists in
+        // non-Attention modes, but the cross-tier promoter visual only makes
+        // sense when tier ordering is in effect.
+        style = Style::default()
+            .fg(theme.error)
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::RAPID_BLINK);
+    } else if show_favorite && crate::session::is_live_favorite(inst) {
+        style = style
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::UNDERLINED);
+    }
+
+    // Prefix priority: archive (no prefix) wins over snooze (`z `) wins over
+    // urgent (`! `) wins over favorite (`* `). Snooze and urgent are
+    // Attention-mode-only so users in Newest / AZ / etc. don't see decoration
+    // for state they didn't opt into managing; the favorite star also shows
+    // elsewhere, because favorites-first pins the row there too.
+    let title_text = if inst.is_archived() || inst.is_trashed() {
+        Cow::Owned(inst.title.clone())
+    } else if in_attention && inst.is_snoozed() {
+        Cow::Owned(format!("z {}", inst.title))
+    } else if in_attention && inst.is_urgent() {
+        Cow::Owned(format!("! {}", inst.title))
+    } else if show_favorite && crate::session::is_live_favorite(inst) {
+        Cow::Owned(format!("* {}", inst.title))
+    } else {
+        Cow::Owned(inst.title.clone())
+    };
+
+    (icon, title_text, style)
+}
+
 /// Append the selected row's `last_error` (in red) to a shelf placeholder's
 /// lines when the row sits in `Status::Error`. A failed permanent delete
 /// parks a trashed/archived row exactly here (`apply_deletion_results`);
@@ -1482,7 +1576,11 @@ impl HomeView {
             }
             Item::Session { id, .. } => {
                 if let Some(inst) = self.get_instance(id) {
-                    match self.view_mode {
+                    // Each view mode contributes only the live-state glyph
+                    // and color for its own backing pane; every overlay on top
+                    // of that (archive/trash, snooze, urgent, favorite) is
+                    // mode-independent and belongs to `decorate_row`.
+                    let (seed, sunk_icon) = match self.view_mode {
                         ViewMode::Structured => {
                             // For Idle sessions, decay color from `fresh_idle`
                             // toward `idle` over `idle_decay_window`. A slow
@@ -1492,11 +1590,6 @@ impl HomeView {
                             // attention-worthy states (Running, Waiting,
                             // Starting). Also serves as a redundant cue for
                             // colorblind users / monochrome terminals.
-                            //
-                            // Archive/snooze then overrides the live spinner.
-                            // A shelved session's underlying status is noise;
-                            // an animated row reads as "still alive" and pulls
-                            // the eye away from real attention items.
                             let idle_age = inst.idle_age();
                             let is_fresh_idle =
                                 matches!(idle_age, Some(age) if age < self.idle_decay_window);
@@ -1530,16 +1623,15 @@ impl HomeView {
                             // Starting/...) supersedes it and keeps its own
                             // color AND spinner. Auto-unread only ever lands
                             // on Idle; a manual flag on a live row defers to
-                            // the live state. Archived/snoozed/urgent below
-                            // still override on top.
-                            // Sunk rows (archived/snoozed) never paint unread:
-                            // the user dismissed the row, so surfacing it as
-                            // unread contradicts that. The flag stays on disk,
-                            // so unarchiving/unsnoozing restores it. Snooze is
-                            // checked in every sort mode here (unlike the
-                            // Attention-only snooze decoration below), so a
-                            // snoozed unread row outside Attention sort still
-                            // drops the dot (#2571).
+                            // the live state. Sunk rows (archived/snoozed)
+                            // never paint unread: the user dismissed the row,
+                            // so surfacing it as unread contradicts that. The
+                            // flag stays on disk, so unarchiving/unsnoozing
+                            // restores it. Snooze is checked in every sort
+                            // mode here (unlike the Attention-only snooze
+                            // decoration in `decorate_row`), so a snoozed
+                            // unread row outside Attention sort still drops
+                            // the dot (#2571).
                             let unread_resting = crate::session::unread_enabled()
                                 && inst.is_unread()
                                 && !inst.is_archived()
@@ -1564,78 +1656,23 @@ impl HomeView {
                                     Status::Creating => theme.accent,
                                 }
                             };
-                            let mut style = Style::default().fg(color);
+                            let mut modifier = ratatui::style::Modifier::empty();
                             if unread_resting {
                                 // Make unread unmistakable: a solid dot glyph
                                 // plus bold, on top of the `theme.unread`
                                 // color set above. A plain color swap read as
-                                // too subtle (#2088 review). Sink/urgent
-                                // states below still override icon + style.
+                                // too subtle (#2088 review).
                                 icon = ICON_UNREAD;
-                                style = style.add_modifier(ratatui::style::Modifier::BOLD);
+                                modifier = ratatui::style::Modifier::BOLD;
                             }
-                            if (inst.is_archived() || inst.is_trashed())
-                                && !matches!(inst.status, Status::Error | Status::Deleting)
-                            {
-                                // Archived and trashed rows render with one
-                                // uniform muted glyph regardless of underlying
-                                // pane status. The pane is dead, so painting
-                                // the persisted Running/Waiting status
-                                // would be misleading. The Archived
-                                // section header is the sole textual
-                                // cue, so no italic/dim modifier is
-                                // applied here; just a dim color. Error and
-                                // Deleting are live delete-operation states,
-                                // not pane statuses, so they keep their real
-                                // glyph and color (see `agent_row_icon`).
-                                icon = agent_row_icon(inst);
-                                style = Style::default().fg(theme.dimmed);
-                            } else if in_attention && inst.is_snoozed() {
-                                // Snooze decoration is Attention-only.
-                                // Outside Attention the row paints its
-                                // real status (the timer keeps running;
-                                // the visual treatment just doesn't
-                                // surface).
-                                icon = agent_row_icon(inst);
-                                style = Style::default()
-                                    .fg(theme.dimmed)
-                                    .add_modifier(ratatui::style::Modifier::ITALIC)
-                                    .add_modifier(ratatui::style::Modifier::DIM);
-                            } else if in_attention && inst.is_urgent() {
-                                // Urgent decoration is Attention-only.
-                                // The flag still persists in non-
-                                // Attention modes, but the cross-tier
-                                // promoter visual only makes sense when
-                                // tier ordering is in effect.
-                                style = Style::default()
-                                    .fg(theme.error)
-                                    .add_modifier(ratatui::style::Modifier::BOLD)
-                                    .add_modifier(ratatui::style::Modifier::RAPID_BLINK);
-                            } else if show_favorite && crate::session::is_live_favorite(inst) {
-                                style = style
-                                    .add_modifier(ratatui::style::Modifier::BOLD)
-                                    .add_modifier(ratatui::style::Modifier::UNDERLINED);
-                            }
-                            // Prefix priority: archive (no prefix) wins
-                            // over snooze (`z `) wins over urgent (`! `)
-                            // wins over favorite (`* `). Snooze and urgent
-                            // are Attention-mode-only so users in Newest /
-                            // AZ / etc. don't see decoration for state they
-                            // didn't opt into managing; the favorite star
-                            // also shows elsewhere, because favorites-first
-                            // pins the row there too.
-                            let title_text = if inst.is_archived() || inst.is_trashed() {
-                                Cow::Owned(inst.title.clone())
-                            } else if in_attention && inst.is_snoozed() {
-                                Cow::Owned(format!("z {}", inst.title))
-                            } else if in_attention && inst.is_urgent() {
-                                Cow::Owned(format!("! {}", inst.title))
-                            } else if show_favorite && crate::session::is_live_favorite(inst) {
-                                Cow::Owned(format!("* {}", inst.title))
-                            } else {
-                                Cow::Owned(inst.title.clone())
-                            };
-                            (icon, title_text, style)
+                            (
+                                RowSeed {
+                                    icon,
+                                    color,
+                                    modifier,
+                                },
+                                agent_row_icon(inst),
+                            )
                         }
                         ViewMode::Terminal => {
                             // For sandboxed sessions, check the appropriate terminal based on mode
@@ -1645,85 +1682,58 @@ impl HomeView {
                                 TerminalMode::Host
                             };
                             let terminal_running = match terminal_mode {
-                                TerminalMode::Container => inst
-                                    .container_terminal_tmux_session()
-                                    .map(|s| s.exists())
-                                    .unwrap_or(false),
-                                TerminalMode::Host => inst
-                                    .terminal_tmux_session()
-                                    .map(|s| s.exists())
-                                    .unwrap_or(false),
+                                TerminalMode::Container => {
+                                    inst.container_terminal_tmux_session().is_ok_and(|s| {
+                                        crate::tmux::session_exists_for_display(s.name())
+                                    })
+                                }
+                                TerminalMode::Host => inst.terminal_tmux_session().is_ok_and(|s| {
+                                    crate::tmux::session_exists_for_display(s.name())
+                                }),
                             };
                             // Unread is an Agent-view concept: it means the agent
                             // produced output the user hasn't looked at. The
                             // paired terminal has no such notion, so Terminal
                             // view never paints the unread dot; the row just
                             // tracks whether its terminal pane is live.
-                            let (mut icon, color) = if terminal_running {
+                            let (icon, color) = if terminal_running {
                                 (spinner_running(&inst.created_at), theme.terminal_active)
                             } else {
                                 (ICON_IDLE, theme.dimmed)
                             };
-                            let mut style = Style::default().fg(color);
-                            if inst.is_archived() || inst.is_trashed() {
-                                // Archive/trash lifecycle override mirrors the
-                                // Agent-view path: dim color, stopped
-                                // icon, no italic/dim modifier; the
-                                // Archived section header is the cue.
-                                icon = ICON_STOPPED;
-                                style = Style::default().fg(theme.dimmed);
-                            } else if in_attention && inst.is_snoozed() {
-                                icon = ICON_STOPPED;
-                                style = Style::default()
-                                    .fg(theme.dimmed)
-                                    .add_modifier(ratatui::style::Modifier::ITALIC)
-                                    .add_modifier(ratatui::style::Modifier::DIM);
-                            } else if in_attention && inst.is_urgent() {
-                                style = Style::default()
-                                    .fg(theme.error)
-                                    .add_modifier(ratatui::style::Modifier::BOLD)
-                                    .add_modifier(ratatui::style::Modifier::RAPID_BLINK);
-                            } else if show_favorite && crate::session::is_live_favorite(inst) {
-                                style = style
-                                    .add_modifier(ratatui::style::Modifier::BOLD)
-                                    .add_modifier(ratatui::style::Modifier::UNDERLINED);
-                            }
-                            let title_text = if inst.is_archived() || inst.is_trashed() {
-                                Cow::Owned(inst.title.clone())
-                            } else if in_attention && inst.is_snoozed() {
-                                Cow::Owned(format!("z {}", inst.title))
-                            } else if in_attention && inst.is_urgent() {
-                                Cow::Owned(format!("! {}", inst.title))
-                            } else if show_favorite && crate::session::is_live_favorite(inst) {
-                                Cow::Owned(format!("* {}", inst.title))
-                            } else {
-                                Cow::Owned(inst.title.clone())
-                            };
-                            (icon, title_text, style)
+                            (
+                                RowSeed {
+                                    icon,
+                                    color,
+                                    modifier: ratatui::style::Modifier::empty(),
+                                },
+                                ICON_STOPPED,
+                            )
                         }
                         ViewMode::Tool(ref tool_name) => {
                             let tool_session =
                                 crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
-                            let tool_running =
-                                tool_session.exists() && !tool_session.is_pane_dead();
+                            let tool_running = crate::tmux::session_exists_for_display(
+                                tool_session.session_name(),
+                            ) && !crate::tmux::pane_dead_for_display(
+                                tool_session.session_name(),
+                            );
                             let (icon, color) = if tool_running {
                                 (spinner_running(&inst.created_at), theme.terminal_active)
                             } else {
                                 (ICON_IDLE, theme.dimmed)
                             };
-                            let mut style = Style::default().fg(color);
-                            let title_text =
-                                if show_favorite && crate::session::is_live_favorite(inst) {
-                                    style = style
-                                        .add_modifier(ratatui::style::Modifier::BOLD)
-                                        .add_modifier(ratatui::style::Modifier::UNDERLINED);
-                                    Cow::Owned(format!("* {}", inst.title))
-                                } else {
-                                    Cow::Owned(inst.title.clone())
-                                };
-                            (icon, title_text, style)
+                            (
+                                RowSeed {
+                                    icon,
+                                    color,
+                                    modifier: ratatui::style::Modifier::empty(),
+                                },
+                                ICON_STOPPED,
+                            )
                         }
-                    }
+                    };
+                    decorate_row(inst, in_attention, show_favorite, seed, sunk_icon, theme)
                 } else {
                     (
                         "?",

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -407,6 +407,23 @@ struct RowSeed {
     modifier: ratatui::style::Modifier,
 }
 
+/// How a view mode resolves a sunk row (archived / trashed / snoozed).
+enum SunkRow {
+    /// Structured: the agent's own resting glyph. Error and Deleting punch
+    /// through the sink mask here, because they are live delete-op states this
+    /// TUI set rather than stale pane statuses, and the seed carries
+    /// `ICON_ERROR` + `theme.error` for them. Swallowing that left a failed
+    /// Empty Trash indistinguishable from a healthy trash row.
+    /// [`agent_row_icon`] applies the same exception to the glyph.
+    AgentStatus(&'static str),
+    /// Terminal / Tool: one muted glyph, unconditionally. These seeds describe
+    /// pane liveness and carry no error affordance, so letting a delete-op
+    /// status punch through would paint a bright animated "the terminal is
+    /// alive" row inside a shelf whose whole premise is that the row is put
+    /// away, while signalling nothing about the failure.
+    Pane,
+}
+
 /// The archive/trash, snooze, urgent, and favorite overlays every view mode
 /// paints on top of its [`RowSeed`], plus the title prefix that goes with them.
 ///
@@ -416,15 +433,13 @@ struct RowSeed {
 /// archived or snoozed session in Tool view kept painting its running glyph
 /// with no `z ` / `! ` prefix.
 ///
-/// `sunk_icon` is the glyph a sunk row (archived / trashed / snoozed) falls
-/// back to: [`agent_row_icon`] for Structured, [`ICON_STOPPED`] for the pane
-/// views, which have no richer resting state to show.
+/// `sunk` says how this view resolves a sunk row; see [`SunkRow`].
 fn decorate_row(
     inst: &crate::session::Instance,
     in_attention: bool,
     show_favorite: bool,
     seed: RowSeed,
-    sunk_icon: &'static str,
+    sunk: SunkRow,
     theme: &Theme,
 ) -> (&'static str, std::borrow::Cow<'static, str>, Style) {
     use ratatui::style::Modifier;
@@ -433,13 +448,14 @@ fn decorate_row(
     let mut icon = seed.icon;
     let mut style = Style::default().fg(seed.color).add_modifier(seed.modifier);
 
-    // Error and Deleting are live delete-op states this TUI set (a failed or
-    // in-flight permanent delete), not stale persisted pane statuses, so they
-    // punch through the sunk-row mask; swallowing them left a failed Empty
-    // Trash indistinguishable from a healthy trash row. `agent_row_icon`
-    // applies the same exception to the glyph.
-    let live_delete_op = matches!(inst.status, Status::Error | Status::Deleting);
-    if (inst.is_archived() || inst.is_trashed()) && !live_delete_op {
+    let (sunk_icon, punches_through) = match sunk {
+        SunkRow::AgentStatus(resting) => (
+            resting,
+            matches!(inst.status, Status::Error | Status::Deleting),
+        ),
+        SunkRow::Pane => (ICON_STOPPED, false),
+    };
+    if (inst.is_archived() || inst.is_trashed()) && !punches_through {
         // Archived and trashed rows render with one uniform muted glyph
         // regardless of underlying pane status. The pane is dead, so painting
         // the persisted status would be misleading. The Archived section
@@ -1580,7 +1596,7 @@ impl HomeView {
                     // and color for its own backing pane; every overlay on top
                     // of that (archive/trash, snooze, urgent, favorite) is
                     // mode-independent and belongs to `decorate_row`.
-                    let (seed, sunk_icon) = match self.view_mode {
+                    let (seed, sunk) = match self.view_mode {
                         ViewMode::Structured => {
                             // For Idle sessions, decay color from `fresh_idle`
                             // toward `idle` over `idle_decay_window`. A slow
@@ -1671,7 +1687,7 @@ impl HomeView {
                                     color,
                                     modifier,
                                 },
-                                agent_row_icon(inst),
+                                SunkRow::AgentStatus(agent_row_icon(inst)),
                             )
                         }
                         ViewMode::Terminal => {
@@ -1707,7 +1723,7 @@ impl HomeView {
                                     color,
                                     modifier: ratatui::style::Modifier::empty(),
                                 },
-                                ICON_STOPPED,
+                                SunkRow::Pane,
                             )
                         }
                         ViewMode::Tool(ref tool_name) => {
@@ -1729,11 +1745,11 @@ impl HomeView {
                                     color,
                                     modifier: ratatui::style::Modifier::empty(),
                                 },
-                                ICON_STOPPED,
+                                SunkRow::Pane,
                             )
                         }
                     };
-                    decorate_row(inst, in_attention, show_favorite, seed, sunk_icon, theme)
+                    decorate_row(inst, in_attention, show_favorite, seed, sunk, theme)
                 } else {
                     (
                         "?",

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2962,22 +2962,25 @@ impl HomeView {
 
                     // Now borrow instance for rendering
                     if let Some(inst) = self.get_instance(&id) {
+                        // Snapshot-backed like the list rows: this runs on
+                        // every frame, and the preview capture above is already
+                        // worker-driven, so a per-name `has-session` here would
+                        // be the only fork left in a steady-state frame.
                         let (terminal_running, preview_text) = match terminal_mode {
                             TerminalMode::Container => {
-                                let running = inst
-                                    .container_terminal_tmux_session()
-                                    .map(|s| s.exists())
-                                    .unwrap_or(false);
+                                let running =
+                                    inst.container_terminal_tmux_session().is_ok_and(|s| {
+                                        crate::tmux::session_exists_for_display(s.name())
+                                    });
                                 (
                                     running,
                                     self.container_terminal_preview_cache.parsed_text.as_ref(),
                                 )
                             }
                             TerminalMode::Host => {
-                                let running = inst
-                                    .terminal_tmux_session()
-                                    .map(|s| s.exists())
-                                    .unwrap_or(false);
+                                let running = inst.terminal_tmux_session().is_ok_and(|s| {
+                                    crate::tmux::session_exists_for_display(s.name())
+                                });
                                 (running, self.terminal_preview_cache.parsed_text.as_ref())
                             }
                         };
@@ -3040,7 +3043,12 @@ impl HomeView {
                     if let Some(inst) = self.get_instance(&id) {
                         let tool_session =
                             crate::tmux::ToolSession::new(&inst.id, &inst.title, &tool_name);
-                        let tool_running = tool_session.exists() && !tool_session.is_pane_dead();
+                        // Snapshot-backed for the same reason as the rows:
+                        // this pair used to be the two remaining per-frame
+                        // forks on the render thread in Tool view.
+                        let tool_running =
+                            crate::tmux::session_exists_for_display(tool_session.session_name())
+                                && !crate::tmux::pane_dead_for_display(tool_session.session_name());
 
                         Preview::render_terminal_preview(
                             frame,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20385,5 +20385,27 @@ fn every_view_mode_paints_the_same_sunk_row_decoration() {
                 "{mode:?}/{label}: wrong title decoration"
             );
         }
+
+        // Error and Deleting punch through the sink mask in Structured only.
+        // There the seed carries ICON_ERROR + theme.error, so a failed Empty
+        // Trash stays distinguishable from a healthy trash row. The pane views
+        // seed from terminal liveness and have no error affordance, so
+        // punching through would paint a bright animated "still alive" row
+        // inside the Archived shelf while signalling nothing about the failure.
+        for status in [Status::Error, Status::Deleting] {
+            seed_panes_live();
+            env.view.mutate_instance(&id, |inst| {
+                inst.status = status;
+                inst.archived_at = Some(chrono::Utc::now());
+                inst.snoozed_until = None;
+            });
+            let line = env.view.render_item_line(&item, false, false, &theme, 120);
+            let sunk = line.spans[1].style.fg == Some(theme.dimmed);
+            assert_eq!(
+                sunk,
+                !matches!(mode, ViewMode::Structured),
+                "{mode:?}/archived+{status:?}: only Structured may punch through the sink mask"
+            );
+        }
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20265,3 +20265,86 @@ mod daemon_status_apply_tests {
         }
     }
 }
+
+#[test]
+#[serial]
+fn every_view_mode_paints_the_same_sunk_row_decoration() {
+    // `render_item_line`'s three view arms each carried their own copy of the
+    // archive / snooze / favorite block (Structured and Terminal had
+    // byte-identical title blocks), and the Tool arm had none at all: an
+    // archived or snoozed session in Tool view kept painting its live glyph
+    // with no `z ` prefix. `decorate_row` owns the overlay for every mode now,
+    // so the three must agree.
+    use super::{ViewMode, ICON_STOPPED};
+    use crate::session::Status;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+    // Snooze decoration is Attention-gated; archive is universal.
+    env.view.sort_order = crate::session::config::SortOrder::Attention;
+    let theme = crate::tui::styles::Theme::default();
+    let item = Item::Session {
+        id: id.clone(),
+        depth: 0,
+    };
+
+    // (label, archived, snoozed, expected title prefix)
+    let cases = [
+        ("archived", true, false, ""),
+        ("snoozed", false, true, "z "),
+    ];
+
+    for mode in [
+        ViewMode::Structured,
+        ViewMode::Terminal,
+        ViewMode::Tool("lazygit".to_string()),
+    ] {
+        env.view.view_mode = mode.clone();
+        for (label, archived, snoozed, prefix) in cases {
+            // Status stays Running so the live-glyph branch would fire in
+            // every mode if the sink override were missing.
+            env.view.mutate_instance(&id, |inst| {
+                inst.status = Status::Running;
+                inst.archived_at = archived.then(chrono::Utc::now);
+                inst.snoozed_until =
+                    snoozed.then(|| chrono::Utc::now() + chrono::Duration::minutes(15));
+            });
+
+            let line = env.view.render_item_line(&item, false, false, &theme, 120);
+            let icon = line.spans[1].content.trim().to_string();
+            let title = line.spans[2].content.to_string();
+
+            assert_eq!(
+                icon, ICON_STOPPED,
+                "{mode:?}/{label}: sunk row must drop its live glyph"
+            );
+            assert_eq!(
+                line.spans[1].style.fg,
+                Some(theme.dimmed),
+                "{mode:?}/{label}: sunk row must paint dimmed"
+            );
+            assert!(
+                title.starts_with(prefix) && title.contains("session0"),
+                "{mode:?}/{label}: expected {prefix:?} prefix, got {title:?}"
+            );
+        }
+    }
+
+    // Sanity: a live row in every mode must NOT collapse to the sunk glyph,
+    // or the assertions above would pass on a renderer that always sinks.
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = Status::Running;
+        inst.archived_at = None;
+        inst.snoozed_until = None;
+    });
+    env.view.view_mode = ViewMode::Structured;
+    let line = env.view.render_item_line(&item, false, false, &theme, 120);
+    assert_ne!(
+        line.spans[1].content.trim(),
+        ICON_STOPPED,
+        "a live Structured row must keep its spinner"
+    );
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20275,14 +20275,29 @@ fn every_view_mode_paints_the_same_sunk_row_decoration() {
     // archived or snoozed session in Tool view kept painting its live glyph
     // with no `z ` prefix. `decorate_row` owns the overlay for every mode now,
     // so the three must agree.
+    //
+    // The pane views are seeded live on purpose. `ICON_IDLE` and `ICON_STOPPED`
+    // are the same glyph and an unseeded pane row is already dimmed, so a row
+    // whose terminal is NOT running renders identically with and without the
+    // sink override, and every assertion below would pass on a renderer that
+    // dropped `decorate_row` entirely. Injecting the pane names into the shared
+    // tmux snapshot makes the seed a bright animated spinner, which is what
+    // gives the override something to actually override.
     use super::{ViewMode, ICON_STOPPED};
     use crate::session::Status;
+    use ratatui::style::Modifier;
 
     let mut env = create_test_env_with_sessions(1);
     let id = match env.view.flat_items.first() {
         Some(Item::Session { id, .. }) => id.clone(),
         _ => panic!("expected the fixture to seed a single Session item"),
     };
+    let title = env
+        .view
+        .get_instance(&id)
+        .expect("session present")
+        .title
+        .clone();
     // Snooze decoration is Attention-gated; archive is universal.
     env.view.sort_order = crate::session::config::SortOrder::Attention;
     let theme = crate::tui::styles::Theme::default();
@@ -20291,10 +20306,25 @@ fn every_view_mode_paints_the_same_sunk_row_decoration() {
         depth: 0,
     };
 
-    // (label, archived, snoozed, expected title prefix)
+    let seed_panes_live = || {
+        crate::tmux::test_inject_session_into_cache(&crate::tmux::TerminalSession::generate_name(
+            &id, &title,
+        ));
+        crate::tmux::test_inject_session_into_cache(&crate::tmux::ToolSession::generate_name(
+            &id, &title, "lazygit",
+        ));
+    };
+
+    // (label, archived, snoozed, expected title prefix, extra modifiers)
     let cases = [
-        ("archived", true, false, ""),
-        ("snoozed", false, true, "z "),
+        ("archived", true, false, "", Modifier::empty()),
+        (
+            "snoozed",
+            false,
+            true,
+            "z ",
+            Modifier::ITALIC | Modifier::DIM,
+        ),
     ];
 
     for mode in [
@@ -20303,7 +20333,25 @@ fn every_view_mode_paints_the_same_sunk_row_decoration() {
         ViewMode::Tool("lazygit".to_string()),
     ] {
         env.view.view_mode = mode.clone();
-        for (label, archived, snoozed, prefix) in cases {
+
+        // Anti-vacuity: a live, unsunk row must NOT already look sunk, or the
+        // sink assertions below prove nothing about this mode.
+        seed_panes_live();
+        env.view.mutate_instance(&id, |inst| {
+            inst.status = Status::Running;
+            inst.archived_at = None;
+            inst.snoozed_until = None;
+        });
+        let live = env.view.render_item_line(&item, false, false, &theme, 120);
+        assert_ne!(
+            live.spans[1].style.fg,
+            Some(theme.dimmed),
+            "{mode:?}: a live row must not already paint dimmed; \
+             the sink assertions below would be vacuous"
+        );
+
+        for (label, archived, snoozed, prefix, extra) in cases {
+            seed_panes_live();
             // Status stays Running so the live-glyph branch would fire in
             // every mode if the sink override were missing.
             env.view.mutate_instance(&id, |inst| {
@@ -20315,7 +20363,7 @@ fn every_view_mode_paints_the_same_sunk_row_decoration() {
 
             let line = env.view.render_item_line(&item, false, false, &theme, 120);
             let icon = line.spans[1].content.trim().to_string();
-            let title = line.spans[2].content.to_string();
+            let rendered = line.spans[2].content.to_string();
 
             assert_eq!(
                 icon, ICON_STOPPED,
@@ -20327,24 +20375,15 @@ fn every_view_mode_paints_the_same_sunk_row_decoration() {
                 "{mode:?}/{label}: sunk row must paint dimmed"
             );
             assert!(
-                title.starts_with(prefix) && title.contains("session0"),
-                "{mode:?}/{label}: expected {prefix:?} prefix, got {title:?}"
+                line.spans[1].style.add_modifier.contains(extra),
+                "{mode:?}/{label}: expected {extra:?}, got {:?}",
+                line.spans[1].style.add_modifier
+            );
+            assert_eq!(
+                rendered,
+                format!("{prefix}{title}"),
+                "{mode:?}/{label}: wrong title decoration"
             );
         }
     }
-
-    // Sanity: a live row in every mode must NOT collapse to the sunk glyph,
-    // or the assertions above would pass on a renderer that always sinks.
-    env.view.mutate_instance(&id, |inst| {
-        inst.status = Status::Running;
-        inst.archived_at = None;
-        inst.snoozed_until = None;
-    });
-    env.view.view_mode = ViewMode::Structured;
-    let line = env.view.render_item_line(&item, false, false, &theme, 120);
-    assert_ne!(
-        line.spans[1].content.trim(),
-        ICON_STOPPED,
-        "a live Structured row must keep its spinner"
-    );
 }


### PR DESCRIPTION
## Description

Scrolling the Terminals list was visibly laggy while the agents list stayed snappy, and the lag persisted with a live terminal view open. Both surfaces asked tmux for pane liveness at paint time: `exists()` routes to `tmux::session_exists`, which trusts the shared session cache only on a HIT and falls through to a live `has-session` on a miss. Most sessions have no paired terminal, so nearly every row missed and forked a subprocess. Tool view forked twice per row, adding an uncached `is_pane_dead()`.

Two render paths were affected:

- **List rows** (`render_item_line`): one fork per visible row per frame.
- **Preview pane** (`render_preview`): one fork per frame in Terminal view, two in Tool view, for the selected session. The preview capture itself is worker-driven and otherwise fork free in steady state, so this was the last fork in a steady state frame.

Measured over 30 rows, before and after:

| View | Before | After |
|---|---|---|
| Structured (agents) | 46.6us/frame | 46.5us/frame |
| Terminal | 52.2ms/frame | 89.2us/frame |
| Tool | ~104ms/frame | 110.2us/frame |

1.74ms/row, matching a 1.86ms `has-session` fork on the same box. Live view targets a 25ms cadence, so the list render alone capped it near 19fps and every keystroke queued behind it.

**Fix.** Add `session_exists_for_display` and `pane_dead_for_display`, both snapshot backed, and seed both render paths from them. `session_exists` keeps its live fallback; teardown and drift decisions still must not act on a cached false negative. `PANE_META_CACHE` mirrors `SESSION_CACHE`, including the rule that a fresh snapshot carrying no data is an answer rather than a stale one, which is what bounds a tmux outage to one fork per TTL instead of one per row per frame.

Trade: a pane created behind this process's back reads idle for up to the 2s TTL. Every start and kill path already calls `refresh_session_cache()`, so anything done through aoe flips the glyph immediately.

**Refactor.** The three view arms of `render_item_line` each carried their own copy of the archive/snooze/urgent/favorite block. Structured and Terminal had byte identical title blocks; the Tool arm had none, so an archived or snoozed session there kept painting its running glyph with no `z ` prefix. `decorate_row` owns it for all three now, with a `SunkRow` enum naming the one policy that legitimately differs: Error and Deleting punch through the sink mask in Structured, where the seed carries `ICON_ERROR` and `theme.error`, but not in the pane views, whose seeds describe terminal liveness and carry no error affordance.

**Behavior change:** Tool view now honors archive, trash, and snooze. That is the only visible difference; everything else renders as before.

**Regression origin:** #2884 centralized existence checks on the authoritative helper to fix a real pane leak, where `kill()` silently no-oped on a stale cached miss. Before it, `TerminalSession::exists()` trusted a cached negative and forked only when the snapshot was stale. That change was right for teardown. The render path was an unnoticed caller.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot: the only visible change is the Tool view decoration noted above, which the new test covers. The user facing change is frame time.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: both behaviors are pinned at the unit tier, which can actually fail on them, and each assertion was mutation verified rather than just observed green. `display_liveness_answers_from_the_snapshot_instead_of_probing_per_name` forces a snapshot that disagrees with a live pane, so it fails the moment the display path probes per name again. `a_failed_pane_snapshot_is_an_answer_so_rows_do_not_re_fork` pins the invariant that bounds a tmux outage. `every_view_mode_paints_the_same_sunk_row_decoration` tables 3 view modes against the sunk states, seeding the pane views live so the assertions are not satisfied by the seed alone (`ICON_IDLE` and `ICON_STOPPED` are the same glyph), plus an anti vacuity check. An e2e test would cost ~2s on the serial critical path to assert glyphs a unit test already covers, and could not observe fork counts at all.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Root cause, measurements, and patch produced by Claude Opus 5 in back and forth with @njbrake. The before/after numbers come from a throwaway timing test run against both trees, not an estimate. The decision to unify the row arms, and the call to keep the delete-op exception Structured only, are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added cached session and pane liveness checks for Terminal and Tool rows.
- Reduced repeated tmux queries during row rendering.
- Preserved live checks for teardown and state-drift decisions.
- Centralized row decoration for archive, snooze, urgent, and favorite states.
- Applied consistent sunk-row styling across view modes.
- Added tests for cached liveness, failed snapshots, live-row rendering, and view-specific decoration.

## Benefits

- Improves Terminal and Tool view performance.
- Keeps row appearance consistent across view modes.
- Handles unavailable snapshot data safely.
- Preserves authoritative checks when live state matters.

## Further enhancement

- Add end-to-end coverage for rendering performance and tmux state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->