### PR TITLE
fix(session): keep Kimi's anchored id when the index is shared

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2714,100 +2714,123 @@ fn select_kimi_session(
 
 /// Capture a Kimi Code session ID for `project_path`.
 ///
-/// Reads `~/.kimi-code/session_index.jsonl` (or
-/// `$KIMI_CODE_HOME/session_index.jsonl`) and returns the id of the most
-/// recently created session whose recorded `workDir` matches `project_path`,
-/// skipping any ids in `exclusion`. `launch_time_ms` gates live polling to
-/// sessions created after this run started (`None` for retroactive recovery).
-/// Kimi resumes the returned id with `kimi --session <id>`.
+/// Reads `session_index.jsonl` under the Kimi home resolved from
+/// `environment` and returns the id of the most recently created session
+/// whose recorded `workDir` matches `project_path`, skipping any ids in
+/// `exclusion`. `environment` must be the launched pane's host environment so
+/// the scan reads the same physical store Kimi writes (`KIMI_CODE_HOME`
+/// honored through launch's `$VAR` / bare-key grammar). `launch_time_ms`
+/// gates live polling to sessions created after this run started (`None` for
+/// retroactive recovery). Kimi resumes the returned id with `kimi --session
+/// <id>`.
 pub(crate) fn capture_kimi_session_id(
     project_path: &str,
     exclusion: &HashSet<String>,
     launch_time_ms: Option<f64>,
+    environment: &[String],
 ) -> Result<String> {
-    let home = resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code")?;
+    let home = kimi_home_for_environment(environment)
+        .ok_or_else(|| anyhow::anyhow!("could not resolve the Kimi home"))?;
     let sessions = read_kimi_session_index(&home.join("session_index.jsonl"))?;
     select_kimi_session(&sessions, project_path, exclusion, launch_time_ms)
 }
 
 /// Polling closure for Kimi Code session tracking. `launch_time_ms` floors the
 /// live poll so it never claims a conversation that predates this launch.
+/// `environment` is snapshotted from the instance at poller construction so
+/// every tick reads the store the launched pane writes.
 pub(crate) fn kimi_poll_fn(
     project_path: String,
     instance_id: String,
     launch_time_ms: f64,
     extra_excludes: HashSet<String>,
+    environment: Vec<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
         let exclusion = compose_exclusion(&instance_id, &extra_excludes);
-        capture_kimi_session_id(&project_path, &exclusion, Some(launch_time_ms))
-            .map_err(
-                |e| tracing::debug!(target: "session.capture", "Kimi poll capture failed: {}", e),
-            )
-            .ok()
-            .and_then(validated_session_id)
+        capture_kimi_session_id(
+            &project_path,
+            &exclusion,
+            Some(launch_time_ms),
+            &environment,
+        )
+        .map_err(|e| tracing::debug!(target: "session.capture", "Kimi poll capture failed: {}", e))
+        .ok()
+        .and_then(validated_session_id)
     }
 }
 
 /// Effective Kimi home for one environment list: `KIMI_CODE_HOME` resolved
 /// through the same `$VAR` / bare-key grammar launch applies
 /// ([`crate::session::environment::resolve_host_environment_value`]), else the
-/// ambient default resolution [`capture_kimi_session_id`] performs. `None`
-/// when even the default cannot be resolved; the sharing predicate fails
-/// closed on `None`.
+/// ambient default resolution. An empty resolved value counts as unset; `None`
+/// when even the default cannot be resolved (the sharing predicate fails
+/// closed on `None`).
 fn kimi_home_for_environment(environment: &[String]) -> Option<PathBuf> {
     crate::session::environment::resolve_host_environment_value(environment, "KIMI_CODE_HOME")
         .map(PathBuf::from)
+        .filter(|home| !home.as_os_str().is_empty())
         .or_else(|| resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code").ok())
 }
 
-/// Whether another live-tracked AoE session shares this one's Kimi store: the
-/// same resolved `$KIMI_CODE_HOME` (or default `~/.kimi-code`) plus the same
-/// canonicalized project path. When true, the newest matching record in the
-/// session index cannot be attributed to this pane, so acquire must not make
-/// the MRU retarget from it (#3516).
+/// Whether another live-tracked AoE session shares this one's Kimi store: a
+/// resolvable own home plus the same canonicalized project path. When true,
+/// the newest matching record in the session index cannot be attributed to
+/// this pane, so the acquire-time MRU scan behind
+/// [`capture_kimi_session_id`] must not run (#3516). The live poller still
+/// runs that scan on shared stores, bounded by its launch-time floor and the
+/// exclusion sets.
 ///
-/// `own_environment` must be the caller's [`Instance::resolved_host_environment`]
-/// so the own side judges sharing on exactly what the launched pane sees,
-/// including `before_session`-minted values. Peers are judged on their
-/// profile's static list because minted pairs are runtime state that is
-/// deliberately not persisted; a profile whose hook mints `KIMI_CODE_HOME`
-/// is therefore judged on its static spelling for the peer side only.
+/// `own_resolved_environment` is the caller's
+/// [`Instance::resolved_host_environment`] and `own_profile_environment` its
+/// static profile list; the own side matches peers against either home so a
+/// hook that deterministically mints a different `KIMI_CODE_HOME` still
+/// counts its profile siblings as sharing. Peers are judged on their static
+/// profile list because minted pairs are runtime state that is deliberately
+/// not persisted.
+///
 /// The walk covers every AoE profile because the store is keyed by resolved
 /// home plus cwd, not by profile: two profiles resolving to one home share
 /// one store. It fails closed: an unreadable profile list, an unreadable
-/// per-profile store, or an unresolvable Kimi home all report shared,
-/// because ownership that cannot be proven must not license an MRU
-/// retarget. Trashed and archived peers are skipped: they need explicit user
-/// action or are skipped by startup recovery, so they cannot take part in a
-/// concurrent start. Stopped and pane-less peers deliberately count as
-/// sharing; pane liveness is exactly what races during a mass recovery, so
-/// filtering on it re-opens the storm window (same reasoning as #3507's
-/// Claude predicate).
+/// per-profile store, or no resolvable own home all report shared, because
+/// ownership that cannot be proven must not license an MRU retarget.
+/// Trashed and archived peers are skipped: they need explicit user action or
+/// are skipped by startup recovery, so they cannot take part in a concurrent
+/// start. Stopped and pane-less peers deliberately count as sharing; pane
+/// liveness is exactly what races during a mass recovery, so filtering on it
+/// re-opens the storm window (same reasoning as #3507's Claude predicate).
 pub(crate) fn kimi_store_is_shared(
     current_instance_id: &str,
     current_project_path: &str,
-    own_environment: &[String],
+    own_resolved_environment: &[String],
+    own_profile_environment: &[String],
 ) -> bool {
     let canonical_current = canonicalize_or_raw(current_project_path);
-    let Some(own_home) = kimi_home_for_environment(own_environment)
+    let mut own_homes = [own_resolved_environment, own_profile_environment]
+        .iter()
+        .filter_map(|env| kimi_home_for_environment(env))
         .map(|home| canonicalize_or_raw(home.to_string_lossy().as_ref()))
-    else {
+        .collect::<Vec<_>>();
+    own_homes.dedup();
+    if own_homes.is_empty() {
         return true;
-    };
+    }
     let Ok(profiles) = crate::session::list_profiles() else {
         return true;
     };
     for peer_profile in profiles {
         // Judge the namespace before paying for the store read: a peer whose
         // resolved home differs cannot share this store however many rows its
-        // sessions.json holds.
+        // sessions.json holds. The per-launch cost of one config read per
+        // profile is accepted; the status-rule install it triggers is
+        // idempotent.
         let Some(peer_home) = kimi_home_for_environment(
             &super::profile_config::resolve_config_or_warn(&peer_profile).environment,
         ) else {
             return true;
         };
-        if canonicalize_or_raw(peer_home.to_string_lossy().as_ref()) != own_home {
+        let peer_home = canonicalize_or_raw(peer_home.to_string_lossy().as_ref());
+        if !own_homes.contains(&peer_home) {
             continue;
         }
         let Ok(storage) = crate::session::storage::Storage::new_unwatched(&peer_profile) else {

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2749,28 +2749,31 @@ pub(crate) fn kimi_poll_fn(
     }
 }
 
-/// Effective Kimi home for one profile's host environment: `KIMI_CODE_HOME`
-/// from that environment when set, else the same ambient default resolution
-/// [`capture_kimi_session_id`] performs. `None` when even the default cannot
-/// be resolved; the sharing predicate fails closed on `None`.
+/// Effective Kimi home for one environment list: `KIMI_CODE_HOME` resolved
+/// through the same `$VAR` / bare-key grammar launch applies
+/// ([`crate::session::environment::resolve_host_environment_value`]), else the
+/// ambient default resolution [`capture_kimi_session_id`] performs. `None`
+/// when even the default cannot be resolved; the sharing predicate fails
+/// closed on `None`.
 fn kimi_home_for_environment(environment: &[String]) -> Option<PathBuf> {
-    for entry in environment {
-        if let Some((key, value)) = entry.split_once('=') {
-            if key == "KIMI_CODE_HOME" && !value.is_empty() {
-                return Some(PathBuf::from(value));
-            }
-        }
-    }
-    resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code").ok()
+    crate::session::environment::resolve_host_environment_value(environment, "KIMI_CODE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code").ok())
 }
 
-/// Whether another live-tracked AoE session shares this one's Kimi store
-/// namespace: the same resolved `$KIMI_CODE_HOME` (or default `~/.kimi-code`)
-/// and the same canonicalized project path. When true, the newest matching
-/// record in `session_index.jsonl` cannot be attributed to this pane, so
-/// acquire must not retarget an anchored session id from it (#3516).
+/// Whether another live-tracked AoE session shares this one's Kimi store: the
+/// same resolved `$KIMI_CODE_HOME` (or default `~/.kimi-code`) plus the same
+/// canonicalized project path. When true, the newest matching record in the
+/// session index cannot be attributed to this pane, so acquire must not make
+/// the MRU retarget from it (#3516).
 ///
-/// The walk covers every AoE profile because the index is keyed by resolved
+/// `own_environment` must be the caller's [`Instance::resolved_host_environment`]
+/// so the own side judges sharing on exactly what the launched pane sees,
+/// including `before_session`-minted values. Peers are judged on their
+/// profile's static list because minted pairs are runtime state that is
+/// deliberately not persisted; a profile whose hook mints `KIMI_CODE_HOME`
+/// is therefore judged on its static spelling for the peer side only.
+/// The walk covers every AoE profile because the store is keyed by resolved
 /// home plus cwd, not by profile: two profiles resolving to one home share
 /// one store. It fails closed: an unreadable profile list, an unreadable
 /// per-profile store, or an unresolvable Kimi home all report shared,
@@ -2784,25 +2787,21 @@ fn kimi_home_for_environment(environment: &[String]) -> Option<PathBuf> {
 pub(crate) fn kimi_store_is_shared(
     current_instance_id: &str,
     current_project_path: &str,
-    profile: &str,
+    own_environment: &[String],
 ) -> bool {
     let canonical_current = canonicalize_or_raw(current_project_path);
-    let Some(own_home) = kimi_home_for_environment(
-        &super::profile_config::resolve_config_or_warn(profile).environment,
-    ) else {
+    let Some(own_home) = kimi_home_for_environment(own_environment)
+        .map(|home| canonicalize_or_raw(home.to_string_lossy().as_ref()))
+    else {
         return true;
     };
-    let own_home = canonicalize_or_raw(own_home.to_string_lossy().as_ref());
     let Ok(profiles) = crate::session::list_profiles() else {
         return true;
     };
     for peer_profile in profiles {
-        let Ok(storage) = crate::session::storage::Storage::new_unwatched(&peer_profile) else {
-            return true;
-        };
-        let Ok(instances) = storage.load() else {
-            return true;
-        };
+        // Judge the namespace before paying for the store read: a peer whose
+        // resolved home differs cannot share this store however many rows its
+        // sessions.json holds.
         let Some(peer_home) = kimi_home_for_environment(
             &super::profile_config::resolve_config_or_warn(&peer_profile).environment,
         ) else {
@@ -2811,6 +2810,12 @@ pub(crate) fn kimi_store_is_shared(
         if canonicalize_or_raw(peer_home.to_string_lossy().as_ref()) != own_home {
             continue;
         }
+        let Ok(storage) = crate::session::storage::Storage::new_unwatched(&peer_profile) else {
+            return true;
+        };
+        let Ok(instances) = storage.load() else {
+            return true;
+        };
         for inst in instances {
             if inst.id == current_instance_id || inst.tool != "kimi" || inst.is_sandboxed() {
                 continue;

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2789,6 +2789,12 @@ fn kimi_home_for_environment(environment: &[String]) -> Option<PathBuf> {
 /// profile list because minted pairs are runtime state that is deliberately
 /// not persisted.
 ///
+/// An unreadable peer profile config silently resolves that peer to the
+/// ambient default home rather than failing closed: the trigger needs a
+/// config readable at launch and unreadable during recovery, and the
+/// fallible-resolution fix would ripple through shared helpers, so the gap
+/// is accepted and stated here instead of hidden.
+///
 /// The walk covers every AoE profile because the store is keyed by resolved
 /// home plus cwd, not by profile: two profiles resolving to one home share
 /// one store. It fails closed: an unreadable profile list, an unreadable

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2749,6 +2749,83 @@ pub(crate) fn kimi_poll_fn(
     }
 }
 
+/// Effective Kimi home for one profile's host environment: `KIMI_CODE_HOME`
+/// from that environment when set, else the same ambient default resolution
+/// [`capture_kimi_session_id`] performs. `None` when even the default cannot
+/// be resolved; the sharing predicate fails closed on `None`.
+fn kimi_home_for_environment(environment: &[String]) -> Option<PathBuf> {
+    for entry in environment {
+        if let Some((key, value)) = entry.split_once('=') {
+            if key == "KIMI_CODE_HOME" && !value.is_empty() {
+                return Some(PathBuf::from(value));
+            }
+        }
+    }
+    resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code").ok()
+}
+
+/// Whether another live-tracked AoE session shares this one's Kimi store
+/// namespace: the same resolved `$KIMI_CODE_HOME` (or default `~/.kimi-code`)
+/// and the same canonicalized project path. When true, the newest matching
+/// record in `session_index.jsonl` cannot be attributed to this pane, so
+/// acquire must not retarget an anchored session id from it (#3516).
+///
+/// The walk covers every AoE profile because the index is keyed by resolved
+/// home plus cwd, not by profile: two profiles resolving to one home share
+/// one store. It fails closed: an unreadable profile list, an unreadable
+/// per-profile store, or an unresolvable Kimi home all report shared,
+/// because ownership that cannot be proven must not license an MRU
+/// retarget. Trashed and archived peers are skipped: they need explicit user
+/// action or are skipped by startup recovery, so they cannot take part in a
+/// concurrent start. Stopped and pane-less peers deliberately count as
+/// sharing; pane liveness is exactly what races during a mass recovery, so
+/// filtering on it re-opens the storm window (same reasoning as #3507's
+/// Claude predicate).
+pub(crate) fn kimi_store_is_shared(
+    current_instance_id: &str,
+    current_project_path: &str,
+    profile: &str,
+) -> bool {
+    let canonical_current = canonicalize_or_raw(current_project_path);
+    let Some(own_home) = kimi_home_for_environment(
+        &super::profile_config::resolve_config_or_warn(profile).environment,
+    ) else {
+        return true;
+    };
+    let own_home = canonicalize_or_raw(own_home.to_string_lossy().as_ref());
+    let Ok(profiles) = crate::session::list_profiles() else {
+        return true;
+    };
+    for peer_profile in profiles {
+        let Ok(storage) = crate::session::storage::Storage::new_unwatched(&peer_profile) else {
+            return true;
+        };
+        let Ok(instances) = storage.load() else {
+            return true;
+        };
+        let Some(peer_home) = kimi_home_for_environment(
+            &super::profile_config::resolve_config_or_warn(&peer_profile).environment,
+        ) else {
+            return true;
+        };
+        if canonicalize_or_raw(peer_home.to_string_lossy().as_ref()) != own_home {
+            continue;
+        }
+        for inst in instances {
+            if inst.id == current_instance_id || inst.tool != "kimi" || inst.is_sandboxed() {
+                continue;
+            }
+            if inst.is_trashed() || inst.is_archived() {
+                continue;
+            }
+            if canonicalize_or_raw(&inst.project_path) == canonical_current {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 // ─── Hermes session capture ───────────────────────────────────────────────────
 
 const HERMES_COMMAND_TIMEOUT_SECS: u64 = 5;

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -991,16 +991,17 @@ pub(crate) fn compose_exclusion(
 /// starts. Parked conversations are no longer published in the peer's tmux
 /// environment, so [`build_exclusion_set`] cannot see them. Without this set,
 /// another session can capture the parked conversation before its owner swaps
-/// back. Claude and host Codex additionally need stopped peer protection
-/// because their mtime fallbacks can select a transcript after the owning tmux
-/// pane disappears (#2355). Sandboxed Codex sessions have instance-private
-/// `CODEX_HOME` directories and do not share a transcript store (#3317).
+/// back. Claude, host Codex, and host Kimi additionally need inactive
+/// same-tool protection because their shared-store MRU scans can select a
+/// conversation after the owning pane disappears. Sandboxed Codex and Kimi
+/// omit that protection because their stores are instance-private or are not
+/// captured from the host (#3317).
 ///
-/// Scope: the host transcript directories are keyed by `$HOME`, not by AoE
-/// profile, but this helper only inspects `sessions.json` for the caller's
-/// effective profile. A stopped peer in a different profile against the same
-/// host `$HOME` will not be excluded; the residual gap is narrower than #2355's
-/// trigger and is left for a follow-up.
+/// Scope: host stores are keyed by each agent's effective home, not by AoE
+/// profile, but this helper inspects only `sessions.json` for the caller's
+/// effective profile. A stopped peer in another profile against the same
+/// agent home will not be excluded; callers needing global ownership must
+/// compose their own cross-profile check.
 pub(crate) fn compose_exclusion_with_persisted_peers(
     current_instance_id: &str,
     current_project_path: &str,
@@ -2771,9 +2772,10 @@ fn kimi_home_for_environment(environment: &[String]) -> Option<PathBuf> {
         .map(PathBuf::from)
         .filter(|home| !home.as_os_str().is_empty())
         .or_else(|| resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code").ok())
+        .filter(|home| !home.as_os_str().is_empty())
 }
 
-/// Whether another live-tracked AoE session shares this one's Kimi store: a
+/// Whether another persisted host AoE session shares this one's Kimi store: a
 /// resolvable own home plus the same canonicalized project path. When true,
 /// the newest matching record in the session index cannot be attributed to
 /// this pane, so the acquire-time MRU scan behind
@@ -2789,22 +2791,15 @@ fn kimi_home_for_environment(environment: &[String]) -> Option<PathBuf> {
 /// profile list because minted pairs are runtime state that is deliberately
 /// not persisted.
 ///
-/// An unreadable peer profile config silently resolves that peer to the
-/// ambient default home rather than failing closed: the trigger needs a
-/// config readable at launch and unreadable during recovery, and the
-/// fallible-resolution fix would ripple through shared helpers, so the gap
-/// is accepted and stated here instead of hidden.
-///
 /// The walk covers every AoE profile because the store is keyed by resolved
 /// home plus cwd, not by profile: two profiles resolving to one home share
-/// one store. It fails closed: an unreadable profile list, an unreadable
-/// per-profile store, or no resolvable own home all report shared, because
-/// ownership that cannot be proven must not license an MRU retarget.
-/// Trashed and archived peers are skipped: they need explicit user action or
-/// are skipped by startup recovery, so they cannot take part in a concurrent
-/// start. Stopped and pane-less peers deliberately count as sharing; pane
-/// liveness is exactly what races during a mass recovery, so filtering on it
-/// re-opens the storm window (same reasoning as #3507's Claude predicate).
+/// one store. It fails closed: an unreadable profile list, config, or store,
+/// or no resolvable own home all report shared, because ownership that cannot
+/// be proven must not license an MRU retarget. Current Kimi peers and peers
+/// with a parked Kimi conversation count even when stopped, pane-less,
+/// archived, or trashed: the former race during recovery and the latter
+/// remain restorable owners. Sandboxed peers are skipped because their Kimi
+/// stores are container-private.
 pub(crate) fn kimi_store_is_shared(
     current_instance_id: &str,
     current_project_path: &str,
@@ -2812,12 +2807,11 @@ pub(crate) fn kimi_store_is_shared(
     own_profile_environment: &[String],
 ) -> bool {
     let canonical_current = canonicalize_or_raw(current_project_path);
-    let mut own_homes = [own_resolved_environment, own_profile_environment]
+    let own_homes = [own_resolved_environment, own_profile_environment]
         .iter()
         .filter_map(|env| kimi_home_for_environment(env))
         .map(|home| canonicalize_or_raw(home.to_string_lossy().as_ref()))
         .collect::<Vec<_>>();
-    own_homes.dedup();
     if own_homes.is_empty() {
         return true;
     }
@@ -2827,12 +2821,13 @@ pub(crate) fn kimi_store_is_shared(
     for peer_profile in profiles {
         // Judge the namespace before paying for the store read: a peer whose
         // resolved home differs cannot share this store however many rows its
-        // sessions.json holds. The per-launch cost of one config read per
-        // profile is accepted; the status-rule install it triggers is
-        // idempotent.
-        let Some(peer_home) = kimi_home_for_environment(
-            &super::profile_config::resolve_config_or_warn(&peer_profile).environment,
-        ) else {
+        // sessions.json holds. A successful resolve idempotently reinstalls
+        // that profile's status rules; a failed resolve returns shared without
+        // installing fallback rules or clearing the prior registry state.
+        let Ok(peer_config) = super::profile_config::resolve_config(&peer_profile) else {
+            return true;
+        };
+        let Some(peer_home) = kimi_home_for_environment(&peer_config.environment) else {
             return true;
         };
         let peer_home = canonicalize_or_raw(peer_home.to_string_lossy().as_ref());
@@ -2846,10 +2841,16 @@ pub(crate) fn kimi_store_is_shared(
             return true;
         };
         for inst in instances {
-            if inst.id == current_instance_id || inst.tool != "kimi" || inst.is_sandboxed() {
+            if inst.id == current_instance_id || inst.is_sandboxed() {
                 continue;
             }
-            if inst.is_trashed() || inst.is_archived() {
+            let owns_kimi = inst.tool == "kimi"
+                || inst
+                    .prior_tool_session_ids
+                    .get("kimi")
+                    .and_then(|prior| prior.agent_session_id.as_deref())
+                    .is_some_and(|sid| !sid.is_empty());
+            if !owns_kimi {
                 continue;
             }
             if canonicalize_or_raw(&inst.project_path) == canonical_current {
@@ -6245,6 +6246,16 @@ mod tests {
         let entries = vec![("a".to_string(), "/work/elsewhere".to_string())];
         let result = select_copilot_session(&entries, "/work/proj", &HashSet::new());
         assert!(result.is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn test_kimi_home_rejects_empty_ambient_fallback() {
+        let _env = EnvGuard::set(&[("KIMI_CODE_HOME", "")]);
+        assert!(
+            kimi_home_for_environment(&[]).is_none(),
+            "an explicitly empty ambient home must not become a relative store path"
+        );
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3179,14 +3179,13 @@ impl Instance {
         )
     }
 
-    /// Whether another AoE session shares this one's Kimi store namespace,
-    /// which makes the session index useless for attributing a conversation
-    /// to a pane.
+    /// Whether another AoE session shares this one's Kimi store, which makes
+    /// the session index useless for attributing a conversation to a pane.
     fn kimi_store_is_shared(&self) -> bool {
         super::capture::kimi_store_is_shared(
             &self.id,
             &self.project_path,
-            &self.effective_profile(),
+            &self.resolved_host_environment(),
         )
     }
 
@@ -3577,12 +3576,13 @@ impl Instance {
                 return override_if_distinct(self.agent_session_id.as_deref(), authoritative);
             }
         }
-        // A shared Kimi index names no pane: its newest same-workDir record is
-        // as likely to be a co-located peer's conversation as this one's, so an
-        // anchored sid is kept rather than swapped for the scan result (#3516).
-        // Sole-owner stores skip this and keep the mtime retarget, which stays
-        // the new-conversation promotion path (#2291); sandboxed Kimi never
-        // captures (its arm in try_retroactive_capture returns None).
+        // A shared Kimi store names no pane: the newest same-workDir record
+        // in its session index is as likely to be a co-located peer's
+        // conversation as this one's, so an anchored sid is kept rather than
+        // swapped for the scan result (#3516). Sole-owner stores skip this and
+        // keep the MRU retarget, which stays the new-conversation promotion
+        // path (#2291); sandboxed Kimi never captures (its arm in
+        // try_retroactive_capture returns None).
         if self.tool == "kimi" && !self.is_sandboxed() && self.kimi_store_is_shared() {
             return None;
         }
@@ -14994,7 +14994,7 @@ mod tests {
 
             #[test]
             #[serial]
-            fn acquire_kimi_keeps_anchor_when_session_index_is_shared() {
+            fn acquire_kimi_keeps_anchor_when_store_is_shared() {
                 let temp = tempdir().unwrap();
                 let _home = isolate_app_dir_at(temp.path());
                 let project = temp.path().join("storm-project");
@@ -15129,6 +15129,117 @@ mod tests {
 
                 let (sid, _is_existing) = inst.acquire_session_id();
                 assert_eq!(sid.as_deref(), Some("kimi-fresh"));
+            }
+            #[test]
+            #[serial]
+            fn kimi_inactive_peers_do_not_block_retarget() {
+                // The skip filters are load-bearing in both directions: a
+                // trashed, archived, or sandboxed peer on the same cwd must
+                // NOT count as sharing, or one stale row would permanently
+                // disable the #2291 retarget through the fail-closed store.
+                // Table rows share the storm fixture; only the peer's state
+                // differs.
+                let cases = [
+                    ("trashed", "kimi-trashed-peer"),
+                    ("archived", "kimi-archived-peer"),
+                    ("sandboxed", "kimi-sandboxed-peer"),
+                ];
+                for (label, peer_sid) in cases {
+                    let temp = tempdir().unwrap();
+                    let _home = isolate_app_dir_at(temp.path());
+                    let project = temp.path().join(format!("filter-project-{label}"));
+                    fs::create_dir_all(&project).unwrap();
+                    let project = project.to_string_lossy().to_string();
+                    let kimi_home = temp.path().join("kimi-home");
+                    fs::create_dir_all(&kimi_home).unwrap();
+                    let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                    seed_kimi_index(&kimi_home, &project, "kimi-stored", peer_sid);
+
+                    let profile = format!("kimi-filter-{label}");
+                    let mut peer = Instance::new("filter-peer", &project);
+                    peer.source_profile = profile.clone();
+                    peer.tool = "kimi".to_string();
+                    peer.agent_session_id = Some(peer_sid.to_string());
+                    match label {
+                        "trashed" => peer.trash(),
+                        "archived" => peer.archive(),
+                        "sandboxed" => {
+                            peer.sandbox_info = Some(crate::session::SandboxInfo {
+                                enabled: true,
+                                container_id: None,
+                                image: "test-image".to_string(),
+                                container_name: format!("aoe-test-{label}"),
+                                extra_env: None,
+                                custom_instruction: None,
+                                container_workdir: None,
+                                before_start_env: Vec::new(),
+                            });
+                        }
+                        _ => unreachable!(),
+                    }
+                    super::seed_disk_for_sidecar_test(&profile, &peer);
+
+                    let mut inst = Instance::new("filter-caller", &project);
+                    inst.source_profile = profile.clone();
+                    inst.tool = "kimi".to_string();
+                    inst.agent_session_id = Some("kimi-stored".to_string());
+                    inst.resume_intent = ResumeIntent::Default;
+
+                    let (sid, _is_existing) = inst.acquire_session_id();
+                    assert_eq!(
+                        sid.as_deref(),
+                        Some(peer_sid),
+                        "{label} peer on the same cwd must not count as shared"
+                    );
+                }
+            }
+
+            #[test]
+            #[serial]
+            fn kimi_var_form_homes_still_detect_shared_store() {
+                // Profiles spell homes in launch's environment grammar: a peer
+                // profile writing `KIMI_CODE_HOME=$KIMI_SHARED` resolves to
+                // the same physical store as the caller's ambient spelling,
+                // and must count as shared rather than compare as the literal
+                // text `$KIMI_SHARED` (#3516 review cycle).
+                let temp = tempdir().unwrap();
+                let _home = isolate_app_dir_at(temp.path());
+                let project = temp.path().join("var-project");
+                fs::create_dir_all(&project).unwrap();
+                let project = project.to_string_lossy().to_string();
+                let kimi_home = temp.path().join("kimi-home");
+                fs::create_dir_all(&kimi_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                let _shared = EnvGuard::set(&[("KIMI_SHARED", kimi_home.to_str().unwrap())]);
+
+                let mut peer_config =
+                    crate::session::profile_config::load_profile_config("kimi-var-peer").unwrap();
+                peer_config.overrides.insert(
+                    "environment".to_string(),
+                    serde_json::json!(["KIMI_CODE_HOME=$KIMI_SHARED"]),
+                );
+                crate::session::profile_config::save_profile_config("kimi-var-peer", &peer_config)
+                    .unwrap();
+
+                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
+                let mut peer = Instance::new("var-peer", &project);
+                peer.source_profile = "kimi-var-peer".to_string();
+                peer.tool = "kimi".to_string();
+                peer.agent_session_id = Some("kimi-peer-fresh".to_string());
+                super::seed_disk_for_sidecar_test("kimi-var-peer", &peer);
+
+                let mut inst = Instance::new("var-caller", &project);
+                inst.source_profile = "kimi-var-caller".to_string();
+                inst.tool = "kimi".to_string();
+                inst.agent_session_id = Some("kimi-stored".to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, _is_existing) = inst.acquire_session_id();
+                assert_eq!(
+                    sid.as_deref(),
+                    Some("kimi-stored"),
+                    "a $VAR-spelled peer home resolving to the same store must count as shared"
+                );
             }
         }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3181,11 +3181,14 @@ impl Instance {
 
     /// Whether another AoE session shares this one's Kimi store, which makes
     /// the session index useless for attributing a conversation to a pane.
+    /// Both own homes are supplied so a hook-minted `KIMI_CODE_HOME` still
+    /// counts static-profile siblings as sharing.
     fn kimi_store_is_shared(&self) -> bool {
         super::capture::kimi_store_is_shared(
             &self.id,
             &self.project_path,
             &self.resolved_host_environment(),
+            &self.profile_host_environment(),
         )
     }
 
@@ -3343,18 +3346,35 @@ impl Instance {
                 }
             }
             "kimi" => {
-                // Kimi records sessions in `~/.kimi-code/session_index.jsonl`
-                // keyed by workDir. Host capture reads it directly; sandbox
-                // resume is a follow-up (the container's index is not read over
-                // `docker exec`), so a sandboxed Kimi session starts fresh on
-                // restart, mirroring Copilot.
+                // Kimi records sessions in `session_index.jsonl` under the
+                // resolved `KIMI_CODE_HOME`, keyed by workDir. Host capture
+                // reads it through the launched pane's environment; sandbox
+                // resume is a follow-up (the container's index is not read
+                // over `docker exec`), so a sandboxed Kimi session starts
+                // fresh on restart, mirroring Copilot.
                 if self.is_sandboxed() {
+                    None
+                } else if self.kimi_store_is_shared() {
+                    // A shared store names no pane: its newest same-workDir
+                    // record is as likely to be a co-located peer's
+                    // conversation as this one's, so the MRU scan is refused
+                    // entirely (#3516). An anchored sid keeps its value on
+                    // the freshest path; an id-less session starts fresh
+                    // rather than adopt a peer conversation. Sole-owner
+                    // stores keep the MRU retarget, which stays the
+                    // new-conversation promotion path (#2291).
                     None
                 } else {
                     let exclusion = self.retroactive_capture_exclusion_set();
                     // Retroactive recovery is unrestricted (no launch floor):
                     // resuming an older session on restart is the goal here.
-                    capture_kimi_session_id(&self.project_path, &exclusion, None).ok()
+                    capture_kimi_session_id(
+                        &self.project_path,
+                        &exclusion,
+                        None,
+                        &self.resolved_host_environment(),
+                    )
+                    .ok()
                 }
             }
             _ => None,
@@ -3576,16 +3596,9 @@ impl Instance {
                 return override_if_distinct(self.agent_session_id.as_deref(), authoritative);
             }
         }
-        // A shared Kimi store names no pane: the newest same-workDir record
-        // in its session index is as likely to be a co-located peer's
-        // conversation as this one's, so an anchored sid is kept rather than
-        // swapped for the scan result (#3516). Sole-owner stores skip this and
-        // keep the MRU retarget, which stays the new-conversation promotion
-        // path (#2291); sandboxed Kimi never captures (its arm in
-        // try_retroactive_capture returns None).
-        if self.tool == "kimi" && !self.is_sandboxed() && self.kimi_store_is_shared() {
-            return None;
-        }
+        // Kimi: a shared store refuses the MRU scan entirely inside
+        // try_retroactive_capture, so reaching this line means the store is
+        // sole-owned and a fresher observation is attributable.
 
         let live = self.try_retroactive_capture()?;
         override_if_distinct(self.agent_session_id.as_deref(), live)
@@ -5871,9 +5884,10 @@ impl Instance {
                 ))
             }
             "kimi" => {
-                // Host-only, mirroring Copilot: the Kimi session index is read
-                // from the host `~/.kimi-code`. Sandboxed sessions have no
-                // poller and start fresh on restart (sandbox resume is a
+                // Host-only, mirroring Copilot: the Kimi session index is
+                // read from the host store under the launched pane's
+                // resolved environment. Sandboxed sessions have no poller
+                // and start fresh on restart (sandbox resume is a
                 // follow-up).
                 if self.is_sandboxed() {
                     return;
@@ -5884,6 +5898,7 @@ impl Instance {
                     self.id.clone(),
                     launch_time_ms,
                     extra_excludes,
+                    self.resolved_host_environment(),
                 ))
             }
             _ => return,
@@ -15239,6 +15254,85 @@ mod tests {
                     sid.as_deref(),
                     Some("kimi-stored"),
                     "a $VAR-spelled peer home resolving to the same store must count as shared"
+                );
+            }
+            #[test]
+            #[serial]
+            fn kimi_shared_store_refuses_id_less_retroactive_fill() {
+                // The shared-store refusal lives in try_retroactive_capture,
+                // so it also covers the id-less doors (recovery of a session
+                // that never captured, read-command self-heal): the scan is
+                // refused entirely, yielding a fresh start instead of an
+                // unattributable adoption, while a sole-owner store keeps
+                // filling from the index.
+                for (label, peer_present, expected) in
+                    [("shared", true, None), ("solo", false, Some("kimi-fresh"))]
+                {
+                    let temp = tempdir().unwrap();
+                    let _home = isolate_app_dir_at(temp.path());
+                    let project = temp.path().join(format!("idless-project-{label}"));
+                    fs::create_dir_all(&project).unwrap();
+                    let project = project.to_string_lossy().to_string();
+                    let kimi_home = temp.path().join("kimi-home");
+                    fs::create_dir_all(&kimi_home).unwrap();
+                    let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                    seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-fresh");
+
+                    if peer_present {
+                        let profile = format!("kimi-idless-{label}");
+                        let mut peer = Instance::new("idless-peer", &project);
+                        peer.source_profile = profile.clone();
+                        peer.tool = "kimi".to_string();
+                        super::seed_disk_for_sidecar_test(&profile, &peer);
+                    }
+
+                    let mut inst = Instance::new("idless-caller", &project);
+                    inst.tool = "kimi".to_string();
+
+                    assert_eq!(
+                        inst.try_retroactive_capture(),
+                        expected.map(str::to_string),
+                        "{label} store"
+                    );
+                }
+            }
+
+            #[test]
+            #[serial]
+            fn kimi_anchor_kept_when_profile_list_unreadable() {
+                // Fail-closed branch: an erroring profile walk must report
+                // shared, keeping the anchored sid rather than licensing the
+                // MRU retarget. Driven through the existing list_profiles
+                // injection seam.
+                let temp = tempdir().unwrap();
+                let _home = isolate_app_dir_at(temp.path());
+                let project = temp.path().join("failclosed-project");
+                fs::create_dir_all(&project).unwrap();
+                let project = project.to_string_lossy().to_string();
+                let kimi_home = temp.path().join("kimi-home");
+                fs::create_dir_all(&kimi_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
+
+                let profile = "kimi-failclosed";
+                let mut peer = Instance::new("failclosed-peer", &project);
+                peer.source_profile = profile.to_string();
+                peer.tool = "kimi".to_string();
+                peer.agent_session_id = Some("kimi-peer-fresh".to_string());
+                super::seed_disk_for_sidecar_test(profile, &peer);
+
+                let mut inst = Instance::new("failclosed-caller", &project);
+                inst.source_profile = profile.to_string();
+                inst.tool = "kimi".to_string();
+                inst.agent_session_id = Some("kimi-stored".to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let _failure = crate::session::FailNextListProfilesGuard::new();
+                let (sid, _is_existing) = inst.acquire_session_id();
+                assert_eq!(
+                    sid.as_deref(),
+                    Some("kimi-stored"),
+                    "an unreadable profile list must count as shared"
                 );
             }
         }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3179,6 +3179,17 @@ impl Instance {
         )
     }
 
+    /// Whether another AoE session shares this one's Kimi store namespace,
+    /// which makes the session index useless for attributing a conversation
+    /// to a pane.
+    fn kimi_store_is_shared(&self) -> bool {
+        super::capture::kimi_store_is_shared(
+            &self.id,
+            &self.project_path,
+            &self.effective_profile(),
+        )
+    }
+
     pub(crate) fn try_retroactive_capture(&self) -> Option<String> {
         let result: Option<String> = match self.tool.as_str() {
             "claude" => {
@@ -3565,6 +3576,15 @@ impl Instance {
                 }
                 return override_if_distinct(self.agent_session_id.as_deref(), authoritative);
             }
+        }
+        // A shared Kimi index names no pane: its newest same-workDir record is
+        // as likely to be a co-located peer's conversation as this one's, so an
+        // anchored sid is kept rather than swapped for the scan result (#3516).
+        // Sole-owner stores skip this and keep the mtime retarget, which stays
+        // the new-conversation promotion path (#2291); sandboxed Kimi never
+        // captures (its arm in try_retroactive_capture returns None).
+        if self.tool == "kimi" && !self.is_sandboxed() && self.kimi_store_is_shared() {
+            return None;
         }
 
         let live = self.try_retroactive_capture()?;
@@ -14936,6 +14956,179 @@ mod tests {
                 assert_eq!(sid.as_deref(), Some(stored));
                 assert!(is_existing);
                 assert_eq!(inst.agent_session_id.as_deref(), Some(stored));
+            }
+            // ── Kimi shared-index anchor (#3516) ─────────────────────────────
+            //
+            // The per-tool bascule tests above run one instance against its
+            // store. Kimi's store is a single append-only
+            // `session_index.jsonl` keyed by workDir with no per-instance
+            // signal, so when two AoE sessions share one cwd the MRU pick can
+            // name either pane's conversation. These fixtures stage the mass
+            // recovery from #3516: every pane holds a stored sid, no peer has
+            // a live tmux pane yet, and the freshest record belongs to a
+            // sibling.
+
+            /// Stage two Kimi index records for one `workDir`, the "fresh"
+            /// one newer than the "stored" one. The recorded `sessionDir`
+            /// paths are regular files rather than directories so their
+            /// mtimes are deterministic through `File::set_times`; the
+            /// selector only stats whatever path the index records.
+            fn seed_kimi_index(home: &std::path::Path, project: &str, stored: &str, fresh: &str) {
+                let now = SystemTime::now();
+                let stored_dir = home.join("sessions").join("stored");
+                let fresh_dir = home.join("sessions").join("fresh");
+                fs::create_dir_all(stored_dir.parent().unwrap()).unwrap();
+                write_with_mtime(&stored_dir, "", now - Duration::from_secs(120));
+                write_with_mtime(&fresh_dir, "", now - Duration::from_secs(5));
+                fs::write(
+                    home.join("session_index.jsonl"),
+                    format!(
+                        "{{\"sessionId\":\"{stored}\",\"sessionDir\":\"{}\",\"workDir\":\"{project}\"}}\n\
+                         {{\"sessionId\":\"{fresh}\",\"sessionDir\":\"{}\",\"workDir\":\"{project}\"}}\n",
+                        stored_dir.display(),
+                        fresh_dir.display(),
+                    ),
+                )
+                .unwrap();
+            }
+
+            #[test]
+            #[serial]
+            fn acquire_kimi_keeps_anchor_when_session_index_is_shared() {
+                let temp = tempdir().unwrap();
+                let _home = isolate_app_dir_at(temp.path());
+                let project = temp.path().join("storm-project");
+                fs::create_dir_all(&project).unwrap();
+                let project = project.to_string_lossy().to_string();
+                let kimi_home = temp.path().join("kimi-home");
+                fs::create_dir_all(&kimi_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
+
+                // The peer shares the cwd and owns the fresher record. It is
+                // persisted but pane-less: exactly the state of every session
+                // in a recovery storm before any pane has come up, when the
+                // live-tmux exclusion scan still sees nothing.
+                let profile = "kimi-shared-anchor";
+                let mut peer = Instance::new("storm-peer", &project);
+                peer.source_profile = profile.to_string();
+                peer.tool = "kimi".to_string();
+                peer.agent_session_id = Some("kimi-peer-fresh".to_string());
+                super::seed_disk_for_sidecar_test(profile, &peer);
+
+                let mut inst = Instance::new("storm-caller", &project);
+                inst.source_profile = profile.to_string();
+                inst.tool = "kimi".to_string();
+                inst.agent_session_id = Some("kimi-stored".to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                // The newest record names the peer's conversation, not this
+                // pane's; acquire must keep the anchored sid instead of
+                // swapping it for the MRU guess.
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some("kimi-stored"));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some("kimi-stored"));
+            }
+
+            #[test]
+            #[serial]
+            fn acquire_kimi_retarget_stays_when_sole_owner_of_cwd() {
+                // Same fixture without the persisted peer: the index cannot
+                // name another pane's conversation, so the #2291-style MRU
+                // retarget stays intact and remains the post-/clear promotion
+                // path for single-session cwds.
+                let temp = tempdir().unwrap();
+                let _home = isolate_app_dir_at(temp.path());
+                let project = temp.path().join("solo-project");
+                fs::create_dir_all(&project).unwrap();
+                let project = project.to_string_lossy().to_string();
+                let kimi_home = temp.path().join("kimi-home");
+                fs::create_dir_all(&kimi_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-fresh");
+
+                let mut inst = Instance::new("solo-caller", &project);
+                inst.tool = "kimi".to_string();
+                inst.agent_session_id = Some("kimi-stored".to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some("kimi-fresh"));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some("kimi-fresh"));
+            }
+
+            #[test]
+            #[serial]
+            fn kimi_shared_detection_walks_across_profiles() {
+                // The session-index namespace is keyed by the resolved Kimi
+                // home plus the canonical cwd, not by the AoE profile: a peer
+                // recovered under a different profile must still block the
+                // MRU retarget (the gap class flagged as P1 on #3507).
+                let temp = tempdir().unwrap();
+                let _home = isolate_app_dir_at(temp.path());
+                let project = temp.path().join("cross-project");
+                fs::create_dir_all(&project).unwrap();
+                let project = project.to_string_lossy().to_string();
+                let kimi_home = temp.path().join("kimi-home");
+                fs::create_dir_all(&kimi_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
+
+                let mut peer = Instance::new("cross-peer", &project);
+                peer.source_profile = "kimi-cross-peer-profile".to_string();
+                peer.tool = "kimi".to_string();
+                peer.agent_session_id = Some("kimi-peer-fresh".to_string());
+                super::seed_disk_for_sidecar_test("kimi-cross-peer-profile", &peer);
+
+                let mut inst = Instance::new("cross-caller", &project);
+                inst.source_profile = "kimi-cross-caller-profile".to_string();
+                inst.tool = "kimi".to_string();
+                inst.agent_session_id = Some("kimi-stored".to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, _is_existing) = inst.acquire_session_id();
+                assert_eq!(
+                    sid.as_deref(),
+                    Some("kimi-stored"),
+                    "a peer in another profile sharing the resolved home and cwd must still count as shared"
+                );
+            }
+
+            #[test]
+            #[serial]
+            fn kimi_peer_on_different_cwd_does_not_block_retarget() {
+                // Sharing is judged on the pair (resolved home, canonical
+                // cwd): a peer on another project leaves this pane the sole
+                // owner of its own workDir slice of the index.
+                let temp = tempdir().unwrap();
+                let _home = isolate_app_dir_at(temp.path());
+                let project = temp.path().join("mine-project");
+                let other_project = temp.path().join("other-project");
+                fs::create_dir_all(&project).unwrap();
+                fs::create_dir_all(&other_project).unwrap();
+                let project = project.to_string_lossy().to_string();
+                let other_project = other_project.to_string_lossy().to_string();
+                let kimi_home = temp.path().join("kimi-home");
+                fs::create_dir_all(&kimi_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-fresh");
+
+                let profile = "kimi-different-cwd";
+                let mut peer = Instance::new("cwd-peer", &other_project);
+                peer.source_profile = profile.to_string();
+                peer.tool = "kimi".to_string();
+                super::seed_disk_for_sidecar_test(profile, &peer);
+
+                let mut inst = Instance::new("mine-caller", &project);
+                inst.source_profile = profile.to_string();
+                inst.tool = "kimi".to_string();
+                inst.agent_session_id = Some("kimi-stored".to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, _is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some("kimi-fresh"));
             }
         }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3166,14 +3166,16 @@ impl Instance {
     }
 
     /// Full set of session IDs capture must skip for this instance: live tmux
-    /// ownership, cascade-cleared ids, and conversations same-project peers
-    /// parked while running another tool.
+    /// ownership, cascade-cleared ids, conversations same-project peers parked
+    /// while running another tool, and inactive peers that still own records
+    /// in a shared host store.
     fn retroactive_capture_exclusion_set(&self) -> HashSet<String> {
         super::capture::compose_exclusion_with_persisted_peers(
             &self.id,
             &self.project_path,
             &self.tool,
-            self.tool == "claude" || (self.tool == "codex" && !self.is_sandboxed()),
+            self.tool == "claude"
+                || (matches!(self.tool.as_str(), "codex" | "kimi") && !self.is_sandboxed()),
             &self.effective_profile(),
             &self.retroactive_capture_excludes,
         )
@@ -15010,160 +15012,196 @@ mod tests {
 
             #[test]
             #[serial]
-            fn acquire_kimi_keeps_anchor_when_store_is_shared() {
-                let temp = tempdir().unwrap();
-                let _home = isolate_app_dir_at(temp.path());
-                let project = temp.path().join("storm-project");
-                fs::create_dir_all(&project).unwrap();
-                let project = project.to_string_lossy().to_string();
-                let kimi_home = temp.path().join("kimi-home");
-                fs::create_dir_all(&kimi_home).unwrap();
-                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
-                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
+            fn acquire_kimi_respects_store_ownership() {
+                #[derive(Clone, Copy)]
+                enum PeerKind {
+                    None,
+                    CurrentKimi,
+                    ParkedKimi,
+                    ArchivedKimi,
+                    TrashedKimi,
+                    SandboxedKimi,
+                }
 
-                // The peer shares the cwd and owns the fresher record. It is
-                // persisted but pane-less: exactly the state of every session
-                // in a recovery storm before any pane has come up, when the
-                // live-tmux exclusion scan still sees nothing.
-                let profile = "kimi-shared-anchor";
-                let mut peer = Instance::new("storm-peer", &project);
-                peer.source_profile = profile.to_string();
-                peer.tool = "kimi".to_string();
-                peer.agent_session_id = Some("kimi-peer-fresh".to_string());
-                super::seed_disk_for_sidecar_test(profile, &peer);
+                struct Case {
+                    label: &'static str,
+                    peer: PeerKind,
+                    cross_profile: bool,
+                    same_cwd: bool,
+                    fresh_sid: &'static str,
+                    expected: &'static str,
+                }
 
-                let mut inst = Instance::new("storm-caller", &project);
-                inst.source_profile = profile.to_string();
-                inst.tool = "kimi".to_string();
-                inst.agent_session_id = Some("kimi-stored".to_string());
-                inst.resume_intent = ResumeIntent::Default;
-
-                // The newest record names the peer's conversation, not this
-                // pane's; acquire must keep the anchored sid instead of
-                // swapping it for the MRU guess.
-                let (sid, is_existing) = inst.acquire_session_id();
-                assert_eq!(sid.as_deref(), Some("kimi-stored"));
-                assert!(is_existing);
-                assert_eq!(inst.agent_session_id.as_deref(), Some("kimi-stored"));
-            }
-
-            #[test]
-            #[serial]
-            fn acquire_kimi_retarget_stays_when_sole_owner_of_cwd() {
-                // Same fixture without the persisted peer: the index cannot
-                // name another pane's conversation, so the #2291-style MRU
-                // retarget stays intact and remains the post-/clear promotion
-                // path for single-session cwds.
-                let temp = tempdir().unwrap();
-                let _home = isolate_app_dir_at(temp.path());
-                let project = temp.path().join("solo-project");
-                fs::create_dir_all(&project).unwrap();
-                let project = project.to_string_lossy().to_string();
-                let kimi_home = temp.path().join("kimi-home");
-                fs::create_dir_all(&kimi_home).unwrap();
-                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
-                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-fresh");
-
-                let mut inst = Instance::new("solo-caller", &project);
-                inst.tool = "kimi".to_string();
-                inst.agent_session_id = Some("kimi-stored".to_string());
-                inst.resume_intent = ResumeIntent::Default;
-
-                let (sid, is_existing) = inst.acquire_session_id();
-                assert_eq!(sid.as_deref(), Some("kimi-fresh"));
-                assert!(is_existing);
-                assert_eq!(inst.agent_session_id.as_deref(), Some("kimi-fresh"));
-            }
-
-            #[test]
-            #[serial]
-            fn kimi_shared_detection_walks_across_profiles() {
-                // The session-index namespace is keyed by the resolved Kimi
-                // home plus the canonical cwd, not by the AoE profile: a peer
-                // recovered under a different profile must still block the
-                // MRU retarget (the gap class flagged as P1 on #3507).
-                let temp = tempdir().unwrap();
-                let _home = isolate_app_dir_at(temp.path());
-                let project = temp.path().join("cross-project");
-                fs::create_dir_all(&project).unwrap();
-                let project = project.to_string_lossy().to_string();
-                let kimi_home = temp.path().join("kimi-home");
-                fs::create_dir_all(&kimi_home).unwrap();
-                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
-                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
-
-                let mut peer = Instance::new("cross-peer", &project);
-                peer.source_profile = "kimi-cross-peer-profile".to_string();
-                peer.tool = "kimi".to_string();
-                peer.agent_session_id = Some("kimi-peer-fresh".to_string());
-                super::seed_disk_for_sidecar_test("kimi-cross-peer-profile", &peer);
-
-                let mut inst = Instance::new("cross-caller", &project);
-                inst.source_profile = "kimi-cross-caller-profile".to_string();
-                inst.tool = "kimi".to_string();
-                inst.agent_session_id = Some("kimi-stored".to_string());
-                inst.resume_intent = ResumeIntent::Default;
-
-                let (sid, _is_existing) = inst.acquire_session_id();
-                assert_eq!(
-                    sid.as_deref(),
-                    Some("kimi-stored"),
-                    "a peer in another profile sharing the resolved home and cwd must still count as shared"
-                );
-            }
-
-            #[test]
-            #[serial]
-            fn kimi_peer_on_different_cwd_does_not_block_retarget() {
-                // Sharing is judged on the pair (resolved home, canonical
-                // cwd): a peer on another project leaves this pane the sole
-                // owner of its own workDir slice of the index.
-                let temp = tempdir().unwrap();
-                let _home = isolate_app_dir_at(temp.path());
-                let project = temp.path().join("mine-project");
-                let other_project = temp.path().join("other-project");
-                fs::create_dir_all(&project).unwrap();
-                fs::create_dir_all(&other_project).unwrap();
-                let project = project.to_string_lossy().to_string();
-                let other_project = other_project.to_string_lossy().to_string();
-                let kimi_home = temp.path().join("kimi-home");
-                fs::create_dir_all(&kimi_home).unwrap();
-                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
-                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-fresh");
-
-                let profile = "kimi-different-cwd";
-                let mut peer = Instance::new("cwd-peer", &other_project);
-                peer.source_profile = profile.to_string();
-                peer.tool = "kimi".to_string();
-                super::seed_disk_for_sidecar_test(profile, &peer);
-
-                let mut inst = Instance::new("mine-caller", &project);
-                inst.source_profile = profile.to_string();
-                inst.tool = "kimi".to_string();
-                inst.agent_session_id = Some("kimi-stored".to_string());
-                inst.resume_intent = ResumeIntent::Default;
-
-                let (sid, _is_existing) = inst.acquire_session_id();
-                assert_eq!(sid.as_deref(), Some("kimi-fresh"));
-            }
-            #[test]
-            #[serial]
-            fn kimi_inactive_peers_do_not_block_retarget() {
-                // The skip filters are load-bearing in both directions: a
-                // trashed, archived, or sandboxed peer on the same cwd must
-                // NOT count as sharing, or one stale row would permanently
-                // disable the #2291 retarget through the fail-closed store.
-                // Table rows share the storm fixture; only the peer's state
-                // differs.
                 let cases = [
-                    ("trashed", "kimi-trashed-peer"),
-                    ("archived", "kimi-archived-peer"),
-                    ("sandboxed", "kimi-sandboxed-peer"),
+                    Case {
+                        label: "same-profile-current",
+                        peer: PeerKind::CurrentKimi,
+                        cross_profile: false,
+                        same_cwd: true,
+                        fresh_sid: "kimi-peer-fresh",
+                        expected: "kimi-stored",
+                    },
+                    Case {
+                        label: "sole-owner",
+                        peer: PeerKind::None,
+                        cross_profile: false,
+                        same_cwd: true,
+                        fresh_sid: "kimi-fresh",
+                        expected: "kimi-fresh",
+                    },
+                    Case {
+                        label: "cross-profile-current",
+                        peer: PeerKind::CurrentKimi,
+                        cross_profile: true,
+                        same_cwd: true,
+                        fresh_sid: "kimi-peer-fresh",
+                        expected: "kimi-stored",
+                    },
+                    Case {
+                        label: "different-cwd",
+                        peer: PeerKind::CurrentKimi,
+                        cross_profile: false,
+                        same_cwd: false,
+                        fresh_sid: "kimi-fresh",
+                        expected: "kimi-fresh",
+                    },
+                    Case {
+                        label: "cross-profile-parked",
+                        peer: PeerKind::ParkedKimi,
+                        cross_profile: true,
+                        same_cwd: true,
+                        fresh_sid: "kimi-parked-peer",
+                        expected: "kimi-stored",
+                    },
+                    Case {
+                        label: "cross-profile-archived",
+                        peer: PeerKind::ArchivedKimi,
+                        cross_profile: true,
+                        same_cwd: true,
+                        fresh_sid: "kimi-archived-peer",
+                        expected: "kimi-stored",
+                    },
+                    Case {
+                        label: "cross-profile-trashed",
+                        peer: PeerKind::TrashedKimi,
+                        cross_profile: true,
+                        same_cwd: true,
+                        fresh_sid: "kimi-trashed-peer",
+                        expected: "kimi-stored",
+                    },
+                    Case {
+                        label: "sandbox-private",
+                        peer: PeerKind::SandboxedKimi,
+                        cross_profile: false,
+                        same_cwd: true,
+                        fresh_sid: "kimi-unrelated-host-fresh",
+                        expected: "kimi-unrelated-host-fresh",
+                    },
                 ];
-                for (label, peer_sid) in cases {
+
+                for case in cases {
                     let temp = tempdir().unwrap();
                     let _home = isolate_app_dir_at(temp.path());
-                    let project = temp.path().join(format!("filter-project-{label}"));
+                    let project = temp.path().join(format!("project-{}", case.label));
+                    let other_project = temp.path().join(format!("other-{}", case.label));
+                    fs::create_dir_all(&project).unwrap();
+                    fs::create_dir_all(&other_project).unwrap();
+                    let project = project.to_string_lossy().to_string();
+                    let other_project = other_project.to_string_lossy().to_string();
+                    let kimi_home = temp.path().join("kimi-home");
+                    fs::create_dir_all(&kimi_home).unwrap();
+                    let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                    seed_kimi_index(&kimi_home, &project, "kimi-stored", case.fresh_sid);
+
+                    let caller_profile = format!("kimi-owner-{}-caller", case.label);
+                    if !matches!(case.peer, PeerKind::None) {
+                        let peer_profile = if case.cross_profile {
+                            format!("kimi-owner-{}-peer", case.label)
+                        } else {
+                            caller_profile.clone()
+                        };
+                        let peer_path = if case.same_cwd {
+                            project.as_str()
+                        } else {
+                            other_project.as_str()
+                        };
+                        let mut peer = Instance::new("ownership-peer", peer_path);
+                        peer.source_profile = peer_profile.clone();
+                        match case.peer {
+                            PeerKind::None => unreachable!(),
+                            PeerKind::CurrentKimi => {
+                                peer.tool = "kimi".to_string();
+                                peer.agent_session_id = Some(case.fresh_sid.to_string());
+                            }
+                            PeerKind::ParkedKimi => {
+                                peer.tool = "claude".to_string();
+                                peer.prior_tool_session_ids.insert(
+                                    "kimi".to_string(),
+                                    crate::session::instance::PriorToolSession {
+                                        agent_session_id: Some(case.fresh_sid.to_string()),
+                                        acp_session_id: None,
+                                    },
+                                );
+                            }
+                            PeerKind::ArchivedKimi => {
+                                peer.tool = "kimi".to_string();
+                                peer.agent_session_id = Some(case.fresh_sid.to_string());
+                                peer.archive();
+                            }
+                            PeerKind::TrashedKimi => {
+                                peer.tool = "kimi".to_string();
+                                peer.agent_session_id = Some(case.fresh_sid.to_string());
+                                peer.trash();
+                            }
+                            PeerKind::SandboxedKimi => {
+                                peer.tool = "kimi".to_string();
+                                peer.agent_session_id = Some("kimi-sandbox-only".to_string());
+                                peer.sandbox_info = Some(crate::session::SandboxInfo {
+                                    enabled: true,
+                                    container_id: None,
+                                    image: "test-image".to_string(),
+                                    container_name: format!("aoe-test-{}", case.label),
+                                    extra_env: None,
+                                    custom_instruction: None,
+                                    container_workdir: None,
+                                    before_start_env: Vec::new(),
+                                });
+                            }
+                        }
+                        super::seed_disk_for_sidecar_test(&peer_profile, &peer);
+                    }
+
+                    let mut inst = Instance::new("ownership-caller", &project);
+                    inst.source_profile = caller_profile;
+                    inst.tool = "kimi".to_string();
+                    inst.agent_session_id = Some("kimi-stored".to_string());
+                    inst.resume_intent = ResumeIntent::Default;
+
+                    let (sid, is_existing) = inst.acquire_session_id();
+                    assert_eq!(sid.as_deref(), Some(case.expected), "{}", case.label);
+                    assert!(is_existing, "{}", case.label);
+                    assert_eq!(
+                        inst.agent_session_id.as_deref(),
+                        Some(case.expected),
+                        "{}",
+                        case.label
+                    );
+                }
+            }
+            #[test]
+            #[serial]
+            fn kimi_inactive_same_profile_sids_are_excluded() {
+                // Restorable inactive rows retain their Kimi conversation.
+                // The same-profile exclusion feeds both acquire and the live
+                // poller snapshot, while the cross-profile table above proves
+                // the all-profile ownership predicate independently.
+                for (label, peer_sid) in [
+                    ("trashed", "kimi-trashed-peer"),
+                    ("archived", "kimi-archived-peer"),
+                ] {
+                    let temp = tempdir().unwrap();
+                    let _home = isolate_app_dir_at(temp.path());
+                    let project = temp.path().join(format!("inactive-project-{label}"));
                     fs::create_dir_all(&project).unwrap();
                     let project = project.to_string_lossy().to_string();
                     let kimi_home = temp.path().join("kimi-home");
@@ -15171,42 +15209,28 @@ mod tests {
                     let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
                     seed_kimi_index(&kimi_home, &project, "kimi-stored", peer_sid);
 
-                    let profile = format!("kimi-filter-{label}");
-                    let mut peer = Instance::new("filter-peer", &project);
+                    let profile = format!("kimi-inactive-{label}");
+                    let mut peer = Instance::new("inactive-peer", &project);
                     peer.source_profile = profile.clone();
                     peer.tool = "kimi".to_string();
                     peer.agent_session_id = Some(peer_sid.to_string());
                     match label {
                         "trashed" => peer.trash(),
                         "archived" => peer.archive(),
-                        "sandboxed" => {
-                            peer.sandbox_info = Some(crate::session::SandboxInfo {
-                                enabled: true,
-                                container_id: None,
-                                image: "test-image".to_string(),
-                                container_name: format!("aoe-test-{label}"),
-                                extra_env: None,
-                                custom_instruction: None,
-                                container_workdir: None,
-                                before_start_env: Vec::new(),
-                            });
-                        }
                         _ => unreachable!(),
                     }
                     super::seed_disk_for_sidecar_test(&profile, &peer);
 
-                    let mut inst = Instance::new("filter-caller", &project);
-                    inst.source_profile = profile.clone();
+                    let mut inst = Instance::new("inactive-caller", &project);
+                    inst.source_profile = profile;
                     inst.tool = "kimi".to_string();
                     inst.agent_session_id = Some("kimi-stored".to_string());
                     inst.resume_intent = ResumeIntent::Default;
 
+                    let exclusion = inst.retroactive_capture_exclusion_set();
+                    assert!(exclusion.contains(peer_sid), "{label} exclusion");
                     let (sid, _is_existing) = inst.acquire_session_id();
-                    assert_eq!(
-                        sid.as_deref(),
-                        Some(peer_sid),
-                        "{label} peer on the same cwd must not count as shared"
-                    );
+                    assert_eq!(sid.as_deref(), Some("kimi-stored"), "{label} anchor");
                 }
             }
 
@@ -15266,9 +15290,11 @@ mod tests {
                 // refused entirely, yielding a fresh start instead of an
                 // unattributable adoption, while a sole-owner store keeps
                 // filling from the index.
-                for (label, peer_present, expected) in
-                    [("shared", true, None), ("solo", false, Some("kimi-fresh"))]
-                {
+                for (label, peer_state, expected) in [
+                    ("shared-unattributed", Some("unattributed"), None),
+                    ("shared-stopped-known", Some("stopped-known"), None),
+                    ("solo", None, Some("kimi-fresh")),
+                ] {
                     let temp = tempdir().unwrap();
                     let _home = isolate_app_dir_at(temp.path());
                     let project = temp.path().join(format!("idless-project-{label}"));
@@ -15277,13 +15303,22 @@ mod tests {
                     let kimi_home = temp.path().join("kimi-home");
                     fs::create_dir_all(&kimi_home).unwrap();
                     let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
-                    seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-fresh");
+                    let old_sid = if peer_state == Some("stopped-known") {
+                        "kimi-stale-peer"
+                    } else {
+                        "kimi-stored"
+                    };
+                    seed_kimi_index(&kimi_home, &project, old_sid, "kimi-fresh");
 
-                    if peer_present {
+                    if let Some(peer_state) = peer_state {
                         let profile = format!("kimi-idless-{label}");
                         let mut peer = Instance::new("idless-peer", &project);
                         peer.source_profile = profile.clone();
                         peer.tool = "kimi".to_string();
+                        if peer_state == "stopped-known" {
+                            peer.status = Status::Stopped;
+                            peer.agent_session_id = Some(old_sid.to_string());
+                        }
                         super::seed_disk_for_sidecar_test(&profile, &peer);
                     }
 
@@ -15334,6 +15369,49 @@ mod tests {
                     sid.as_deref(),
                     Some("kimi-stored"),
                     "an unreadable profile list must count as shared"
+                );
+            }
+
+            #[test]
+            #[serial]
+            fn kimi_invalid_peer_config_fails_closed_without_resetting_aliases() {
+                let temp = tempdir().unwrap();
+                let _home = isolate_app_dir_at(temp.path());
+                let project = temp.path().join("invalid-config-project");
+                fs::create_dir_all(&project).unwrap();
+                let project = project.to_string_lossy().to_string();
+                let kimi_home = temp.path().join("kimi-home");
+                fs::create_dir_all(&kimi_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
+
+                let peer_profile = "kimi-invalid-config-peer";
+                let mut peer = Instance::new("invalid-config-peer", &project);
+                peer.source_profile = peer_profile.to_string();
+                peer.tool = "kimi".to_string();
+                peer.agent_session_id = Some("kimi-peer-fresh".to_string());
+                super::seed_disk_for_sidecar_test(peer_profile, &peer);
+                super::super::install_aliases(peer_profile, &[("kimi-alias", "kimi")]);
+                fs::write(
+                    crate::session::get_profile_dir_path(peer_profile)
+                        .unwrap()
+                        .join("config.toml"),
+                    "environment = [",
+                )
+                .unwrap();
+
+                let mut inst = Instance::new("invalid-config-caller", &project);
+                inst.source_profile = "kimi-invalid-config-caller".to_string();
+                inst.tool = "kimi".to_string();
+                inst.agent_session_id = Some("kimi-stored".to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, _is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some("kimi-stored"));
+                assert_eq!(
+                    crate::tmux::status_rules::effective_detect_as(peer_profile, "kimi-alias", ""),
+                    "kimi",
+                    "an attribution read must not reset a peer profile's aliases"
                 );
             }
         }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3597,9 +3597,10 @@ impl Instance {
             }
         }
         // Kimi: a shared store refuses the MRU scan entirely inside
-        // try_retroactive_capture, so reaching this line means the store is
-        // sole-owned and a fresher observation is attributable.
-
+        // try_retroactive_capture and surfaces here as None, so a Some from
+        // the call below implies the store was sole-owned and the fresher
+        // observation attributable. Execution reaches this line for every
+        // tool; the gating lives in the callee.
         let live = self.try_retroactive_capture()?;
         override_if_distinct(self.agent_session_id.as_deref(), live)
     }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -14975,7 +14975,6 @@ mod tests {
                 assert!(is_existing);
                 assert_eq!(inst.agent_session_id.as_deref(), Some(stored));
             }
-            // ── Kimi shared-index anchor (#3516) ─────────────────────────────
             //
             // The per-tool bascule tests above run one instance against its
             // store. Kimi's store is a single append-only
@@ -15377,6 +15376,19 @@ mod tests {
             fn kimi_invalid_peer_config_fails_closed_without_resetting_aliases() {
                 let temp = tempdir().unwrap();
                 let _home = isolate_app_dir_at(temp.path());
+                // Registry writers using an empty profile normalize through
+                // the process-global default. Pin it away from `peer_profile`
+                // so unrelated parallel tests cannot clear the alias this
+                // fixture is observing.
+                fs::write(
+                    crate::session::get_app_dir().unwrap().join("config.toml"),
+                    "default_profile = \"status-default\"\n",
+                )
+                .unwrap();
+                assert_eq!(
+                    crate::session::config::resolve_default_profile(),
+                    "status-default"
+                );
                 let project = temp.path().join("invalid-config-project");
                 fs::create_dir_all(&project).unwrap();
                 let project = project.to_string_lossy().to_string();

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -15373,29 +15373,28 @@ mod tests {
 
             #[test]
             #[serial]
-            fn kimi_invalid_peer_config_fails_closed_without_resetting_aliases() {
+            fn kimi_invalid_peer_config_fails_closed() {
                 let temp = tempdir().unwrap();
                 let _home = isolate_app_dir_at(temp.path());
-                // Registry writers using an empty profile normalize through
-                // the process-global default. Pin it away from `peer_profile`
-                // so unrelated parallel tests cannot clear the alias this
-                // fixture is observing.
-                fs::write(
-                    crate::session::get_app_dir().unwrap().join("config.toml"),
-                    "default_profile = \"status-default\"\n",
-                )
-                .unwrap();
-                assert_eq!(
-                    crate::session::config::resolve_default_profile(),
-                    "status-default"
-                );
                 let project = temp.path().join("invalid-config-project");
                 fs::create_dir_all(&project).unwrap();
                 let project = project.to_string_lossy().to_string();
                 let kimi_home = temp.path().join("kimi-home");
+                let ambient_home = temp.path().join("ambient-kimi-home");
                 fs::create_dir_all(&kimi_home).unwrap();
-                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", kimi_home.to_str().unwrap())]);
+                fs::create_dir_all(&ambient_home).unwrap();
+                let _kimi = EnvGuard::set(&[("KIMI_CODE_HOME", ambient_home.to_str().unwrap())]);
                 seed_kimi_index(&kimi_home, &project, "kimi-stored", "kimi-peer-fresh");
+
+                let caller_profile = "kimi-invalid-config-caller";
+                let mut caller_config =
+                    crate::session::profile_config::load_profile_config(caller_profile).unwrap();
+                caller_config.overrides.insert(
+                    "environment".to_string(),
+                    serde_json::json!([format!("KIMI_CODE_HOME={}", kimi_home.display())]),
+                );
+                crate::session::profile_config::save_profile_config(caller_profile, &caller_config)
+                    .unwrap();
 
                 let peer_profile = "kimi-invalid-config-peer";
                 let mut peer = Instance::new("invalid-config-peer", &project);
@@ -15403,7 +15402,6 @@ mod tests {
                 peer.tool = "kimi".to_string();
                 peer.agent_session_id = Some("kimi-peer-fresh".to_string());
                 super::seed_disk_for_sidecar_test(peer_profile, &peer);
-                super::super::install_aliases(peer_profile, &[("kimi-alias", "kimi")]);
                 fs::write(
                     crate::session::get_profile_dir_path(peer_profile)
                         .unwrap()
@@ -15413,17 +15411,16 @@ mod tests {
                 .unwrap();
 
                 let mut inst = Instance::new("invalid-config-caller", &project);
-                inst.source_profile = "kimi-invalid-config-caller".to_string();
+                inst.source_profile = caller_profile.to_string();
                 inst.tool = "kimi".to_string();
                 inst.agent_session_id = Some("kimi-stored".to_string());
                 inst.resume_intent = ResumeIntent::Default;
 
                 let (sid, _is_existing) = inst.acquire_session_id();
-                assert_eq!(sid.as_deref(), Some("kimi-stored"));
                 assert_eq!(
-                    crate::tmux::status_rules::effective_detect_as(peer_profile, "kimi-alias", ""),
-                    "kimi",
-                    "an attribution read must not reset a peer profile's aliases"
+                    sid.as_deref(),
+                    Some("kimi-stored"),
+                    "invalid peer config must not license ambient-home MRU"
                 );
             }
         }


### PR DESCRIPTION
## Description

First slice of #3516: host Kimi. The Claude path is owned by #3507 and is not touched here.

Host Kimi capture reads one append-only `session_index.jsonl` under the launched pane's resolved `KIMI_CODE_HOME`. Records are keyed by `workDir`; capture selects the record whose `sessionDir` has the newest mtime. During a co-located mass recovery, that MRU observation cannot attribute a conversation to a pane: each pane can replace its stored sid with a peer's conversation.

### What this PR does

- Detects shared stores on the real namespace: resolved Kimi home plus canonical project path, across every AoE profile. Profile-list, profile-config, home-resolution, and profile-storage failures fail closed.
- Treats current host Kimi sessions, stopped or pane-less sessions, archived/trashed restorable sessions, and sessions with a parked `prior_tool_session_ids["kimi"]` conversation as owners. Sandboxed Kimi is skipped because its store is container-private.
- Composes host Kimi with the existing inactive same-tool exclusion policy, protecting same-profile acquisition and poller snapshots as well as the cross-profile predicate.
- Refuses acquire-time MRU capture when ownership is shared. An anchored pane keeps its stored sid; an id-less pane starts fresh instead of guessing. Sole-owner stores retain the #2291-style MRU retarget.
- Resolves scanner and poller homes through the launched pane's environment, including `$VAR` / bare-key expansion. An explicitly empty ambient `KIMI_CODE_HOME` is rejected rather than becoming a relative store path.
- Uses fallible peer-profile resolution: an attribution read fails closed without resetting another profile's live status-rule/alias registry.

### Attribution and recovery policy

Kimi exposes no per-instance signal equivalent to Claude's hook sidecar.

- A stale persisted peer can therefore make an otherwise recoverable id-less pane start fresh, even when the newest index record happened to belong to that pane. This is the deliberate safety-first direction: the index also contains non-AoE and otherwise unattributed records, so excluding known stale sids does not prove which remaining record belongs to the caller.
- Anchors already corrupted before this fix are preserved. Shared-store MRU cannot identify the pane's original conversation safely, and the floored live poller cannot repair a resumed directory. Recovery requires an explicit clear or manual session choice; no guessed self-heal is added.
- Post-`/clear` adoption on a shared store still relies on the live poller's launch-time floor plus exclusion sets. Simultaneous new conversations remain an accepted residual until Kimi provides a pane-attributable signal.

### Scope note

The remaining agents in #3516 are deliberately not touched: each store has a different namespace and requires its own adoption decision. Design intent: https://github.com/agent-of-empires/agent-of-empires/issues/3516#issuecomment-5414769516

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (behavioral contracts live at the call sites and here)
- [ ] For UI changes: N/A, no UI changes

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped an e2e test, because: this is a deterministic attribution decision. Unit fixtures stage the real Kimi index schema, staggered mtimes, persisted AoE ownership, and profile failures without requiring concurrent live agent panes.

Regression coverage:

- `acquire_kimi_respects_store_ownership` (table): same-profile current owner, sole owner, cross-profile current owner, different cwd, cross-profile parked owner, cross-profile archived owner, cross-profile trashed owner, and private sandbox peer with an unrelated host MRU.
- `kimi_inactive_same_profile_sids_are_excluded` (table): archived and trashed sids feed the established inactive-peer exclusion used by acquisition and poller snapshots.
- `kimi_var_form_homes_still_detect_shared_store`: `$VAR`-spelled peer homes resolve to the physical shared store.
- `kimi_shared_store_refuses_id_less_retroactive_fill` (table): unattributed shared store and stopped-known stale peer both start fresh; sole owner still fills from MRU.
- `kimi_anchor_kept_when_profile_list_unreadable`: profile enumeration failure fails closed.
- `kimi_invalid_peer_config_fails_closed`: caller and ambient homes differ; invalid peer config fails closed and keeps the caller anchor.
- `test_kimi_home_rejects_empty_ambient_fallback`: empty ambient fallback cannot become a cwd-relative store.

Red/green and sensitivity evidence:

- On the previous head, the corrected inactive-owner, parked-owner, and empty-home tests failed with the reviewed wrong values; all pass on `f3297b16`.
- Removing inactive Kimi exclusions, parked ownership, restorable inactive ownership, the final empty-home filter, or fallible peer resolution makes its corresponding test red. All mutations were reverted.

Validation at `cbb4f70c8826368574872da54bcdf89ae94cb271`:

- `cargo fmt --all -- --check`: clean
- `cargo clippy --lib --tests -- -D warnings`: clean
- `cargo clippy --features serve -- -D warnings`: clean
- Focused Kimi suite: 18 passed, 0 failed
- `cargo test --no-default-features --lib --bins`: 4,690 passed, 2 ignored
- `cargo test --features serve`: 6,681 passed across 24 suites, 8 ignored
- GitHub CI (`CI` + `Tests` workflows): all jobs passed

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:** AI implemented and independently cross-validated the deterministic attribution fixtures and reviewed every published finding before applying corrections.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents incorrect Kimi session reassignment when panes share the same store.
- Identifies shared stores by resolved `KIMI_CODE_HOME` and canonical project path.
- Preserves existing session IDs in shared stores.
- Starts id-less panes without adopting an unrelated recent conversation.
- Keeps existing recent-conversation retargeting for sole-owner stores.
- Protects sessions across inactive, parked, pane-less, and cross-profile peers.
- Keeps sandboxed sessions isolated.
- Fails safely when profile or storage data cannot be resolved.
- Adds regression tests and updates the related documentation.

## Benefits

This reduces incorrect conversation assignments while preserving existing behavior for independent Kimi stores.

## Potential areas for further enhancement

Kimi does not provide per-instance attribution, so simultaneous new conversations can still race. Previously corrupted session anchors require manual repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

