### PR TITLE
fix(tmux): detect custom OMP spinner frames

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2169,10 +2169,12 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         let wrapped = if pos <= 3 && i > 0 {
             let (frame_line_index, frame_line) = loader_window[i - 1];
             let continuation_is_indented = line.len() > line.trim_start().len();
-            let frame_is_unfinished = !matches!(
-                frame_line.trim_end().chars().next_back(),
-                Some('.' | '!' | '?' | ':' | ';')
-            );
+            let frame_text = frame_line.trim_end();
+            let frame_is_unfinished = frame_text.ends_with("...")
+                || !matches!(
+                    frame_text.chars().next_back(),
+                    Some('.' | '!' | '?' | ':' | ';')
+                );
             frame_line_index + 1 == line_index
                 && continuation_is_indented
                 && frame_is_unfinished
@@ -6319,6 +6321,10 @@ Final prose line.\n";
             (
                 "manual compaction",
                 format!("⠼ Compacting context... (esc to cancel)\n{box_unicode}"),
+            ),
+            (
+                "wrapped ascii ellipsis maintenance",
+                format!("⠼ Compacting context...\n (esc to cancel)\n{box_unicode}"),
             ),
             (
                 "auto compaction",

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -3,7 +3,7 @@
 use crate::session::Status;
 
 use regex::Regex;
-use std::sync::OnceLock;
+use std::{collections::VecDeque, sync::OnceLock};
 
 use super::utils::strip_ansi;
 
@@ -2058,9 +2058,10 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
 ///
 /// A live loader has a built-in activity frame or configured symbolic frame,
 /// or an ASCII preset frame (`- \ | /`), plus its marker on the same row. A
-/// wrapped marker must be indented beneath an unfinished frame row, matching
-/// OMP's text layout rather than an adjacent prose sentence. Known braille
-/// frames retain the historical `Working` marker; other symbolic and ASCII
+/// wrapped marker must be physically adjacent and indented beneath an
+/// unfinished frame row. This matches OMP's text layout and rejects prose
+/// separated by blank output. Known braille frames retain the historical
+/// `Working` marker; other symbolic and ASCII
 /// frames require an esc hint (`⟦esc⟧`, `⟨esc⟩`, `[esc]`, or `(esc to cancel)`).
 /// OMP intents are arbitrary, so hint-bearing ASCII or symbolic prose can be
 /// textually identical to a direct loader row. The bottom-three-line window
@@ -2086,10 +2087,18 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
 /// error/retry path (herdr-style extension) is tracked in #3380.
 pub fn detect_omp_status(raw_content: &str) -> Status {
     let clean = strip_ansi(raw_content);
-    let non_empty_lines: Vec<&str> = clean
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .collect();
+    let mut non_empty_lines = Vec::new();
+    let mut loader_window = VecDeque::with_capacity(4);
+    for (line_index, line) in clean.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        non_empty_lines.push(line);
+        if loader_window.len() == 4 {
+            loader_window.pop_front();
+        }
+        loader_window.push_back((line_index, line));
+    }
 
     // Each signal registers the position of its lowest matching line (1 =
     // bottom, within its freshness window); the lowest position wins, ties
@@ -2105,8 +2114,8 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
     // Live loader rows sit directly above the composer. Known braille frames
     // keep the historical Working/hint markers. Configured symbolic and ASCII
     // frames require an esc hint because their glyphs can prefix ordinary prose.
-    // A wrapped hint must be an indented continuation of an unfinished frame row.
-    let loader_window = tail_lines(&non_empty_lines, 4);
+    // A wrapped hint must be physically adjacent and indented beneath an
+    // unfinished frame row.
     let starts_with_braille_frame = |line: &str| {
         let line = line.trim_start();
         SPINNER_CHARS.iter().any(|frame| {
@@ -2153,18 +2162,19 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         |line: &str| starts_with_ascii_frame(line) || starts_with_symbolic_frame(line);
     let loader_pos = (0..loader_window.len()).rev().find_map(|i| {
         let pos = loader_window.len() - i;
-        let line = loader_window[i];
+        let (line_index, line) = loader_window[i];
         let direct = pos <= 3
             && ((starts_with_braille_frame(line) && has_loader_marker(line))
                 || (starts_with_hint_gated_frame(line) && has_hint_marker(line)));
         let wrapped = if pos <= 3 && i > 0 {
-            let frame_line = loader_window[i - 1];
+            let (frame_line_index, frame_line) = loader_window[i - 1];
             let continuation_is_indented = line.len() > line.trim_start().len();
             let frame_is_unfinished = !matches!(
                 frame_line.trim_end().chars().next_back(),
                 Some('.' | '!' | '?' | ':' | ';')
             );
-            continuation_is_indented
+            frame_line_index + 1 == line_index
+                && continuation_is_indented
                 && frame_is_unfinished
                 && !has_hint_marker(frame_line)
                 && (starts_with_braille_frame(frame_line)
@@ -6132,7 +6142,7 @@ Final prose line.\n";
             ),
             (
                 "symbolic prose pair across blank row",
-                format!("→ Some heading\n\nThe cancel key is [esc]\n{prompt_box}"),
+                format!("→ Some heading\n\n The cancel key is [esc]\n{prompt_box}"),
                 Status::Idle,
             ),
             (

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2056,11 +2056,14 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
 /// it the signal is ignored, so a completed turn's loader or a dismissed
 /// banner in scrollback cannot pin the session.
 ///
-/// A live loader has a preset activity frame (braille for unicode/nerd,
-/// `- \ | /` for ascii) plus its marker on the same row, or on the next row
-/// after a narrow-pane wrap. The markers are `Working`, an esc hint glyph
-/// (`⟦esc⟧`, `⟨esc⟩`, `[esc]`), and the maintenance hint
-/// `(esc to cancel)`.
+/// A live loader has a built-in or configured symbolic frame, or an ASCII
+/// preset frame (`- \ | /`), plus its marker on the same row or on the next
+/// row after a narrow-pane wrap. Known braille frames retain the historical
+/// `Working` marker; other symbolic and ASCII frames require an esc hint
+/// (`⟦esc⟧`, `⟨esc⟩`, `[esc]`, or `(esc to cancel)`). OMP intents are arbitrary,
+/// so hint-bearing ASCII prose can be textually identical to a live loader.
+/// The bottom-three-line window intentionally favors the active direction for
+/// that irreducible case, avoiding a false Idle while a turn runs.
 ///
 /// A tool approval replaces the composer with a selector panel. Exact
 /// bordered `Approve`/`Deny` option rows corroborate its navigation footer;
@@ -2097,10 +2100,11 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         }
     };
 
-    // Live loader rows sit directly above the composer. Braille frames keep
-    // the historical Working/hint markers; ASCII frames additionally require
-    // their esc hint so Markdown bullets such as "- Working …" stay prose.
-    // A wrapped hint is accepted only beside the preceding activity frame.
+    // Live loader rows sit directly above the composer. Known braille frames
+    // keep the historical Working/hint markers. Configured symbolic frames
+    // require an esc hint, the invariant OMP appends to its live loader. ASCII
+    // frames require the same hint because their glyphs are ordinary prose
+    // prefixes. A wrapped hint is accepted only beside the preceding frame.
     let loader_window = tail_lines(&non_empty_lines, 4);
     let starts_with_braille_frame = |line: &str| {
         let line = line.trim_start();
@@ -2116,6 +2120,24 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
                 .is_some_and(|rest| rest.starts_with(' '))
         })
     };
+    let starts_with_symbolic_frame = |line: &str| {
+        let Some((frame, _)) = line.trim_start().split_once(' ') else {
+            return false;
+        };
+        const RESERVED_PREFIXES: &[&str] = &["•", "※", "❯", "\u{f054}", "│", "┃", "▎"];
+        if frame.is_empty() || RESERVED_PREFIXES.contains(&frame) {
+            return false;
+        }
+        let mut has_non_ascii = false;
+        for ch in frame.chars() {
+            if ch.is_alphanumeric() {
+                return false;
+            }
+            has_non_ascii |= !ch.is_ascii();
+        }
+        has_non_ascii
+    };
+
     let has_hint_marker = |line: &str| {
         let line = line.trim().to_lowercase();
         line.ends_with("⟦esc⟧")
@@ -2125,16 +2147,18 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
     };
     let has_loader_marker =
         |line: &str| line.to_lowercase().contains("working") || has_hint_marker(line);
+    let starts_with_hint_gated_frame =
+        |line: &str| starts_with_ascii_frame(line) || starts_with_symbolic_frame(line);
     let loader_pos = (0..loader_window.len()).rev().find_map(|i| {
         let pos = loader_window.len() - i;
         let line = loader_window[i];
         let direct = pos <= 3
             && ((starts_with_braille_frame(line) && has_loader_marker(line))
-                || (starts_with_ascii_frame(line) && has_hint_marker(line)));
+                || (starts_with_hint_gated_frame(line) && has_hint_marker(line)));
         let wrapped = pos <= 3
             && i > 0
             && (starts_with_braille_frame(loader_window[i - 1])
-                || starts_with_ascii_frame(loader_window[i - 1]))
+                || starts_with_hint_gated_frame(loader_window[i - 1]))
             && has_hint_marker(line);
         (direct || wrapped).then_some(pos)
     });
@@ -6073,6 +6097,21 @@ Final prose line.\n";
                 format!("- Working tree status is clean.\n{prompt_box}"),
                 Status::Idle,
             ),
+            (
+                "unicode markdown bullet",
+                format!("• The interrupt key is [esc]\n{prompt_box}"),
+                Status::Idle,
+            ),
+            (
+                "idle recap prefix",
+                format!("※ Working… ⟦esc⟧\n{prompt_box}"),
+                Status::Idle,
+            ),
+            (
+                "symbolic prose without hint",
+                format!("◐ Working through the explanation\n{prompt_box}"),
+                Status::Idle,
+            ),
             // Precedences: the lowest live signal wins. Approval fixtures
             // use omp's real bordered selector rather than synthetic text.
             (
@@ -6196,8 +6235,8 @@ Final prose line.\n";
 
     #[test]
     fn test_detect_omp_status_running_loaders() {
-        // Same behavior and setup: every live loader has a preset frame and
-        // marker on one row, or on an adjacent row after a narrow-pane wrap.
+        // Same behavior and setup: every live loader has a built-in or configured
+        // frame and marker on one row, or on an adjacent row after a narrow wrap.
         let box_unicode = "╭── π ─╮\n╰─ ─╯";
         let box_ascii = "+-- pi ---+\n+- -------+";
         let answered_panel = "\
@@ -6214,12 +6253,24 @@ Final prose line.\n";
         let cases = [
             ("unicode default", format!("⠋ Working… ⟦esc⟧\n{box_unicode}")),
             (
+                "unicode status frame",
+                format!("⣾ Working… ⟦esc⟧\n{box_unicode}"),
+            ),
+            (
+                "nerd status frame",
+                format!("󱑖 Working… ⟨esc⟩\n{box_unicode}"),
+            ),
+            (
                 "unicode intent",
                 format!("⠴ Set permissions on audit bait path ⟦esc⟧\n{box_unicode}"),
             ),
             (
                 "nerd intent",
                 format!("⠹ Reading audit fixtures ⟨esc⟩\n{box_unicode}"),
+            ),
+            (
+                "custom symbolic frame",
+                format!("◐ Working… ⟦esc⟧\n{box_unicode}"),
             ),
             (
                 "ascii intent",
@@ -6244,6 +6295,10 @@ Final prose line.\n";
             (
                 "wrapped unicode intent",
                 format!("⠹ Locating audit config files in parent tree\n ⟦esc⟧\n{box_unicode}"),
+            ),
+            (
+                "wrapped custom symbolic frame",
+                format!("◐ Locating audit config files in parent tree\n ⟦esc⟧\n{box_unicode}"),
             ),
             (
                 "wrapped ascii intent",

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2056,14 +2056,16 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
 /// it the signal is ignored, so a completed turn's loader or a dismissed
 /// banner in scrollback cannot pin the session.
 ///
-/// A live loader has a built-in or configured symbolic frame, or an ASCII
-/// preset frame (`- \ | /`), plus its marker on the same row or on the next
-/// row after a narrow-pane wrap. Known braille frames retain the historical
-/// `Working` marker; other symbolic and ASCII frames require an esc hint
-/// (`⟦esc⟧`, `⟨esc⟩`, `[esc]`, or `(esc to cancel)`). OMP intents are arbitrary,
-/// so hint-bearing ASCII prose can be textually identical to a live loader.
-/// The bottom-three-line window intentionally favors the active direction for
-/// that irreducible case, avoiding a false Idle while a turn runs.
+/// A live loader has a built-in activity frame or configured symbolic frame,
+/// or an ASCII preset frame (`- \ | /`), plus its marker on the same row. A
+/// wrapped marker must be indented beneath an unfinished frame row, matching
+/// OMP's text layout rather than an adjacent prose sentence. Known braille
+/// frames retain the historical `Working` marker; other symbolic and ASCII
+/// frames require an esc hint (`⟦esc⟧`, `⟨esc⟩`, `[esc]`, or `(esc to cancel)`).
+/// OMP intents are arbitrary, so hint-bearing ASCII or symbolic prose can be
+/// textually identical to a direct loader row. The bottom-three-line window
+/// favors the active direction for that irreducible case, avoiding a false
+/// Idle while a turn runs.
 ///
 /// A tool approval replaces the composer with a selector panel. Exact
 /// bordered `Approve`/`Deny` option rows corroborate its navigation footer;
@@ -2101,10 +2103,9 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
     };
 
     // Live loader rows sit directly above the composer. Known braille frames
-    // keep the historical Working/hint markers. Configured symbolic frames
-    // require an esc hint, the invariant OMP appends to its live loader. ASCII
-    // frames require the same hint because their glyphs are ordinary prose
-    // prefixes. A wrapped hint is accepted only beside the preceding frame.
+    // keep the historical Working/hint markers. Configured symbolic and ASCII
+    // frames require an esc hint because their glyphs can prefix ordinary prose.
+    // A wrapped hint must be an indented continuation of an unfinished frame row.
     let loader_window = tail_lines(&non_empty_lines, 4);
     let starts_with_braille_frame = |line: &str| {
         let line = line.trim_start();
@@ -2124,7 +2125,8 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         let Some((frame, _)) = line.trim_start().split_once(' ') else {
             return false;
         };
-        const RESERVED_PREFIXES: &[&str] = &["•", "※", "❯", "\u{f054}", "│", "┃", "▎"];
+        const RESERVED_PREFIXES: &[&str] =
+            &["•", "\u{f111}", "※", "❯", "\u{f054}", "│", "┃", "▏", "▎"];
         if frame.is_empty() || RESERVED_PREFIXES.contains(&frame) {
             return false;
         }
@@ -2155,11 +2157,22 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         let direct = pos <= 3
             && ((starts_with_braille_frame(line) && has_loader_marker(line))
                 || (starts_with_hint_gated_frame(line) && has_hint_marker(line)));
-        let wrapped = pos <= 3
-            && i > 0
-            && (starts_with_braille_frame(loader_window[i - 1])
-                || starts_with_hint_gated_frame(loader_window[i - 1]))
-            && has_hint_marker(line);
+        let wrapped = if pos <= 3 && i > 0 {
+            let frame_line = loader_window[i - 1];
+            let continuation_is_indented = line.len() > line.trim_start().len();
+            let frame_is_unfinished = !matches!(
+                frame_line.trim_end().chars().next_back(),
+                Some('.' | '!' | '?' | ':' | ';')
+            );
+            continuation_is_indented
+                && frame_is_unfinished
+                && !has_hint_marker(frame_line)
+                && (starts_with_braille_frame(frame_line)
+                    || starts_with_hint_gated_frame(frame_line))
+                && has_hint_marker(line)
+        } else {
+            false
+        };
         (direct || wrapped).then_some(pos)
     });
     if let Some(pos) = loader_pos {
@@ -6112,6 +6125,31 @@ Final prose line.\n";
                 format!("◐ Working through the explanation\n{prompt_box}"),
                 Status::Idle,
             ),
+            (
+                "unindented symbolic prose pair",
+                format!("✓ Done with step 3\nSee docs: press [esc]\n{prompt_box}"),
+                Status::Idle,
+            ),
+            (
+                "symbolic prose pair across blank row",
+                format!("→ Some heading\n\nThe cancel key is [esc]\n{prompt_box}"),
+                Status::Idle,
+            ),
+            (
+                "indented prose after completed sentence",
+                format!("✓ Done with step 3.\n See docs: press [esc]\n{prompt_box}"),
+                Status::Idle,
+            ),
+            (
+                "unicode quote border",
+                format!("▏ quoted: press [esc]\n{prompt_box}"),
+                Status::Idle,
+            ),
+            (
+                "nerd markdown bullet",
+                format!("\u{f111} The interrupt key is [esc]\n{prompt_box}"),
+                Status::Idle,
+            ),
             // Precedences: the lowest live signal wins. Approval fixtures
             // use omp's real bordered selector rather than synthetic text.
             (
@@ -6235,8 +6273,8 @@ Final prose line.\n";
 
     #[test]
     fn test_detect_omp_status_running_loaders() {
-        // Same behavior and setup: every live loader has a built-in or configured
-        // frame and marker on one row, or on an adjacent row after a narrow wrap.
+        // Same behavior and setup: every live loader has a preset activity or
+        // configured frame plus a direct marker or indented wrapped continuation.
         let box_unicode = "╭── π ─╮\n╰─ ─╯";
         let box_ascii = "+-- pi ---+\n+- -------+";
         let answered_panel = "\
@@ -6252,14 +6290,6 @@ Final prose line.\n";
 ╰──────────────────────────────────────────────────────────╯";
         let cases = [
             ("unicode default", format!("⠋ Working… ⟦esc⟧\n{box_unicode}")),
-            (
-                "unicode status frame",
-                format!("⣾ Working… ⟦esc⟧\n{box_unicode}"),
-            ),
-            (
-                "nerd status frame",
-                format!("󱑖 Working… ⟨esc⟩\n{box_unicode}"),
-            ),
             (
                 "unicode intent",
                 format!("⠴ Set permissions on audit bait path ⟦esc⟧\n{box_unicode}"),


### PR DESCRIPTION
## Description

Follow-up to #3494, which merged while its final automated re-review was being evaluated.

OMP `160ed439` allows themes to override `symbols.spinnerFrames.activity`, and the pane-bottom working, maintenance, retry, and handoff loaders consume that activity-frame set. A configured frame such as `◐ Working… ⟦esc⟧` previously returned `Idle` because the detector recognized only the preset braille and ASCII frames.

The detector now accepts a line-leading non-ASCII symbolic frame when the direct row carries OMP's esc hint. Narrow-pane continuations additionally require OMP's physically adjacent, indented wrap shape beneath an unfinished frame row; ASCII `...` remains active loader punctuation; blank-separated or unrelated symbol-led prose cannot satisfy that branch. Unicode and Nerd Markdown quote/bullet prefixes are excluded alongside the existing transcript, cursor, and panel prefixes.

The two speculative NF2 shapes, a frame inside a panel border and a frame without OMP's separating space, remain unsupported because neither can be tied to the source render.

The existing table-driven tests cover the custom `◐` activity frame, direct and wrapped forms, reserved prefixes, missing hints, unrelated prose pairs, physically separated rows, sentence-complete frame rows, and wrapped maintenance rows ending in ASCII ellipses.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass. The full library and changed module pass; full-target environmental failures are documented below.
- [x] Documentation was updated where necessary
- [x] For UI changes: N/A, no rendering change

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped an e2e test, because: the observable contract is pure pane-text classification and is covered by the existing table-driven Rust test.

## Verification

- Red before the wrap fixes: unrelated symbol-led prose returned `Running`, including an indented hint physically separated by a blank row. A wrapped `⠼ Compacting context...` row also returned `Idle` before the ellipsis fix.
- `cargo test --lib tmux::status_detection`: 174 passed.
- `cargo test --lib`: 4701 passed, 2 ignored.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -- -D warnings`: clean.
- `build_version_rerun`: 4 passed with command-scoped `commit.gpgsign=false`; the default developer configuration requires interactive GPG pinentry inside those temporary repositories.
- A full `cargo test` with the same command-scoped signing override reached one unrelated tmux timing failure, `send_key_tokens_appends_no_implicit_enter`; it passed immediately in isolation.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI GPT-5.6 Sol via Oh My Pi

**Any Additional AI Details you'd like to share:** The agent verified each review finding against OMP `160ed439`, reproduced the valid false-positive paths, corrected the detector and PR premise, and ran the checks listed above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed tmux detection for custom Oh My Posh `spinnerFrames.activity` values.
- Added reliable handling for directly adjacent, indented wrapped frames.
- Preserved support for wrapped rows that end with ASCII ellipses.
- Kept exclusions for reserved transcript, Markdown, cursor, and panel prefixes.
- Added regression coverage for valid frames and unrelated prose.

## Benefits

- Improves loader detection for custom Oh My Posh configurations.
- Reduces false positives from separated or complete prose rows.
- Keeps existing reserved-prefix behavior intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->