### PR TITLE
test(acp): serialize serve-gated registry writers

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -12316,6 +12316,7 @@ done
     /// old-session updates to the fresh conversation.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial]
     async fn reset_between_prompts_with_open_tool_is_refused() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let initial_update = serde_json::json!({
@@ -12357,6 +12358,7 @@ done
     /// tailer removes the agent from the between-prompt in-flight set.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial]
     async fn reset_between_prompts_with_background_agent_is_refused() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let transcript = tmp.path().join("background-agent.jsonl");
@@ -12410,6 +12412,7 @@ done
     /// abandoned request.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial]
     async fn reset_session_new_timeout_releases_the_connection_loop() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let (script, _capture) = write_reset_fake_agent(tmp.path(), 0, 1, 0);
@@ -12455,6 +12458,7 @@ done
     /// client and runner would disagree about the live session.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial]
     async fn reset_config_timeout_commits_and_releases_the_connection_loop() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let (script, capture) = write_reset_fake_agent(tmp.path(), 0, 0, 1);
@@ -12642,6 +12646,7 @@ done
     /// The success-only `SessionCleared` boundary must remain absent.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial]
     async fn reset_during_in_flight_prompt_is_refused_with_prompt_rejected() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         // 3s prompt delay: long enough to land the reset mid-turn, short
@@ -12844,6 +12849,7 @@ done
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn spawn_with_nonexistent_command_errors_cleanly() {
         let config = SpawnConfig {
             wrapper_substitution: None,

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -277,11 +277,7 @@ impl ProfileRegistryGuard {
     /// between the phases can leave a half-swapped pair standing. Guarding a
     /// profile nothing else writes therefore needs nothing more, since the
     /// keys never overlap; guarding a profile other tests write needs those
-    /// writers held off, and a config resolve counts as a write. One known
-    /// case that is not held off: the serve-gated `#[tokio::test]` functions
-    /// in `src/acp/acp_client.rs` reach this registry through
-    /// `resolved_acp_config` and write `default` outside serial_test's default
-    /// key, so a `take("default")` can be raced under `--features serve`.
+    /// writers held off, and a config resolve counts as a write.
     /// Audit the writers of the profile you guard rather than assuming a group
     /// already covers them. The guard covers exactly these two registries and
     /// only its caller's writes; a future process-global needs its own restore


### PR DESCRIPTION
## Description

Follow-up to #3510 after its final review found a serve-feature gap in the registry exclusion audit.

Six #[tokio::test] functions in src/acp/acp_client.rs call the structured-view spawn path with no source profile. Host environment resolution then resolves the configured default profile and calls install_from_config, which writes both process-global status registries. Those tests did not share serial_test's default key, so they could interleave with a ProfileRegistryGuard::take("default") snapshot or restore.

Validation used an isolated XDG config with default_profile = "default" plus temporary writer instrumentation. The five reset tests and spawn_with_nonexistent_command_errors_cleanly each logged a write to default. With the workstation's normal default_profile = "beta", the same tests wrote beta, confirming the key follows process config rather than a dedicated test profile.

The fix adds #[serial_test::serial] to exactly those six tests. It also removes #3510's now-obsolete documentation note naming them as the known unexcluded cohort. No production code changes.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording, N/A because there is no UI change

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under web/tests/ and updated web/tests/coverage-matrix.json
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under tests/e2e/
- [ ] Skipped a test, because:

## Validation

- cargo test --lib --features serve acp::acp_client::tests::reset_ -- --test-threads=8: 6 passed
- cargo test --lib --features serve acp::acp_client::tests::spawn_with_nonexistent_command_errors_cleanly -- --test-threads=8: 1 passed
- cargo test --lib --features serve tmux::status_rules::tests:: -- --test-threads=8: 12 passed
- cargo test --features serve: 6695 passed across 24 suites, 8 ignored
- cargo fmt --all -- --check: clean
- cargo clippy --features serve -- -D warnings: clean

The additional local cargo clippy --lib --tests --features serve -- -D warnings probe reaches test-only code and reports five current-main warnings outside this diff. The standard CI clippy invocation above is clean.

No new test function is warranted: the change corrects execution exclusion on six existing behavior tests, and the registry restoration contract remains covered by #3510's sensitivity-tested probes.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex coding harness

**Any Additional AI Details you'd like to share:**

Review findings were treated as untrusted input, traced through inherited_host_env and resolve_config_or_warn, and checked with isolated-config writer instrumentation before correction.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Serialized six ACP tests that modify process-global default-profile registries.
- Removed obsolete documentation about a registry race condition.
- Improved test isolation without changing production behavior.

## Validation

- Ran targeted tests, the full `serve` feature test suite, formatting, and Clippy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->