### PR TITLE
fix: keep new-session lifecycle badge visible

### DIFF
--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -14,7 +14,7 @@ mod text;
 mod text_input;
 mod tool_config;
 
-pub use cycler::{profile_cycler_spans, tool_cycler_spans, tool_lifecycle_spans};
+pub use cycler::{profile_cycler_spans, tool_cycler_spans};
 pub use dir_picker::{DirPicker, DirPickerResult};
 pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
@@ -26,5 +26,5 @@ pub use text_input::{
     set_input_cursor_position, set_prefixed_input_cursor_position, GroupGhostCompletion,
 };
 pub use tool_config::{
-    handle_tool_config_key, render_tool_config_overlay, tool_config_suffix_spans, ToolConfigOutcome,
+    handle_tool_config_key, render_tool_config_overlay, tool_row_suffix_spans, ToolConfigOutcome,
 };

--- a/src/tui/components/tool_config.rs
+++ b/src/tui/components/tool_config.rs
@@ -12,7 +12,7 @@ use ratatui::widgets::*;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
-use super::render_text_field;
+use super::{cycler::tool_lifecycle_spans, render_text_field};
 use crate::tui::styles::Theme;
 
 /// Tool-config overlay fields: command override, then extra args.
@@ -20,12 +20,28 @@ pub const TOOL_CONFIG_CMD: usize = 0;
 pub const TOOL_CONFIG_ARGS: usize = 1;
 const TOOL_CONFIG_FIELD_COUNT: usize = 2;
 
-/// Trailing spans appended to the Tool row: a dimmed (configured) marker
-/// when an override is set, plus the Ctrl+P hint while the row is focused.
-/// has_config is true when either the command override or extra args is
-/// non-empty. compact shortens the focused configured hint so a higher-
-/// priority status badge can share the fixed-width row without clipping.
-pub fn tool_config_suffix_spans(
+/// Trailing lifecycle and configuration spans appended to the Tool row.
+/// Lifecycle status comes first so lower-priority configuration metadata cannot
+/// clip it. The focused configuration hint is compact when a status is present.
+pub fn tool_row_suffix_spans(
+    tool: &str,
+    has_config: bool,
+    focused: bool,
+    theme: &Theme,
+) -> Vec<Span<'static>> {
+    let mut spans = tool_lifecycle_spans(tool, theme);
+    let compact_config = !spans.is_empty();
+    spans.extend(tool_config_suffix_spans(
+        has_config,
+        focused,
+        compact_config,
+        theme,
+    ));
+    spans
+}
+
+/// Configuration spans appended after higher-priority Tool row status.
+fn tool_config_suffix_spans(
     has_config: bool,
     focused: bool,
     compact: bool,

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -10,7 +10,7 @@ use super::{NewSessionDialog, FIELD_HELP, HELP_DIALOG_WIDTH};
 use crate::tui::components::{
     focused_input_spans, input_scroll, profile_cycler_spans, render_text_field,
     render_text_field_with_ghost, render_tool_config_overlay, set_prefixed_input_cursor_position,
-    tool_config_suffix_spans, tool_cycler_spans, tool_lifecycle_spans, visible_slice,
+    tool_cycler_spans, tool_row_suffix_spans, visible_slice,
 };
 use crate::tui::styles::Theme;
 
@@ -218,14 +218,14 @@ impl NewSessionDialog {
         self.focusable_rects.push((title_field, area));
         ci += 1;
 
-        // Tool (always shown, interactive or read-only). The cycler itself is
-        // shared with the Restart dialog via `tool_cycler_spans`; the New
-        // dialog appends its own config summary and Ctrl+P hint afterwards.
+        // Tool (always shown, interactive or read-only). The cycler and suffix
+        // ordering are shared with the Restart dialog.
         let tool_field = base + 2;
         let is_tool_focused = has_tool_selection && self.focused_field == tool_field;
+        let selected_tool = self.available_tools[self.tool_index].as_str();
         let mut tool_spans = tool_cycler_spans(
             "Tool:",
-            self.available_tools[self.tool_index].as_str(),
+            selected_tool,
             self.tool_index,
             self.available_tools.len(),
             is_tool_focused,
@@ -233,14 +233,10 @@ impl NewSessionDialog {
         );
         let has_config =
             !self.extra_args.value().is_empty() || !self.command_override.value().is_empty();
-        tool_spans.extend(tool_config_suffix_spans(
+        tool_spans.extend(tool_row_suffix_spans(
+            selected_tool,
             has_config,
             is_tool_focused,
-            false,
-            theme,
-        ));
-        tool_spans.extend(tool_lifecycle_spans(
-            self.available_tools[self.tool_index].as_str(),
             theme,
         ));
         let area = chunks[ci];

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -49,28 +49,50 @@ fn test_esc_cancels() {
 }
 
 #[test]
-fn test_deprecated_tool_badge_renders_on_single_tool_read_only_row() {
-    // Alternate render path: one available tool drops the cycler affordances
-    // (total <= 1 early return), but the lifecycle suffix must still reach
-    // the row through the unconditional extend at the call site.
-    let mut dialog = NewSessionDialog::new_with_tools(vec!["gemini"], TEST_PATH.to_string());
-    let mut terminal =
-        ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 40)).expect("terminal");
+fn test_deprecated_tool_badge_remains_visible_on_tool_rows() {
+    use ratatui::{backend::TestBackend, Terminal};
+
+    let mut cases = [
+        (
+            "single-tool read-only",
+            NewSessionDialog::new_with_tools(vec!["gemini"], TEST_PATH.to_string()),
+            100,
+        ),
+        (
+            "constrained configured",
+            NewSessionDialog::new_with_tools(
+                vec!["claude", "codex", "gemini"],
+                TEST_PATH.to_string(),
+            ),
+            64,
+        ),
+    ];
+    cases[1].1.tool_index = 2;
+    cases[1].1.focused_field = 2;
+    cases[1].1.command_override = Input::new("custom-wrapper".to_string());
+    cases[1].1.extra_args = Input::new("--model long --verbose".to_string());
+
     let theme = crate::tui::styles::Theme::default();
-    terminal
-        .draw(|frame| dialog.render(frame, frame.area(), &theme))
-        .expect("render");
-    let content = terminal
-        .backend()
-        .buffer()
-        .content()
-        .iter()
-        .map(|cell| cell.symbol())
-        .collect::<String>();
-    assert!(
-        content.contains("⚠ deprecated"),
-        "single-tool gemini row must carry the deprecation suffix; got: {content}"
-    );
+    for (name, dialog, width) in &mut cases {
+        let mut terminal = Terminal::new(TestBackend::new(*width, 40)).expect("terminal");
+        terminal
+            .draw(|frame| dialog.render(frame, frame.area(), &theme))
+            .expect("render");
+        let content = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(
+            content.contains("⚠ deprecated"),
+            "{name} gemini row must carry the deprecation suffix; got: {content}"
+        );
+        if *name == "constrained configured" {
+            assert!(content.contains("(configured) Ctrl+P"), "{content}");
+        }
+    }
 }
 
 #[test]

--- a/src/tui/dialogs/restart.rs
+++ b/src/tui/dialogs/restart.rs
@@ -16,8 +16,8 @@ use super::DialogResult;
 use crate::session::profile_config::resolve_config_or_warn;
 use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::components::{
-    handle_tool_config_key, profile_cycler_spans, render_tool_config_overlay,
-    tool_config_suffix_spans, tool_cycler_spans, tool_lifecycle_spans, ToolConfigOutcome,
+    handle_tool_config_key, profile_cycler_spans, render_tool_config_overlay, tool_cycler_spans,
+    tool_row_suffix_spans, ToolConfigOutcome,
 };
 use crate::tui::styles::Theme;
 
@@ -518,16 +518,10 @@ impl RestartDialog {
         );
         let has_config =
             !self.extra_args.value().is_empty() || !self.command_override.value().is_empty();
-        // Lifecycle is the load-bearing status: append it before the config
-        // metadata. The compact configured hint keeps (configured) Ctrl+P
-        // visible in the dialog's real 60-column inner width.
-        let lifecycle_spans = tool_lifecycle_spans(value, theme);
-        let compact_config = !lifecycle_spans.is_empty();
-        spans.extend(lifecycle_spans);
-        spans.extend(tool_config_suffix_spans(
+        spans.extend(tool_row_suffix_spans(
+            value,
             has_config,
             self.is_tool_field(),
-            compact_config,
             theme,
         ));
         frame.render_widget(Paragraph::new(Line::from(spans)), area);


### PR DESCRIPTION
## Description

Follow-up to #3495. The New Session dialog appended configuration metadata before the lifecycle badge, so a configured Gemini row clipped `⚠ deprecated` to `⚠ dep` on terminals narrower than roughly 76 columns.

This change centralizes lifecycle and configuration suffix ordering for both New Session and Restart. Lifecycle status now renders first, and the focused configuration hint uses the existing compact form whenever a lifecycle badge is present.

64-column TUI capture after the fix:

```text
│ Tool: ← ● gemini  [3/3]  → ⚠ deprecated  (configured) Ctrl+P │
```

Review finding: https://github.com/agent-of-empires/agent-of-empires/pull/3495#pullrequestreview-5021984424

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the deterministic Ratatui TestBackend contract exercises the exact 64-column configured row and failed before the fix. The actual TUI was also launched in isolated tmux at 64 columns and verified with the Tool row focused.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** openai-codex/gpt-5.6-sol

**Any Additional AI Details you'd like to share:**

The agent reproduced the clipping, implemented the shared suffix ordering, ran the regression and full Rust suites, and drove the actual TUI in isolated tmux.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Centralized lifecycle and configuration suffix rendering for New Session and Restart dialogs.
- Rendered lifecycle badges before configuration hints to prevent clipping in narrow terminals.
- Added compact configuration hints when a lifecycle badge is present.
- Added regression coverage for narrow, configured rows and expanded deprecated badge tests.

## Benefits

- Prevents the `⚠ deprecated` badge from being clipped.
- Keeps suffix behavior consistent across dialogs.
- Preserves useful configuration hints in constrained layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->