### PR TITLE
fix(web): one-row cursor/mouse offset in split live terminal windows

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -21,6 +21,13 @@
 //!   `#{mouse_sgr_flag}`: when the pane is a full-screen mouse app the
 //!   client forwards the wheel to it (as input bytes) instead of widening
 //!   the capture window, since the alternate screen has no scrollback.
+//!   On a composited (split) window the frame also carries `"pane0"`:
+//!   `{"cols":..,"rows":..,"left":..,"top":..}`, pane 0's rectangle within
+//!   the window grid. The cursor is translated onto that grid before it is
+//!   sent, and clients map pointer cells back by subtracting
+//!   `(left, top)` (#3515). Absent on single-pane frames; older clients
+//!   that ignore `left`/`top` render correctly whenever pane 0 sits at the
+//!   window origin.
 //!   `{"type":"size_owner","is_owner":bool}`: whether this client holds
 //!     the session's size-owner lock. Only the owner resizes the shared
 //!     tmux window and may type; a non-owner renders best-effort at the
@@ -1027,10 +1034,19 @@ async fn handle_live_ws(
 /// virtual scroll spacer off `history` and slices the live screen off
 /// the content's last `rows` lines, independent of cursor visibility.
 fn frame_json(content: &str, cursor: Option<&crate::tmux::PaneCursor>) -> String {
+    // On a composited frame the content grid is the whole WINDOW while
+    // `x`/`y` are pane 0 relative; the client paints the cursor by indexing
+    // that grid directly, so translate onto the composite here (#3515).
+    // `composite_pane0` is `None` (or at the origin) on every other frame,
+    // where this is the identity. The origin also rides on `pane0` so the
+    // client's inverse mapping, pointer cell -> pane coordinate, can
+    // subtract it again.
+    let pane0 = cursor.and_then(|c| c.composite_pane0);
+    let (origin_x, origin_y) = pane0.map_or((0, 0), |p| (p.left, p.top));
     let cursor_value = match cursor {
         Some(c) if c.visible => serde_json::json!({
-            "x": c.x,
-            "y": c.y,
+            "x": c.x.saturating_add(origin_x),
+            "y": c.y.saturating_add(origin_y),
         }),
         _ => serde_json::Value::Null,
     };
@@ -1046,8 +1062,13 @@ fn frame_json(content: &str, cursor: Option<&crate::tmux::PaneCursor>) -> String
         "altScreen": cursor.map(|c| c.alternate_on).unwrap_or(false),
         "mouse": cursor.map(|c| c.mouse_tracking).unwrap_or(false),
         "mouseSgr": cursor.map(|c| c.mouse_sgr).unwrap_or(false),
-        "pane0": cursor.and_then(|c| c.composite_pane0).map(|(cols, rows)| {
-            serde_json::json!({ "cols": cols, "rows": rows })
+        "pane0": pane0.map(|p| {
+            serde_json::json!({
+                "cols": p.width,
+                "rows": p.height,
+                "left": p.left,
+                "top": p.top,
+            })
         }),
     })
     .to_string()
@@ -1139,33 +1160,56 @@ mod tests {
 
     #[test]
     fn frame_json_includes_geometry_and_cursor() {
-        let cursor = crate::tmux::PaneCursor {
-            x: 3,
-            y: 7,
-            visible: true,
-            pane_height: 46,
-            history_size: 1200,
-            pane_width: 74,
-            alternate_on: false,
-            mouse_tracking: false,
-            mouse_sgr: false,
-            mouse_all: false,
-            position_reliable: true,
-            composite_pane0: Some((37, 46)),
-        };
-        let json = frame_json("hello\nworld", Some(&cursor));
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["type"], "frame");
-        assert_eq!(v["content"], "hello\nworld");
-        assert_eq!(v["rows"], 46);
-        assert_eq!(v["history"], 1200);
-        assert_eq!(v["cursor"]["x"], 3);
-        assert_eq!(v["cursor"]["y"], 7);
-        assert_eq!(v["altScreen"], false);
-        assert_eq!(v["mouse"], false);
-        assert_eq!(v["mouseSgr"], false);
-        assert_eq!(v["pane0"]["cols"], 37);
-        assert_eq!(v["pane0"]["rows"], 46);
+        let cases = [
+            // Unsplit (or pane 0 at the window origin): the translation is
+            // the identity and `pane0` is absent.
+            (None, (3, 7), serde_json::Value::Null),
+            // Composited with pane-border-status top: the wire cursor moves
+            // onto the window grid by pane 0's origin (#3515).
+            (
+                Some(crate::tmux::Pane0Rect {
+                    left: 2,
+                    top: 1,
+                    width: 37,
+                    height: 46,
+                }),
+                (5, 8),
+                serde_json::json!({
+                    "cols": 37,
+                    "rows": 46,
+                    "left": 2,
+                    "top": 1,
+                }),
+            ),
+        ];
+        for (pane0, want_cursor, want_pane0) in cases {
+            let cursor = crate::tmux::PaneCursor {
+                x: 3,
+                y: 7,
+                visible: true,
+                pane_height: 46,
+                history_size: 1200,
+                pane_width: 74,
+                alternate_on: false,
+                mouse_tracking: false,
+                mouse_sgr: false,
+                mouse_all: false,
+                position_reliable: true,
+                composite_pane0: pane0,
+            };
+            let json = frame_json("hello\nworld", Some(&cursor));
+            let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(v["type"], "frame");
+            assert_eq!(v["content"], "hello\nworld");
+            assert_eq!(v["rows"], 46);
+            assert_eq!(v["history"], 1200);
+            assert_eq!(v["cursor"]["x"], want_cursor.0, "{pane0:?}");
+            assert_eq!(v["cursor"]["y"], want_cursor.1, "{pane0:?}");
+            assert_eq!(v["altScreen"], false);
+            assert_eq!(v["mouse"], false);
+            assert_eq!(v["mouseSgr"], false);
+            assert_eq!(v["pane0"], want_pane0, "{pane0:?}");
+        }
     }
 
     #[test]

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -25,9 +25,11 @@
 //!   `{"cols":..,"rows":..,"left":..,"top":..}`, pane 0's rectangle within
 //!   the window grid. The cursor is translated onto that grid before it is
 //!   sent, and clients map pointer cells back by subtracting
-//!   `(left, top)` (#3515). Absent on single-pane frames; older clients
-//!   that ignore `left`/`top` render correctly whenever pane 0 sits at the
-//!   window origin.
+//!   `(left, top)` (#3515). Absent on single-pane frames. Clients that
+//!   ignore `left`/`top` still paint the cursor correctly at any origin,
+//!   because the translation already happened here; their mouse forwarding
+//!   is what degrades, back to the one-row shift of #3515 whenever the
+//!   origin is not `(0, 0)`.
 //!   `{"type":"size_owner","is_owner":bool}`: whether this client holds
 //!     the session's size-owner lock. Only the owner resizes the shared
 //!     tmux window and may type; a non-owner renders best-effort at the
@@ -1167,7 +1169,7 @@ mod tests {
             // Composited with pane-border-status top: the wire cursor moves
             // onto the window grid by pane 0's origin (#3515).
             (
-                Some(crate::tmux::Pane0Rect {
+                Some(crate::tmux::PaneGeom {
                     left: 2,
                     top: 1,
                     width: 37,

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -1163,9 +1163,25 @@ mod tests {
     #[test]
     fn frame_json_includes_geometry_and_cursor() {
         let cases = [
-            // Unsplit (or pane 0 at the window origin): the translation is
-            // the identity and `pane0` is absent.
+            // Unsplit: `pane0` is absent and the cursor is untouched.
             (None, (3, 7), serde_json::Value::Null),
+            // Composited with pane 0 at the corner (a borderless split):
+            // identity translation, but `pane0` rides with zero origin.
+            (
+                Some(crate::tmux::PaneGeom {
+                    left: 0,
+                    top: 0,
+                    width: 37,
+                    height: 46,
+                }),
+                (3, 7),
+                serde_json::json!({
+                    "cols": 37,
+                    "rows": 46,
+                    "left": 0,
+                    "top": 0,
+                }),
+            ),
             // Composited with pane-border-status top: the wire cursor moves
             // onto the window grid by pane 0's origin (#3515).
             (

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -18,9 +18,12 @@
 //! `window_height` and rebasing every consumer, so the rule stays.
 
 /// One pane's rectangle within its window, from
-/// `#{pane_left} #{pane_top} #{pane_width} #{pane_height}`.
+/// `#{pane_left} #{pane_top} #{pane_width} #{pane_height}`. Pub because
+/// pane 0's copy rides on the public [`crate::tmux::PaneCursor::
+/// composite_pane0`] so composited frames can translate between pane
+/// coordinates and the window grid (#3515).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct PaneGeom {
+pub struct PaneGeom {
     pub left: u16,
     pub top: u16,
     pub width: u16,

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -366,9 +366,10 @@ mod tests {
 
     #[test]
     fn first_pane_is_the_one_at_the_window_origin() {
-        // tmux orders pane indices by layout, so index 0 is the top-left pane.
-        // The live path relies on this to paint pane 0's cursor onto the
-        // composite without translating its coordinates.
+        // tmux orders pane indices by layout, so index 0 is the top-left
+        // pane. Consumers no longer assume that corner paints untranslated:
+        // they translate the cursor by the origin carried on
+        // `composite_pane0` (#3515).
         let l = layout(
             9,
             1,

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -10,6 +10,12 @@
 //!
 //! Compositing is read-only and changes nothing about input routing, which
 //! stays pinned to `^.0` (#435, #488).
+//!
+//! Known residual: a window row covered by NO pane (a `pane-border-status
+//! top` status line, which tmux draws itself and no capture sees) is filled
+//! with a full-width border rule. Translating the cursor (#3515) does not
+//! remove that row; dropping it would mean rendering a grid shorter than
+//! `window_height` and rebasing every consumer, so the rule stays.
 
 /// One pane's rectangle within its window, from
 /// `#{pane_left} #{pane_top} #{pane_width} #{pane_height}`.
@@ -87,11 +93,16 @@ impl WindowLayout {
         composite_window(self.window_width, self.window_height, &self.panes)
     }
 
-    /// The first pane's rectangle, which tmux guarantees sits at the window
-    /// origin: pane indices follow layout order, so index 0 is the top-left
-    /// pane, and closing it renumbers whichever pane takes that corner. That
-    /// is what lets a VT grid's cursor be painted onto the composite with no
-    /// coordinate translation.
+    /// The first pane's rectangle. Pane indices follow layout order, so
+    /// index 0 is the top-left pane and closing it renumbers whichever pane
+    /// takes that corner; the composite therefore paints pane 0's rows at
+    /// `geom.top` and its columns at `geom.left`, which is `(0, 0)` for the
+    /// common layouts but NOT always: a window option like
+    /// `pane-border-status top` reserves a border row above every pane,
+    /// shifting pane 0 down to `top == 1` (#3515). Consumers of the cursor
+    /// must translate by the origin carried on
+    /// [`crate::tmux::PaneCursor::composite_pane0`] rather than assuming the
+    /// window origin.
     pub(crate) fn first_pane(&self) -> Option<PaneGeom> {
         self.panes.first().map(|p| p.geom)
     }

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -14,7 +14,9 @@ pub(crate) mod utils;
 #[cfg(unix)]
 pub(crate) mod vt;
 
-pub use session::{PaneCursor, PaneEnvMutation, Session, SIZE_OWNER_HEARTBEAT, SIZE_OWNER_TTL};
+pub use session::{
+    Pane0Rect, PaneCursor, PaneEnvMutation, Session, SIZE_OWNER_HEARTBEAT, SIZE_OWNER_TTL,
+};
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
 pub(crate) use status_detection::{
     claude_pane_is_ambiguous_typed_prompt, claude_pane_marker_fingerprint,

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -14,9 +14,8 @@ pub(crate) mod utils;
 #[cfg(unix)]
 pub(crate) mod vt;
 
-pub use session::{
-    Pane0Rect, PaneCursor, PaneEnvMutation, Session, SIZE_OWNER_HEARTBEAT, SIZE_OWNER_TTL,
-};
+pub use composite::PaneGeom;
+pub use session::{PaneCursor, PaneEnvMutation, Session, SIZE_OWNER_HEARTBEAT, SIZE_OWNER_TTL};
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
 pub(crate) use status_detection::{
     claude_pane_is_ambiguous_typed_prompt, claude_pane_marker_fingerprint,

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -79,6 +79,17 @@ pub const SIZE_OWNER_TTL: Duration = Duration::from_secs(4);
 /// the lock only frees on disconnect/crash (TTL expiry) or explicit take-over.
 pub const SIZE_OWNER_HEARTBEAT: Duration = Duration::from_millis(1500);
 
+/// One pane's rectangle within its window. Pane 0's copy rides on
+/// [`PaneCursor::composite_pane0`] so composited frames can translate
+/// between pane coordinates and the window grid (#3515).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pane0Rect {
+    pub left: u16,
+    pub top: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
 /// The active pane's cursor, queried alongside a `capture-pane` so the
 /// live-send preview can paint a real cursor (`capture-pane` returns cell
 /// text only; tmux's own client draws the cursor from these pane fields).
@@ -133,22 +144,20 @@ pub struct PaneCursor {
     /// works while an agent streams. `parse` sets it `true`; only the
     /// cross-probe check downgrades it.
     pub position_reliable: bool,
-    /// Pane 0's `(width, height)` within a COMPOSITED preview, or `None` when
+    /// Pane 0's rectangle within a COMPOSITED preview window, or `None` when
     /// the preview shows a single pane.
     ///
     /// Mouse forwarding maps the hovered cell into the previewed app's
     /// coordinate space by treating the preview rect as the pane, which holds
-    /// while the two describe the same rectangle. A composite makes the rect the
-    /// whole window, so a pointer over a neighbouring pane maps to a column past
-    /// pane 0's right edge and is reported to the agent as though its own pane
-    /// were that wide. Pane 0 is the only pane that receives input (#435, #488),
-    /// so this carries its extent and the forward clamps to it, dropping events
-    /// that land outside.
-    ///
-    /// Only the extent is needed, never the origin: tmux keeps pane 0 at the
-    /// window origin, because pane indices follow layout order and closing pane
-    /// 0 renumbers whichever pane takes that corner.
-    pub composite_pane0: Option<(u16, u16)>,
+    /// while the two describe the same rectangle. A composite makes the rect
+    /// the whole window while input still goes to pane 0 alone (#435, #488),
+    /// and the cursor stays pane relative over a window-relative grid: with
+    /// `pane-border-status top`, pane 0 starts at `pane_top == 1` and every
+    /// row paints one below the cursor row that indexes it (#3515). So this
+    /// carries the full rectangle, not just the extent: consumers translate
+    /// `x`/`y` onto the composite by adding `(left, top)`, and map pointer
+    /// cells back by subtracting it, clamping to `(width, height)`.
+    pub composite_pane0: Option<Pane0Rect>,
 }
 
 /// tmux format line every cursor probe requests, parsed by
@@ -1035,9 +1044,14 @@ impl Session {
             c.pane_width = layout.window_width;
             c.history_size = 0;
             // Rebasing the frame onto the window is what the renderer needs, but
-            // it also erases the only record of how wide the input pane is, which
-            // mouse forwarding maps into. Carry pane 0's extent alongside.
-            c.composite_pane0 = layout.first_pane().map(|p| (p.width, p.height));
+            // it also erases where pane 0 sits in it, which cursor painting and
+            // mouse forwarding both need. Carry pane 0's rectangle alongside.
+            c.composite_pane0 = layout.first_pane().map(|p| Pane0Rect {
+                left: p.left,
+                top: p.top,
+                width: p.width,
+                height: p.height,
+            });
             c
         });
         let content = pane0_rows.as_deref().map_or_else(
@@ -3327,6 +3341,114 @@ mod tests {
             seam_row.contains("BRAVO"),
             "panes should share a row, not stack:\n{seam_row:?}"
         );
+    }
+
+    /// Pane 0's rectangle as tmux reports it, `(left, top, width, height)`.
+    fn pane0_tmux_geometry(session: &Session) -> (u16, u16, u16, u16) {
+        let out = crate::tmux::tmux_command()
+            .args([
+                "display-message",
+                "-p",
+                "-t",
+                &format!("{}:^.0", session.name),
+                "-F",
+                "#{pane_left} #{pane_top} #{pane_width} #{pane_height}",
+            ])
+            .output()
+            .expect("display-message");
+        assert!(out.status.success(), "display-message failed");
+        let text = String::from_utf8_lossy(&out.stdout);
+        let mut fields = text.split_whitespace();
+        let left = fields.next().expect("pane_left").parse().expect("u16");
+        let top = fields.next().expect("pane_top").parse().expect("u16");
+        let width = fields.next().expect("pane_width").parse().expect("u16");
+        let height = fields.next().expect("pane_height").parse().expect("u16");
+        (left, top, width, height)
+    }
+
+    /// #3515: a composited preview paints the whole WINDOW grid while the
+    /// cursor stays pane 0 relative, so the two agree only while pane 0 sits
+    /// at the window origin. `pane-border-status top` shifts pane 0 down to
+    /// `pane_top == 1`, and the invariant must hold there: the composite
+    /// paints the pane's cursor row at `cursor.y + top`, and
+    /// `composite_pane0` carries that real origin. Exercised across the three
+    /// split shapes (horizontal, vertical, stacked).
+    #[test]
+    #[serial_test::serial]
+    fn composited_cursor_and_pane0_origin_track_pane_border_offset() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        // Each layout's second-pane splits; the pane parks its cursor right
+        // after `MARKER` on its row 0 (`printf` emits no newline).
+        let layouts: [(&str, &[&[&str]]); 3] = [
+            ("aoe_test_cursor_h", &[&["split-window", "-h"]]),
+            ("aoe_test_cursor_v", &[&["split-window", "-v"]]),
+            (
+                "aoe_test_cursor_stack",
+                &[&["split-window", "-v"], &["split-window", "-v"]],
+            ),
+        ];
+        for (name, splits) in layouts {
+            let guard = TmuxTestSession::new(name);
+            let session =
+                start_composite_session(guard.name(), 80, 24, "sh -c 'printf MARKER; sleep 60'");
+            for args in splits {
+                let status = crate::tmux::tmux_command()
+                    .args(args.iter().copied().chain(["-t", session.name.as_str()]))
+                    .status()
+                    .expect("tmux split-window");
+                assert!(status.success(), "{name}: split failed");
+            }
+            let status = crate::tmux::tmux_command()
+                .args([
+                    "set-option",
+                    "-w",
+                    "-t",
+                    &session.name,
+                    "pane-border-status",
+                    "top",
+                ])
+                .status()
+                .expect("tmux set-option");
+            assert!(status.success(), "{name}: set-option failed");
+            wait_for_composite_text(&session, "MARKER");
+
+            let (content, cursor) = session
+                .capture_window_composited_with_cursor(20)
+                .expect("capture_window_composited_with_cursor");
+            let cursor = cursor.unwrap_or_else(|| panic!("{name}: composited cursor missing"));
+            let rect = cursor
+                .composite_pane0
+                .unwrap_or_else(|| panic!("{name}: composite_pane0 missing"));
+            assert_eq!(
+                (rect.left, rect.top, rect.width, rect.height),
+                pane0_tmux_geometry(&session),
+                "{name}: carried rectangle must match tmux"
+            );
+            assert_eq!(rect.top, 1, "{name}: border status must shift pane 0");
+
+            // The untranslated index (cursor.y alone) must NOT land on the
+            // marker row, or the assertion below proves nothing.
+            let lines: Vec<&str> = content.lines().collect();
+            assert!(
+                !lines[cursor.y as usize].contains("MARKER"),
+                "{name}: marker unexpectedly at untranslated row {}",
+                cursor.y
+            );
+            let painted = lines
+                .get(cursor.y as usize + rect.top as usize)
+                .unwrap_or_else(|| panic!("{name}: translated row out of range"));
+            assert!(
+                painted.contains("MARKER"),
+                "{name}: cursor row {} painted {:?}, expected MARKER at +{}",
+                cursor.y,
+                painted,
+                rect.top
+            );
+        }
     }
 
     /// A full-screen TUI (opencode's dimmed modal backdrop, its empty home

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -79,17 +79,6 @@ pub const SIZE_OWNER_TTL: Duration = Duration::from_secs(4);
 /// the lock only frees on disconnect/crash (TTL expiry) or explicit take-over.
 pub const SIZE_OWNER_HEARTBEAT: Duration = Duration::from_millis(1500);
 
-/// One pane's rectangle within its window. Pane 0's copy rides on
-/// [`PaneCursor::composite_pane0`] so composited frames can translate
-/// between pane coordinates and the window grid (#3515).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Pane0Rect {
-    pub left: u16,
-    pub top: u16,
-    pub width: u16,
-    pub height: u16,
-}
-
 /// The active pane's cursor, queried alongside a `capture-pane` so the
 /// live-send preview can paint a real cursor (`capture-pane` returns cell
 /// text only; tmux's own client draws the cursor from these pane fields).
@@ -157,7 +146,7 @@ pub struct PaneCursor {
     /// carries the full rectangle, not just the extent: consumers translate
     /// `x`/`y` onto the composite by adding `(left, top)`, and map pointer
     /// cells back by subtracting it, clamping to `(width, height)`.
-    pub composite_pane0: Option<Pane0Rect>,
+    pub composite_pane0: Option<PaneGeom>,
 }
 
 /// tmux format line every cursor probe requests, parsed by
@@ -1046,12 +1035,7 @@ impl Session {
             // Rebasing the frame onto the window is what the renderer needs, but
             // it also erases where pane 0 sits in it, which cursor painting and
             // mouse forwarding both need. Carry pane 0's rectangle alongside.
-            c.composite_pane0 = layout.first_pane().map(|p| Pane0Rect {
-                left: p.left,
-                top: p.top,
-                width: p.width,
-                height: p.height,
-            });
+            c.composite_pane0 = layout.first_pane();
             c
         });
         let content = pane0_rows.as_deref().map_or_else(

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -869,11 +869,12 @@ impl Session {
     /// [`capture_window_composited`](Self::capture_window_composited) plus pane
     /// 0's cursor, for the live preview.
     ///
-    /// Pane 0 owns the cursor because it is the pane that receives input, and
-    /// tmux puts it at the window origin, so its coordinates index the
-    /// composite untranslated. The probe targets `^.0` explicitly rather than
-    /// the window, whose format fields would resolve against whichever pane the
-    /// user happens to have selected.
+    /// Pane 0 owns the cursor because it is the pane that receives input; its
+    /// coordinates are pane relative, and the composite they index is the
+    /// whole window, so consumers translate them by pane 0's origin carried
+    /// on [`PaneCursor::composite_pane0`] (#3515). The probe targets `^.0`
+    /// explicitly rather than the window, whose format fields would resolve
+    /// against whichever pane the user happens to have selected.
     ///
     /// On a composite the cursor is rebased onto the window's dimensions: the
     /// renderer anchors it by `pane_height` against the painted line count,
@@ -3617,8 +3618,10 @@ mod tests {
     }
 
     /// The live path caches a layout and re-renders only pane 0 from its VT
-    /// grid, so the layout must come back with pane 0 first, at the window
-    /// origin, and with rectangles that tile the real window.
+    /// grid, so the layout must come back with pane 0 first and with
+    /// rectangles that tile the real window. This split sets no
+    /// border-status option, so pane 0 additionally sits at the window
+    /// origin here.
     #[test]
     #[serial_test::serial]
     fn captured_layout_puts_pane_zero_first_at_the_origin() {
@@ -3669,7 +3672,7 @@ mod tests {
         assert_eq!(
             (first.left, first.top),
             (0, 0),
-            "pane 0 must sit at the window origin for the cursor math to hold"
+            "pane 0 must sit at the origin in this split; a border-status row would shift it (#3515)"
         );
         // Pane 0 is the agent's, even though pane 1 is the active one.
         assert!(

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -202,8 +202,12 @@ fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
 /// report at all, so it is dropped rather than clamped to the nearest edge,
 /// which would otherwise synthesise a click or hover on pane 0's border.
 ///
-/// Pane 0 sits at the window origin, so the sub-rectangle shares the preview's
-/// top-left corner and only its extent differs.
+/// Pane 0 usually sits at the window origin, so the sub-rectangle shares the
+/// preview's top-left corner and only its extent differs. A window option
+/// like `pane-border-status top` can shift it down (`pane_top == 1`, #3515);
+/// this mapping still assumes the shared corner, so a composited preview with
+/// a shifted pane 0 clamps against the wrong row. Known residual: the TUI
+/// side of #3515 was never reproduced there.
 fn mouse_target_rect(
     cursor: &crate::tmux::PaneCursor,
     pane: ratatui::layout::Rect,
@@ -236,11 +240,11 @@ fn mouse_pane_rect(
     pane: ratatui::layout::Rect,
 ) -> ratatui::layout::Rect {
     match cursor.composite_pane0 {
-        Some((width, height)) => ratatui::layout::Rect {
+        Some(rect) => ratatui::layout::Rect {
             x: pane.x,
             y: pane.y,
-            width: width.min(pane.width),
-            height: height.min(pane.height),
+            width: rect.width.min(pane.width),
+            height: rect.height.min(pane.height),
         },
         None => pane,
     }
@@ -7113,7 +7117,12 @@ mod tests {
         let pane = Rect::new(0, 0, 80, 24);
         let mut split = cursor_for(true, true, true);
         split.mouse_all = true;
-        split.composite_pane0 = Some((40, 24));
+        split.composite_pane0 = Some(crate::tmux::Pane0Rect {
+            left: 0,
+            top: 0,
+            width: 40,
+            height: 24,
+        });
 
         // Inside pane 0: maps as before, 1-based.
         assert_eq!(
@@ -7131,7 +7140,12 @@ mod tests {
         // A no-mouse full-screen agent gets no page key from a wheel aimed at
         // the neighbour either, but keeps it over pane 0.
         let mut no_mouse = cursor_for(true, false, false);
-        no_mouse.composite_pane0 = Some((40, 24));
+        no_mouse.composite_pane0 = Some(crate::tmux::Pane0Rect {
+            left: 0,
+            top: 0,
+            width: 40,
+            height: 24,
+        });
         assert_eq!(wheel_forward_key(&no_mouse, true, pane, 60, 5), None);
         assert!(wheel_forward_key(&no_mouse, true, pane, 10, 5).is_some());
 
@@ -7164,7 +7178,12 @@ mod tests {
         use ratatui::layout::Rect;
         let pane = Rect::new(2, 3, 20, 10);
         let mut cursor = cursor_for(true, true, true);
-        cursor.composite_pane0 = Some((999, 999));
+        cursor.composite_pane0 = Some(crate::tmux::Pane0Rect {
+            left: 0,
+            top: 0,
+            width: 999,
+            height: 999,
+        });
         assert_eq!(mouse_pane_rect(&cursor, pane), pane);
         // And the origin is honoured: a cell above/left of the rect is outside.
         assert_eq!(mouse_target_rect(&cursor, pane, 1, 3), None);

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -7117,7 +7117,7 @@ mod tests {
         let pane = Rect::new(0, 0, 80, 24);
         let mut split = cursor_for(true, true, true);
         split.mouse_all = true;
-        split.composite_pane0 = Some(crate::tmux::Pane0Rect {
+        split.composite_pane0 = Some(crate::tmux::PaneGeom {
             left: 0,
             top: 0,
             width: 40,
@@ -7140,7 +7140,7 @@ mod tests {
         // A no-mouse full-screen agent gets no page key from a wheel aimed at
         // the neighbour either, but keeps it over pane 0.
         let mut no_mouse = cursor_for(true, false, false);
-        no_mouse.composite_pane0 = Some(crate::tmux::Pane0Rect {
+        no_mouse.composite_pane0 = Some(crate::tmux::PaneGeom {
             left: 0,
             top: 0,
             width: 40,
@@ -7178,7 +7178,7 @@ mod tests {
         use ratatui::layout::Rect;
         let pane = Rect::new(2, 3, 20, 10);
         let mut cursor = cursor_for(true, true, true);
-        cursor.composite_pane0 = Some(crate::tmux::Pane0Rect {
+        cursor.composite_pane0 = Some(crate::tmux::PaneGeom {
             left: 0,
             top: 0,
             width: 999,

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -951,11 +951,13 @@ fn capture_composited_over_grid(
 
     // The cursor is pane 0's and pane relative, while the painted grid is
     // the whole window; the two agree only while pane 0 sits at the window
-    // origin, which a `pane-border-status` row breaks (#3515). Consumers
-    // translate by the origin carried on `composite_pane0`. What must be
-    // restated here is the frame the cursor is measured against: the
-    // renderer anchors it by `pane_height` against the painted line count,
-    // which is now the whole window rather than one pane.
+    // origin, which a `pane-border-status` row breaks (#3515). Consumers are
+    // expected to translate by the origin carried on `composite_pane0`; this
+    // path feeds the TUI preview, whose cursor painting and mouse mapping do
+    // not yet (see `map_live_preview_cursor` and the input.rs residual).
+    // What must be restated here is the frame the cursor is measured
+    // against: the renderer anchors it by `pane_height` against the painted
+    // line count, which is now the whole window rather than one pane.
     cursor.pane_height = layout.window_height;
     cursor.pane_width = layout.window_width;
     // A composite carries no scrollback (panes have independent histories), so

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -949,19 +949,24 @@ fn capture_composited_over_grid(
         return capture_composited(name, lines, forward_empty);
     };
 
-    // The cursor is pane 0's, and tmux puts pane 0 at the window origin, so its
-    // coordinates already index the composite with no translation. What must be
-    // restated is the frame it is measured against: the renderer anchors the
-    // cursor by `pane_height` against the painted line count, which is now the
-    // whole window rather than one pane.
+    // The cursor is pane 0's and pane relative, while the painted grid is
+    // the whole window; the two agree only while pane 0 sits at the window
+    // origin, which a `pane-border-status` row breaks (#3515). Consumers
+    // translate by the origin carried on `composite_pane0`. What must be
+    // restated here is the frame the cursor is measured against: the
+    // renderer anchors it by `pane_height` against the painted line count,
+    // which is now the whole window rather than one pane.
     cursor.pane_height = layout.window_height;
     cursor.pane_width = layout.window_width;
     // A composite carries no scrollback (panes have independent histories), so
     // the preview must not advertise any to scroll into.
     cursor.history_size = 0;
-    // Rebasing onto the window erases how wide the input pane is, which mouse
-    // forwarding maps into; carry pane 0's extent so it can clamp.
-    cursor.composite_pane0 = Some((first.width, first.height));
+    cursor.composite_pane0 = Some(crate::tmux::Pane0Rect {
+        left: first.left,
+        top: first.top,
+        width: first.width,
+        height: first.height,
+    });
     (
         Some(layout.composite_with_first_pane_rows(&rows)),
         Some(cursor),

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -961,12 +961,7 @@ fn capture_composited_over_grid(
     // A composite carries no scrollback (panes have independent histories), so
     // the preview must not advertise any to scroll into.
     cursor.history_size = 0;
-    cursor.composite_pane0 = Some(crate::tmux::Pane0Rect {
-        left: first.left,
-        top: first.top,
-        width: first.width,
-        height: first.height,
-    });
+    cursor.composite_pane0 = Some(first);
     (
         Some(layout.composite_with_first_pane_rows(&rows)),
         Some(cursor),

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -131,6 +131,13 @@ const READING_CAPTURE_LINES: u16 = 2000;
 /// resize), using the bare `visible_rows` here would paint the cursor a row
 /// BELOW the text the user typed (#2742); clamping to `line_count` keeps them
 /// aligned. A hidden cursor, or one that maps outside `output`, yields `None`.
+///
+/// Residual #3515 (TUI side, never reproduced): `y` is pane relative, while
+/// on a COMPOSITED preview the painted grid is the whole window and a
+/// `pane-border-status` row shifts pane 0 down. Indexing that grid with the
+/// untranslated `y` would paint one row high; consumers of
+/// [`crate::tmux::PaneCursor::composite_pane0`] are supposed to translate by
+/// `(left, top)`. This path does not yet.
 fn map_live_preview_cursor(
     output: Rect,
     visible_rows: usize,

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -11,7 +11,7 @@ import {
   wrapLine,
   type CellRun,
 } from "../lib/liveTermLines";
-import { wheelNotches } from "../lib/liveMouse";
+import { cursorLineIndex, pointerPaneCell, wheelNotches } from "../lib/liveMouse";
 import { registerMobileKeyboardProxyReceiver, type MobileKeyboardProxyInput } from "../lib/mobileKeyboardProxy";
 import { writeClipboard } from "../lib/clipboard";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
@@ -859,7 +859,7 @@ export function MobileLiveTerminal({
   const live = useMemo(() => {
     const cursor = !reading ? (frame?.cursor ?? null) : null;
     if (!cursor) return { row: -1, col: -1, top: null as number | null };
-    const lineIdx = Math.max(0, lines.length - screenRows) + cursor.y;
+    const lineIdx = cursorLineIndex(lines.length, screenRows, cursor.y);
     if (lineIdx < 0 || lineIdx >= lines.length) return { row: -1, col: -1, top: null };
     const cols = renderCols > 0 ? renderCols : Number.POSITIVE_INFINITY;
     const baseRow = visual.lineStartRow[lineIdx] ?? -1;
@@ -978,14 +978,18 @@ export function MobileLiveTerminal({
       const r = el.getBoundingClientRect();
       const content = el.querySelector<HTMLElement>("[data-live-content]");
       const gridTop = content?.getBoundingClientRect().top ?? r.top;
-      const cols = frame?.pane0?.cols ?? (renderCols > 0 ? renderCols : 1);
-      const rows = frame?.pane0?.rows ?? Math.max(1, screenRows || rowsRef.current);
-      const col = Math.min(cols, Math.max(1, Math.floor((clientX - r.left) / charW) + 1));
+      const pane0 = frame?.pane0 ?? {
+        cols: renderCols > 0 ? renderCols : 1,
+        rows: Math.max(1, screenRows || rowsRef.current),
+      };
+      const compositeCol = Math.floor((clientX - r.left) / charW) + 1;
       const visualRow = Math.floor((clientY - gridTop) / lineH) - effectiveSpacerLines;
       const firstScreenLine = Math.max(0, lines.length - screenRows);
       const screenTopVisual = visual.lineStartRow[firstScreenLine] ?? 0;
-      const row = Math.min(rows, Math.max(1, visualRow - screenTopVisual + 1));
-      return { col, row };
+      // The hovered cell is on the window grid; the app receives pane 0
+      // coordinates, so the inverse projection subtracts pane 0's origin
+      // (#3515).
+      return pointerPaneCell(compositeCol, visualRow - screenTopVisual, pane0);
     },
     [charW, lineH, renderCols, screenRows, effectiveSpacerLines, lines.length, visual, frame?.pane0],
   );

--- a/web/src/hooks/useLiveTerminal.forward.test.ts
+++ b/web/src/hooks/useLiveTerminal.forward.test.ts
@@ -104,14 +104,14 @@ describe("useLiveTerminal forwardWheel", () => {
           altScreen: true,
           mouse: true,
           mouseSgr: false,
-          pane0: { cols: 40, rows: 24 },
+          pane0: { cols: 40, rows: 24, left: 0, top: 1 },
         }),
       });
     });
     expect(result.current.state.frame?.altScreen).toBe(true);
     expect(result.current.state.frame?.mouse).toBe(true);
     expect(result.current.state.frame?.mouseSgr).toBe(false);
-    expect(result.current.state.frame?.pane0).toEqual({ cols: 40, rows: 24 });
+    expect(result.current.state.frame?.pane0).toEqual({ cols: 40, rows: 24, left: 0, top: 1 });
   });
 
   it("delivers every clipboard event even when the copied text repeats", () => {

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -27,7 +27,7 @@ export interface LiveCursor {
   y: number;
 }
 
-export interface LivePaneExtent {
+export interface LivePaneRect {
   cols: number;
   rows: number;
   /** Pane 0's offset within the composited window grid. A
@@ -59,8 +59,9 @@ export interface LiveFrame {
   /** App is in SGR (1006) mouse encoding; picks the forwarded wire format
    *  (SGR vs legacy X10). */
   mouseSgr: boolean;
-  /** Pane 0's input extent when the frame composites a split window. */
-  pane0?: LivePaneExtent | null;
+  /** Pane 0's rectangle within the composited window grid (a split
+   *  window). */
+  pane0?: LivePaneRect | null;
 }
 
 export interface LiveTerminalState {
@@ -271,7 +272,7 @@ export function useLiveTerminal(
           altScreen?: boolean;
           mouse?: boolean;
           mouseSgr?: boolean;
-          pane0?: LivePaneExtent | null;
+          pane0?: LivePaneRect | null;
         };
         try {
           msg = JSON.parse(text) as typeof msg;

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -30,6 +30,13 @@ export interface LiveCursor {
 export interface LivePaneExtent {
   cols: number;
   rows: number;
+  /** Pane 0's offset within the composited window grid. A
+   *  `pane-border-status` row pushes every pane down, so the cursor and
+   *  pointer cells the client sees are window-relative while the app speaks
+   *  pane-relative coordinates (#3515). Absent means the origin (pre-fix
+   *  servers, unsplit windows). */
+  left?: number;
+  top?: number;
 }
 
 export interface LiveFrame {

--- a/web/src/lib/__tests__/liveMouse.test.ts
+++ b/web/src/lib/__tests__/liveMouse.test.ts
@@ -86,6 +86,12 @@ describe("cursorLineIndex", () => {
     expect(cursorLineIndex(120, 72, 0)).toBe(48);
     expect(cursorLineIndex(120, 72, 63)).toBe(111);
   });
+
+  it("clamps the live edge at zero when the viewport is taller than the capture", () => {
+    // A short capture in a tall viewport must index from the top, not go
+    // negative (which the renderer reads as "no cursor").
+    expect(cursorLineIndex(5, 72, 3)).toBe(3);
+  });
 });
 
 describe("pointerPaneCell", () => {

--- a/web/src/lib/__tests__/liveMouse.test.ts
+++ b/web/src/lib/__tests__/liveMouse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buttonMouseBytes, wheelMouseBytes, wheelNotches } from "../liveMouse";
+import { cursorLineIndex, pointerPaneCell, buttonMouseBytes, wheelMouseBytes, wheelNotches } from "../liveMouse";
 
 const bytes = (...n: number[]) => new Uint8Array(n);
 const ascii = (s: string) => new Uint8Array([...s].map((c) => c.charCodeAt(0)));
@@ -72,5 +72,58 @@ describe("wheelNotches", () => {
 
   it("is a no-op for a zero threshold", () => {
     expect(wheelNotches(99, 0, 8)).toEqual({ notches: 0, remainder: 99 });
+  });
+});
+
+describe("cursorLineIndex", () => {
+  it("indexes the live edge when every line fits on screen", () => {
+    // 72-line composite fully visible: cursor row indexes directly.
+    expect(cursorLineIndex(72, 72, 63)).toBe(63);
+  });
+
+  it("keeps the mapping when scrolled back (screenRows < lines.length)", () => {
+    // The viewport shows the LAST screenRows lines of the capture.
+    expect(cursorLineIndex(120, 72, 0)).toBe(48);
+    expect(cursorLineIndex(120, 72, 63)).toBe(111);
+  });
+});
+
+describe("pointerPaneCell", () => {
+  it("is the identity when pane 0 sits at the window origin", () => {
+    expect(pointerPaneCell(10, 5, { cols: 80, rows: 24 })).toEqual({ col: 10, row: 6 });
+    expect(pointerPaneCell(10, 5, { cols: 80, rows: 24, left: 0, top: 0 })).toEqual({
+      col: 10,
+      row: 6,
+    });
+  });
+
+  it("subtracts a non-zero origin (#3515: pane-border-status shifts pane 0 down)", () => {
+    // Composite cell (10, 5) over a pane starting one row down: the app
+    // hears its own row 5, not the border row above it.
+    expect(pointerPaneCell(10, 5, { cols: 164, rows: 71, left: 0, top: 1 })).toEqual({
+      col: 10,
+      row: 5,
+    });
+    // Cells past pane 0's right edge (a neighbouring pane's columns) clamp
+    // into it; the web surface clamps rather than drops forwarded events.
+    expect(pointerPaneCell(170, 5, { cols: 164, rows: 71, left: 165, top: 1 })).toEqual({
+      col: 5,
+      row: 5,
+    });
+  });
+
+  it("clamps to pane 0's extent", () => {
+    expect(pointerPaneCell(500, 100, { cols: 164, rows: 71, left: 0, top: 1 })).toEqual({
+      col: 164,
+      row: 71,
+    });
+    expect(pointerPaneCell(0, 0, { cols: 164, rows: 71, left: 0, top: 1 })).toEqual({
+      col: 1,
+      row: 1,
+    });
+  });
+
+  it("treats a missing extent as a 1x1 pane", () => {
+    expect(pointerPaneCell(7, 9, null)).toEqual({ col: 1, row: 1 });
   });
 });

--- a/web/src/lib/__tests__/liveMouse.test.ts
+++ b/web/src/lib/__tests__/liveMouse.test.ts
@@ -104,15 +104,22 @@ describe("pointerPaneCell", () => {
       col: 10,
       row: 5,
     });
-    // Cells past pane 0's right edge (a neighbouring pane's columns) clamp
-    // into it; the web surface clamps rather than drops forwarded events.
+    // A right-hand neighbour's columns (pane 0 spans composite 1-based
+    // cols 166..329 here) clamp into pane 0; the web surface clamps rather
+    // than drops forwarded events.
+    expect(pointerPaneCell(340, 5, { cols: 164, rows: 71, left: 165, top: 1 })).toEqual({
+      col: 164,
+      row: 5,
+    });
+    // Inside the neighbour-adjacent pane itself the origin subtraction lands
+    // on the app's own column.
     expect(pointerPaneCell(170, 5, { cols: 164, rows: 71, left: 165, top: 1 })).toEqual({
       col: 5,
       row: 5,
     });
   });
 
-  it("clamps to pane 0's extent", () => {
+  it("clamps to pane 0's rectangle", () => {
     expect(pointerPaneCell(500, 100, { cols: 164, rows: 71, left: 0, top: 1 })).toEqual({
       col: 164,
       row: 71,
@@ -123,7 +130,7 @@ describe("pointerPaneCell", () => {
     });
   });
 
-  it("treats a missing extent as a 1x1 pane", () => {
+  it("treats a missing rectangle as a 1x1 pane", () => {
     expect(pointerPaneCell(7, 9, null)).toEqual({ col: 1, row: 1 });
   });
 });

--- a/web/src/lib/liveMouse.ts
+++ b/web/src/lib/liveMouse.ts
@@ -89,3 +89,39 @@ export function wheelNotches(
   const notches = Math.max(-maxNotches, Math.min(maxNotches, raw));
   return { notches, remainder: accumPx - notches * thresholdPx };
 }
+
+/**
+ * The composite line index a frame's cursor points at. Frame content is
+ * bottom-anchored to the viewport (`screenRows` lines), so the live edge
+ * starts at `lineCount - screenRows`; `cursorY` is already composite-space
+ * (the server translates pane 0's row by its origin, #3515). Pure so the
+ * cursor mapping is testable without a DOM.
+ */
+export function cursorLineIndex(lineCount: number, screenRows: number, cursorY: number): number {
+  return Math.max(0, lineCount - screenRows) + cursorY;
+}
+
+/**
+ * Inverse projection for pointer forwarding: map a hovered cell of the
+ * composited window grid onto pane 0's 1-based mouse coordinate space.
+ * `compositeCol` is 1-based, `compositeRow` is the 0-based composite row
+ * under the pointer. Pane 0 may sit away from the window origin (a
+ * `pane-border-status` row pushes every pane down one), so subtract the
+ * origin the frame reports and clamp to the pane extent (#3515). A missing
+ * origin means pane 0 at the corner, which keeps unsplit and pre-fix frames
+ * unchanged.
+ */
+export function pointerPaneCell(
+  compositeCol: number,
+  compositeRow: number,
+  pane0: { cols: number; rows: number; left?: number; top?: number } | null | undefined,
+): { col: number; row: number } {
+  const left = pane0?.left ?? 0;
+  const top = pane0?.top ?? 0;
+  const cols = pane0?.cols ?? 1;
+  const rows = pane0?.rows ?? 1;
+  return {
+    col: Math.min(cols, Math.max(1, compositeCol - left)),
+    row: Math.min(rows, Math.max(1, compositeRow - top + 1)),
+  };
+}

--- a/web/src/lib/liveMouse.ts
+++ b/web/src/lib/liveMouse.ts
@@ -107,9 +107,9 @@ export function cursorLineIndex(lineCount: number, screenRows: number, cursorY: 
  * `compositeCol` is 1-based, `compositeRow` is the 0-based composite row
  * under the pointer. Pane 0 may sit away from the window origin (a
  * `pane-border-status` row pushes every pane down one), so subtract the
- * origin the frame reports and clamp to the pane extent (#3515). A missing
- * origin means pane 0 at the corner, which keeps unsplit and pre-fix frames
- * unchanged.
+ * origin the frame reports and clamp to the pane rectangle (#3515). A
+ * missing rectangle means pane 0 at the corner, which keeps unsplit and
+ * pre-fix frames unchanged.
  */
 export function pointerPaneCell(
   compositeCol: number,

--- a/web/tests/live-click-forward.spec.ts
+++ b/web/tests/live-click-forward.spec.ts
@@ -81,6 +81,28 @@ test("a click on a bottom-aligned row reports that row to the mouse app", async 
   await expect.poll(() => texts(handle).find((text) => /\x1b\[<0;\d+;\d+M/.test(text))).toMatch(/\x1b\[<0;\d+;2M/);
 });
 
+test("a pane-border-status offset shifts forwarded rows up one (#3515)", async ({ page }) => {
+  const handle = await setup(page);
+  const lines = ["first", "second", ...Array<string>(22).fill("")];
+  handle.pushLiveFrame({
+    content: `${lines.join("\n")}\n`,
+    rows: 24,
+    history: 120,
+    altScreen: true,
+    mouse: true,
+    mouseSgr: true,
+    // Pane 0 starts one composite row down (`pane-border-status top`), so a
+    // click on composite row 1 must report the app's row 1, not 2.
+    pane0: { cols: 80, rows: 24, left: 0, top: 1 },
+  } as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  const secondRow = page.getByText("second", { exact: true });
+  await expect(secondRow).toBeVisible();
+  const box = (await secondRow.boundingBox())!;
+
+  await pointer(page, "pointerdown", box.x + 10, box.y + box.height / 2);
+  await expect.poll(() => texts(handle).find((text) => /\x1b\[<0;\d+;\d+M/.test(text))).toMatch(/\x1b\[<0;\d+;1M/);
+});
+
 test("dragging forwards a motion report (button + 32) per new cell", async ({ page }) => {
   const handle = await setup(page);
   pushFrame(handle, { altScreen: true, mouse: true, mouseSgr: true });


### PR DESCRIPTION
## Description

In the web live terminal, any composited (split) window whose pane 0 is not at the window origin rendered pane 0's cursor one row too high and mapped forwarded mouse rows one row low. The trigger in the wild is Claude Code's subagent split, which sets `pane-border-status top` and pushes every pane down to `pane_top == 1` (closes #3515).

Root cause: the compositor lays panes out on the window grid, but `capture_window_composited_with_cursor` shipped the cursor still in pane 0's coordinate space, and the frame's `pane0` payload carried only `{cols, rows}`, so neither the server nor the client had pane 0's origin to translate with.

Fix: transport pane 0's full rectangle (`left`, `top`, `width`, `height`) through `PaneCursor::composite_pane0`, emit it on the wire as `pane0.{left,top}` next to the existing `cols`/`rows`, translate the cursor onto the window grid once at emission (`frame_json`), and subtract it again in the client's inverse pointer projection. The client projection is extracted into pure functions (`cursorLineIndex`, `pointerPaneCell`) in `web/src/lib/liveMouse.ts`.

Protocol compatibility: both new fields are optional additions; frames without them (single-pane windows) are byte-identical to before. A client that ignores `left`/`top` still paints the cursor correctly at any origin, because translation happens at emission; its mouse forwarding is what degrades to the one-row shift whenever pane 0's origin is not `(0, 0)`.

Known residual (documented in code, not hacked around): the border-status row itself is covered by no pane, so it is still drawn as a full-width gap-fill rule; dropping it would render a grid shorter than `window_height` and rebase every consumer. The TUI preview shares this geometry and its mouse mapping still assumes a shared top-left corner; that side was never reproduced, so this PR only corrects its now-false doc comments.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No screenshot: I could not stand up a real split session with `pane-border-status top` plus a dashboard browser against it in this environment; the behavioral guarantees rest on the real-tmux geometric test below plus the real-browser Playwright test.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added a mocked-playwright case in `tests/live-click-forward.spec.ts`: clicking composite row 1 with `pane0.top = 1` must forward SGR row 1, not 2. The touched flows (`terminal.live-split-composite`, `terminal.mobile-live-click-forward*`) were already registered in the coverage matrix, so no matrix entry changed; `node tests/validate-coverage-matrix.mjs` passes.

New tests:
- Rust, `frame_json_includes_geometry_and_cursor` (table): origin-carrying frame serializes cursor `{x+left, y+top}` and `pane0.{cols,rows,left,top}`; the origin-less case pins the unchanged unsplit wire shape.
- Rust, tmux-gated `composited_cursor_and_pane0_origin_track_pane_border_offset`: for horizontal, vertical, and stacked splits with `pane-border-status top`, `composite_pane0` matches tmux-reported geometry and the composite paints the pane's cursor row at `cursor.y + top` (with an anti-vacuity guard that the untranslated row does not contain the marker).
- Vitest: `cursorLineIndex` (including the `screenRows < lines.length` scrollback case) and `pointerPaneCell` (identity, shifted origin, clamping).
- Playwright mocked: the offset click case above.

Mutation checks (both reverted translations made the new tests fail, identity cases stayed green):
- Reverting the `frame_json` translation fails `frame_json_includes_geometry_and_cursor` (got x 3, expected 5).
- Reverting `pointerPaneCell`'s origin subtraction fails the new Vitest case and the new Playwright case in a real Chromium bundle rebuild.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The TUI consumes the same struct mechanically (type change), but no TUI behavior was deliberately altered and none was reproduced.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5) produced the diagnosis in the issue; the fix, tests, and this PR were implemented by ox-alpha.

**Any Additional AI Details you'd like to share:** Verification ran `cargo fmt --all -- --check`, `cargo clippy --features serve -- -D warnings`, `cargo test --lib --features serve` (6404 passed), targeted tmux-gated tests, web `format:check`/`lint`/full Vitest (2 pre-existing locale-dependent failures in `Composer.usageHint.test.tsx` also failing on the base commit), `validate-coverage-matrix.mjs`, and the mocked Playwright suite file (7/7).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes cursor and mouse-coordinate offsets in split live-terminal windows when pane 0 starts away from the window origin.
- Sends pane 0’s complete position and size from the server to the web client.
- Translates cursor and mouse coordinates between window space and pane space.
- Reuses `PaneGeom` across the Rust code and removes the older `Pane0Rect` type.
- Keeps unsplit frames and older metadata compatible.
- Adds Rust, Vitest, and Playwright coverage for offsets, clamping, and borderless splits.
- Preserves the full-width gap-fill row for `pane-border-status top`.
- Documents the remaining TUI preview offset behavior.

## Benefits

Users receive more accurate cursor positions and mouse input in split web live-terminal windows. The shared geometry type and tested coordinate helpers make the behavior easier to maintain and extend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
