### PR TITLE
fix(session): reconcile interrupted profile moves from a durable journal

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -26,6 +26,7 @@ mod instance;
 pub mod mcp_model;
 pub mod mcp_overrides;
 pub mod mcp_state;
+mod move_journal;
 pub mod poller;
 pub mod profile_config;
 pub mod project_mcp;
@@ -84,7 +85,10 @@ pub use instance::{
     SandboxInfo, SessionBucket, StartOutcome, Status, TerminalInfo, View, WorkspaceInfo,
     WorkspaceRepo, WorktreeInfo, SESSION_COLORS, TMUX_SESSION_GONE_ERROR,
 };
+#[cfg(test)]
+pub(crate) use move_journal::{record as record_move_journal, MoveJournalEntry};
 pub(crate) use storage::acquire_session_identity_lock;
+pub(crate) use storage::{reconcile_profile_duplicates, DuplicateIdReport};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -86,7 +86,9 @@ pub use instance::{
     WorkspaceRepo, WorktreeInfo, SESSION_COLORS, TMUX_SESSION_GONE_ERROR,
 };
 #[cfg(test)]
-pub(crate) use move_journal::{record as record_move_journal, MoveJournalEntry};
+pub(crate) use move_journal::{
+    record as record_move_journal, MoveJournalEntry, MOVE_JOURNAL_VERSION,
+};
 pub(crate) use storage::acquire_session_identity_lock;
 pub(crate) use storage::{reconcile_profile_duplicates, DuplicateIdReport};
 

--- a/src/session/move_journal.rs
+++ b/src/session/move_journal.rs
@@ -1,0 +1,127 @@
+//! Durable journal for cross-profile session moves (#3459).
+//!
+//! `Storage::move_instances_to_inner` writes target rows before removing
+//! source rows, so a crash in between leaves the same session id in two
+//! profiles. This module is the evidence that arbitrates such states: one
+//! versioned JSON file per attempted move, written (and fsynced) before the
+//! first mutation and deleted only after the move completed or a recovery
+//! pass consumed it.
+//!
+//! Winner policy: a valid, current-version journal entry is proof that a
+//! move was in flight between exactly the two recorded stores. Because the
+//! transaction publishes the target before touching the source, whichever
+//! store currently holds the id is the winner; the other copy loses. No
+//! iteration order is ever consulted. An entry that cannot be parsed or
+//! whose version differs is treated as insufficient evidence: the duplicate
+//! is surfaced for manual resolution instead of arbitrated.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::get_app_dir;
+use super::storage::{atomic_write_verified, sync_parent_directory};
+
+/// Bump when the entry shape changes. Entries written by an older version
+/// carry no arbitration authority (see [`MoveJournalEntry::is_current`]).
+pub(crate) const MOVE_JOURNAL_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MoveJournalEntry {
+    pub(crate) version: u32,
+    /// Sorted session ids covered by one move batch.
+    pub(crate) ids: Vec<String>,
+    pub(crate) source_profile: String,
+    pub(crate) target_profile: String,
+    /// Absolute paths of both profiles' `sessions.json`, as recorded at
+    /// journal-write time. Recovery re-checks them against the live stores.
+    pub(crate) source_sessions_path: PathBuf,
+    pub(crate) target_sessions_path: PathBuf,
+    pub(crate) group_move_source_path: String,
+    pub(crate) group_move_target_path: String,
+    pub(crate) group_move_subtree: bool,
+    pub(crate) created_at_epoch_ms: u64,
+}
+
+impl MoveJournalEntry {
+    pub(crate) fn is_current(&self) -> bool {
+        self.version == MOVE_JOURNAL_VERSION
+    }
+}
+
+fn journal_dir() -> Result<PathBuf> {
+    Ok(get_app_dir()?.join("move-journal"))
+}
+
+/// Persist one entry under `<app_dir>/move-journal/` and return its path.
+/// The write is atomic and fsynced (file content plus parent directory), so
+/// once [`record`] returns Ok the entry survives a power loss.
+pub(crate) fn record(entry: &MoveJournalEntry) -> Result<PathBuf> {
+    let dir = journal_dir()?;
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let path = dir.join(format!("move-{}-{}.json", nanos, std::process::id()));
+    let bytes = serde_json::to_vec_pretty(entry)?;
+    atomic_write_verified(&path, &bytes)
+        .with_context(|| format!("failed to write move journal {}", path.display()))?;
+    sync_parent_directory(&path)
+        .with_context(|| format!("move journal {} was not made durable", path.display()))?;
+    Ok(path)
+}
+
+/// Delete one consumed entry and sync its parent directory so the removal
+/// itself is durable. Idempotent: a missing file is already consumed.
+pub(crate) fn consume(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to remove {}", path.display()))
+        }
+    }
+    sync_parent_directory(path)
+        .with_context(|| format!("removal of {} was not made durable", path.display()))
+}
+
+/// Every on-disk entry paired with its parse outcome. `Err` covers unreadable
+/// files, malformed JSON, and wrong-version entries: all of them are evidence
+/// that *something* happened but not enough to arbitrate automatically.
+pub(crate) fn scan() -> Result<Vec<(PathBuf, std::result::Result<MoveJournalEntry, String>)>> {
+    let dir = journal_dir()?;
+    let mut out = Vec::new();
+    let read_dir = match fs::read_dir(&dir) {
+        Ok(read_dir) => read_dir,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to list {}", dir.display()))
+        }
+    };
+    let mut paths: Vec<PathBuf> = read_dir
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    paths.sort();
+    for path in paths {
+        let parsed = fs::read(&path)
+            .context("failed to read move journal entry")
+            .and_then(|bytes| serde_json::from_slice::<MoveJournalEntry>(&bytes).context("malformed move journal entry"))
+            .map_err(|error| format!("{error:#}"))
+            .and_then(|entry| {
+                if entry.is_current() {
+                    Ok(entry)
+                } else {
+                    Err(format!(
+                        "move journal version {} is not supported (current: {MOVE_JOURNAL_VERSION})",
+                        entry.version
+                    ))
+                }
+            });
+        out.push((path, parsed));
+    }
+    Ok(out)
+}

--- a/src/session/move_journal.rs
+++ b/src/session/move_journal.rs
@@ -102,8 +102,6 @@ where
     Ok(path)
 }
 
-/// Delete one consumed entry and sync its parent directory so the removal
-/// itself is durable. Idempotent: a missing file is already consumed.
 /// Nanosecond creation order encoded in record's filename. Used only as a
 /// durable tie-breaker when two entries share the millisecond JSON timestamp.
 pub(crate) fn file_created_at_nanos(path: &Path) -> Option<u128> {
@@ -114,6 +112,8 @@ pub(crate) fn file_created_at_nanos(path: &Path) -> Option<u128> {
         .and_then(|nanos| nanos.parse().ok())
 }
 
+/// Delete one consumed entry and sync its parent directory so the removal
+/// itself is durable. Idempotent: a missing file is already consumed.
 pub(crate) fn consume(path: &Path) -> Result<()> {
     match fs::remove_file(path) {
         Ok(()) => {}

--- a/src/session/move_journal.rs
+++ b/src/session/move_journal.rs
@@ -11,7 +11,9 @@
 //! The journal lives with the source store instead of a global app-dir folder
 //! so its lifetime is bounded by exactly the stores it arbitrates between,
 //! and tests driving `Storage` at arbitrary paths stay hermetic without
-//! process-global coordination.
+//! process-global coordination. Successfully completed or reconciled entries
+//! are consumed; permanently unusable entries intentionally remain for manual
+//! inspection and have no automatic GC.
 //!
 //! Winner policy: a valid, current-version journal entry is proof that a move
 //! was in flight between exactly the two recorded stores. Because the
@@ -70,8 +72,24 @@ fn journal_dir_for(sessions_path: &Path) -> PathBuf {
 /// its path. The write is atomic and fsynced (file content plus parent
 /// directory), so once [`record`] returns Ok the entry survives a power loss.
 pub(crate) fn record(entry: &MoveJournalEntry, source_sessions_path: &Path) -> Result<PathBuf> {
+    record_with_sync(entry, source_sessions_path, sync_parent_directory)
+}
+
+fn record_with_sync<S>(
+    entry: &MoveJournalEntry,
+    source_sessions_path: &Path,
+    mut sync: S,
+) -> Result<PathBuf>
+where
+    S: FnMut(&Path) -> Result<()>,
+{
     let dir = journal_dir_for(source_sessions_path);
     fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    // create_dir_all only makes the new journal directory itself visible.
+    // Sync its profile parent too so the .move-journal directory entry
+    // survives power loss before any profile mutation is allowed to run.
+    sync(&dir)
+        .with_context(|| format!("journal directory {} was not made durable", dir.display()))?;
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
@@ -80,13 +98,22 @@ pub(crate) fn record(entry: &MoveJournalEntry, source_sessions_path: &Path) -> R
     let bytes = serde_json::to_vec_pretty(entry)?;
     atomic_write_verified(&path, &bytes)
         .with_context(|| format!("failed to write move journal {}", path.display()))?;
-    sync_parent_directory(&path)
-        .with_context(|| format!("move journal {} was not made durable", path.display()))?;
+    sync(&path).with_context(|| format!("move journal {} was not made durable", path.display()))?;
     Ok(path)
 }
 
 /// Delete one consumed entry and sync its parent directory so the removal
 /// itself is durable. Idempotent: a missing file is already consumed.
+/// Nanosecond creation order encoded in record's filename. Used only as a
+/// durable tie-breaker when two entries share the millisecond JSON timestamp.
+pub(crate) fn file_created_at_nanos(path: &Path) -> Option<u128> {
+    path.file_stem()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("move-"))
+        .and_then(|name| name.split_once('-').map(|(nanos, _)| nanos))
+        .and_then(|nanos| nanos.parse().ok())
+}
+
 pub(crate) fn consume(path: &Path) -> Result<()> {
     match fs::remove_file(path) {
         Ok(()) => {}
@@ -99,14 +126,22 @@ pub(crate) fn consume(path: &Path) -> Result<()> {
         .with_context(|| format!("removal of {} was not made durable", path.display()))
 }
 
-/// Every entry under each given profile directory paired with its parse
-/// outcome. `Err` covers unreadable files, malformed JSON, and wrong-version
-/// entries: all of them are evidence that *something* happened but not enough
-/// to arbitrate automatically.
-pub(crate) fn scan(
-    sessions_paths: impl IntoIterator<Item = PathBuf>,
-) -> Vec<(PathBuf, std::result::Result<MoveJournalEntry, String>)> {
-    let mut out = Vec::new();
+/// Result of scanning every loaded profile's journal directory. Entry results
+/// always name journal files; directory-list failures stay transient and
+/// separate, so callers never blacklist a directory as bad journal evidence.
+pub(crate) struct ScanResult {
+    pub(crate) entries: Vec<(PathBuf, std::result::Result<MoveJournalEntry, String>)>,
+    pub(crate) unreadable_dirs: Vec<(PathBuf, String)>,
+}
+
+/// Every journal file under each given profile directory paired with its parse
+/// outcome. Err covers unreadable files, malformed JSON, and wrong-version
+/// entries. Directory-listing failures are retried on later scans.
+pub(crate) fn scan(sessions_paths: impl IntoIterator<Item = PathBuf>) -> ScanResult {
+    let mut result = ScanResult {
+        entries: Vec::new(),
+        unreadable_dirs: Vec::new(),
+    };
     let mut dirs: Vec<PathBuf> = sessions_paths
         .into_iter()
         .map(|sessions_path| journal_dir_for(&sessions_path))
@@ -118,9 +153,9 @@ pub(crate) fn scan(
             Ok(read_dir) => read_dir,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
             Err(error) => {
-                out.push((
+                result.unreadable_dirs.push((
                     dir.clone(),
-                    Err(format!("failed to list {}: {error}", dir.display())),
+                    format!("failed to list {}: {error}", dir.display()),
                 ));
                 continue;
             }
@@ -148,8 +183,73 @@ pub(crate) fn scan(
                         ))
                     }
                 });
-            out.push((path, parsed));
+            result.entries.push((path, parsed));
         }
     }
-    out
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(source: &Path, target: &Path) -> MoveJournalEntry {
+        MoveJournalEntry {
+            version: MOVE_JOURNAL_VERSION,
+            ids: vec!["session-id".to_string()],
+            source_profile: "source".to_string(),
+            target_profile: "target".to_string(),
+            source_sessions_path: source.to_path_buf(),
+            target_sessions_path: target.to_path_buf(),
+            group_move_source_path: "work".to_string(),
+            group_move_target_path: "moved".to_string(),
+            group_move_subtree: false,
+            created_at_epoch_ms: 1,
+        }
+    }
+
+    #[test]
+    fn record_requires_profile_parent_barrier_before_writing_entry() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let source = temp.path().join("source/sessions.json");
+        let target = temp.path().join("target/sessions.json");
+        fs::create_dir_all(source.parent().unwrap())?;
+        fs::create_dir_all(target.parent().unwrap())?;
+        let expected_dir = journal_dir_for(&source);
+        let mut calls = Vec::new();
+
+        let error = record_with_sync(&entry(&source, &target), &source, |path| {
+            calls.push(path.to_path_buf());
+            Err(anyhow::anyhow!("forced profile-parent barrier failure"))
+        })
+        .expect_err("journal record must fail before an unverified directory can be used");
+
+        assert!(error.to_string().contains("journal directory"));
+        assert_eq!(calls, vec![expected_dir.clone()]);
+        assert!(
+            expected_dir.exists(),
+            "directory was created before its barrier"
+        );
+        assert!(
+            fs::read_dir(expected_dir)?.next().is_none(),
+            "no entry may be written before the parent barrier"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scan_separates_directory_failures_from_entry_results() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let sessions = temp.path().join("profile/sessions.json");
+        fs::create_dir_all(sessions.parent().unwrap())?;
+        let journal_dir = journal_dir_for(&sessions);
+        fs::write(&journal_dir, b"not-a-directory")?;
+
+        let result = scan([sessions]);
+
+        assert!(result.entries.is_empty());
+        assert_eq!(result.unreadable_dirs.len(), 1);
+        assert_eq!(result.unreadable_dirs[0].0, journal_dir);
+        Ok(())
+    }
 }

--- a/src/session/move_journal.rs
+++ b/src/session/move_journal.rs
@@ -3,12 +3,18 @@
 //! `Storage::move_instances_to_inner` writes target rows before removing
 //! source rows, so a crash in between leaves the same session id in two
 //! profiles. This module is the evidence that arbitrates such states: one
-//! versioned JSON file per attempted move, written (and fsynced) before the
-//! first mutation and deleted only after the move completed or a recovery
-//! pass consumed it.
+//! versioned JSON file per attempted move, stored under the source profile's
+//! directory (`.move-journal/` next to `sessions.json`), written (and fsynced)
+//! before the first mutation and deleted only after the move completed or a
+//! recovery pass consumed it.
 //!
-//! Winner policy: a valid, current-version journal entry is proof that a
-//! move was in flight between exactly the two recorded stores. Because the
+//! The journal lives with the source store instead of a global app-dir folder
+//! so its lifetime is bounded by exactly the stores it arbitrates between,
+//! and tests driving `Storage` at arbitrary paths stay hermetic without
+//! process-global coordination.
+//!
+//! Winner policy: a valid, current-version journal entry is proof that a move
+//! was in flight between exactly the two recorded stores. Because the
 //! transaction publishes the target before touching the source, whichever
 //! store currently holds the id is the winner; the other copy loses. No
 //! iteration order is ever consulted. An entry that cannot be parsed or
@@ -21,12 +27,13 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use super::get_app_dir;
 use super::storage::{atomic_write_verified, sync_parent_directory};
 
 /// Bump when the entry shape changes. Entries written by an older version
 /// carry no arbitration authority (see [`MoveJournalEntry::is_current`]).
 pub(crate) const MOVE_JOURNAL_VERSION: u32 = 1;
+
+const JOURNAL_DIR_NAME: &str = ".move-journal";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MoveJournalEntry {
@@ -51,15 +58,19 @@ impl MoveJournalEntry {
     }
 }
 
-fn journal_dir() -> Result<PathBuf> {
-    Ok(get_app_dir()?.join("move-journal"))
+/// `.move-journal/` inside the directory holding `sessions_path`.
+fn journal_dir_for(sessions_path: &Path) -> PathBuf {
+    sessions_path
+        .parent()
+        .unwrap_or(sessions_path)
+        .join(JOURNAL_DIR_NAME)
 }
 
-/// Persist one entry under `<app_dir>/move-journal/` and return its path.
-/// The write is atomic and fsynced (file content plus parent directory), so
-/// once [`record`] returns Ok the entry survives a power loss.
-pub(crate) fn record(entry: &MoveJournalEntry) -> Result<PathBuf> {
-    let dir = journal_dir()?;
+/// Persist one entry next to the source profile's `sessions.json` and return
+/// its path. The write is atomic and fsynced (file content plus parent
+/// directory), so once [`record`] returns Ok the entry survives a power loss.
+pub(crate) fn record(entry: &MoveJournalEntry, source_sessions_path: &Path) -> Result<PathBuf> {
+    let dir = journal_dir_for(source_sessions_path);
     fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -88,40 +99,57 @@ pub(crate) fn consume(path: &Path) -> Result<()> {
         .with_context(|| format!("removal of {} was not made durable", path.display()))
 }
 
-/// Every on-disk entry paired with its parse outcome. `Err` covers unreadable
-/// files, malformed JSON, and wrong-version entries: all of them are evidence
-/// that *something* happened but not enough to arbitrate automatically.
-pub(crate) fn scan() -> Result<Vec<(PathBuf, std::result::Result<MoveJournalEntry, String>)>> {
-    let dir = journal_dir()?;
+/// Every entry under each given profile directory paired with its parse
+/// outcome. `Err` covers unreadable files, malformed JSON, and wrong-version
+/// entries: all of them are evidence that *something* happened but not enough
+/// to arbitrate automatically.
+pub(crate) fn scan(
+    sessions_paths: impl IntoIterator<Item = PathBuf>,
+) -> Vec<(PathBuf, std::result::Result<MoveJournalEntry, String>)> {
     let mut out = Vec::new();
-    let read_dir = match fs::read_dir(&dir) {
-        Ok(read_dir) => read_dir,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(out),
-        Err(error) => {
-            return Err(error).with_context(|| format!("failed to list {}", dir.display()))
-        }
-    };
-    let mut paths: Vec<PathBuf> = read_dir
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+    let mut dirs: Vec<PathBuf> = sessions_paths
+        .into_iter()
+        .map(|sessions_path| journal_dir_for(&sessions_path))
         .collect();
-    paths.sort();
-    for path in paths {
-        let parsed = fs::read(&path)
-            .context("failed to read move journal entry")
-            .and_then(|bytes| serde_json::from_slice::<MoveJournalEntry>(&bytes).context("malformed move journal entry"))
-            .map_err(|error| format!("{error:#}"))
-            .and_then(|entry| {
-                if entry.is_current() {
-                    Ok(entry)
-                } else {
-                    Err(format!(
-                        "move journal version {} is not supported (current: {MOVE_JOURNAL_VERSION})",
-                        entry.version
-                    ))
-                }
-            });
-        out.push((path, parsed));
+    dirs.sort();
+    dirs.dedup();
+    for dir in dirs {
+        let read_dir = match fs::read_dir(&dir) {
+            Ok(read_dir) => read_dir,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                out.push((
+                    dir.clone(),
+                    Err(format!("failed to list {}: {error}", dir.display())),
+                ));
+                continue;
+            }
+        };
+        let mut paths: Vec<PathBuf> = read_dir
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            let parsed = fs::read(&path)
+                .context("failed to read move journal entry")
+                .and_then(|bytes| {
+                    serde_json::from_slice::<MoveJournalEntry>(&bytes)
+                        .context("malformed move journal entry")
+                })
+                .map_err(|error| format!("{error:#}"))
+                .and_then(|entry| {
+                    if entry.is_current() {
+                        Ok(entry)
+                    } else {
+                        Err(format!(
+                            "move journal version {} is not supported (current: {MOVE_JOURNAL_VERSION})",
+                            entry.version
+                        ))
+                    }
+                });
+            out.push((path, parsed));
+        }
     }
-    Ok(out)
+    out
 }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1017,6 +1017,15 @@ impl Storage {
             )
         })?;
         let _flock = acquire_storage_flock(profile_dir, STORAGE_LOCK_FILENAME)?;
+        self.update_under_lock(f)
+    }
+
+    /// Apply one storage mutation while the caller already owns this profile's
+    /// in-process save lock and cross-process storage flock.
+    fn update_under_lock<F, R>(&self, f: F) -> Result<R>
+    where
+        F: FnOnce(&mut Vec<Instance>, &mut Vec<Group>) -> Result<R>,
+    {
         let (mut instances, mut groups) = self.load_with_groups()?;
         let groups_before = groups.clone();
         let result = f(&mut instances, &mut groups)?;
@@ -1037,11 +1046,6 @@ impl Storage {
         if let Some(buf) = groups_buf {
             let groups_path = self.sessions_path.with_file_name("groups.json");
             atomic_write(&groups_path, &buf)?;
-            // Surface the rename to in-process subscribers immediately;
-            // the kernel echo arrives ~ms later for the same rename and
-            // collapses into the same per-key debounce slot. Runs strictly
-            // AFTER atomic_write returns so any subscriber waking on the
-            // notify is guaranteed to read the post-rename file.
             self.file_watch.notify_local_change(&groups_path);
         }
         #[cfg(test)]
@@ -1867,105 +1871,115 @@ pub(crate) fn reconcile_profile_duplicates(
             .iter()
             .map(|(_, storage)| storage.sessions_path().to_path_buf()),
     );
+    let mut opaque_failure = !scan.unreadable_dirs.is_empty();
     for (dir, error) in scan.unreadable_dirs {
         tracing::warn!(
             target: "session.store",
             path = %dir.display(),
             error = %error,
-            "move journal directory could not be listed; retrying on the next reload"
+            "move journal directory could not be listed; all arbitration is deferred"
         );
     }
-    let mut entries = scan.entries;
-    // The newest entry is the only current intent after a reverse move. Apply
-    // it first; older evidence then degrades harmlessly to already-consistent.
-    // Unparseable entries sort last and can never consume anything.
-    entries.sort_by_key(|(path, parsed)| {
-        std::cmp::Reverse((
-            parsed
-                .as_ref()
-                .map(|entry| entry.created_at_epoch_ms)
-                .unwrap_or_default(),
-            super::move_journal::file_created_at_nanos(path).unwrap_or_default(),
-        ))
-    });
-    if entries.is_empty() && !duplicated {
-        return outcome;
-    }
-    for (path, parsed) in entries {
-        // Unusable entries stay on disk by design; without this guard every
-        // 5-10s reload would re-log and re-attempt them forever.
-        if UNUSABLE_JOURNAL_ENTRIES
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .iter()
-            .any(|unusable| unusable == &path)
-        {
-            continue;
-        }
-        let entry = match parsed {
-            Ok(entry) => entry,
+    let mut valid_entries = Vec::new();
+    for (path, parsed) in scan.entries {
+        match parsed {
+            Ok(entry) => valid_entries.push((path, entry)),
             Err(reason) => {
-                mark_unusable_journal_entry(&path);
-                tracing::error!(
-                    target: "session.store",
-                    path = %path.display(),
-                    reason = %reason,
-                    "move journal entry is insufficient evidence for arbitration; duplicates stay surfaced"
-                );
-                continue;
-            }
-        };
-        // Expired evidence arbitrates nothing: a journal that outlived its
-        // move must never delete a copy the user created or edited later.
-        // It degrades to the same surfaced-legacy path as having no journal.
-        if entry_age(&entry) > MOVE_JOURNAL_MAX_AGE {
-            mark_unusable_journal_entry(&path);
-            tracing::error!(
-                target: "session.store",
-                path = %path.display(),
-                ids = %entry.ids.join(","),
-                "expired move journal entry is insufficient evidence for arbitration; duplicates stay surfaced"
-            );
-            continue;
-        }
-        match repair_journal_entry(&entry, storages, &path) {
-            Ok(true) => {
-                outcome.repaired = true;
-                tracing::info!(
-                    target: "session.store",
-                    ids = %entry.ids.join(","),
-                    "reconciled interrupted profile move from its journal"
-                );
-            }
-            Ok(false) => {
-                // Transient: the referenced stores may simply not be loaded
-                // right now (single-profile mode). Never blacklist these:
-                // blacklisting would poison a perfectly usable entry once the
-                // missing profile is loaded later in the same process.
-                tracing::debug!(
-                    target: "session.store",
-                    path = %path.display(),
-                    "journal-guided repair skipped: entry references stores that are missing or moved"
-                );
-            }
-            Err(error) => {
-                // Genuinely transient failures keep retrying on later passes;
-                // only their logging is once-per-path so a persistently
-                // failing repair cannot spam ERROR lines every reload tick.
-                if mark_repair_failure_logged(&path) {
+                opaque_failure = true;
+                let already_reported = UNUSABLE_JOURNAL_ENTRIES
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .iter()
+                    .any(|unusable| unusable == &path);
+                if !already_reported {
+                    mark_unusable_journal_entry(&path);
                     tracing::error!(
                         target: "session.store",
                         path = %path.display(),
-                        error = %error,
-                        "journal-guided repair failed; the duplicate stays excluded"
+                        reason = %reason,
+                        "opaque move journal evidence blocks arbitration for this reload"
                     );
-                } else {
+                }
+            }
+        }
+    }
+    valid_entries.sort_by_key(|(path, entry)| {
+        std::cmp::Reverse((
+            entry.created_at_epoch_ms,
+            super::move_journal::file_created_at_nanos(path).unwrap_or_default(),
+        ))
+    });
+    if valid_entries.is_empty() && !duplicated {
+        return outcome;
+    }
+    if !opaque_failure {
+        let mut blocked_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (path, entry) in valid_entries {
+            if entry.ids.iter().any(|id| blocked_ids.contains(id)) {
+                // Shadowing is transitive across a multi-id batch: if X blocks
+                // this X+Y entry, Y must also block still-older evidence.
+                blocked_ids.extend(entry.ids.iter().cloned());
+                tracing::debug!(
+                    target: "session.store",
+                    path = %path.display(),
+                    "older move journal is shadowed by unresolved newer intent"
+                );
+                continue;
+            }
+            let already_unusable = UNUSABLE_JOURNAL_ENTRIES
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .any(|unusable| unusable == &path);
+            if already_unusable {
+                blocked_ids.extend(entry.ids.iter().cloned());
+                continue;
+            }
+            if entry_age(&entry) > MOVE_JOURNAL_MAX_AGE {
+                mark_unusable_journal_entry(&path);
+                blocked_ids.extend(entry.ids.iter().cloned());
+                tracing::error!(
+                    target: "session.store",
+                    path = %path.display(),
+                    ids = %entry.ids.join(","),
+                    "expired move journal entry is insufficient evidence for arbitration; duplicates stay surfaced"
+                );
+                continue;
+            }
+            match repair_journal_entry(&entry, storages, &path) {
+                Ok(true) => {
+                    outcome.repaired = true;
+                    tracing::info!(
+                        target: "session.store",
+                        ids = %entry.ids.join(","),
+                        "reconciled interrupted profile move from its journal"
+                    );
+                }
+                Ok(false) => {
+                    blocked_ids.extend(entry.ids.iter().cloned());
                     tracing::debug!(
                         target: "session.store",
                         path = %path.display(),
-                        error = %error,
-                        "journal-guided repair failed again"
+                        "newer unresolved move intent blocks older overlapping journals"
                     );
+                }
+                Err(error) => {
+                    blocked_ids.extend(entry.ids.iter().cloned());
+                    if mark_repair_failure_logged(&path) {
+                        tracing::error!(
+                            target: "session.store",
+                            path = %path.display(),
+                            error = %error,
+                            "journal-guided repair failed; older overlapping intent is blocked"
+                        );
+                    } else {
+                        tracing::debug!(
+                            target: "session.store",
+                            path = %path.display(),
+                            error = %error,
+                            "journal-guided repair failed again"
+                        );
+                    }
                 }
             }
         }
@@ -2048,6 +2062,92 @@ fn group_path_covers(candidate: &str, path: &str) -> bool {
     candidate == path || path.starts_with(&format!("{candidate}/"))
 }
 
+fn validate_recovery_journal(
+    entry: &super::move_journal::MoveJournalEntry,
+    source: &Storage,
+    target: &Storage,
+) -> Result<Option<String>> {
+    let mut ids = std::collections::HashSet::with_capacity(entry.ids.len());
+    for id in &entry.ids {
+        if let Err(error) = super::validate_instance_id(id) {
+            return Ok(Some(format!("invalid session id {id:?}: {error}")));
+        }
+        if !ids.insert(id.as_str()) {
+            return Ok(Some(format!(
+                "duplicate session id {id:?} in journal batch"
+            )));
+        }
+    }
+    if std::ptr::eq(source, target) || entry.source_profile == entry.target_profile {
+        return Ok(Some(
+            "source and target resolve to the same loaded store".to_string(),
+        ));
+    }
+    let source_dir = source
+        .sessions_path
+        .parent()
+        .ok_or_else(|| anyhow!("source sessions path has no parent"))?
+        .canonicalize()?;
+    let target_dir = target
+        .sessions_path
+        .parent()
+        .ok_or_else(|| anyhow!("target sessions path has no parent"))?
+        .canonicalize()?;
+    if source_dir == target_dir || paths_share_filesystem_identity(&source_dir, &target_dir)? {
+        return Ok(Some(
+            "source and target resolve to the same physical profile directory".to_string(),
+        ));
+    }
+    if existing_paths_share_filesystem_identity(source.sessions_path(), target.sessions_path())? {
+        return Ok(Some(
+            "source and target resolve to the same physical sessions file".to_string(),
+        ));
+    }
+    Ok(None)
+}
+
+fn with_two_storage_locks<F, R>(source: &Storage, target: &Storage, f: F) -> Result<R>
+where
+    F: FnOnce() -> Result<R>,
+{
+    let source_dir = source
+        .sessions_path
+        .parent()
+        .ok_or_else(|| anyhow!("source sessions path has no parent"))?
+        .canonicalize()?;
+    let target_dir = target
+        .sessions_path
+        .parent()
+        .ok_or_else(|| anyhow!("target sessions path has no parent"))?
+        .canonicalize()?;
+    if source_dir == target_dir || paths_share_filesystem_identity(&source_dir, &target_dir)? {
+        anyhow::bail!("source and target resolve to the same physical profile directory");
+    }
+    let (first, second) = if source_dir < target_dir {
+        (source, target)
+    } else {
+        (target, source)
+    };
+    let _first_mu = first
+        .save_lock
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _second_mu = second
+        .save_lock
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let first_dir = first.sessions_path.parent().unwrap();
+    let second_dir = second.sessions_path.parent().unwrap();
+    let (first_file, first_path) = open_storage_lock_file(first_dir, STORAGE_LOCK_FILENAME)?;
+    let (second_file, second_path) = open_storage_lock_file(second_dir, STORAGE_LOCK_FILENAME)?;
+    if same_filesystem_identity(&first_file.metadata()?, &second_file.metadata()?) {
+        anyhow::bail!("source and target resolve to the same physical storage lock");
+    }
+    let _first_flock = acquire_open_storage_flock(first_file, &first_path)?;
+    let _second_flock = acquire_open_storage_flock(second_file, &second_path)?;
+    f()
+}
+
 /// Apply the winner policy to one journal entry. Returns Ok(true) when the
 /// entry was consumed (state repaired or already consistent) and Ok(false)
 /// when it cannot be applied because a referenced store is missing or has
@@ -2080,20 +2180,15 @@ where
             None => return Ok(false),
         };
 
-    // An id that fails validation can never pass the title/lifecycle lock
-    // acquisition below: permanently insufficient evidence, blacklisted.
-    for id in &entry.ids {
-        if let Err(error) = super::validate_instance_id(id) {
-            mark_unusable_journal_entry(journal_path);
-            tracing::error!(
-                target: "session.store",
-                path = %journal_path.display(),
-                id = %id,
-                error = %error,
-                "move journal entry carries an invalid session id; duplicates stay surfaced"
-            );
-            return Ok(false);
-        }
+    if let Some(reason) = validate_recovery_journal(entry, source_storage, target_storage)? {
+        mark_unusable_journal_entry(journal_path);
+        tracing::error!(
+            target: "session.store",
+            path = %journal_path.display(),
+            reason = %reason,
+            "move journal entry is semantically invalid; duplicates stay surfaced"
+        );
+        return Ok(false);
     }
 
     // Freshness gate: a losing store modified well after the journal was
@@ -2123,75 +2218,74 @@ where
     let _identity_lock = acquire_session_identity_lock()?;
     let mut ids_sorted = entry.ids.clone();
     ids_sorted.sort();
+    ids_sorted.dedup();
     let mut guards = Vec::with_capacity(ids_sorted.len() * 2);
     for id in &ids_sorted {
         guards.push(acquire_session_title_lock(id)?);
     }
+    let source_scope = source_storage
+        .sessions_path()
+        .parent()
+        .unwrap()
+        .canonicalize()?;
+    let target_scope = target_storage
+        .sessions_path()
+        .parent()
+        .unwrap()
+        .canonicalize()?;
     for id in &ids_sorted {
         guards.push(source_storage.acquire_instance_lifecycle_lock(id)?);
-        guards.push(target_storage.acquire_instance_lifecycle_lock(id)?);
-    }
-
-    let (source_instances, _source_groups) = source_storage.load_with_groups()?;
-    let (target_instances, _) = target_storage.load_with_groups()?;
-    let plan = crate::session::GroupMovePlan {
-        source_path: entry.group_move_source_path.clone(),
-        target_path: entry.group_move_target_path.clone(),
-        move_subtree: entry.group_move_subtree,
-    };
-    // Winner policy: target published means target wins. An id absent from
-    // both stores was already resolved outside this journal (hand edit or
-    // external delete); it is filtered out so sibling ids in the same batch
-    // still arbitrate, and nothing is ever deleted for it.
-    let source_losers: Vec<String> = entry
-        .ids
-        .iter()
-        .filter(|id| {
-            target_instances.iter().any(|row| &row.id == *id)
-                && source_instances.iter().any(|row| &row.id == *id)
-        })
-        .cloned()
-        .collect();
-    if source_losers.is_empty() {
-        // The journal proves no profile mutation phase. It cannot distinguish
-        // pre-existing empty groups from partial target-side residue, so never
-        // prune sidecars without a duplicated row that proves publication.
-        // A prior repair may already have removed the source row but failed its
-        // directory barrier; repeat that barrier before consuming evidence.
-        sync_repaired_profile_durably(source_storage, &mut sync)?;
-        super::move_journal::consume(journal_path)?;
-        return Ok(true);
-    }
-
-    source_storage.update(|instances, groups| {
-        // Re-check the winner evidence against the target file bytes at write
-        // time: the unlocked read plus our own flock acquisition leaves a
-        // window another process could delete the target copy in, and
-        // retaining then would zero out the session. Runs before the backups
-        // so a persistently failing retry cannot accumulate orphan copies.
-        if !target_still_holds(target_storage.sessions_path(), &source_losers)? {
-            anyhow::bail!(
-                "target copies vanished while the repair was starting; leaving the journal for a retry"
-            );
+        if source_scope != target_scope {
+            guards.push(target_storage.acquire_instance_lifecycle_lock(id)?);
         }
-        // Backups run inside the closure so the snapshot is taken under the
-        // save_lock and storage flock it protects, not before them.
-        backup_before_repair(source_storage.sessions_path())?;
-        backup_before_repair(&source_storage.sessions_path().with_file_name("groups.json"))?;
-        instances.retain(|row| !source_losers.contains(&row.id));
-        let winners: Vec<crate::session::Instance> = instances
+    }
+
+    with_two_storage_locks(source_storage, target_storage, || {
+        let (source_instances, _source_groups) = source_storage.load_with_groups()?;
+        let (target_instances, _) = target_storage.load_with_groups()?;
+        let plan = crate::session::GroupMovePlan {
+            source_path: entry.group_move_source_path.clone(),
+            target_path: entry.group_move_target_path.clone(),
+            move_subtree: entry.group_move_subtree,
+        };
+        let source_losers: Vec<String> = entry
+            .ids
             .iter()
-            .filter(|row| entry.ids.contains(&row.id))
+            .filter(|id| {
+                target_instances.iter().any(|row| &row.id == *id)
+                    && source_instances.iter().any(|row| &row.id == *id)
+            })
             .cloned()
             .collect();
-        reconcile_groups_after_repair(instances, groups, &winners, &plan);
-        Ok(())
-    })?;
-    sync_repaired_profile_durably(source_storage, &mut sync)?;
-    #[cfg(test)]
-    test_crash_point("profile-repair-source-written");
-    super::move_journal::consume(journal_path)?;
-    Ok(true)
+        if source_losers.is_empty() {
+            sync_repaired_profile_durably(source_storage, &mut sync)?;
+            super::move_journal::consume(journal_path)?;
+            return Ok(true);
+        }
+
+        source_storage.update_under_lock(|instances, groups| {
+            if !target_still_holds(target_storage.sessions_path(), &source_losers)? {
+                anyhow::bail!(
+                    "target copies vanished while the repair was starting; leaving the journal for a retry"
+                );
+            }
+            backup_before_repair(source_storage.sessions_path())?;
+            backup_before_repair(&source_storage.sessions_path().with_file_name("groups.json"))?;
+            instances.retain(|row| !source_losers.contains(&row.id));
+            let winners: Vec<crate::session::Instance> = instances
+                .iter()
+                .filter(|row| entry.ids.contains(&row.id))
+                .cloned()
+                .collect();
+            reconcile_groups_after_repair(instances, groups, &winners, &plan);
+            Ok(())
+        })?;
+        sync_repaired_profile_durably(source_storage, &mut sync)?;
+        #[cfg(test)]
+        test_crash_point("profile-repair-source-written");
+        super::move_journal::consume(journal_path)?;
+        Ok(true)
+    })
 }
 
 fn sync_repaired_profile_durably<S>(storage: &Storage, mut sync: S) -> Result<()>
@@ -4832,6 +4926,164 @@ mod tests {
             super::unusable_journal_entries_contains(&journal_path),
             "mtime-degraded entry is blacklisted like other permanent causes"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_ids_and_aliased_endpoints_are_rejected_before_locks() -> Result<()> {
+        for case in ["duplicate-ids", "aliased-endpoints"] {
+            let (_temp, _guard, source, target, before, _after) = setup_recovery_env(case)?;
+            let mut entry = fresh_journal_entry(&source, &target, &before.id);
+            let stores: Vec<(&str, &Storage)>;
+            if case == "duplicate-ids" {
+                entry.ids.push(before.id.clone());
+                stores = vec![(source.profile(), &source), (target.profile(), &target)];
+            } else {
+                entry.target_profile = source.profile().to_string();
+                entry.target_sessions_path = source.sessions_path().to_path_buf();
+                stores = vec![(source.profile(), &source)];
+            }
+            let journal_path = super::super::move_journal::record(&entry, source.sessions_path())?;
+
+            let outcome = if case == "duplicate-ids" {
+                reconcile_loaded(&[&source, &target], &stores)
+            } else {
+                reconcile_loaded(&[&source], &stores)
+            };
+
+            assert!(!outcome.repaired, "{case}");
+            assert_eq!(journal_entry_count(&source), 1, "{case}: evidence remains");
+            assert!(
+                super::unusable_journal_entries_contains(&journal_path),
+                "{case}: semantic invalidity is permanently recorded"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn dual_storage_lock_blocks_target_only_writer() -> Result<()> {
+        let (_temp, _guard, source, target, _before, _after) = setup_recovery_env("dual-lock")?;
+        let target_path = target.sessions_path().to_path_buf();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let mut writer = None;
+
+        with_two_storage_locks(&source, &target, || {
+            writer = Some(std::thread::spawn(move || {
+                let target = Storage::new_for_test_path("dual-lock-target", target_path);
+                started_tx.send(()).unwrap();
+                target
+                    .update(|instances, _| {
+                        instances.clear();
+                        Ok(())
+                    })
+                    .unwrap();
+                done_tx.send(()).unwrap();
+            }));
+            started_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("writer reached the target update attempt");
+            assert!(
+                done_rx
+                    .recv_timeout(std::time::Duration::from_millis(150))
+                    .is_err(),
+                "target-only writer must block while repair owns both storage flocks"
+            );
+            Ok(())
+        })?;
+
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("target writer proceeds after dual lock release");
+        writer.unwrap().join().unwrap();
+        Ok(())
+    }
+
+    #[test]
+    fn unresolved_newer_intent_blocks_older_overlapping_journal() -> Result<()> {
+        for case in ["resolve-miss", "opaque"] {
+            let (_temp, _guard, a, b, before, _after) = setup_recovery_env(case)?;
+            b.update(|instances, _| {
+                let mut copy = before.clone();
+                copy.source_profile = b.profile().to_string();
+                instances.push(copy);
+                Ok(())
+            })?;
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_millis() as u64;
+            let mut older = fresh_journal_entry(&a, &b, &before.id);
+            older.created_at_epoch_ms = now - 60_000;
+            super::super::move_journal::record(&older, a.sessions_path())?;
+            if case == "resolve-miss" {
+                let mut newer = fresh_journal_entry(&b, &a, &before.id);
+                newer.created_at_epoch_ms = now;
+                newer.target_profile = "missing-profile".to_string();
+                newer.target_sessions_path = a.sessions_path().with_file_name("missing.json");
+                super::super::move_journal::record(&newer, b.sessions_path())?;
+            } else {
+                let journal_dir = b.sessions_path().parent().unwrap().join(".move-journal");
+                fs::create_dir_all(&journal_dir)?;
+                fs::write(
+                    journal_dir.join("move-99999999999999999999-1.json"),
+                    b"not-json",
+                )?;
+            }
+            let stores: Vec<(&str, &Storage)> = vec![(a.profile(), &a), (b.profile(), &b)];
+
+            let outcome = reconcile_loaded(&[&a, &b], &stores);
+
+            assert!(!outcome.repaired, "{case}: older intent must not apply");
+            assert_eq!(outcome.reports.len(), 1, "{case}: duplicate stays surfaced");
+            assert_eq!(a.load()?.len(), 1, "{case}: newer target copy remains");
+            assert_eq!(b.load()?.len(), 1, "{case}: no copy is removed");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn shadowed_batch_propagates_block_to_every_id() -> Result<()> {
+        let (_temp, _guard, a, b, x, _after) = setup_recovery_env("transitive")?;
+        let mut y = Instance::new("y", "/repo/y");
+        y.source_profile = a.profile().to_string();
+        a.update(|instances, _| {
+            instances.push(y.clone());
+            Ok(())
+        })?;
+        b.update(|instances, _| {
+            let mut x_copy = x.clone();
+            x_copy.source_profile = b.profile().to_string();
+            let mut y_copy = y.clone();
+            y_copy.source_profile = b.profile().to_string();
+            instances.extend([x_copy, y_copy]);
+            Ok(())
+        })?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_millis() as u64;
+
+        let mut j1 = fresh_journal_entry(&a, &b, &y.id);
+        j1.created_at_epoch_ms = now - 120_000;
+        let mut j2 = fresh_journal_entry(&b, &a, &x.id);
+        j2.ids.push(y.id.clone());
+        j2.ids.sort();
+        j2.created_at_epoch_ms = now - 60_000;
+        let mut j3 = fresh_journal_entry(&a, &b, &x.id);
+        j3.target_profile = "missing".to_string();
+        j3.target_sessions_path = a.sessions_path().with_file_name("missing.json");
+        j3.created_at_epoch_ms = now;
+        super::super::move_journal::record(&j1, a.sessions_path())?;
+        super::super::move_journal::record(&j2, b.sessions_path())?;
+        super::super::move_journal::record(&j3, a.sessions_path())?;
+        let stores: Vec<(&str, &Storage)> = vec![(a.profile(), &a), (b.profile(), &b)];
+
+        let outcome = reconcile_loaded(&[&a, &b], &stores);
+
+        assert!(!outcome.repaired);
+        assert_eq!(outcome.reports.len(), 2);
+        assert_eq!(a.load()?.len(), 2, "newer X+Y target remains intact");
+        assert_eq!(b.load()?.len(), 2, "no stale journal deletes either copy");
         Ok(())
     }
 

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1814,6 +1814,22 @@ pub(crate) fn unusable_journal_entries_contains(path: &Path) -> bool {
         .any(|seen| seen == path)
 }
 
+/// Paths whose repair failure has already been reported at ERROR level, so a
+/// persistently failing (retrying) repair logs once per process.
+static REPAIR_FAILURES_REPORTED: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
+
+fn mark_repair_failure_logged(path: &Path) -> bool {
+    let mut seen = REPAIR_FAILURES_REPORTED
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if seen.iter().any(|seen| seen == path) {
+        false
+    } else {
+        seen.push(path.to_path_buf());
+        true
+    }
+}
+
 fn mark_unusable_journal_entry(path: &Path) {
     let mut seen = UNUSABLE_JOURNAL_ENTRIES
         .lock()
@@ -1921,12 +1937,24 @@ pub(crate) fn reconcile_profile_duplicates(
                 );
             }
             Err(error) => {
-                tracing::error!(
-                    target: "session.store",
-                    path = %path.display(),
-                    error = %error,
-                    "journal-guided repair failed; the duplicate stays excluded"
-                );
+                // Genuinely transient failures keep retrying on later passes;
+                // only their logging is once-per-path so a persistently
+                // failing repair cannot spam ERROR lines every reload tick.
+                if mark_repair_failure_logged(&path) {
+                    tracing::error!(
+                        target: "session.store",
+                        path = %path.display(),
+                        error = %error,
+                        "journal-guided repair failed; the duplicate stays excluded"
+                    );
+                } else {
+                    tracing::debug!(
+                        target: "session.store",
+                        path = %path.display(),
+                        error = %error,
+                        "journal-guided repair failed again"
+                    );
+                }
             }
         }
     }
@@ -2004,6 +2032,22 @@ fn repair_journal_entry(
             Some(storage) => storage,
             None => return Ok(false),
         };
+
+    // An id that fails validation can never pass the title/lifecycle lock
+    // acquisition below: permanently insufficient evidence, blacklisted.
+    for id in &entry.ids {
+        if let Err(error) = super::validate_instance_id(id) {
+            mark_unusable_journal_entry(journal_path);
+            tracing::error!(
+                target: "session.store",
+                path = %journal_path.display(),
+                id = %id,
+                error = %error,
+                "move journal entry carries an invalid session id; duplicates stay surfaced"
+            );
+            return Ok(false);
+        }
+    }
 
     // Freshness gate: a losing store modified well after the journal was
     // written means the user edited it since the crash; arbitrating on the
@@ -2106,20 +2150,23 @@ fn repair_journal_entry(
 /// and only narrows the race window; the identity/title/lifecycle locks held
 /// by the caller already exclude every lifecycle-mutating surface.
 fn target_still_holds(target_sessions_path: &Path, losers: &[String]) -> Result<bool> {
-    #[derive(serde::Deserialize)]
-    struct RowId {
-        id: String,
-    }
+    // Two-phase parse mirroring `Storage::load`: a single corrupt row is
+    // skipped, not a whole-file failure, so a quarantined-row file cannot
+    // wedge the repair into retrying forever.
     let content = match fs::read_to_string(target_sessions_path) {
         Ok(content) => content,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => return Err(error).context("failed re-reading target sessions during repair"),
     };
-    let rows: Vec<RowId> = serde_json::from_str(&content)
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&content)
         .context("failed parsing target sessions during repair re-check")?;
+    let held: Vec<String> = rows
+        .iter()
+        .filter_map(|row| row.get("id").and_then(|id| id.as_str()).map(str::to_string))
+        .collect();
     Ok(losers
         .iter()
-        .all(|loser| rows.iter().any(|row| row.id == *loser)))
+        .all(|loser| held.iter().any(|row_id| row_id == loser)))
 }
 
 /// Remove explicit group rows attributable to the move that no longer have
@@ -4680,6 +4727,43 @@ mod tests {
     }
 
     #[test]
+    fn invalid_id_entry_is_permanently_insufficient() -> Result<()> {
+        // An id that cannot pass validation would fail the title/lifecycle
+        // lock acquisition inside every repair attempt: permanently
+        // insufficient, so it blacklists like parse/version/expired causes.
+        let (_temp, source, target, before, _after) = setup_recovery_env("badid")?;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let entry = super::super::move_journal::MoveJournalEntry {
+            ids: vec!["../escape".to_string()],
+            ..fresh_journal_entry(&source, &target, &before.id)
+        };
+        super::super::move_journal::record(&entry, source.sessions_path())?;
+        assert_eq!(journal_entry_count(&source), 1);
+
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let outcome = reconcile_loaded(&[&source, &target], &view);
+
+        assert!(!outcome.repaired);
+        assert_eq!(journal_entry_count(&source), 1, "entry stays on disk");
+        let journal_path = super::super::move_journal::scan([source.sessions_path().to_path_buf()])
+            .into_iter()
+            .next()
+            .map(|(path, _)| path)
+            .expect("entry present");
+        assert!(
+            super::unusable_journal_entries_contains(&journal_path),
+            "invalid-id entry is blacklisted"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn target_still_holds_checks_every_loser_id() -> Result<()> {
         let temp = tempdir()?;
         let path = temp.path().join("sessions.json");
@@ -4694,6 +4778,19 @@ mod tests {
             &path,
             &[winner.id.clone(), "gone".to_string()]
         )?);
+
+        // A corrupt row is skipped the way Storage::load quarantines it: the
+        // surviving winner still holds instead of wedging the repair into
+        // retrying forever.
+        let mut corrupt_row = serde_json::Map::new();
+        corrupt_row.insert("id".to_string(), serde_json::Value::from(42));
+        let mixed = vec![
+            serde_json::Value::Object(corrupt_row),
+            serde_json::to_value(&winner)?,
+        ];
+        fs::write(&path, serde_json::to_vec_pretty(&mixed)?)?;
+        assert!(target_still_holds(&path, std::slice::from_ref(&winner.id))?);
+
         fs::remove_file(&path)?;
         assert!(!target_still_holds(&path, &[winner.id])?);
         Ok(())

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1727,7 +1727,8 @@ pub(crate) struct DuplicateIdReport {
 
 impl DuplicateIdReport {
     /// Single-line, user-actionable summary naming every copy's profile,
-    /// store file, and mtime. Rendered by the TUI and written to the log.
+    /// store file, and mtime. Written to the log by the reconciliation
+    /// layer; the TUI surfaces a count marker derived from these reports.
     pub(crate) fn actionable_message(&self) -> String {
         let copies = self
             .copies
@@ -1761,29 +1762,29 @@ fn file_mtime_epoch_ms(path: &Path) -> Option<u64> {
         .map(|duration| duration.as_millis() as u64)
 }
 
-/// Ids present in more than one profile among `loaded` (per-profile instance
-/// lists), in deterministic first-seen order.
+/// Ids appearing more than once across `loaded` (within one profile or
+/// across profiles), in deterministic first-seen order.
 pub(crate) fn detect_duplicate_ids<'a>(
     loaded: impl IntoIterator<Item = (&'a str, &'a [Instance])>,
 ) -> Vec<String> {
-    let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
-    let mut duplicates: Vec<String> = Vec::new();
-    for (profile, instances) in loaded {
+    // Counts occurrences across every profile; an id repeated even within
+    // one profile is ambiguous the same way (corrupt file or writer bug) and
+    // must surface, not silently fail closed.
+    let mut order: Vec<String> = Vec::new();
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (_, instances) in loaded {
         for instance in instances {
-            match seen.get(instance.id.as_str()) {
-                Some(previous) if *previous == profile => {}
-                Some(_) => {
-                    if !duplicates.iter().any(|id| id == &instance.id) {
-                        duplicates.push(instance.id.clone());
-                    }
-                }
-                None => {
-                    seen.insert(&instance.id, profile);
-                }
-            }
+            let count = counts.entry(instance.id.as_str()).or_insert_with(|| {
+                order.push(instance.id.clone());
+                0
+            });
+            *count += 1;
         }
     }
-    duplicates
+    order
+        .into_iter()
+        .filter(|id| counts[id.as_str()] > 1)
+        .collect()
 }
 
 /// Journal evidence older than this is insufficient for arbitration (#3459):
@@ -1803,6 +1804,15 @@ const MOVE_JOURNAL_MTIME_SLACK_MS: u64 = 5 * 60 * 1000;
 /// Paths already reported as unusable this process lifetime, so a permanently
 /// broken entry cannot produce ERROR spam and lock churn on every reload tick.
 static UNUSABLE_JOURNAL_ENTRIES: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
+
+#[cfg(test)]
+pub(crate) fn unusable_journal_entries_contains(path: &Path) -> bool {
+    UNUSABLE_JOURNAL_ENTRIES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .any(|seen| seen == path)
+}
 
 fn mark_unusable_journal_entry(path: &Path) {
     let mut seen = UNUSABLE_JOURNAL_ENTRIES
@@ -1831,7 +1841,11 @@ pub(crate) fn reconcile_profile_duplicates(
     storages: &[(&str, &Storage)],
 ) -> ReconciliationOutcome {
     let mut outcome = ReconciliationOutcome::default();
-    let duplicated = !detect_duplicate_ids(loaded.iter().copied()).is_empty();
+    // Normalize to a name-sorted view so report and copy ordering are
+    // deterministic regardless of how the caller iterates its storages.
+    let mut normalized: Vec<(&str, &[Instance])> = loaded.to_vec();
+    normalized.sort_by(|left, right| left.0.cmp(right.0));
+    let duplicated = !detect_duplicate_ids(normalized.iter().copied()).is_empty();
     let mut entries = super::move_journal::scan(
         storages
             .iter()
@@ -1919,7 +1933,7 @@ pub(crate) fn reconcile_profile_duplicates(
     if !outcome.repaired {
         // Nothing changed on disk: build reports from the caller's fresh
         // load instead of re-reading every profile again.
-        outcome.reports = duplicate_reports(loaded, storages);
+        outcome.reports = duplicate_reports(&normalized, storages);
         return outcome;
     }
     // Recompute from fresh disk state so reports reflect post-repair reality.
@@ -1998,11 +2012,15 @@ fn repair_journal_entry(
     for storage in [source_storage, target_storage] {
         let mtime = file_mtime_epoch_ms(storage.sessions_path()).unwrap_or_default();
         if mtime.saturating_sub(entry.created_at_epoch_ms) > MOVE_JOURNAL_MTIME_SLACK_MS {
+            // Permanent: mtimes only grow relative to created_at, so this
+            // entry can never become applicable again. Blacklist it like the
+            // other permanent insufficiency causes to avoid tick spam.
+            mark_unusable_journal_entry(journal_path);
             tracing::warn!(
                 target: "session.store",
                 path = %journal_path.display(),
                 ids = %entry.ids.join(","),
-                "store was modified after the move journal was written; degrading to surfaced legacy instead of arbitrating"
+                "store was modified after the move journal was written; entry is permanently insufficient evidence and stays surfaced"
             );
             return Ok(false);
         }
@@ -4646,6 +4664,18 @@ mod tests {
         assert_eq!(source.load()?.len(), 1);
         assert_eq!(target.load()?.len(), 1);
         assert_eq!(journal_entry_count(&source), 1);
+        // The degradation is permanent (mtimes only grow relative to the
+        // journal timestamp), so it lands in the log-once registry instead of
+        // re-warning on every reload tick.
+        let journal_path = super::super::move_journal::scan([source.sessions_path().to_path_buf()])
+            .into_iter()
+            .next()
+            .map(|(path, _)| path)
+            .expect("entry still on disk");
+        assert!(
+            super::unusable_journal_entries_contains(&journal_path),
+            "mtime-degraded entry is blacklisted like other permanent causes"
+        );
         Ok(())
     }
 
@@ -4666,6 +4696,29 @@ mod tests {
         )?);
         fs::remove_file(&path)?;
         assert!(!target_still_holds(&path, &[winner.id])?);
+        Ok(())
+    }
+
+    #[test]
+    fn same_profile_duplicate_id_is_surfaced() -> Result<()> {
+        // An id repeated inside ONE profile (corrupt file or writer bug) is
+        // ambiguous exactly like a cross-profile duplicate: it must surface,
+        // not silently fail closed without a report or title marker.
+        let (_temp, source, _target, before, _after) = setup_recovery_env("intraprofile")?;
+        source.update(|instances, _| {
+            instances.push(before.clone());
+            Ok(())
+        })?;
+
+        let view: Vec<(&str, &Storage)> = vec![(source.profile(), &source)];
+        let outcome = reconcile_loaded(&[&source], &view);
+
+        assert!(!outcome.repaired);
+        assert_eq!(outcome.reports.len(), 1, "the repeated id surfaces");
+        let report = &outcome.reports[0];
+        assert_eq!(report.id, before.id);
+        assert!(report.actionable_message().contains(&before.id));
+        assert_eq!(source.load()?.len(), 2, "nothing is deleted automatically");
         Ok(())
     }
 

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -4874,6 +4874,39 @@ mod tests {
     }
 
     #[test]
+    fn post_repair_load_error_prevents_home_reload_and_keeps_report() -> Result<()> {
+        let (temp, _guard, source, target, before, _after) = setup_recovery_env("reload-fallback")?;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let entry = fresh_journal_entry(&source, &target, &before.id);
+        super::super::move_journal::record(&entry, source.sessions_path())?;
+        let bad_dir = temp.path().join("bad");
+        fs::create_dir_all(&bad_dir)?;
+        let bad = Storage::new_for_test_path("bad", bad_dir.join("sessions.json"));
+        fs::write(bad.sessions_path(), b"not-json")?;
+        let stores: Vec<(&str, &Storage)> = vec![
+            (source.profile(), &source),
+            (target.profile(), &target),
+            (bad.profile(), &bad),
+        ];
+
+        let outcome = reconcile_loaded(&[&source, &target, &bad], &stores);
+
+        assert!(source.load()?.is_empty(), "repair reached disk");
+        assert_eq!(target.load()?.len(), 1);
+        assert!(
+            !outcome.repaired,
+            "Home must keep pre-repair loads instead of repeating the failed reload"
+        );
+        assert_eq!(outcome.reports.len(), 1, "ambiguity remains surfaced");
+        Ok(())
+    }
+
+    #[test]
     fn target_still_holds_checks_every_loser_id() -> Result<()> {
         let temp = tempdir()?;
         let path = temp.path().join("sessions.json");

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -498,6 +498,26 @@ pub(crate) fn disarm_test_crash_points() {
     TEST_CRASH_POINTS.with(|points| points.borrow_mut().clear());
 }
 
+/// RAII wrapper so a failing assertion between arm and disarm can never leave
+/// an armed point panicking an unrelated test scheduled on the same thread.
+#[cfg(test)]
+pub(crate) struct ArmedCrashPoint;
+
+#[cfg(test)]
+impl ArmedCrashPoint {
+    pub(crate) fn arm(name: &'static str) -> Self {
+        arm_test_crash_point(name);
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for ArmedCrashPoint {
+    fn drop(&mut self) {
+        disarm_test_crash_points();
+    }
+}
+
 pub(crate) fn sync_parent_directory(path: &Path) -> Result<()> {
     let resolved = resolve_symlink_chain(path)?;
     sync_resolved_parent_directory(&resolved)
@@ -1270,11 +1290,8 @@ impl Storage {
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or_default(),
         };
-        let journal_path = Some(
-            super::move_journal::record(&journal_entry, &self.sessions_path).context(
-                "recording the durable move journal failed; no profile rows were changed",
-            )?,
-        );
+        let journal_path = super::move_journal::record(&journal_entry, &self.sessions_path)
+            .context("recording the durable move journal failed; no profile rows were changed")?;
         #[cfg(test)]
         test_crash_point("profile-move-journal");
 
@@ -1498,10 +1515,15 @@ impl Storage {
             ));
         }
         // Every write and directory barrier above has passed: the move is
-        // complete, so the journal that guarded it can be dropped.
-        if let Some(path) = journal_path.as_ref() {
-            super::move_journal::consume(path)
-                .context("consuming the completed move journal failed")?;
+        // complete. A failed cleanup must not turn a committed move into a
+        // reported failure (a retry would then hit "already exists in
+        // target"); the leftover entry self-heals at the next reconcile pass.
+        if let Err(error) = super::move_journal::consume(&journal_path) {
+            tracing::warn!(
+                target: "session.store",
+                error = %error,
+                "completed profile move could not consume its journal; recovery will discard it"
+            );
         }
         if source_groups_changed {
             self.file_watch.notify_local_change(&source_groups_path);
@@ -1772,6 +1794,35 @@ pub(crate) fn detect_duplicate_ids(loaded: &[(String, Vec<Instance>)]) -> Vec<St
     duplicates
 }
 
+/// Journal evidence older than this is insufficient for arbitration (#3459):
+/// an entry that outlived its move (leaked by a consume failure, a crash
+/// before the TUI ever reloaded, CLI-only usage) must never delete a copy the
+/// user created or edited afterwards. Expired entries degrade to the surfaced
+/// legacy path. Generous by design: live residuals are consumed within one
+/// reload of the crash.
+const MOVE_JOURNAL_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(7 * 24 * 3600);
+
+/// Paths already reported as unusable this process lifetime, so a permanently
+/// broken entry cannot produce ERROR spam and lock churn on every reload tick.
+static UNUSABLE_JOURNAL_ENTRIES: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
+
+fn mark_unusable_journal_entry(path: &Path) {
+    let mut seen = UNUSABLE_JOURNAL_ENTRIES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !seen.iter().any(|seen| seen == path) {
+        seen.push(path.to_path_buf());
+    }
+}
+
+fn entry_age(entry: &super::move_journal::MoveJournalEntry) -> std::time::Duration {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or_default();
+    std::time::Duration::from_millis(now_ms.saturating_sub(entry.created_at_epoch_ms))
+}
+
 /// Detect duplicates across the loaded profiles, run journal-guided repair
 /// for the cases with durable evidence, and return reports for whatever
 /// remains ambiguous. Repairs happen under the app-global identity lock, the
@@ -1792,41 +1843,74 @@ pub(crate) fn reconcile_profile_duplicates(
         return outcome;
     }
     for (path, parsed) in entries {
-        match parsed {
-            Ok(entry) => match repair_journal_entry(&entry, storages, &path) {
-                Ok(true) => {
-                    outcome.repaired = true;
-                    tracing::info!(
-                        target: "session.store",
-                        ids = %entry.ids.join(","),
-                        "reconciled interrupted profile move from its journal"
-                    );
-                }
-                Ok(false) => {
-                    tracing::warn!(
-                        target: "session.store",
-                        path = %path.display(),
-                        "move journal entry references stores that are missing or moved; leaving it for manual inspection"
-                    );
-                }
-                Err(error) => {
-                    tracing::error!(
-                        target: "session.store",
-                        path = %path.display(),
-                        error = %error,
-                        "move-journal-guided repair failed; the duplicate stays excluded"
-                    );
-                }
-            },
+        // Unusable entries stay on disk by design; without this guard every
+        // 5-10s reload would re-log and re-attempt them forever.
+        if UNUSABLE_JOURNAL_ENTRIES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .any(|unusable| unusable == &path)
+        {
+            continue;
+        }
+        let entry = match parsed {
+            Ok(entry) => entry,
             Err(reason) => {
+                mark_unusable_journal_entry(&path);
                 tracing::error!(
                     target: "session.store",
                     path = %path.display(),
                     reason = %reason,
                     "unreadable move journal entry cannot arbitrate a duplicate session id"
                 );
+                continue;
+            }
+        };
+        // Expired evidence arbitrates nothing: a journal that outlived its
+        // move must never delete a copy the user created or edited later.
+        // It degrades to the same surfaced-legacy path as having no journal.
+        if entry_age(&entry) > MOVE_JOURNAL_MAX_AGE {
+            mark_unusable_journal_entry(&path);
+            tracing::error!(
+                target: "session.store",
+                path = %path.display(),
+                ids = %entry.ids.join(","),
+                "expired move journal entry is insufficient evidence for arbitration; duplicates stay surfaced"
+            );
+            continue;
+        }
+        match repair_journal_entry(&entry, storages, &path) {
+            Ok(true) => {
+                outcome.repaired = true;
+                tracing::info!(
+                    target: "session.store",
+                    ids = %entry.ids.join(","),
+                    "reconciled interrupted profile move from its journal"
+                );
+            }
+            Ok(false) => {
+                mark_unusable_journal_entry(&path);
+                tracing::warn!(
+                    target: "session.store",
+                    path = %path.display(),
+                    "journal-guided repair skipped: entry references stores that are missing or moved; leaving it for manual inspection"
+                );
+            }
+            Err(error) => {
+                tracing::error!(
+                    target: "session.store",
+                    path = %path.display(),
+                    error = %error,
+                    "journal-guided repair failed; the duplicate stays excluded"
+                );
             }
         }
+    }
+    if !outcome.repaired {
+        // Nothing changed on disk: build reports from the caller's fresh
+        // load instead of re-reading every profile again.
+        outcome.reports = duplicate_reports(loaded, storages);
+        return outcome;
     }
     // Recompute from fresh disk state so reports reflect post-repair reality.
     let mut reloaded: Vec<(String, Vec<Instance>)> = storages
@@ -1834,9 +1918,20 @@ pub(crate) fn reconcile_profile_duplicates(
         .map(|(_, storage)| (storage.profile.clone(), storage.load().unwrap_or_default()))
         .collect();
     reloaded.sort_by(|left, right| left.0.cmp(&right.0));
+    outcome.reports = duplicate_reports(&reloaded, storages);
+    outcome
+}
+
+/// Build one report per duplicated id with per-copy profile, store path, and
+/// mtime. `loaded` must be sorted deterministically or first-seen order is
+/// used as-is; reports follow `detect_duplicate_ids` order.
+fn duplicate_reports(
+    loaded: &[(String, Vec<Instance>)],
+    storages: &[(&str, &Storage)],
+) -> Vec<DuplicateIdReport> {
     let mut reports: Vec<DuplicateIdReport> = Vec::new();
-    for id in detect_duplicate_ids(&reloaded) {
-        let copies = reloaded
+    for id in detect_duplicate_ids(loaded) {
+        let copies = loaded
             .iter()
             .filter(|(_, instances)| instances.iter().any(|instance| instance.id == id))
             .filter_map(|(profile, _)| {
@@ -1853,8 +1948,7 @@ pub(crate) fn reconcile_profile_duplicates(
             .collect();
         reports.push(DuplicateIdReport { id, copies });
     }
-    outcome.reports = reports;
-    outcome
+    reports
 }
 
 /// True when `candidate` equals or contains `path` as an ancestor segment.
@@ -1929,9 +2023,11 @@ fn repair_journal_entry(
         target_path: entry.group_move_target_path.clone(),
         move_subtree: entry.group_move_subtree,
     };
-    backup_before_repair(source_storage.sessions_path())?;
-    backup_before_repair(&source_storage.sessions_path().with_file_name("groups.json"))?;
     source_storage.update(|instances, groups| {
+        // Backups run inside the closure so the snapshot is taken under the
+        // save_lock and storage flock it protects, not before them.
+        backup_before_repair(source_storage.sessions_path())?;
+        backup_before_repair(&source_storage.sessions_path().with_file_name("groups.json"))?;
         instances.retain(|row| !source_losers.contains(&row.id));
         let winners: Vec<crate::session::Instance> = instances
             .iter()
@@ -1993,11 +2089,13 @@ fn backup_before_repair(path: &Path) -> Result<()> {
         .context(format!("backup {} was not made durable", backup.display()))
 }
 
-/// Keep the losing profile's groups sidecar consistent with the winning rows:
-/// drop explicit group rows attributable to the move that no longer have any
-/// member, and materialize any group row a winning row references but that a
-/// partially-applied transaction never wrote. Rows unrelated to the move are
-/// untouched.
+/// Keep the repaired profile's groups sidecar consistent with what an
+/// uninterrupted `apply_group_move` would have left on disk: explicit group
+/// rows attributable to the move lose their members when the losing rows go,
+/// winning rows' groups are materialized, and the sidecar is re-treeed
+/// exactly like `apply_group_move` does so ancestor rows and metadata match.
+/// Attributable follows `apply_group_move`'s own matching: the moved path
+/// itself always, descendants only for a subtree move.
 fn reconcile_groups_after_repair(
     instances: &[Instance],
     groups: &mut Vec<Group>,
@@ -2005,14 +2103,14 @@ fn reconcile_groups_after_repair(
     plan: &crate::session::GroupMovePlan,
 ) {
     let source_prefix = format!("{}/", plan.source_path);
+    let target_prefix = format!("{}/", plan.target_path);
     let attributable = |path: &str| {
         (!plan.source_path.is_empty()
-            && (group_path_covers(&plan.source_path, path)
+            && (path == plan.source_path
                 || (plan.move_subtree && path.starts_with(&source_prefix))))
-            || (!plan.target_path.is_empty() && group_path_covers(&plan.target_path, path))
-            || (plan.move_subtree
-                && !plan.target_path.is_empty()
-                && path.starts_with(&format!("{}/", plan.target_path)))
+            || (!plan.target_path.is_empty()
+                && (path == plan.target_path
+                    || (plan.move_subtree && path.starts_with(&target_prefix))))
     };
     let has_member = |path: &str| {
         instances
@@ -2033,6 +2131,9 @@ fn reconcile_groups_after_repair(
             groups.push(Group::new(leaf, &winner.group_path));
         }
     }
+    // Same final re-tree `apply_group_move` performs, so the durable sidecar
+    // carries the full explicit ancestor chain with preserved metadata.
+    *groups = super::GroupTree::new_with_groups(instances, groups).get_all_groups();
 }
 
 #[cfg(test)]
@@ -4121,8 +4222,8 @@ mod tests {
         Ok((temp, source, target, before, after))
     }
 
-    fn run_crashing_move(source: &Storage, target: &Storage, point: &str) {
-        arm_test_crash_point(point);
+    fn run_crashing_move(source: &Storage, target: &Storage, point: &'static str) {
+        let _crash = ArmedCrashPoint::arm(point);
         // Panic output for the simulated crash is expected noise.
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut after = source.load().unwrap().remove(0);
@@ -4140,7 +4241,6 @@ mod tests {
                 sync_resolved_parent_directory,
             );
         }));
-        disarm_test_crash_points();
     }
 
     #[test]
@@ -4325,6 +4425,119 @@ mod tests {
     }
 
     #[test]
+    fn expired_journal_is_insufficient_evidence() -> Result<()> {
+        // A journal that outlived its move must never arbitrate: if the user
+        // later duplicates the id by hand, months-old evidence would delete
+        // the newer copy. Expired entries degrade to the surfaced legacy path.
+        let (_temp, source, target, before, _after) = setup_recovery_env("expired")?;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let week_ago_ms = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_millis() as u64)
+            - 8 * 24 * 3600 * 1000;
+        let expired = super::super::move_journal::MoveJournalEntry {
+            created_at_epoch_ms: week_ago_ms,
+            ..fresh_journal_entry(&source, &target, &before.id)
+        };
+        super::super::move_journal::record(&expired, source.sessions_path())?;
+        assert_eq!(journal_entry_count(&source), 1);
+
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let loaded = collect_loaded(&[&source, &target]);
+        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+
+        assert!(!outcome.repaired, "expired evidence must not arbitrate");
+        assert_eq!(outcome.reports.len(), 1);
+        assert_eq!(source.load()?.len(), 1);
+        assert_eq!(target.load()?.len(), 1);
+        assert_eq!(journal_entry_count(&source), 1, "expired entry stays");
+        Ok(())
+    }
+
+    #[test]
+    fn group_repair_scope_matches_apply_group_move() -> Result<()> {
+        // Table over subtree mode: an explicit memberless child under the
+        // moved path survives a single-group repair (apply_group_move's
+        // non-subtree branch preserves explicit descendants) and is pruned
+        // for a subtree move. Either way the losing path itself is pruned.
+        let cases = [
+            ("gscope-single", false, true),
+            ("gscope-subtree", true, false),
+        ];
+        for (tag, move_subtree, child_survives) in cases {
+            let (_temp, source, target, before, _after) = setup_recovery_env(tag)?;
+            source.update(|_instances, groups| {
+                let mut child = Group::new("archive", "work/archive");
+                child.collapsed = true;
+                groups.push(child);
+                Ok(())
+            })?;
+            target.update(|instances, _| {
+                let mut copy = before.clone();
+                copy.source_profile = target.profile().to_string();
+                instances.push(copy);
+                Ok(())
+            })?;
+            let entry = super::super::move_journal::MoveJournalEntry {
+                group_move_subtree: move_subtree,
+                ..fresh_journal_entry(&source, &target, &before.id)
+            };
+            super::super::move_journal::record(&entry, source.sessions_path())?;
+
+            let view: Vec<(&str, &Storage)> =
+                vec![(source.profile(), &source), (target.profile(), &target)];
+            let loaded = collect_loaded(&[&source, &target]);
+            let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+
+            assert!(outcome.repaired, "{tag}");
+            assert!(outcome.reports.is_empty(), "{tag}");
+            assert!(source.load()?.is_empty(), "{tag}: loser emptied");
+            let source_groups = source.load_with_groups()?.1;
+            assert!(
+                !source_groups.iter().any(|group| group.path == "work"),
+                "{tag}: moved path pruned"
+            );
+            assert_eq!(
+                source_groups
+                    .iter()
+                    .any(|group| group.path == "work/archive"),
+                child_survives,
+                "{tag}: explicit descendant handling must mirror apply_group_move"
+            );
+            assert_eq!(journal_entry_count(&source), 0, "{tag}");
+        }
+        Ok(())
+    }
+
+    fn fresh_journal_entry(
+        source: &Storage,
+        target: &Storage,
+        id: &str,
+    ) -> super::super::move_journal::MoveJournalEntry {
+        super::super::move_journal::MoveJournalEntry {
+            version: super::super::move_journal::MOVE_JOURNAL_VERSION,
+            ids: vec![id.to_string()],
+            source_profile: source.profile().to_string(),
+            target_profile: target.profile().to_string(),
+            source_sessions_path: source.sessions_path().to_path_buf(),
+            target_sessions_path: target.sessions_path().to_path_buf(),
+            group_move_source_path: "work".to_string(),
+            group_move_target_path: "moved".to_string(),
+            group_move_subtree: false,
+            created_at_epoch_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or_default(),
+        }
+    }
+
+    #[test]
     fn recovery_survives_a_panic_mid_repair_and_stays_idempotent() -> Result<()> {
         // A panic between the repair write and the journal consumption must
         // leave a state a plain rerun converges on, and further reruns are
@@ -4333,16 +4546,17 @@ mod tests {
         run_crashing_move(&source, &target, "profile-move-source-sessions");
         assert_eq!(journal_entry_count(&source), 1);
 
-        arm_test_crash_point("profile-repair-source-written");
         let view: Vec<(&str, &Storage)> =
             vec![(source.profile(), &source), (target.profile(), &target)];
         {
+            // Guard scoped to the interrupted pass only, so its Drop runs
+            // before the converging rerun below.
+            let _crash = ArmedCrashPoint::arm("profile-repair-source-written");
             let loaded = collect_loaded(&[&source, &target]);
             let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 super::reconcile_profile_duplicates(&loaded, &view);
             }));
         }
-        disarm_test_crash_points();
         // The interrupted pass wrote the repaired source but died before
         // consuming the journal; the rerun finishes the job.
         let loaded = collect_loaded(&[&source, &target]);

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1710,16 +1710,6 @@ pub(crate) struct ReconciliationOutcome {
     pub(crate) reports: Vec<DuplicateIdReport>,
 }
 
-// ---------------------------------------------------------------------------
-// Cross-profile duplicate reconciliation (#3459)
-//
-// An interrupted profile move can leave the same session id in two profiles.
-// A valid, current-version move journal is authoritative evidence that a move
-// was in flight between exactly the two recorded stores; because the
-// transaction publishes the target before removing the source rows, whichever
-// store holds the id wins. Duplicates without journal evidence are never
-// arbitrated: they are reported with actionable per-copy details instead.
-
 /// One ambiguous copy of a duplicated session id.
 #[derive(Debug, Clone)]
 pub(crate) struct DuplicateCopy {
@@ -1773,7 +1763,9 @@ fn file_mtime_epoch_ms(path: &Path) -> Option<u64> {
 
 /// Ids present in more than one profile among `loaded` (per-profile instance
 /// lists), in deterministic first-seen order.
-pub(crate) fn detect_duplicate_ids(loaded: &[(String, Vec<Instance>)]) -> Vec<String> {
+pub(crate) fn detect_duplicate_ids<'a>(
+    loaded: impl IntoIterator<Item = (&'a str, &'a [Instance])>,
+) -> Vec<String> {
     let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
     let mut duplicates: Vec<String> = Vec::new();
     for (profile, instances) in loaded {
@@ -1802,6 +1794,12 @@ pub(crate) fn detect_duplicate_ids(loaded: &[(String, Vec<Instance>)]) -> Vec<St
 /// reload of the crash.
 const MOVE_JOURNAL_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(7 * 24 * 3600);
 
+/// How long after journal creation a store mtime still counts as part of the
+/// crashed transaction itself rather than a later user edit. Legit residuals
+/// are written within seconds of record; edits beyond this slack degrade the
+/// entry to surfaced legacy instead of arbitrating.
+const MOVE_JOURNAL_MTIME_SLACK_MS: u64 = 5 * 60 * 1000;
+
 /// Paths already reported as unusable this process lifetime, so a permanently
 /// broken entry cannot produce ERROR spam and lock churn on every reload tick.
 static UNUSABLE_JOURNAL_ENTRIES: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
@@ -1829,16 +1827,25 @@ fn entry_age(entry: &super::move_journal::MoveJournalEntry) -> std::time::Durati
 /// sorted per-session title/lifecycle locks, and each profile's own storage
 /// flock (`Storage::update`). `repaired` tells the caller to reload from disk.
 pub(crate) fn reconcile_profile_duplicates(
-    loaded: &[(String, Vec<Instance>)],
+    loaded: &[(&str, &[Instance])],
     storages: &[(&str, &Storage)],
 ) -> ReconciliationOutcome {
     let mut outcome = ReconciliationOutcome::default();
-    let duplicated = !detect_duplicate_ids(loaded).is_empty();
-    let entries = super::move_journal::scan(
+    let duplicated = !detect_duplicate_ids(loaded.iter().copied()).is_empty();
+    let mut entries = super::move_journal::scan(
         storages
             .iter()
             .map(|(_, storage)| storage.sessions_path().to_path_buf()),
     );
+    // Oldest evidence first, so chained moves (a leaked completed move plus a
+    // newer reverse move) arbitrate in the order the user actually performed
+    // them; unparseable entries sort last and can never consume anything.
+    entries.sort_by_key(|(_, parsed)| {
+        parsed
+            .as_ref()
+            .map(|entry| entry.created_at_epoch_ms)
+            .unwrap_or(u64::MAX)
+    });
     if entries.is_empty() && !duplicated {
         return outcome;
     }
@@ -1861,7 +1868,7 @@ pub(crate) fn reconcile_profile_duplicates(
                     target: "session.store",
                     path = %path.display(),
                     reason = %reason,
-                    "unreadable move journal entry cannot arbitrate a duplicate session id"
+                    "move journal entry is insufficient evidence for arbitration; duplicates stay surfaced"
                 );
                 continue;
             }
@@ -1889,11 +1896,14 @@ pub(crate) fn reconcile_profile_duplicates(
                 );
             }
             Ok(false) => {
-                mark_unusable_journal_entry(&path);
-                tracing::warn!(
+                // Transient: the referenced stores may simply not be loaded
+                // right now (single-profile mode). Never blacklist these:
+                // blacklisting would poison a perfectly usable entry once the
+                // missing profile is loaded later in the same process.
+                tracing::debug!(
                     target: "session.store",
                     path = %path.display(),
-                    "journal-guided repair skipped: entry references stores that are missing or moved; leaving it for manual inspection"
+                    "journal-guided repair skipped: entry references stores that are missing or moved"
                 );
             }
             Err(error) => {
@@ -1918,7 +1928,11 @@ pub(crate) fn reconcile_profile_duplicates(
         .map(|(_, storage)| (storage.profile.clone(), storage.load().unwrap_or_default()))
         .collect();
     reloaded.sort_by(|left, right| left.0.cmp(&right.0));
-    outcome.reports = duplicate_reports(&reloaded, storages);
+    let reloaded_refs: Vec<(&str, &[Instance])> = reloaded
+        .iter()
+        .map(|(profile, instances)| (profile.as_str(), instances.as_slice()))
+        .collect();
+    outcome.reports = duplicate_reports(&reloaded_refs, storages);
     outcome
 }
 
@@ -1926,18 +1940,19 @@ pub(crate) fn reconcile_profile_duplicates(
 /// mtime. `loaded` must be sorted deterministically or first-seen order is
 /// used as-is; reports follow `detect_duplicate_ids` order.
 fn duplicate_reports(
-    loaded: &[(String, Vec<Instance>)],
+    loaded: &[(&str, &[Instance])],
     storages: &[(&str, &Storage)],
 ) -> Vec<DuplicateIdReport> {
     let mut reports: Vec<DuplicateIdReport> = Vec::new();
-    for id in detect_duplicate_ids(loaded) {
+    for id in detect_duplicate_ids(loaded.iter().copied()) {
         let copies = loaded
             .iter()
             .filter(|(_, instances)| instances.iter().any(|instance| instance.id == id))
             .filter_map(|(profile, _)| {
+                let profile = *profile;
                 storages
                     .iter()
-                    .find(|(name, _)| *name == profile.as_str())
+                    .find(|(name, _)| *name == profile)
                     .map(|(_, storage)| storage)
             })
             .map(|storage| DuplicateCopy {
@@ -1976,6 +1991,23 @@ fn repair_journal_entry(
             None => return Ok(false),
         };
 
+    // Freshness gate: a losing store modified well after the journal was
+    // written means the user edited it since the crash; arbitrating on the
+    // journal would discard those edits. Legit residuals are written within
+    // seconds of record, so a slack separates them from real edits.
+    for storage in [source_storage, target_storage] {
+        let mtime = file_mtime_epoch_ms(storage.sessions_path()).unwrap_or_default();
+        if mtime.saturating_sub(entry.created_at_epoch_ms) > MOVE_JOURNAL_MTIME_SLACK_MS {
+            tracing::warn!(
+                target: "session.store",
+                path = %journal_path.display(),
+                ids = %entry.ids.join(","),
+                "store was modified after the move journal was written; degrading to surfaced legacy instead of arbitrating"
+            );
+            return Ok(false);
+        }
+    }
+
     // App-global identity lock first, then sorted title/lifecycle locks, then
     // the per-profile storage flocks taken inside `Storage::update`. This is
     // the same global-to-local order every other identity mutation uses.
@@ -1993,37 +2025,45 @@ fn repair_journal_entry(
 
     let (source_instances, _source_groups) = source_storage.load_with_groups()?;
     let (target_instances, _) = target_storage.load_with_groups()?;
-    let source_losers: Vec<String> = entry
-        .ids
-        .iter()
-        .filter(|id| target_instances.iter().any(|row| &row.id == *id))
-        .cloned()
-        .collect();
-    // Winner policy: target published means target wins. An id absent from
-    // both stores would mean the row vanished entirely, which contradicts the
-    // transaction's never-zero-copies invariant; refuse to touch anything.
-    for id in &entry.ids {
-        let in_source = source_instances.iter().any(|row| &row.id == id);
-        let in_target = target_instances.iter().any(|row| &row.id == id);
-        if !in_source && !in_target && !source_losers.is_empty() {
-            anyhow::bail!(
-                "journal claims session {id} was moving but neither store holds it; refusing to reconcile"
-            );
-        }
-    }
-    if source_losers.is_empty() {
-        // Nothing to arbitrate: either the move completed and only the journal
-        // leaked, or it aborted cleanly. Verify consistency, then consume.
-        super::move_journal::consume(journal_path)?;
-        return Ok(true);
-    }
-
     let plan = crate::session::GroupMovePlan {
         source_path: entry.group_move_source_path.clone(),
         target_path: entry.group_move_target_path.clone(),
         move_subtree: entry.group_move_subtree,
     };
+    // Winner policy: target published means target wins. An id absent from
+    // both stores was already resolved outside this journal (hand edit or
+    // external delete); it is filtered out so sibling ids in the same batch
+    // still arbitrate, and nothing is ever deleted for it.
+    let source_losers: Vec<String> = entry
+        .ids
+        .iter()
+        .filter(|id| {
+            target_instances.iter().any(|row| &row.id == *id)
+                && source_instances.iter().any(|row| &row.id == *id)
+        })
+        .cloned()
+        .collect();
+    if source_losers.is_empty() {
+        // Nothing to arbitrate. Clean any group rows an interrupted
+        // groups-then-sessions write sequence left behind on either side,
+        // then consume the entry as resolved.
+        prune_moved_group_residue(source_storage, &plan)?;
+        prune_moved_group_residue(target_storage, &plan)?;
+        super::move_journal::consume(journal_path)?;
+        return Ok(true);
+    }
+
     source_storage.update(|instances, groups| {
+        // Re-check the winner evidence against the target file bytes at write
+        // time: the unlocked read plus our own flock acquisition leaves a
+        // window another process could delete the target copy in, and
+        // retaining then would zero out the session. Runs before the backups
+        // so a persistently failing retry cannot accumulate orphan copies.
+        if !target_still_holds(target_storage.sessions_path(), &source_losers)? {
+            anyhow::bail!(
+                "target copies vanished while the repair was starting; leaving the journal for a retry"
+            );
+        }
         // Backups run inside the closure so the snapshot is taken under the
         // save_lock and storage flock it protects, not before them.
         backup_before_repair(source_storage.sessions_path())?;
@@ -2041,6 +2081,46 @@ fn repair_journal_entry(
     test_crash_point("profile-repair-source-written");
     super::move_journal::consume(journal_path)?;
     Ok(true)
+}
+
+/// True when the target sessions file currently holds every loser id.
+/// Deliberately lock-free: it runs inside the source profile's update closure
+/// and only narrows the race window; the identity/title/lifecycle locks held
+/// by the caller already exclude every lifecycle-mutating surface.
+fn target_still_holds(target_sessions_path: &Path, losers: &[String]) -> Result<bool> {
+    #[derive(serde::Deserialize)]
+    struct RowId {
+        id: String,
+    }
+    let content = match fs::read_to_string(target_sessions_path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error).context("failed re-reading target sessions during repair"),
+    };
+    let rows: Vec<RowId> = serde_json::from_str(&content)
+        .context("failed parsing target sessions during repair re-check")?;
+    Ok(losers
+        .iter()
+        .all(|loser| rows.iter().any(|row| row.id == *loser)))
+}
+
+/// Remove explicit group rows attributable to the move that no longer have
+/// members from `storage`'s sidecar. No-op when nothing would change, so the
+/// consume-as-consistent path never rewrites healthy profiles.
+fn prune_moved_group_residue(
+    storage: &Storage,
+    plan: &crate::session::GroupMovePlan,
+) -> Result<()> {
+    let (instances, groups) = storage.load_with_groups()?;
+    let mut candidate = groups.clone();
+    reconcile_groups_after_repair(&instances, &mut candidate, &[], plan);
+    if candidate == groups {
+        return Ok(());
+    }
+    storage.update(|instances, groups| {
+        reconcile_groups_after_repair(instances, groups, &[], plan);
+        Ok(())
+    })
 }
 
 fn resolve_journal_store<'a>(
@@ -2091,9 +2171,11 @@ fn backup_before_repair(path: &Path) -> Result<()> {
 
 /// Keep the repaired profile's groups sidecar consistent with what an
 /// uninterrupted `apply_group_move` would have left on disk: explicit group
-/// rows attributable to the move lose their members when the losing rows go,
-/// winning rows' groups are materialized, and the sidecar is re-treeed
-/// exactly like `apply_group_move` does so ancestor rows and metadata match.
+/// rows attributable to the move are dropped when their members left, except
+/// that a non-subtree move keeps the moved-path row alive while an explicit
+/// child row survives (apply_group_move's own rule); winning rows' groups are
+/// materialized and the sidecar is re-treeed through GroupTree so ancestor
+/// chains and metadata match.
 /// Attributable follows `apply_group_move`'s own matching: the moved path
 /// itself always, descendants only for a subtree move.
 fn reconcile_groups_after_repair(
@@ -2117,7 +2199,23 @@ fn reconcile_groups_after_repair(
             .iter()
             .any(|instance| group_path_covers(path, &instance.group_path))
     };
-    groups.retain(|group| !attributable(&group.path) || has_member(&group.path));
+    // Mirror apply_group_move's non-subtree branch: an explicitly created
+    // child under the moved path keeps the parent row alive (removing it
+    // would orphan the surviving child below a nonexistent ancestor).
+    let explicit_descendants: std::collections::HashSet<String> = groups
+        .iter()
+        .filter_map(|group| {
+            group
+                .path
+                .rsplit_once('/')
+                .map(|(parent, _)| parent.to_string())
+        })
+        .collect();
+    groups.retain(|group| {
+        !attributable(&group.path)
+            || has_member(&group.path)
+            || (!plan.move_subtree && explicit_descendants.contains(&group.path))
+    });
     for winner in winners {
         if winner.group_path.is_empty() {
             continue;
@@ -4269,8 +4367,7 @@ mod tests {
 
             let view: Vec<(&str, &Storage)> =
                 vec![(source.profile(), &source), (target.profile(), &target)];
-            let loaded = collect_loaded(&[&source, &target]);
-            let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+            let outcome = reconcile_loaded(&[&source, &target], &view);
 
             assert!(outcome.repaired, "{point}: repair must run");
             assert!(
@@ -4297,15 +4394,14 @@ mod tests {
                 "{point}: losing attributable group entry pruned"
             );
             assert_eq!(journal_entry_count(&source), 0, "{point}: journal consumed");
-            let backup_count = fs_extra_count_backups(source.sessions_path());
+            let backup_count = count_recovery_backups(source.sessions_path());
             assert!(
                 backup_count >= 1,
                 "{point}: sessions.json backed up before repair"
             );
 
             // Idempotence: reconciling an already-repaired state is a no-op.
-            let loaded = collect_loaded(&[&source, &target]);
-            let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+            let outcome = reconcile_loaded(&[&source, &target], &view);
             assert!(!outcome.repaired && outcome.reports.is_empty(), "{point}");
         }
         Ok(())
@@ -4326,8 +4422,7 @@ mod tests {
 
         let view: Vec<(&str, &Storage)> =
             vec![(source.profile(), &source), (target.profile(), &target)];
-        let loaded = collect_loaded(&[&source, &target]);
-        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+        let outcome = reconcile_loaded(&[&source, &target], &view);
 
         assert!(outcome.repaired, "the leaked journal must be consumed");
         assert!(outcome.reports.is_empty());
@@ -4353,8 +4448,7 @@ mod tests {
 
         let view: Vec<(&str, &Storage)> =
             vec![(source.profile(), &source), (target.profile(), &target)];
-        let loaded = collect_loaded(&[&source, &target]);
-        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+        let outcome = reconcile_loaded(&[&source, &target], &view);
 
         assert!(!outcome.repaired);
         assert_eq!(
@@ -4384,39 +4478,194 @@ mod tests {
     }
 
     #[test]
-    fn stale_version_journal_is_insufficient_evidence() -> Result<()> {
-        // A journal from an older version carries no arbitration authority:
-        // the duplicate stays surfaced and the entry is not consumed.
-        let (_temp, source, target, before, _after) = setup_recovery_env("stale")?;
+    fn insufficient_evidence_journal_is_surfaced_never_consumed() -> Result<()> {
+        // Table over the two permanent insufficiency causes: an entry from
+        // another version and an entry older than MOVE_JOURNAL_MAX_AGE.
+        // Neither may arbitrate; both stay on disk untouched.
+        let week_ago_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_millis() as u64
+            - 8 * 24 * 3600 * 1000;
+        let cases = [
+            (
+                "insuff-wrong-version",
+                super::super::move_journal::MOVE_JOURNAL_VERSION + 1,
+                0,
+            ),
+            (
+                "insuff-expired",
+                super::super::move_journal::MOVE_JOURNAL_VERSION,
+                week_ago_ms,
+            ),
+        ];
+        for (tag, version, created_at) in cases {
+            let (_temp, source, target, before, _after) = setup_recovery_env(tag)?;
+            target.update(|instances, _| {
+                let mut copy = before.clone();
+                copy.source_profile = target.profile().to_string();
+                instances.push(copy);
+                Ok(())
+            })?;
+            let entry = super::super::move_journal::MoveJournalEntry {
+                version,
+                created_at_epoch_ms: created_at,
+                ..fresh_journal_entry(&source, &target, &before.id)
+            };
+            super::super::move_journal::record(&entry, source.sessions_path())?;
+            assert_eq!(journal_entry_count(&source), 1, "{tag}");
+
+            let view: Vec<(&str, &Storage)> =
+                vec![(source.profile(), &source), (target.profile(), &target)];
+            let outcome = reconcile_loaded(&[&source, &target], &view);
+
+            assert!(
+                !outcome.repaired,
+                "{tag}: insufficient evidence must not arbitrate"
+            );
+            assert_eq!(outcome.reports.len(), 1, "{tag}: duplicate stays surfaced");
+            assert_eq!(source.load()?.len(), 1, "{tag}");
+            assert_eq!(target.load()?.len(), 1, "{tag}");
+            assert_eq!(
+                journal_entry_count(&source),
+                1,
+                "{tag}: entry stays on disk"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_miss_is_transient_not_permanent() -> Result<()> {
+        // A journal whose target store is missing from the loaded view is a
+        // transient skip, not corruption: the same entry must repair once the
+        // missing profile appears, which is exactly the single-profile ->
+        // unified switch flow.
+        let (_temp, source, target, before, _after) = setup_recovery_env("resolvemiss")?;
         target.update(|instances, _| {
             let mut copy = before.clone();
             copy.source_profile = target.profile().to_string();
             instances.push(copy);
             Ok(())
         })?;
-        let stale = super::super::move_journal::MoveJournalEntry {
-            version: super::super::move_journal::MOVE_JOURNAL_VERSION + 1,
-            ids: vec![before.id.clone()],
-            source_profile: source.profile().to_string(),
-            target_profile: target.profile().to_string(),
-            source_sessions_path: source.sessions_path().to_path_buf(),
-            target_sessions_path: target.sessions_path().to_path_buf(),
-            group_move_source_path: "work".to_string(),
-            group_move_target_path: "moved".to_string(),
-            group_move_subtree: false,
-            created_at_epoch_ms: 0,
-        };
-        super::super::move_journal::record(&stale, source.sessions_path())?;
-        assert_eq!(journal_entry_count(&source), 1);
+        super::super::move_journal::record(
+            &fresh_journal_entry(&source, &target, &before.id),
+            source.sessions_path(),
+        )?;
+
+        // First pass: only the source profile is loaded (single-profile mode).
+        let source_only_view: Vec<(&str, &Storage)> = vec![(source.profile(), &source)];
+        let outcome = reconcile_loaded(&[&source], &source_only_view);
+        assert!(!outcome.repaired, "nothing to arbitrate without the target");
+        assert_eq!(
+            journal_entry_count(&source),
+            1,
+            "entry must survive the miss"
+        );
+
+        // Second pass: unified view. The previously skipped entry repairs.
+        let full_view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let outcome = reconcile_loaded(&[&source, &target], &full_view);
+        assert!(
+            outcome.repaired,
+            "resolve-miss must not poison later passes"
+        );
+        assert!(source.load()?.is_empty());
+        assert_eq!(journal_entry_count(&source), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn multi_id_batch_arbitrates_surviving_ids_and_skips_vanished_ones() -> Result<()> {
+        // Mixed batch: id `a` is duplicated (target published -> target wins,
+        // source copy removed); id `b` vanished from both stores (hand
+        // resolved). The batch arbitrates `a`, consumes the journal, and
+        // touches nothing for `b`.
+        let (_temp, source, target, before, _after) = setup_recovery_env("multi")?;
+        // Never persisted anywhere: hand-resolved before recovery ran.
+        let vanished_id = Instance::new("vanished", "/repo/vanished").id;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let mut entry = fresh_journal_entry(&source, &target, &before.id);
+        entry.ids.push(vanished_id.clone());
+        entry.ids.sort();
+        super::super::move_journal::record(&entry, source.sessions_path())?;
+
         let view: Vec<(&str, &Storage)> =
             vec![(source.profile(), &source), (target.profile(), &target)];
-        let loaded = collect_loaded(&[&source, &target]);
-        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+        let outcome = reconcile_loaded(&[&source, &target], &view);
 
-        assert!(!outcome.repaired, "stale evidence must not arbitrate");
-        assert_eq!(journal_entry_count(&source), 1, "stale entry stays on disk");
+        assert!(outcome.repaired, "the duplicated sibling must arbitrate");
+        assert!(outcome.reports.is_empty());
+        assert!(
+            !source.load()?.iter().any(|row| row.id == before.id),
+            "loser copy removed"
+        );
+        assert_eq!(target.load()?.len(), 1, "winner kept");
+        assert!(
+            !journal_entry_scan_ids(&source)
+                .iter()
+                .any(|id| id == &before.id),
+            "journal consumed despite the vanished sibling"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn post_journal_store_edits_degrade_to_legacy() -> Result<()> {
+        // A losing store edited after the journal was written carries user
+        // changes the journal must never overwrite: degrade instead of
+        // arbitrating even though the entry itself is still young.
+        let (_temp, source, target, before, _after) = setup_recovery_env("edited")?;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let mut entry = fresh_journal_entry(&source, &target, &before.id);
+        entry.created_at_epoch_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_millis() as u64
+            - 10 * 60 * 1000;
+        super::super::move_journal::record(&entry, source.sessions_path())?;
+
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let outcome = reconcile_loaded(&[&source, &target], &view);
+
+        assert!(
+            !outcome.repaired,
+            "post-journal edits must block arbitration"
+        );
+        assert_eq!(outcome.reports.len(), 1);
         assert_eq!(source.load()?.len(), 1);
         assert_eq!(target.load()?.len(), 1);
+        assert_eq!(journal_entry_count(&source), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn target_still_holds_checks_every_loser_id() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("sessions.json");
+        let winner = Instance::new("winner", "/repo/winner");
+        let bystander = Instance::new("bystander", "/repo/bystander");
+        let rows = vec![winner.clone(), bystander.clone()];
+        fs::write(&path, serde_json::to_vec_pretty(&rows)?)?;
+
+        // Both present -> holds. One missing -> does not hold. No file -> no.
+        assert!(target_still_holds(&path, std::slice::from_ref(&winner.id))?);
+        assert!(!target_still_holds(
+            &path,
+            &[winner.id.clone(), "gone".to_string()]
+        )?);
+        fs::remove_file(&path)?;
+        assert!(!target_still_holds(&path, &[winner.id])?);
         Ok(())
     }
 
@@ -4424,40 +4673,12 @@ mod tests {
         super::super::move_journal::scan([source.sessions_path().to_path_buf()]).len()
     }
 
-    #[test]
-    fn expired_journal_is_insufficient_evidence() -> Result<()> {
-        // A journal that outlived its move must never arbitrate: if the user
-        // later duplicates the id by hand, months-old evidence would delete
-        // the newer copy. Expired entries degrade to the surfaced legacy path.
-        let (_temp, source, target, before, _after) = setup_recovery_env("expired")?;
-        target.update(|instances, _| {
-            let mut copy = before.clone();
-            copy.source_profile = target.profile().to_string();
-            instances.push(copy);
-            Ok(())
-        })?;
-        let week_ago_ms = (std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_millis() as u64)
-            - 8 * 24 * 3600 * 1000;
-        let expired = super::super::move_journal::MoveJournalEntry {
-            created_at_epoch_ms: week_ago_ms,
-            ..fresh_journal_entry(&source, &target, &before.id)
-        };
-        super::super::move_journal::record(&expired, source.sessions_path())?;
-        assert_eq!(journal_entry_count(&source), 1);
-
-        let view: Vec<(&str, &Storage)> =
-            vec![(source.profile(), &source), (target.profile(), &target)];
-        let loaded = collect_loaded(&[&source, &target]);
-        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
-
-        assert!(!outcome.repaired, "expired evidence must not arbitrate");
-        assert_eq!(outcome.reports.len(), 1);
-        assert_eq!(source.load()?.len(), 1);
-        assert_eq!(target.load()?.len(), 1);
-        assert_eq!(journal_entry_count(&source), 1, "expired entry stays");
-        Ok(())
+    fn journal_entry_scan_ids(source: &Storage) -> Vec<String> {
+        super::super::move_journal::scan([source.sessions_path().to_path_buf()])
+            .into_iter()
+            .filter_map(|(_, parsed)| parsed.ok())
+            .flat_map(|entry| entry.ids)
+            .collect()
     }
 
     #[test]
@@ -4466,11 +4687,14 @@ mod tests {
         // moved path survives a single-group repair (apply_group_move's
         // non-subtree branch preserves explicit descendants) and is pruned
         // for a subtree move. Either way the losing path itself is pruned.
+        // Single move: apply_group_move's non-subtree branch keeps the
+        // moved-path row alive while an explicit child survives. Subtree
+        // move: the whole moved namespace goes.
         let cases = [
-            ("gscope-single", false, true),
-            ("gscope-subtree", true, false),
+            ("gscope-single", false, true, true),
+            ("gscope-subtree", true, false, false),
         ];
-        for (tag, move_subtree, child_survives) in cases {
+        for (tag, move_subtree, path_survives, child_survives) in cases {
             let (_temp, source, target, before, _after) = setup_recovery_env(tag)?;
             source.update(|_instances, groups| {
                 let mut child = Group::new("archive", "work/archive");
@@ -4492,16 +4716,16 @@ mod tests {
 
             let view: Vec<(&str, &Storage)> =
                 vec![(source.profile(), &source), (target.profile(), &target)];
-            let loaded = collect_loaded(&[&source, &target]);
-            let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+            let outcome = reconcile_loaded(&[&source, &target], &view);
 
             assert!(outcome.repaired, "{tag}");
             assert!(outcome.reports.is_empty(), "{tag}");
             assert!(source.load()?.is_empty(), "{tag}: loser emptied");
             let source_groups = source.load_with_groups()?.1;
-            assert!(
-                !source_groups.iter().any(|group| group.path == "work"),
-                "{tag}: moved path pruned"
+            assert_eq!(
+                source_groups.iter().any(|group| group.path == "work"),
+                path_survives,
+                "{tag}: moved-path row must mirror apply_group_move"
             );
             assert_eq!(
                 source_groups
@@ -4552,28 +4776,39 @@ mod tests {
             // Guard scoped to the interrupted pass only, so its Drop runs
             // before the converging rerun below.
             let _crash = ArmedCrashPoint::arm("profile-repair-source-written");
-            let loaded = collect_loaded(&[&source, &target]);
             let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                super::reconcile_profile_duplicates(&loaded, &view);
+                reconcile_loaded(&[&source, &target], &view);
             }));
         }
         // The interrupted pass wrote the repaired source but died before
         // consuming the journal; the rerun finishes the job.
-        let loaded = collect_loaded(&[&source, &target]);
-        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+        let outcome = reconcile_loaded(&[&source, &target], &view);
         assert!(outcome.repaired || journal_entry_count(&source) == 0);
         assert!(outcome.reports.is_empty());
         assert!(source.load()?.is_empty());
         assert_eq!(target.load()?.len(), 1);
         assert_eq!(journal_entry_count(&source), 0);
 
-        let loaded = collect_loaded(&[&source, &target]);
-        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+        let outcome = reconcile_loaded(&[&source, &target], &view);
         assert!(
             !outcome.repaired && outcome.reports.is_empty(),
             "rerun is a no-op"
         );
         Ok(())
+    }
+
+    /// Run one reconciliation pass over freshly loaded copies of the given
+    /// storages, matching the production call shape (borrowed views only).
+    fn reconcile_loaded(
+        storages: &[&Storage],
+        view: &[(&str, &Storage)],
+    ) -> super::ReconciliationOutcome {
+        let loaded = collect_loaded(storages);
+        let refs: Vec<(&str, &[Instance])> = loaded
+            .iter()
+            .map(|(name, instances)| (name.as_str(), instances.as_slice()))
+            .collect();
+        super::reconcile_profile_duplicates(&refs, view)
     }
 
     fn collect_loaded(storages: &[&Storage]) -> Vec<(String, Vec<Instance>)> {
@@ -4588,7 +4823,7 @@ mod tests {
             .collect()
     }
 
-    fn fs_extra_count_backups(sessions_path: &Path) -> usize {
+    fn count_recovery_backups(sessions_path: &Path) -> usize {
         let dir = match sessions_path.parent() {
             Some(dir) => dir,
             None => return 0,

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -469,27 +469,25 @@ pub(crate) fn acquire_session_title_lock(instance_id: &str) -> Result<StorageFlo
     )
 }
 
-/// Test-only crash injection for the profile-move transaction (#3459). Tests
-/// arm a named point and `move_instances_to_inner` panics when it is reached,
-/// unwinding through the rollback paths exactly like a process death would.
+// Test-only crash injection for the profile-move transaction (#3459). Tests
+// arm a named point and `move_instances_to_inner` panics when it is reached,
+// unwinding through the rollback paths exactly like a process death would.
+// Thread-local so concurrent test threads can never trip each other's
+// armed points.
 #[cfg(test)]
-static TEST_CRASH_POINTS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+thread_local! {
+    static TEST_CRASH_POINTS: std::cell::RefCell<Vec<String>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
 
 #[cfg(test)]
 pub(crate) fn arm_test_crash_point(name: &str) {
-    TEST_CRASH_POINTS
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .push(name.to_string());
+    TEST_CRASH_POINTS.with(|points| points.borrow_mut().push(name.to_string()));
 }
 
 #[cfg(test)]
 fn test_crash_point(name: &str) {
-    let armed = TEST_CRASH_POINTS
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .iter()
-        .any(|armed| armed == name);
+    let armed = TEST_CRASH_POINTS.with(|points| points.borrow().iter().any(|armed| armed == name));
     if armed {
         panic!("simulated crash at crash point `{name}`");
     }
@@ -497,10 +495,7 @@ fn test_crash_point(name: &str) {
 
 #[cfg(test)]
 pub(crate) fn disarm_test_crash_points() {
-    TEST_CRASH_POINTS
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .clear();
+    TEST_CRASH_POINTS.with(|points| points.borrow_mut().clear());
 }
 
 pub(crate) fn sync_parent_directory(path: &Path) -> Result<()> {
@@ -1275,10 +1270,11 @@ impl Storage {
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or_default(),
         };
-        let journal_path =
-            Some(super::move_journal::record(&journal_entry).context(
+        let journal_path = Some(
+            super::move_journal::record(&journal_entry, &self.sessions_path).context(
                 "recording the durable move journal failed; no profile rows were changed",
-            )?);
+            )?,
+        );
         #[cfg(test)]
         test_crash_point("profile-move-journal");
 
@@ -1787,20 +1783,11 @@ pub(crate) fn reconcile_profile_duplicates(
 ) -> ReconciliationOutcome {
     let mut outcome = ReconciliationOutcome::default();
     let duplicated = !detect_duplicate_ids(loaded).is_empty();
-    let entries = match super::move_journal::scan() {
-        Ok(entries) => entries,
-        Err(error) => {
-            if !duplicated {
-                return outcome;
-            }
-            tracing::error!(
-                target: "session.store",
-                error = %error,
-                "failed to scan the move journal while reconciling duplicate session ids"
-            );
-            Vec::new()
-        }
-    };
+    let entries = super::move_journal::scan(
+        storages
+            .iter()
+            .map(|(_, storage)| storage.sessions_path().to_path_buf()),
+    );
     if entries.is_empty() && !duplicated {
         return outcome;
     }
@@ -4104,21 +4091,14 @@ mod tests {
         Ok(())
     }
 
-    /// Shared harness for the #3459 recovery tests: isolated app dir (the
-    /// move journal lives there), one source row in group `work`, empty
-    /// target, and a realistic post-move candidate in group `moved`.
+    /// Shared harness for the #3459 recovery tests: one source row in group
+    /// `work`, empty target, and a realistic post-move candidate in group
+    /// `moved`. Journals live inside the temp profile directories, so no
+    /// process-global isolation is needed.
     fn setup_recovery_env(
         tag: &str,
-    ) -> Result<(
-        tempfile::TempDir,
-        AppDirGuard,
-        Storage,
-        Storage,
-        Instance,
-        Instance,
-    )> {
+    ) -> Result<(tempfile::TempDir, Storage, Storage, Instance, Instance)> {
         let temp = tempfile::TempDir::new()?;
-        let guard = isolate_app_dir_at(temp.path());
         let source_dir = temp.path().join(format!("{tag}-source"));
         let target_dir = temp.path().join(format!("{tag}-target"));
         fs::create_dir_all(&source_dir)?;
@@ -4138,7 +4118,7 @@ mod tests {
         target.update(|_instances, _groups| Ok(()))?;
         let mut after = before.clone();
         after.group_path = "moved".to_string();
-        Ok((temp, guard, source, target, before, after))
+        Ok((temp, source, target, before, after))
     }
 
     fn run_crashing_move(source: &Storage, target: &Storage, point: &str) {
@@ -4164,7 +4144,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn profile_move_crash_recovery_target_wins_from_each_crash_point() -> Result<()> {
         // One case per crash point #3459 requires: target write/fsync,
         // source group write/fsync, source session write/fsync. In all
@@ -4176,14 +4155,14 @@ mod tests {
             "profile-move-source-groups",
             "profile-move-source-sessions",
         ] {
-            let (_temp, _guard, source, target, _before, _after) =
+            let (_temp, source, target, _before, _after) =
                 setup_recovery_env(point.replace('-', "_").as_str())?;
             run_crashing_move(&source, &target, point);
 
             assert_eq!(source.load()?.len(), 1, "{point}: source row remains");
             assert_eq!(target.load()?.len(), 1, "{point}: target copy durable");
             assert_eq!(
-                journal_entry_count()?,
+                journal_entry_count(&source),
                 1,
                 "{point}: exactly one journal entry guards the residual"
             );
@@ -4217,7 +4196,7 @@ mod tests {
                 !source_groups.iter().any(|group| group.path == "work"),
                 "{point}: losing attributable group entry pruned"
             );
-            assert_eq!(journal_entry_count()?, 0, "{point}: journal consumed");
+            assert_eq!(journal_entry_count(&source), 0, "{point}: journal consumed");
             let backup_count = fs_extra_count_backups(source.sessions_path());
             assert!(
                 backup_count >= 1,
@@ -4233,18 +4212,17 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn profile_move_crash_before_publication_source_wins() -> Result<()> {
         // Crash right after the journal is written but before any row was
         // touched: the evidence says the target never published, so the
         // source row wins and nothing is removed. The leaked journal entry
         // is still consumed as consistent.
-        let (_temp, _guard, source, target, _before, _after) = setup_recovery_env("prepub")?;
+        let (_temp, source, target, _before, _after) = setup_recovery_env("prepub")?;
         run_crashing_move(&source, &target, "profile-move-journal");
 
         assert_eq!(source.load()?.len(), 1, "source row untouched");
         assert!(target.load()?.is_empty(), "target never published");
-        assert_eq!(journal_entry_count()?, 1);
+        assert_eq!(journal_entry_count(&source), 1);
 
         let view: Vec<(&str, &Storage)> =
             vec![(source.profile(), &source), (target.profile(), &target)];
@@ -4255,17 +4233,16 @@ mod tests {
         assert!(outcome.reports.is_empty());
         assert_eq!(source.load()?.len(), 1, "source wins, nothing removed");
         assert!(target.load()?.is_empty());
-        assert_eq!(journal_entry_count()?, 0);
+        assert_eq!(journal_entry_count(&source), 0);
         Ok(())
     }
 
     #[test]
-    #[serial]
     fn legacy_duplicate_without_journal_is_surfaced_never_arbitrated() -> Result<()> {
         // Two copies of one id with no usable journal evidence: neither may
         // be chosen by iteration order. Both rows stay on disk, both are
         // excluded upstream, and the report names profiles, files, mtimes.
-        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("legacy")?;
+        let (_temp, source, target, before, _after) = setup_recovery_env("legacy")?;
         let id = before.id.clone();
         target.update(|instances, _| {
             let mut copy = before.clone();
@@ -4302,16 +4279,15 @@ mod tests {
             );
             assert_eq!(storage.load()?.len(), 1, "no automatic arbitration");
         }
-        assert_eq!(journal_entry_count()?, 0);
+        assert_eq!(journal_entry_count(&source), 0);
         Ok(())
     }
 
     #[test]
-    #[serial]
     fn stale_version_journal_is_insufficient_evidence() -> Result<()> {
         // A journal from an older version carries no arbitration authority:
         // the duplicate stays surfaced and the entry is not consumed.
-        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("stale")?;
+        let (_temp, source, target, before, _after) = setup_recovery_env("stale")?;
         target.update(|instances, _| {
             let mut copy = before.clone();
             copy.source_profile = target.profile().to_string();
@@ -4330,31 +4306,32 @@ mod tests {
             group_move_subtree: false,
             created_at_epoch_ms: 0,
         };
-        super::super::move_journal::record(&stale)?;
-        assert_eq!(journal_entry_count()?, 1);
-
+        super::super::move_journal::record(&stale, source.sessions_path())?;
+        assert_eq!(journal_entry_count(&source), 1);
         let view: Vec<(&str, &Storage)> =
             vec![(source.profile(), &source), (target.profile(), &target)];
         let loaded = collect_loaded(&[&source, &target]);
         let outcome = super::reconcile_profile_duplicates(&loaded, &view);
 
         assert!(!outcome.repaired, "stale evidence must not arbitrate");
-        assert_eq!(outcome.reports.len(), 1);
+        assert_eq!(journal_entry_count(&source), 1, "stale entry stays on disk");
         assert_eq!(source.load()?.len(), 1);
         assert_eq!(target.load()?.len(), 1);
-        assert_eq!(journal_entry_count()?, 1, "stale entry stays on disk");
         Ok(())
     }
 
+    fn journal_entry_count(source: &Storage) -> usize {
+        super::super::move_journal::scan([source.sessions_path().to_path_buf()]).len()
+    }
+
     #[test]
-    #[serial]
     fn recovery_survives_a_panic_mid_repair_and_stays_idempotent() -> Result<()> {
         // A panic between the repair write and the journal consumption must
         // leave a state a plain rerun converges on, and further reruns are
         // exact no-ops.
-        let (_temp, _guard, source, target, _before, _after) = setup_recovery_env("midpanic")?;
+        let (_temp, source, target, _before, _after) = setup_recovery_env("midpanic")?;
         run_crashing_move(&source, &target, "profile-move-source-sessions");
-        assert_eq!(journal_entry_count()?, 1);
+        assert_eq!(journal_entry_count(&source), 1);
 
         arm_test_crash_point("profile-repair-source-written");
         let view: Vec<(&str, &Storage)> =
@@ -4370,11 +4347,11 @@ mod tests {
         // consuming the journal; the rerun finishes the job.
         let loaded = collect_loaded(&[&source, &target]);
         let outcome = super::reconcile_profile_duplicates(&loaded, &view);
-        assert!(outcome.repaired || journal_entry_count()? == 0);
+        assert!(outcome.repaired || journal_entry_count(&source) == 0);
         assert!(outcome.reports.is_empty());
         assert!(source.load()?.is_empty());
         assert_eq!(target.load()?.len(), 1);
-        assert_eq!(journal_entry_count()?, 0);
+        assert_eq!(journal_entry_count(&source), 0);
 
         let loaded = collect_loaded(&[&source, &target]);
         let outcome = super::reconcile_profile_duplicates(&loaded, &view);
@@ -4383,10 +4360,6 @@ mod tests {
             "rerun is a no-op"
         );
         Ok(())
-    }
-
-    fn journal_entry_count() -> Result<usize> {
-        Ok(super::super::move_journal::scan()?.len())
     }
 
     fn collect_loaded(storages: &[&Storage]) -> Vec<(String, Vec<Instance>)> {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -469,7 +469,41 @@ pub(crate) fn acquire_session_title_lock(instance_id: &str) -> Result<StorageFlo
     )
 }
 
-fn sync_parent_directory(path: &Path) -> Result<()> {
+/// Test-only crash injection for the profile-move transaction (#3459). Tests
+/// arm a named point and `move_instances_to_inner` panics when it is reached,
+/// unwinding through the rollback paths exactly like a process death would.
+#[cfg(test)]
+static TEST_CRASH_POINTS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+#[cfg(test)]
+pub(crate) fn arm_test_crash_point(name: &str) {
+    TEST_CRASH_POINTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .push(name.to_string());
+}
+
+#[cfg(test)]
+fn test_crash_point(name: &str) {
+    let armed = TEST_CRASH_POINTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .any(|armed| armed == name);
+    if armed {
+        panic!("simulated crash at crash point `{name}`");
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn disarm_test_crash_points() {
+    TEST_CRASH_POINTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+}
+
+pub(crate) fn sync_parent_directory(path: &Path) -> Result<()> {
     let resolved = resolve_symlink_chain(path)?;
     sync_resolved_parent_directory(&resolved)
 }
@@ -495,7 +529,7 @@ fn sync_resolved_parent_directory(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn atomic_write_verified(path: &Path, content: &[u8]) -> Result<()> {
+pub(crate) fn atomic_write_verified(path: &Path, content: &[u8]) -> Result<()> {
     atomic_write_verified_resolved(path, content).map(|_| ())
 }
 
@@ -783,6 +817,12 @@ impl Storage {
         &self.profile
     }
 
+    /// Absolute path of this profile's `sessions.json`. Recovery and the
+    /// duplicate-detection surface report it so users can act on exact files.
+    pub(crate) fn sessions_path(&self) -> &Path {
+        &self.sessions_path
+    }
+
     pub fn load(&self) -> Result<Vec<Instance>> {
         if !self.sessions_path.exists() {
             return Ok(Vec::new());
@@ -1034,6 +1074,8 @@ impl Storage {
     /// File contents are synced on every platform; Unix also verifies the
     /// target parent-directory rename before removing source rows. Runtime
     /// source-write failures restore both profiles when the source is clear.
+    /// A durable move journal written before the first mutation lets
+    /// `reconcile_profile_duplicates` arbitrate any crash residual (#3459).
     pub(crate) fn move_instances_to<F>(
         &self,
         target: &Storage,
@@ -1182,8 +1224,9 @@ impl Storage {
         validate_target(&target_instances, &moved)?;
         // Effect-first ordering may run a bounded worktree or container effect
         // before any row is written, so the common failure (the effect itself
-        // failing) aborts cleanly with every row untouched. The tradeoff is the
-        // documented residual window if a later write fails, see the module docs.
+        // failing) aborts cleanly with every row untouched. A failure after
+        // this point leaves the durable move journal behind, which recovery
+        // uses to arbitrate the residual deterministically (#3459).
         before_commit(&moved)?;
 
         let source_groups_before = serde_json::to_vec_pretty(&source_groups)?;
@@ -1206,6 +1249,38 @@ impl Storage {
         let target_groups_after = serde_json::to_vec_pretty(&target_groups)?;
         let source_groups_changed = source_groups_after != source_groups_before;
         let target_groups_changed = target_groups_after != target_groups_before;
+        // Durable move journal (#3459): written (and fsynced) before the
+        // first mutation so any crash between the target publication and the
+        // source removal leaves evidence that arbitrates the duplicate
+        // deterministically at recovery time. Consumed only after every
+        // durability barrier below has passed; error paths deliberately
+        // leave it in place, where recovery either repairs the residual or
+        // verifies the state is consistent and discards it.
+        let journal_entry = super::move_journal::MoveJournalEntry {
+            version: super::move_journal::MOVE_JOURNAL_VERSION,
+            ids: {
+                let mut ids: Vec<String> = ids.iter().map(|id| (*id).to_string()).collect();
+                ids.sort();
+                ids
+            },
+            source_profile: self.profile.clone(),
+            target_profile: target.profile.clone(),
+            source_sessions_path: self.sessions_path.clone(),
+            target_sessions_path: target.sessions_path.clone(),
+            group_move_source_path: plan.group_move.source_path.clone(),
+            group_move_target_path: plan.group_move.target_path.clone(),
+            group_move_subtree: plan.group_move.move_subtree,
+            created_at_epoch_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or_default(),
+        };
+        let journal_path =
+            Some(super::move_journal::record(&journal_entry).context(
+                "recording the durable move journal failed; no profile rows were changed",
+            )?);
+        #[cfg(test)]
+        test_crash_point("profile-move-journal");
 
         let resolved_target_groups_path = if target_groups_changed {
             Some(atomic_write_verified_resolved(
@@ -1244,6 +1319,8 @@ impl Storage {
             sync_target_parent(path)?;
         }
         sync_target_parent(&resolved_target_sessions_path)?;
+        #[cfg(test)]
+        test_crash_point("profile-move-target");
         if target_groups_changed {
             target.file_watch.notify_local_change(&target_groups_path);
         }
@@ -1305,7 +1382,14 @@ impl Storage {
                 }
                 return Err(source_group_error);
             }
+            #[cfg(test)]
+            test_crash_point("profile-move-source-groups");
         }
+        // Crash window #3459: dying here leaves the target published while
+        // the source rows are not yet durably removed, i.e. the duplicate
+        // state recovery must arbitrate.
+        #[cfg(test)]
+        test_crash_point("profile-move-source-sessions");
         if let Err(source_error) =
             atomic_write_verified(&self.sessions_path, &source_instances_after)
         {
@@ -1416,6 +1500,12 @@ impl Storage {
             return Err(anyhow!(
                 "source session removal was not durable ({sync_error}); source rows were restored and target copies retained"
             ));
+        }
+        // Every write and directory barrier above has passed: the move is
+        // complete, so the journal that guarded it can be dropped.
+        if let Some(path) = journal_path.as_ref() {
+            super::move_journal::consume(path)
+                .context("consuming the completed move journal failed")?;
         }
         if source_groups_changed {
             self.file_watch.notify_local_change(&source_groups_path);
@@ -1590,6 +1680,372 @@ fn save_recent_projects(store: &RecentProjects) -> Result<()> {
     let content = serde_json::to_string_pretty(store)?;
     atomic_write(&path, content.as_bytes())?;
     Ok(())
+}
+
+/// Outcome of one reconciliation pass over the loaded profiles.
+#[derive(Debug, Default)]
+pub(crate) struct ReconciliationOutcome {
+    /// True when at least one journal-guided repair changed durable state, so
+    /// the caller must reload from disk before publishing anything.
+    pub(crate) repaired: bool,
+    /// Duplicates that lack arbitration evidence and remain excluded.
+    pub(crate) reports: Vec<DuplicateIdReport>,
+}
+
+// ---------------------------------------------------------------------------
+// Cross-profile duplicate reconciliation (#3459)
+//
+// An interrupted profile move can leave the same session id in two profiles.
+// A valid, current-version move journal is authoritative evidence that a move
+// was in flight between exactly the two recorded stores; because the
+// transaction publishes the target before removing the source rows, whichever
+// store holds the id wins. Duplicates without journal evidence are never
+// arbitrated: they are reported with actionable per-copy details instead.
+
+/// One ambiguous copy of a duplicated session id.
+#[derive(Debug, Clone)]
+pub(crate) struct DuplicateCopy {
+    pub(crate) profile: String,
+    pub(crate) sessions_path: PathBuf,
+    pub(crate) modified_at_epoch_ms: Option<u64>,
+}
+
+/// A duplicate id that could not be repaired automatically.
+#[derive(Debug, Clone)]
+pub(crate) struct DuplicateIdReport {
+    pub(crate) id: String,
+    pub(crate) copies: Vec<DuplicateCopy>,
+}
+
+impl DuplicateIdReport {
+    /// Single-line, user-actionable summary naming every copy's profile,
+    /// store file, and mtime. Rendered by the TUI and written to the log.
+    pub(crate) fn actionable_message(&self) -> String {
+        let copies = self
+            .copies
+            .iter()
+            .map(|copy| {
+                let modified = copy
+                    .modified_at_epoch_ms
+                    .map(|ms| format!("mtime {ms}ms"))
+                    .unwrap_or_else(|| "unknown mtime".to_string());
+                format!(
+                    "profile `{}` at {} ({modified})",
+                    copy.profile,
+                    copy.sessions_path.display()
+                )
+            })
+            .collect::<Vec<String>>()
+            .join(" and ");
+        format!(
+            "session id `{}` exists in multiple profiles without a usable move journal; \
+             nothing was changed automatically. Resolve it manually by keeping one copy \
+             and deleting the other from its sessions.json (and groups.json sidecar): {copies}",
+            self.id
+        )
+    }
+}
+fn file_mtime_epoch_ms(path: &Path) -> Option<u64> {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as u64)
+}
+
+/// Ids present in more than one profile among `loaded` (per-profile instance
+/// lists), in deterministic first-seen order.
+pub(crate) fn detect_duplicate_ids(loaded: &[(String, Vec<Instance>)]) -> Vec<String> {
+    let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    let mut duplicates: Vec<String> = Vec::new();
+    for (profile, instances) in loaded {
+        for instance in instances {
+            match seen.get(instance.id.as_str()) {
+                Some(previous) if *previous == profile => {}
+                Some(_) => {
+                    if !duplicates.iter().any(|id| id == &instance.id) {
+                        duplicates.push(instance.id.clone());
+                    }
+                }
+                None => {
+                    seen.insert(&instance.id, profile);
+                }
+            }
+        }
+    }
+    duplicates
+}
+
+/// Detect duplicates across the loaded profiles, run journal-guided repair
+/// for the cases with durable evidence, and return reports for whatever
+/// remains ambiguous. Repairs happen under the app-global identity lock, the
+/// sorted per-session title/lifecycle locks, and each profile's own storage
+/// flock (`Storage::update`). `repaired` tells the caller to reload from disk.
+pub(crate) fn reconcile_profile_duplicates(
+    loaded: &[(String, Vec<Instance>)],
+    storages: &[(&str, &Storage)],
+) -> ReconciliationOutcome {
+    let mut outcome = ReconciliationOutcome::default();
+    let duplicated = !detect_duplicate_ids(loaded).is_empty();
+    let entries = match super::move_journal::scan() {
+        Ok(entries) => entries,
+        Err(error) => {
+            if !duplicated {
+                return outcome;
+            }
+            tracing::error!(
+                target: "session.store",
+                error = %error,
+                "failed to scan the move journal while reconciling duplicate session ids"
+            );
+            Vec::new()
+        }
+    };
+    if entries.is_empty() && !duplicated {
+        return outcome;
+    }
+    for (path, parsed) in entries {
+        match parsed {
+            Ok(entry) => match repair_journal_entry(&entry, storages, &path) {
+                Ok(true) => {
+                    outcome.repaired = true;
+                    tracing::info!(
+                        target: "session.store",
+                        ids = %entry.ids.join(","),
+                        "reconciled interrupted profile move from its journal"
+                    );
+                }
+                Ok(false) => {
+                    tracing::warn!(
+                        target: "session.store",
+                        path = %path.display(),
+                        "move journal entry references stores that are missing or moved; leaving it for manual inspection"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        target: "session.store",
+                        path = %path.display(),
+                        error = %error,
+                        "move-journal-guided repair failed; the duplicate stays excluded"
+                    );
+                }
+            },
+            Err(reason) => {
+                tracing::error!(
+                    target: "session.store",
+                    path = %path.display(),
+                    reason = %reason,
+                    "unreadable move journal entry cannot arbitrate a duplicate session id"
+                );
+            }
+        }
+    }
+    // Recompute from fresh disk state so reports reflect post-repair reality.
+    let mut reloaded: Vec<(String, Vec<Instance>)> = storages
+        .iter()
+        .map(|(_, storage)| (storage.profile.clone(), storage.load().unwrap_or_default()))
+        .collect();
+    reloaded.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut reports: Vec<DuplicateIdReport> = Vec::new();
+    for id in detect_duplicate_ids(&reloaded) {
+        let copies = reloaded
+            .iter()
+            .filter(|(_, instances)| instances.iter().any(|instance| instance.id == id))
+            .filter_map(|(profile, _)| {
+                storages
+                    .iter()
+                    .find(|(name, _)| *name == profile.as_str())
+                    .map(|(_, storage)| storage)
+            })
+            .map(|storage| DuplicateCopy {
+                profile: storage.profile.clone(),
+                sessions_path: storage.sessions_path().to_path_buf(),
+                modified_at_epoch_ms: file_mtime_epoch_ms(storage.sessions_path()),
+            })
+            .collect();
+        reports.push(DuplicateIdReport { id, copies });
+    }
+    outcome.reports = reports;
+    outcome
+}
+
+/// True when `candidate` equals or contains `path` as an ancestor segment.
+fn group_path_covers(candidate: &str, path: &str) -> bool {
+    candidate == path || path.starts_with(&format!("{candidate}/"))
+}
+
+/// Apply the winner policy to one journal entry. Returns Ok(true) when the
+/// entry was consumed (state repaired or already consistent) and Ok(false)
+/// when it cannot be applied because a referenced store is missing or has
+/// moved; those entries stay on disk and their duplicates surface as legacy.
+fn repair_journal_entry(
+    entry: &super::move_journal::MoveJournalEntry,
+    storages: &[(&str, &Storage)],
+    journal_path: &Path,
+) -> Result<bool> {
+    let source_storage =
+        match resolve_journal_store(&entry.source_profile, &entry.source_sessions_path, storages) {
+            Some(storage) => storage,
+            None => return Ok(false),
+        };
+    let target_storage =
+        match resolve_journal_store(&entry.target_profile, &entry.target_sessions_path, storages) {
+            Some(storage) => storage,
+            None => return Ok(false),
+        };
+
+    // App-global identity lock first, then sorted title/lifecycle locks, then
+    // the per-profile storage flocks taken inside `Storage::update`. This is
+    // the same global-to-local order every other identity mutation uses.
+    let _identity_lock = acquire_session_identity_lock()?;
+    let mut ids_sorted = entry.ids.clone();
+    ids_sorted.sort();
+    let mut guards = Vec::with_capacity(ids_sorted.len() * 2);
+    for id in &ids_sorted {
+        guards.push(acquire_session_title_lock(id)?);
+    }
+    for id in &ids_sorted {
+        guards.push(source_storage.acquire_instance_lifecycle_lock(id)?);
+        guards.push(target_storage.acquire_instance_lifecycle_lock(id)?);
+    }
+
+    let (source_instances, _source_groups) = source_storage.load_with_groups()?;
+    let (target_instances, _) = target_storage.load_with_groups()?;
+    let source_losers: Vec<String> = entry
+        .ids
+        .iter()
+        .filter(|id| target_instances.iter().any(|row| &row.id == *id))
+        .cloned()
+        .collect();
+    // Winner policy: target published means target wins. An id absent from
+    // both stores would mean the row vanished entirely, which contradicts the
+    // transaction's never-zero-copies invariant; refuse to touch anything.
+    for id in &entry.ids {
+        let in_source = source_instances.iter().any(|row| &row.id == id);
+        let in_target = target_instances.iter().any(|row| &row.id == id);
+        if !in_source && !in_target && !source_losers.is_empty() {
+            anyhow::bail!(
+                "journal claims session {id} was moving but neither store holds it; refusing to reconcile"
+            );
+        }
+    }
+    if source_losers.is_empty() {
+        // Nothing to arbitrate: either the move completed and only the journal
+        // leaked, or it aborted cleanly. Verify consistency, then consume.
+        super::move_journal::consume(journal_path)?;
+        return Ok(true);
+    }
+
+    let plan = crate::session::GroupMovePlan {
+        source_path: entry.group_move_source_path.clone(),
+        target_path: entry.group_move_target_path.clone(),
+        move_subtree: entry.group_move_subtree,
+    };
+    backup_before_repair(source_storage.sessions_path())?;
+    backup_before_repair(&source_storage.sessions_path().with_file_name("groups.json"))?;
+    source_storage.update(|instances, groups| {
+        instances.retain(|row| !source_losers.contains(&row.id));
+        let winners: Vec<crate::session::Instance> = instances
+            .iter()
+            .filter(|row| entry.ids.contains(&row.id))
+            .cloned()
+            .collect();
+        reconcile_groups_after_repair(instances, groups, &winners, &plan);
+        Ok(())
+    })?;
+    #[cfg(test)]
+    test_crash_point("profile-repair-source-written");
+    super::move_journal::consume(journal_path)?;
+    Ok(true)
+}
+
+fn resolve_journal_store<'a>(
+    profile: &str,
+    recorded_path: &Path,
+    storages: &'a [(&str, &'a Storage)],
+) -> Option<&'a Storage> {
+    let storage = storages
+        .iter()
+        .find(|(name, _)| *name == profile)
+        .map(|(_, storage)| *storage)?;
+    if storage.sessions_path() == recorded_path {
+        return Some(storage);
+    }
+    // Tolerate symlinked or differently-spelled paths when they still resolve
+    // to the same physical file.
+    match (
+        recorded_path.canonicalize(),
+        storage.sessions_path().canonicalize(),
+    ) {
+        (Ok(recorded), Ok(live)) if recorded == live => Some(storage),
+        _ => None,
+    }
+}
+
+fn backup_before_repair(path: &Path) -> Result<()> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).context(format!("failed reading {} for backup", path.display()))
+        }
+    };
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or_default();
+    let mut name = path
+        .file_name()
+        .expect("sessions path has a file name")
+        .to_os_string();
+    name.push(format!(".pre-recovery-{stamp}"));
+    let backup = path.with_file_name(name);
+    atomic_write_verified(&backup, &bytes)?;
+    sync_parent_directory(&backup)
+        .context(format!("backup {} was not made durable", backup.display()))
+}
+
+/// Keep the losing profile's groups sidecar consistent with the winning rows:
+/// drop explicit group rows attributable to the move that no longer have any
+/// member, and materialize any group row a winning row references but that a
+/// partially-applied transaction never wrote. Rows unrelated to the move are
+/// untouched.
+fn reconcile_groups_after_repair(
+    instances: &[Instance],
+    groups: &mut Vec<Group>,
+    winners: &[Instance],
+    plan: &crate::session::GroupMovePlan,
+) {
+    let source_prefix = format!("{}/", plan.source_path);
+    let attributable = |path: &str| {
+        (!plan.source_path.is_empty()
+            && (group_path_covers(&plan.source_path, path)
+                || (plan.move_subtree && path.starts_with(&source_prefix))))
+            || (!plan.target_path.is_empty() && group_path_covers(&plan.target_path, path))
+            || (plan.move_subtree
+                && !plan.target_path.is_empty()
+                && path.starts_with(&format!("{}/", plan.target_path)))
+    };
+    let has_member = |path: &str| {
+        instances
+            .iter()
+            .any(|instance| group_path_covers(path, &instance.group_path))
+    };
+    groups.retain(|group| !attributable(&group.path) || has_member(&group.path));
+    for winner in winners {
+        if winner.group_path.is_empty() {
+            continue;
+        }
+        let leaf = winner
+            .group_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(&winner.group_path);
+        if !groups.iter().any(|group| group.path == winner.group_path) {
+            groups.push(Group::new(leaf, &winner.group_path));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -3599,5 +4055,369 @@ mod tests {
             "no duplicate entry"
         );
         Ok(())
+    }
+    #[test]
+    fn profile_move_crash_after_target_publication_leaves_duplicate_id() -> Result<()> {
+        // Ground truth for #3459: a process death after the target copy is
+        // durable but before the source row is removed leaves two rows with
+        // the same globally unique id across profiles.
+        let temp = tempdir()?;
+        let source_dir = temp.path().join("repro-source");
+        let target_dir = temp.path().join("repro-target");
+        fs::create_dir_all(&source_dir)?;
+        fs::create_dir_all(&target_dir)?;
+        let source = Storage::new_for_test_path("repro-source", source_dir.join("sessions.json"));
+        let target = Storage::new_for_test_path("repro-target", target_dir.join("sessions.json"));
+        let mut before = Instance::new("session", "/repo/session");
+        before.source_profile = "repro-source".to_string();
+        before.group_path = "work".to_string();
+        source.update(|instances, groups| {
+            instances.push(before.clone());
+            groups.push(Group::new("work", "work"));
+            Ok(())
+        })?;
+        target.update(|_instances, _groups| Ok(()))?;
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = source.move_instances_to_inner(
+                &target,
+                &[(before.clone(), before.clone())],
+                MoveTransactionPlan {
+                    group_move: &GroupMovePlan::single("work", "moved"),
+                    merge_complete_post: true,
+                },
+                |_existing, _candidates| Ok(()),
+                |_| Ok(()),
+                |_path| panic!("simulated crash after target publication"),
+            );
+        }));
+        assert!(result.is_err(), "the simulated crash must abort the move");
+
+        let source_rows = source.load()?;
+        let target_rows = target.load()?;
+        assert_eq!(source_rows.len(), 1, "source row survives the crash");
+        assert_eq!(target_rows.len(), 1, "target copy is durable");
+        assert_eq!(
+            source_rows[0].id, target_rows[0].id,
+            "both profiles hold the same session id: ambiguous state"
+        );
+        Ok(())
+    }
+
+    /// Shared harness for the #3459 recovery tests: isolated app dir (the
+    /// move journal lives there), one source row in group `work`, empty
+    /// target, and a realistic post-move candidate in group `moved`.
+    fn setup_recovery_env(
+        tag: &str,
+    ) -> Result<(
+        tempfile::TempDir,
+        AppDirGuard,
+        Storage,
+        Storage,
+        Instance,
+        Instance,
+    )> {
+        let temp = tempfile::TempDir::new()?;
+        let guard = isolate_app_dir_at(temp.path());
+        let source_dir = temp.path().join(format!("{tag}-source"));
+        let target_dir = temp.path().join(format!("{tag}-target"));
+        fs::create_dir_all(&source_dir)?;
+        fs::create_dir_all(&target_dir)?;
+        let source =
+            Storage::new_for_test_path(&format!("{tag}-source"), source_dir.join("sessions.json"));
+        let target =
+            Storage::new_for_test_path(&format!("{tag}-target"), target_dir.join("sessions.json"));
+        let mut before = Instance::new("session", "/repo/session");
+        before.source_profile = format!("{tag}-source");
+        before.group_path = "work".to_string();
+        source.update(|instances, groups| {
+            instances.push(before.clone());
+            groups.push(Group::new("work", "work"));
+            Ok(())
+        })?;
+        target.update(|_instances, _groups| Ok(()))?;
+        let mut after = before.clone();
+        after.group_path = "moved".to_string();
+        Ok((temp, guard, source, target, before, after))
+    }
+
+    fn run_crashing_move(source: &Storage, target: &Storage, point: &str) {
+        arm_test_crash_point(point);
+        // Panic output for the simulated crash is expected noise.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut after = source.load().unwrap().remove(0);
+            after.group_path = "moved".to_string();
+            let before = source.load().unwrap().remove(0);
+            let _ = source.move_instances_to_inner(
+                target,
+                &[(before, after)],
+                MoveTransactionPlan {
+                    group_move: &GroupMovePlan::single("work", "moved"),
+                    merge_complete_post: true,
+                },
+                |_existing, _candidates| Ok(()),
+                |_| Ok(()),
+                sync_resolved_parent_directory,
+            );
+        }));
+        disarm_test_crash_points();
+    }
+
+    #[test]
+    #[serial]
+    fn profile_move_crash_recovery_target_wins_from_each_crash_point() -> Result<()> {
+        // One case per crash point #3459 requires: target write/fsync,
+        // source group write/fsync, source session write/fsync. In all
+        // three the target copy is already durable when the process dies,
+        // so the journal arbitrates: target wins, source copy removed,
+        // sidecars consistent, journal consumed, backups left behind.
+        for point in [
+            "profile-move-target",
+            "profile-move-source-groups",
+            "profile-move-source-sessions",
+        ] {
+            let (_temp, _guard, source, target, _before, _after) =
+                setup_recovery_env(point.replace('-', "_").as_str())?;
+            run_crashing_move(&source, &target, point);
+
+            assert_eq!(source.load()?.len(), 1, "{point}: source row remains");
+            assert_eq!(target.load()?.len(), 1, "{point}: target copy durable");
+            assert_eq!(
+                journal_entry_count()?,
+                1,
+                "{point}: exactly one journal entry guards the residual"
+            );
+
+            let view: Vec<(&str, &Storage)> =
+                vec![(source.profile(), &source), (target.profile(), &target)];
+            let loaded = collect_loaded(&[&source, &target]);
+            let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+
+            assert!(outcome.repaired, "{point}: repair must run");
+            assert!(
+                outcome.reports.is_empty(),
+                "{point}: no legacy ambiguity may remain: {reports:?}",
+                reports = outcome
+                    .reports
+                    .iter()
+                    .map(|r| r.actionable_message())
+                    .collect::<Vec<_>>()
+            );
+            assert!(source.load()?.is_empty(), "{point}: losing source emptied");
+            let target_rows = target.load()?;
+            assert_eq!(target_rows.len(), 1, "{point}");
+            assert_eq!(target_rows[0].group_path, "moved", "{point}");
+            let target_groups = target.load_with_groups()?.1;
+            assert!(
+                target_groups.iter().any(|group| group.path == "moved"),
+                "{point}: winning sidecar keeps the moved group"
+            );
+            let source_groups = source.load_with_groups()?.1;
+            assert!(
+                !source_groups.iter().any(|group| group.path == "work"),
+                "{point}: losing attributable group entry pruned"
+            );
+            assert_eq!(journal_entry_count()?, 0, "{point}: journal consumed");
+            let backup_count = fs_extra_count_backups(source.sessions_path());
+            assert!(
+                backup_count >= 1,
+                "{point}: sessions.json backed up before repair"
+            );
+
+            // Idempotence: reconciling an already-repaired state is a no-op.
+            let loaded = collect_loaded(&[&source, &target]);
+            let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+            assert!(!outcome.repaired && outcome.reports.is_empty(), "{point}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn profile_move_crash_before_publication_source_wins() -> Result<()> {
+        // Crash right after the journal is written but before any row was
+        // touched: the evidence says the target never published, so the
+        // source row wins and nothing is removed. The leaked journal entry
+        // is still consumed as consistent.
+        let (_temp, _guard, source, target, _before, _after) = setup_recovery_env("prepub")?;
+        run_crashing_move(&source, &target, "profile-move-journal");
+
+        assert_eq!(source.load()?.len(), 1, "source row untouched");
+        assert!(target.load()?.is_empty(), "target never published");
+        assert_eq!(journal_entry_count()?, 1);
+
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let loaded = collect_loaded(&[&source, &target]);
+        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+
+        assert!(outcome.repaired, "the leaked journal must be consumed");
+        assert!(outcome.reports.is_empty());
+        assert_eq!(source.load()?.len(), 1, "source wins, nothing removed");
+        assert!(target.load()?.is_empty());
+        assert_eq!(journal_entry_count()?, 0);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn legacy_duplicate_without_journal_is_surfaced_never_arbitrated() -> Result<()> {
+        // Two copies of one id with no usable journal evidence: neither may
+        // be chosen by iteration order. Both rows stay on disk, both are
+        // excluded upstream, and the report names profiles, files, mtimes.
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("legacy")?;
+        let id = before.id.clone();
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let loaded = collect_loaded(&[&source, &target]);
+        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+
+        assert!(!outcome.repaired);
+        assert_eq!(
+            outcome.reports.len(),
+            1,
+            "exactly the duplicated id surfaces"
+        );
+        let report = &outcome.reports[0];
+        assert_eq!(report.id, id);
+        assert_eq!(report.copies.len(), 2);
+        let message = report.actionable_message();
+        assert!(message.contains(&id), "message names the session id");
+        assert!(
+            message.contains("sessions.json"),
+            "message names store files"
+        );
+        for storage in [&source, &target] {
+            assert!(
+                message.contains(storage.profile()),
+                "message names profile {}: {message}",
+                storage.profile()
+            );
+            assert_eq!(storage.load()?.len(), 1, "no automatic arbitration");
+        }
+        assert_eq!(journal_entry_count()?, 0);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn stale_version_journal_is_insufficient_evidence() -> Result<()> {
+        // A journal from an older version carries no arbitration authority:
+        // the duplicate stays surfaced and the entry is not consumed.
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("stale")?;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let stale = super::super::move_journal::MoveJournalEntry {
+            version: super::super::move_journal::MOVE_JOURNAL_VERSION + 1,
+            ids: vec![before.id.clone()],
+            source_profile: source.profile().to_string(),
+            target_profile: target.profile().to_string(),
+            source_sessions_path: source.sessions_path().to_path_buf(),
+            target_sessions_path: target.sessions_path().to_path_buf(),
+            group_move_source_path: "work".to_string(),
+            group_move_target_path: "moved".to_string(),
+            group_move_subtree: false,
+            created_at_epoch_ms: 0,
+        };
+        super::super::move_journal::record(&stale)?;
+        assert_eq!(journal_entry_count()?, 1);
+
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let loaded = collect_loaded(&[&source, &target]);
+        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+
+        assert!(!outcome.repaired, "stale evidence must not arbitrate");
+        assert_eq!(outcome.reports.len(), 1);
+        assert_eq!(source.load()?.len(), 1);
+        assert_eq!(target.load()?.len(), 1);
+        assert_eq!(journal_entry_count()?, 1, "stale entry stays on disk");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn recovery_survives_a_panic_mid_repair_and_stays_idempotent() -> Result<()> {
+        // A panic between the repair write and the journal consumption must
+        // leave a state a plain rerun converges on, and further reruns are
+        // exact no-ops.
+        let (_temp, _guard, source, target, _before, _after) = setup_recovery_env("midpanic")?;
+        run_crashing_move(&source, &target, "profile-move-source-sessions");
+        assert_eq!(journal_entry_count()?, 1);
+
+        arm_test_crash_point("profile-repair-source-written");
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        {
+            let loaded = collect_loaded(&[&source, &target]);
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                super::reconcile_profile_duplicates(&loaded, &view);
+            }));
+        }
+        disarm_test_crash_points();
+        // The interrupted pass wrote the repaired source but died before
+        // consuming the journal; the rerun finishes the job.
+        let loaded = collect_loaded(&[&source, &target]);
+        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+        assert!(outcome.repaired || journal_entry_count()? == 0);
+        assert!(outcome.reports.is_empty());
+        assert!(source.load()?.is_empty());
+        assert_eq!(target.load()?.len(), 1);
+        assert_eq!(journal_entry_count()?, 0);
+
+        let loaded = collect_loaded(&[&source, &target]);
+        let outcome = super::reconcile_profile_duplicates(&loaded, &view);
+        assert!(
+            !outcome.repaired && outcome.reports.is_empty(),
+            "rerun is a no-op"
+        );
+        Ok(())
+    }
+
+    fn journal_entry_count() -> Result<usize> {
+        Ok(super::super::move_journal::scan()?.len())
+    }
+
+    fn collect_loaded(storages: &[&Storage]) -> Vec<(String, Vec<Instance>)> {
+        storages
+            .iter()
+            .map(|storage| {
+                (
+                    storage.profile().to_string(),
+                    storage.load().unwrap_or_default(),
+                )
+            })
+            .collect()
+    }
+
+    fn fs_extra_count_backups(sessions_path: &Path) -> usize {
+        let dir = match sessions_path.parent() {
+            Some(dir) => dir,
+            None => return 0,
+        };
+        std::fs::read_dir(dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|entry| entry.ok())
+                    .filter(|entry| {
+                        entry
+                            .file_name()
+                            .to_string_lossy()
+                            .contains(".pre-recovery-")
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
     }
 }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1237,12 +1237,6 @@ impl Storage {
             }
         }
         validate_target(&target_instances, &moved)?;
-        // Effect-first ordering may run a bounded worktree or container effect
-        // before any row is written, so the common failure (the effect itself
-        // failing) aborts cleanly with every row untouched. A failure after
-        // this point leaves the durable move journal behind, which recovery
-        // uses to arbitrate the residual deterministically (#3459).
-        before_commit(&moved)?;
 
         let source_groups_before = serde_json::to_vec_pretty(&source_groups)?;
         let target_instances_before = serde_json::to_vec_pretty(&target_instances)?;
@@ -1291,9 +1285,15 @@ impl Storage {
                 .unwrap_or_default(),
         };
         let journal_path = super::move_journal::record(&journal_entry, &self.sessions_path)
-            .context("recording the durable move journal failed; no profile rows were changed")?;
+            .context(
+                "recording the durable move journal failed; no move effect or profile row changed",
+            )?;
         #[cfg(test)]
         test_crash_point("profile-move-journal");
+        // The durable journal precedes every mutation, including the external
+        // worktree/container effect. If the effect fails or partially lands,
+        // the retained journal proves which profiles the recovery may inspect.
+        before_commit(&moved)?;
 
         let resolved_target_groups_path = if target_groups_changed {
             Some(atomic_write_verified_resolved(
@@ -1862,19 +1862,31 @@ pub(crate) fn reconcile_profile_duplicates(
     let mut normalized: Vec<(&str, &[Instance])> = loaded.to_vec();
     normalized.sort_by(|left, right| left.0.cmp(right.0));
     let duplicated = !detect_duplicate_ids(normalized.iter().copied()).is_empty();
-    let mut entries = super::move_journal::scan(
+    let scan = super::move_journal::scan(
         storages
             .iter()
             .map(|(_, storage)| storage.sessions_path().to_path_buf()),
     );
-    // Oldest evidence first, so chained moves (a leaked completed move plus a
-    // newer reverse move) arbitrate in the order the user actually performed
-    // them; unparseable entries sort last and can never consume anything.
-    entries.sort_by_key(|(_, parsed)| {
-        parsed
-            .as_ref()
-            .map(|entry| entry.created_at_epoch_ms)
-            .unwrap_or(u64::MAX)
+    for (dir, error) in scan.unreadable_dirs {
+        tracing::warn!(
+            target: "session.store",
+            path = %dir.display(),
+            error = %error,
+            "move journal directory could not be listed; retrying on the next reload"
+        );
+    }
+    let mut entries = scan.entries;
+    // The newest entry is the only current intent after a reverse move. Apply
+    // it first; older evidence then degrades harmlessly to already-consistent.
+    // Unparseable entries sort last and can never consume anything.
+    entries.sort_by_key(|(path, parsed)| {
+        std::cmp::Reverse((
+            parsed
+                .as_ref()
+                .map(|entry| entry.created_at_epoch_ms)
+                .unwrap_or_default(),
+            super::move_journal::file_created_at_nanos(path).unwrap_or_default(),
+        ))
     });
     if entries.is_empty() && !duplicated {
         return outcome;
@@ -1964,18 +1976,41 @@ pub(crate) fn reconcile_profile_duplicates(
         outcome.reports = duplicate_reports(&normalized, storages);
         return outcome;
     }
-    // Recompute from fresh disk state so reports reflect post-repair reality.
-    let mut reloaded: Vec<(String, Vec<Instance>)> = storages
-        .iter()
-        .map(|(_, storage)| (storage.profile.clone(), storage.load().unwrap_or_default()))
-        .collect();
+    let (reports, reload_succeeded) = reports_after_repair(&normalized, storages);
+    outcome.reports = reports;
+    if !reload_succeeded {
+        // Keep the caller on its pre-repair loads so fail-closed reports can be
+        // published instead of immediately repeating the same failed reload.
+        outcome.repaired = false;
+    }
+    outcome
+}
+
+fn reports_after_repair(
+    fallback: &[(&str, &[Instance])],
+    storages: &[(&str, &Storage)],
+) -> (Vec<DuplicateIdReport>, bool) {
+    let mut reloaded: Vec<(String, Vec<Instance>)> = Vec::with_capacity(storages.len());
+    for (_, storage) in storages {
+        match storage.load() {
+            Ok(instances) => reloaded.push((storage.profile.clone(), instances)),
+            Err(error) => {
+                tracing::error!(
+                    target: "session.store",
+                    profile = %storage.profile,
+                    error = %error,
+                    "post-repair reload failed; preserving the pre-repair duplicate report"
+                );
+                return (duplicate_reports(fallback, storages), false);
+            }
+        }
+    }
     reloaded.sort_by(|left, right| left.0.cmp(&right.0));
     let reloaded_refs: Vec<(&str, &[Instance])> = reloaded
         .iter()
         .map(|(profile, instances)| (profile.as_str(), instances.as_slice()))
         .collect();
-    outcome.reports = duplicate_reports(&reloaded_refs, storages);
-    outcome
+    (duplicate_reports(&reloaded_refs, storages), true)
 }
 
 /// Build one report per duplicated id with per-copy profile, store path, and
@@ -2022,6 +2057,18 @@ fn repair_journal_entry(
     storages: &[(&str, &Storage)],
     journal_path: &Path,
 ) -> Result<bool> {
+    repair_journal_entry_with_sync(entry, storages, journal_path, sync_parent_directory)
+}
+
+fn repair_journal_entry_with_sync<S>(
+    entry: &super::move_journal::MoveJournalEntry,
+    storages: &[(&str, &Storage)],
+    journal_path: &Path,
+    mut sync: S,
+) -> Result<bool>
+where
+    S: FnMut(&Path) -> Result<()>,
+{
     let source_storage =
         match resolve_journal_store(&entry.source_profile, &entry.source_sessions_path, storages) {
             Some(storage) => storage,
@@ -2106,11 +2153,12 @@ fn repair_journal_entry(
         .cloned()
         .collect();
     if source_losers.is_empty() {
-        // Nothing to arbitrate. Clean any group rows an interrupted
-        // groups-then-sessions write sequence left behind on either side,
-        // then consume the entry as resolved.
-        prune_moved_group_residue(source_storage, &plan)?;
-        prune_moved_group_residue(target_storage, &plan)?;
+        // The journal proves no profile mutation phase. It cannot distinguish
+        // pre-existing empty groups from partial target-side residue, so never
+        // prune sidecars without a duplicated row that proves publication.
+        // A prior repair may already have removed the source row but failed its
+        // directory barrier; repeat that barrier before consuming evidence.
+        sync_repaired_profile_durably(source_storage, &mut sync)?;
         super::move_journal::consume(journal_path)?;
         return Ok(true);
     }
@@ -2139,10 +2187,23 @@ fn repair_journal_entry(
         reconcile_groups_after_repair(instances, groups, &winners, &plan);
         Ok(())
     })?;
+    sync_repaired_profile_durably(source_storage, &mut sync)?;
     #[cfg(test)]
     test_crash_point("profile-repair-source-written");
     super::move_journal::consume(journal_path)?;
     Ok(true)
+}
+
+fn sync_repaired_profile_durably<S>(storage: &Storage, mut sync: S) -> Result<()>
+where
+    S: FnMut(&Path) -> Result<()>,
+{
+    // The two files normally share a profile directory, but supported
+    // symlinks may resolve them into different directories. Verify both rename
+    // parents before journal removal can become durable.
+    sync(storage.sessions_path()).context("repaired sessions directory was not made durable")?;
+    sync(&storage.sessions_path().with_file_name("groups.json"))
+        .context("repaired groups directory was not made durable")
 }
 
 /// True when the target sessions file currently holds every loser id.
@@ -2169,25 +2230,8 @@ fn target_still_holds(target_sessions_path: &Path, losers: &[String]) -> Result<
         .all(|loser| held.iter().any(|row_id| row_id == loser)))
 }
 
-/// Remove explicit group rows attributable to the move that no longer have
-/// members from `storage`'s sidecar. No-op when nothing would change, so the
-/// consume-as-consistent path never rewrites healthy profiles.
-fn prune_moved_group_residue(
-    storage: &Storage,
-    plan: &crate::session::GroupMovePlan,
-) -> Result<()> {
-    let (instances, groups) = storage.load_with_groups()?;
-    let mut candidate = groups.clone();
-    reconcile_groups_after_repair(&instances, &mut candidate, &[], plan);
-    if candidate == groups {
-        return Ok(());
-    }
-    storage.update(|instances, groups| {
-        reconcile_groups_after_repair(instances, groups, &[], plan);
-        Ok(())
-    })
-}
-
+/// Resolve one journal-recorded profile only when the loaded store still
+/// names the same sessions file (including symlink aliases).
 fn resolve_journal_store<'a>(
     profile: &str,
     recorded_path: &Path,
@@ -2211,6 +2255,10 @@ fn resolve_journal_store<'a>(
     }
 }
 
+const RECOVERY_BACKUPS_TO_KEEP: usize = 3;
+
+/// Back up one repaired file and keep only the newest bounded set for that
+/// filename. Backups are durably written before old entries are pruned.
 fn backup_before_repair(path: &Path) -> Result<()> {
     let bytes = match fs::read(path) {
         Ok(bytes) => bytes,
@@ -2231,7 +2279,48 @@ fn backup_before_repair(path: &Path) -> Result<()> {
     let backup = path.with_file_name(name);
     atomic_write_verified(&backup, &bytes)?;
     sync_parent_directory(&backup)
-        .context(format!("backup {} was not made durable", backup.display()))
+        .context(format!("backup {} was not made durable", backup.display()))?;
+    prune_old_recovery_backups(path, RECOVERY_BACKUPS_TO_KEEP)
+}
+
+fn prune_old_recovery_backups(path: &Path, keep: usize) -> Result<()> {
+    prune_old_recovery_backups_with_sync(path, keep, sync_resolved_parent_directory)
+}
+
+fn prune_old_recovery_backups_with_sync<S>(path: &Path, keep: usize, mut sync: S) -> Result<()>
+where
+    S: FnMut(&Path) -> Result<()>,
+{
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(());
+    };
+    let prefix = format!("{file_name}.pre-recovery-");
+    let mut backups: Vec<(u128, PathBuf)> = fs::read_dir(parent)?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter_map(|candidate| {
+            let timestamp = candidate
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_prefix(&prefix))
+                .and_then(|stamp| stamp.parse::<u128>().ok())?;
+            Some((timestamp, candidate))
+        })
+        .collect();
+    backups.sort_by_key(|(timestamp, _)| *timestamp);
+    let remove_count = backups.len().saturating_sub(keep);
+    if remove_count == 0 {
+        return Ok(());
+    }
+    for (_, old) in backups.into_iter().take(remove_count) {
+        fs::remove_file(&old)
+            .with_context(|| format!("failed pruning old recovery backup {}", old.display()))?;
+    }
+    // Backup files are lexical siblings of path even when path itself is a
+    // symlink. Sync that lexical parent, not the symlink target directory.
+    sync(path).context("recovery backup pruning was not made durable")
 }
 
 /// Keep the repaired profile's groups sidecar consistent with what an
@@ -2250,14 +2339,9 @@ fn reconcile_groups_after_repair(
     plan: &crate::session::GroupMovePlan,
 ) {
     let source_prefix = format!("{}/", plan.source_path);
-    let target_prefix = format!("{}/", plan.target_path);
     let attributable = |path: &str| {
-        (!plan.source_path.is_empty()
-            && (path == plan.source_path
-                || (plan.move_subtree && path.starts_with(&source_prefix))))
-            || (!plan.target_path.is_empty()
-                && (path == plan.target_path
-                    || (plan.move_subtree && path.starts_with(&target_prefix))))
+        !plan.source_path.is_empty()
+            && (path == plan.source_path || (plan.move_subtree && path.starts_with(&source_prefix)))
     };
     let has_member = |path: &str| {
         instances
@@ -2267,19 +2351,17 @@ fn reconcile_groups_after_repair(
     // Mirror apply_group_move's non-subtree branch: an explicitly created
     // child under the moved path keeps the parent row alive (removing it
     // would orphan the surviving child below a nonexistent ancestor).
-    let explicit_descendants: std::collections::HashSet<String> = groups
-        .iter()
-        .filter_map(|group| {
-            group
-                .path
-                .rsplit_once('/')
-                .map(|(parent, _)| parent.to_string())
-        })
-        .collect();
+    let existing_paths: Vec<String> = groups.iter().map(|group| group.path.clone()).collect();
+    let has_explicit_descendant = |path: &str| {
+        let prefix = format!("{path}/");
+        existing_paths
+            .iter()
+            .any(|candidate| candidate.starts_with(&prefix))
+    };
     groups.retain(|group| {
         !attributable(&group.path)
             || has_member(&group.path)
-            || (!plan.move_subtree && explicit_descendants.contains(&group.path))
+            || (!plan.move_subtree && has_explicit_descendant(&group.path))
     });
     for winner in winners {
         if winner.group_path.is_empty() {
@@ -4355,14 +4437,20 @@ mod tests {
         Ok(())
     }
 
-    /// Shared harness for the #3459 recovery tests: one source row in group
-    /// `work`, empty target, and a realistic post-move candidate in group
-    /// `moved`. Journals live inside the temp profile directories, so no
-    /// process-global isolation is needed.
+    /// Shared harness for the #3459 recovery tests: stores, journals, and
+    /// app-global identity/title locks all live below one isolated temp root.
     fn setup_recovery_env(
         tag: &str,
-    ) -> Result<(tempfile::TempDir, Storage, Storage, Instance, Instance)> {
+    ) -> Result<(
+        tempfile::TempDir,
+        AppDirGuard,
+        Storage,
+        Storage,
+        Instance,
+        Instance,
+    )> {
         let temp = tempfile::TempDir::new()?;
+        let guard = isolate_app_dir_at(temp.path());
         let source_dir = temp.path().join(format!("{tag}-source"));
         let target_dir = temp.path().join(format!("{tag}-target"));
         fs::create_dir_all(&source_dir)?;
@@ -4382,7 +4470,7 @@ mod tests {
         target.update(|_instances, _groups| Ok(()))?;
         let mut after = before.clone();
         after.group_path = "moved".to_string();
-        Ok((temp, source, target, before, after))
+        Ok((temp, guard, source, target, before, after))
     }
 
     fn run_crashing_move(source: &Storage, target: &Storage, point: &'static str) {
@@ -4418,7 +4506,7 @@ mod tests {
             "profile-move-source-groups",
             "profile-move-source-sessions",
         ] {
-            let (_temp, source, target, _before, _after) =
+            let (_temp, _guard, source, target, _before, _after) =
                 setup_recovery_env(point.replace('-', "_").as_str())?;
             run_crashing_move(&source, &target, point);
 
@@ -4478,7 +4566,25 @@ mod tests {
         // touched: the evidence says the target never published, so the
         // source row wins and nothing is removed. The leaked journal entry
         // is still consumed as consistent.
-        let (_temp, source, target, _before, _after) = setup_recovery_env("prepub")?;
+        let (temp, _guard, source, target, _before, _after) = setup_recovery_env("prepub")?;
+        assert!(
+            crate::session::get_app_dir()?.starts_with(temp.path()),
+            "identity/title locks must stay below the fixture temp root"
+        );
+        source.update(|_instances, groups| {
+            let mut bystander = Group::new("moved", "moved");
+            bystander.collapsed = true;
+            groups.push(bystander);
+            Ok(())
+        })?;
+        target.update(|_instances, groups| {
+            let mut existing = Group::new("moved", "moved");
+            existing.collapsed = true;
+            groups.push(existing);
+            Ok(())
+        })?;
+        let source_groups_before = source.load_with_groups()?.1;
+        let target_groups_before = target.load_with_groups()?.1;
         run_crashing_move(&source, &target, "profile-move-journal");
 
         assert_eq!(source.load()?.len(), 1, "source row untouched");
@@ -4493,6 +4599,8 @@ mod tests {
         assert!(outcome.reports.is_empty());
         assert_eq!(source.load()?.len(), 1, "source wins, nothing removed");
         assert!(target.load()?.is_empty());
+        assert_eq!(source.load_with_groups()?.1, source_groups_before);
+        assert_eq!(target.load_with_groups()?.1, target_groups_before);
         assert_eq!(journal_entry_count(&source), 0);
         Ok(())
     }
@@ -4502,7 +4610,7 @@ mod tests {
         // Two copies of one id with no usable journal evidence: neither may
         // be chosen by iteration order. Both rows stay on disk, both are
         // excluded upstream, and the report names profiles, files, mtimes.
-        let (_temp, source, target, before, _after) = setup_recovery_env("legacy")?;
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("legacy")?;
         let id = before.id.clone();
         target.update(|instances, _| {
             let mut copy = before.clone();
@@ -4564,7 +4672,7 @@ mod tests {
             ),
         ];
         for (tag, version, created_at) in cases {
-            let (_temp, source, target, before, _after) = setup_recovery_env(tag)?;
+            let (_temp, _guard, source, target, before, _after) = setup_recovery_env(tag)?;
             target.update(|instances, _| {
                 let mut copy = before.clone();
                 copy.source_profile = target.profile().to_string();
@@ -4605,7 +4713,7 @@ mod tests {
         // transient skip, not corruption: the same entry must repair once the
         // missing profile appears, which is exactly the single-profile ->
         // unified switch flow.
-        let (_temp, source, target, before, _after) = setup_recovery_env("resolvemiss")?;
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("resolvemiss")?;
         target.update(|instances, _| {
             let mut copy = before.clone();
             copy.source_profile = target.profile().to_string();
@@ -4646,7 +4754,7 @@ mod tests {
         // source copy removed); id `b` vanished from both stores (hand
         // resolved). The batch arbitrates `a`, consumes the journal, and
         // touches nothing for `b`.
-        let (_temp, source, target, before, _after) = setup_recovery_env("multi")?;
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("multi")?;
         // Never persisted anywhere: hand-resolved before recovery ran.
         let vanished_id = Instance::new("vanished", "/repo/vanished").id;
         target.update(|instances, _| {
@@ -4685,7 +4793,7 @@ mod tests {
         // A losing store edited after the journal was written carries user
         // changes the journal must never overwrite: degrade instead of
         // arbitrating even though the entry itself is still young.
-        let (_temp, source, target, before, _after) = setup_recovery_env("edited")?;
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("edited")?;
         target.update(|instances, _| {
             let mut copy = before.clone();
             copy.source_profile = target.profile().to_string();
@@ -4715,6 +4823,7 @@ mod tests {
         // journal timestamp), so it lands in the log-once registry instead of
         // re-warning on every reload tick.
         let journal_path = super::super::move_journal::scan([source.sessions_path().to_path_buf()])
+            .entries
             .into_iter()
             .next()
             .map(|(path, _)| path)
@@ -4731,7 +4840,7 @@ mod tests {
         // An id that cannot pass validation would fail the title/lifecycle
         // lock acquisition inside every repair attempt: permanently
         // insufficient, so it blacklists like parse/version/expired causes.
-        let (_temp, source, target, before, _after) = setup_recovery_env("badid")?;
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("badid")?;
         target.update(|instances, _| {
             let mut copy = before.clone();
             copy.source_profile = target.profile().to_string();
@@ -4752,6 +4861,7 @@ mod tests {
         assert!(!outcome.repaired);
         assert_eq!(journal_entry_count(&source), 1, "entry stays on disk");
         let journal_path = super::super::move_journal::scan([source.sessions_path().to_path_buf()])
+            .entries
             .into_iter()
             .next()
             .map(|(path, _)| path)
@@ -4801,7 +4911,7 @@ mod tests {
         // An id repeated inside ONE profile (corrupt file or writer bug) is
         // ambiguous exactly like a cross-profile duplicate: it must surface,
         // not silently fail closed without a report or title marker.
-        let (_temp, source, _target, before, _after) = setup_recovery_env("intraprofile")?;
+        let (_temp, _guard, source, _target, before, _after) = setup_recovery_env("intraprofile")?;
         source.update(|instances, _| {
             instances.push(before.clone());
             Ok(())
@@ -4820,11 +4930,14 @@ mod tests {
     }
 
     fn journal_entry_count(source: &Storage) -> usize {
-        super::super::move_journal::scan([source.sessions_path().to_path_buf()]).len()
+        super::super::move_journal::scan([source.sessions_path().to_path_buf()])
+            .entries
+            .len()
     }
 
     fn journal_entry_scan_ids(source: &Storage) -> Vec<String> {
         super::super::move_journal::scan([source.sessions_path().to_path_buf()])
+            .entries
             .into_iter()
             .filter_map(|(_, parsed)| parsed.ok())
             .flat_map(|entry| entry.ids)
@@ -4845,7 +4958,7 @@ mod tests {
             ("gscope-subtree", true, false, false),
         ];
         for (tag, move_subtree, path_survives, child_survives) in cases {
-            let (_temp, source, target, before, _after) = setup_recovery_env(tag)?;
+            let (_temp, _guard, source, target, before, _after) = setup_recovery_env(tag)?;
             source.update(|_instances, groups| {
                 let mut child = Group::new("archive", "work/archive");
                 child.collapsed = true;
@@ -4889,6 +5002,256 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn chained_move_journals_apply_newest_intent_first() -> Result<()> {
+        // J1 records A -> B and leaks after completion. J2 is the newer
+        // reverse B -> A move and crashes after publishing A, leaving both
+        // stores populated. The newest intent must win.
+        let (_temp, _guard, a, b, before, _after) = setup_recovery_env("chain")?;
+        b.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = b.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_millis() as u64;
+        let mut j1 = fresh_journal_entry(&a, &b, &before.id);
+        j1.created_at_epoch_ms = now;
+        let mut j2 = fresh_journal_entry(&b, &a, &before.id);
+        j2.group_move_source_path = "moved".to_string();
+        j2.group_move_target_path = "work".to_string();
+        j2.created_at_epoch_ms = now;
+        super::super::move_journal::record(&j1, a.sessions_path())?;
+        super::super::move_journal::record(&j2, b.sessions_path())?;
+
+        let view: Vec<(&str, &Storage)> = vec![(a.profile(), &a), (b.profile(), &b)];
+        let outcome = reconcile_loaded(&[&a, &b], &view);
+
+        assert!(outcome.repaired);
+        assert!(outcome.reports.is_empty());
+        assert_eq!(a.load()?.len(), 1, "new reverse-move target survives");
+        assert!(b.load()?.is_empty(), "superseded profile is emptied");
+        assert_eq!(journal_entry_count(&a), 0);
+        assert_eq!(journal_entry_count(&b), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn group_repair_preserves_indirect_metadata_and_other_side_name() -> Result<()> {
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("gparity")?;
+        let archived_at = chrono::Utc::now();
+        source.update(|_instances, groups| {
+            let work = groups
+                .iter_mut()
+                .find(|group| group.path == "work")
+                .unwrap();
+            work.collapsed = true;
+            work.archived_at = Some(archived_at);
+            let mut indirect = Group::new("b", "work/a/b");
+            indirect.collapsed = true;
+            groups.push(indirect);
+            let mut bystander = Group::new("moved", "moved");
+            bystander.collapsed = true;
+            groups.push(bystander);
+            Ok(())
+        })?;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let entry = fresh_journal_entry(&source, &target, &before.id);
+        super::super::move_journal::record(&entry, source.sessions_path())?;
+
+        let view: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let outcome = reconcile_loaded(&[&source, &target], &view);
+
+        assert!(outcome.repaired);
+        let groups = source.load_with_groups()?.1;
+        let work = groups.iter().find(|group| group.path == "work").unwrap();
+        assert!(
+            work.collapsed,
+            "indirect descendant preserves parent metadata"
+        );
+        assert_eq!(work.archived_at, Some(archived_at));
+        assert!(groups.iter().any(|group| group.path == "work/a/b"));
+        let bystander = groups.iter().find(|group| group.path == "moved").unwrap();
+        assert!(
+            bystander.collapsed,
+            "other-side name is unrelated on source"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn journal_is_durable_before_external_effect_runs() -> Result<()> {
+        let (_temp, _guard, source, target, before, after) = setup_recovery_env("effect-order")?;
+        let effect_ran = std::cell::Cell::new(false);
+        let crash = ArmedCrashPoint::arm("profile-move-journal");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = source.move_instances_to_inner(
+                &target,
+                &[(before, after)],
+                MoveTransactionPlan {
+                    group_move: &GroupMovePlan::single("work", "moved"),
+                    merge_complete_post: true,
+                },
+                |_existing, _candidates| Ok(()),
+                |_| {
+                    effect_ran.set(true);
+                    Ok(())
+                },
+                sync_resolved_parent_directory,
+            );
+        }));
+        drop(crash);
+        assert!(result.is_err(), "journal crash point must fire");
+        assert!(
+            !effect_ran.get(),
+            "journal must precede the external effect"
+        );
+        assert_eq!(journal_entry_count(&source), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_repair_directory_sync_retains_journal() -> Result<()> {
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("sync-fail")?;
+        target.update(|instances, _| {
+            let mut copy = before.clone();
+            copy.source_profile = target.profile().to_string();
+            instances.push(copy);
+            Ok(())
+        })?;
+        let entry = fresh_journal_entry(&source, &target, &before.id);
+        let journal_path = super::super::move_journal::record(&entry, source.sessions_path())?;
+        let stores: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+        let error = repair_journal_entry_with_sync(&entry, &stores, &journal_path, |_path| {
+            Err(anyhow!("forced repaired-profile sync failure"))
+        })
+        .expect_err("failed durability barrier must fail recovery completion");
+        assert!(error.to_string().contains("not made durable"));
+        assert!(source.load()?.is_empty(), "repair row write reached disk");
+        assert_eq!(journal_entry_count(&source), 1, "evidence must remain");
+
+        let retry_error = repair_journal_entry_with_sync(&entry, &stores, &journal_path, |_path| {
+            Err(anyhow!("forced retry sync failure"))
+        })
+        .expect_err("no-loser retry must repeat the durability barrier");
+        assert!(retry_error.to_string().contains("not made durable"));
+        assert_eq!(journal_entry_count(&source), 1, "retry keeps evidence too");
+
+        let outcome = reconcile_loaded(&[&source, &target], &stores);
+        assert!(outcome.repaired, "rerun consumes retained evidence safely");
+        assert_eq!(journal_entry_count(&source), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn repaired_profile_sync_covers_sessions_and_groups_paths() -> Result<()> {
+        let (_temp, _guard, source, _target, _before, _after) = setup_recovery_env("sync-both")?;
+        let mut calls = Vec::new();
+
+        sync_repaired_profile_durably(&source, |path| {
+            calls.push(path.to_path_buf());
+            Ok(())
+        })?;
+
+        assert_eq!(
+            calls,
+            vec![
+                source.sessions_path().to_path_buf(),
+                source.sessions_path().with_file_name("groups.json"),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn backup_pruning_syncs_the_lexical_backup_directory() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("profile/sessions.json");
+        fs::create_dir_all(path.parent().unwrap())?;
+        for stamp in 1..=4 {
+            fs::write(
+                path.with_file_name(format!("sessions.json.pre-recovery-{stamp}")),
+                stamp.to_string(),
+            )?;
+        }
+        let mut synced = Vec::new();
+
+        prune_old_recovery_backups_with_sync(&path, 3, |candidate| {
+            synced.push(candidate.to_path_buf());
+            Ok(())
+        })?;
+
+        assert_eq!(synced, vec![path]);
+        Ok(())
+    }
+
+    #[test]
+    fn recovery_backup_retention_keeps_newest_three() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("sessions.json");
+        fs::write(&path, b"[]")?;
+        for stamp in 1..=5 {
+            fs::write(
+                temp.path()
+                    .join(format!("sessions.json.pre-recovery-{stamp}")),
+                stamp.to_string(),
+            )?;
+        }
+        backup_before_repair(&path)?;
+        let mut stamps: Vec<u128> = fs::read_dir(temp.path())?
+            .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+            .filter_map(|name| {
+                name.to_string_lossy()
+                    .strip_prefix("sessions.json.pre-recovery-")
+                    .and_then(|value| value.parse().ok())
+            })
+            .collect();
+        stamps.sort();
+        assert_eq!(stamps.len(), RECOVERY_BACKUPS_TO_KEEP);
+        assert_eq!(&stamps[..2], &[4, 5], "oldest backups are pruned");
+        Ok(())
+    }
+
+    #[test]
+    fn post_repair_load_error_preserves_pre_repair_report() -> Result<()> {
+        let temp = tempdir()?;
+        let good_dir = temp.path().join("good");
+        let bad_dir = temp.path().join("bad");
+        fs::create_dir_all(&good_dir)?;
+        fs::create_dir_all(&bad_dir)?;
+        let good = Storage::new_for_test_path("good", good_dir.join("sessions.json"));
+        let bad = Storage::new_for_test_path("bad", bad_dir.join("sessions.json"));
+        let row = Instance::new("duplicate", "/repo/duplicate");
+        good.update(|instances, _| {
+            instances.push(row.clone());
+            Ok(())
+        })?;
+        fs::write(bad.sessions_path(), b"not-json")?;
+        let good_rows = good.load()?;
+        let fallback_bad = vec![row.clone()];
+        let fallback: Vec<(&str, &[Instance])> = vec![
+            ("good", good_rows.as_slice()),
+            ("bad", fallback_bad.as_slice()),
+        ];
+        let stores: Vec<(&str, &Storage)> = vec![("good", &good), ("bad", &bad)];
+
+        let (reports, reload_succeeded) = reports_after_repair(&fallback, &stores);
+
+        assert!(!reload_succeeded, "Home must keep its pre-repair loads");
+        assert_eq!(reports.len(), 1, "load error keeps ambiguity surfaced");
+        assert_eq!(reports[0].id, row.id);
+        Ok(())
+    }
+
     fn fresh_journal_entry(
         source: &Storage,
         target: &Storage,
@@ -4916,7 +5279,7 @@ mod tests {
         // A panic between the repair write and the journal consumption must
         // leave a state a plain rerun converges on, and further reruns are
         // exact no-ops.
-        let (_temp, source, target, _before, _after) = setup_recovery_env("midpanic")?;
+        let (_temp, _guard, source, target, _before, _after) = setup_recovery_env("midpanic")?;
         run_crashing_move(&source, &target, "profile-move-source-sessions");
         assert_eq!(journal_entry_count(&source), 1);
 

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -2248,6 +2248,15 @@ where
             target_path: entry.group_move_target_path.clone(),
             move_subtree: entry.group_move_subtree,
         };
+        // Automatic arbitration requires one valid row on each side. If
+        // either profile already contains repeated rows for this id, preserve
+        // every copy and the journal so duplicate surfacing stays in control.
+        if entry.ids.iter().any(|id| {
+            source_instances.iter().filter(|row| &row.id == id).count() > 1
+                || target_instances.iter().filter(|row| &row.id == id).count() > 1
+        }) {
+            return Ok(false);
+        }
         let source_losers: Vec<String> = entry
             .ids
             .iter()
@@ -2317,7 +2326,11 @@ fn target_still_holds(target_sessions_path: &Path, losers: &[String]) -> Result<
         .context("failed parsing target sessions during repair re-check")?;
     let held: Vec<String> = rows
         .iter()
-        .filter_map(|row| row.get("id").and_then(|id| id.as_str()).map(str::to_string))
+        .filter_map(|row| {
+            <Instance as serde::Deserialize>::deserialize(row)
+                .ok()
+                .map(|instance| instance.id)
+        })
         .collect();
     Ok(losers
         .iter()
@@ -5084,6 +5097,40 @@ mod tests {
         assert_eq!(outcome.reports.len(), 2);
         assert_eq!(a.load()?.len(), 2, "newer X+Y target remains intact");
         assert_eq!(b.load()?.len(), 2, "no stale journal deletes either copy");
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_target_rows_never_become_an_automatic_winner() -> Result<()> {
+        let (_temp, _guard, source, target, before, _after) = setup_recovery_env("target-dup")?;
+        target.update(|instances, _| {
+            for _ in 0..2 {
+                let mut copy = before.clone();
+                copy.source_profile = target.profile().to_string();
+                instances.push(copy);
+            }
+            Ok(())
+        })?;
+        let entry = fresh_journal_entry(&source, &target, &before.id);
+        super::super::move_journal::record(&entry, source.sessions_path())?;
+        let stores: Vec<(&str, &Storage)> =
+            vec![(source.profile(), &source), (target.profile(), &target)];
+
+        let outcome = reconcile_loaded(&[&source, &target], &stores);
+
+        assert!(!outcome.repaired);
+        assert_eq!(outcome.reports.len(), 1);
+        assert_eq!(source.load()?.len(), 1, "source copy is preserved");
+        assert_eq!(
+            target.load()?.len(),
+            2,
+            "ambiguous target copies remain surfaced"
+        );
+        assert_eq!(
+            journal_entry_count(&source),
+            1,
+            "evidence remains for manual resolution"
+        );
         Ok(())
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2064,6 +2064,23 @@ impl ReloadFailureState {
     }
 }
 
+/// Log each legacy duplicate's actionable details once per process; the
+/// condition can persist until the user hand-edits files, so repeating it at
+/// ERROR level on every reload tick would be spam.
+pub(super) fn log_legacy_duplicates_once(reports: &[crate::session::DuplicateIdReport]) {
+    static REPORTED_IDS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+    let mut seen = REPORTED_IDS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for report in reports {
+        if seen.iter().any(|id| id == &report.id) {
+            continue;
+        }
+        seen.push(report.id.clone());
+        tracing::error!(target: "tui.home", "{}", report.actionable_message());
+    }
+}
+
 impl HomeView {
     pub fn new(
         active_profile: Option<String>,
@@ -2141,9 +2158,9 @@ impl HomeView {
         // durable state under lock here, so a clean reload below publishes
         // exactly one row per session. Legacy ambiguities stay excluded.
         let legacy_duplicate_reports = {
-            let loads_view: Vec<(String, Vec<Instance>)> = profile_loads
+            let loads_view: Vec<(&str, &[Instance])> = profile_loads
                 .iter()
-                .map(|(name, instances, _)| (name.clone(), instances.clone()))
+                .map(|(name, instances, _)| (name.as_str(), instances.as_slice()))
                 .collect();
             let storages_view: Vec<(&str, &Storage)> = storages
                 .iter()
@@ -2160,13 +2177,7 @@ impl HomeView {
                     *groups = fresh_groups;
                 }
             }
-            for report in &outcome.reports {
-                tracing::error!(
-                    target: "tui.home",
-                    "{}",
-                    report.actionable_message()
-                );
-            }
+            log_legacy_duplicates_once(&outcome.reports);
             outcome.reports
         };
         for (profile_name, instances, groups) in &profile_loads {
@@ -2692,9 +2703,9 @@ impl HomeView {
             Ok(loads)
         };
         let mut loads = collect_loads(&self.storages, &self.instances)?;
-        let loads_view: Vec<(String, Vec<Instance>)> = loads
+        let loads_view: Vec<(&str, &[Instance])> = loads
             .iter()
-            .map(|(name, instances, _)| (name.clone(), instances.clone()))
+            .map(|(name, instances, _)| (name.as_str(), instances.as_slice()))
             .collect();
         let storages_view: Vec<(&str, &Storage)> = self
             .storages
@@ -2707,9 +2718,7 @@ impl HomeView {
             // session is published.
             loads = collect_loads(&self.storages, &self.instances)?;
         }
-        for report in &outcome.reports {
-            tracing::error!(target: "tui.home", "{}", report.actionable_message());
-        }
+        log_legacy_duplicates_once(&outcome.reports);
         self.legacy_duplicate_reports = outcome.reports;
 
         for (profile_name, instances, groups) in &loads {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -484,6 +484,10 @@ pub struct HomeView {
     /// in-memory mirror. Drained on Ok save.
     pending_added: HashMap<String, HashSet<String>>,
     pub(super) group_trees: HashMap<String, GroupTree>,
+    /// Duplicate session ids that remain ambiguous after journal-guided
+    /// reconciliation (#3459): every copy is excluded from `instances` and
+    /// these details name the exact profiles, files, and mtimes to resolve.
+    pub(super) legacy_duplicate_reports: Vec<crate::session::DuplicateIdReport>,
     pub(super) flat_items: Vec<Item>,
 
     // UI state
@@ -2071,6 +2075,7 @@ impl HomeView {
         let mut storages = HashMap::new();
         let mut all_instances = Vec::new();
         let mut group_trees = HashMap::new();
+        let mut profile_loads: Vec<(String, Vec<Instance>, Vec<Group>)> = Vec::new();
 
         let profile_names = match &active_profile {
             Some(name) => vec![name.clone()],
@@ -2127,10 +2132,47 @@ impl HomeView {
                     }
                 }
             }
-            let tree = GroupTree::new_with_groups(&instances, &groups);
-            group_trees.insert(profile_name.clone(), tree);
-            all_instances.extend(instances);
+            profile_loads.push((profile_name.clone(), instances, groups));
             storages.insert(profile_name.clone(), storage);
+        }
+
+        // Duplicate detection across every loaded profile runs before any of
+        // the loaded state is published (#3459). Journal-guided repairs fix
+        // durable state under lock here, so a clean reload below publishes
+        // exactly one row per session. Legacy ambiguities stay excluded.
+        let legacy_duplicate_reports = {
+            let loads_view: Vec<(String, Vec<Instance>)> = profile_loads
+                .iter()
+                .map(|(name, instances, _)| (name.clone(), instances.clone()))
+                .collect();
+            let storages_view: Vec<(&str, &Storage)> = storages
+                .iter()
+                .map(|(name, storage)| (name.as_str(), storage))
+                .collect();
+            let outcome = crate::session::reconcile_profile_duplicates(&loads_view, &storages_view);
+            if outcome.repaired {
+                for (name, instances, groups) in &mut profile_loads {
+                    let (mut fresh, fresh_groups) = storages[name].load_with_groups()?;
+                    for inst in &mut fresh {
+                        inst.source_profile = name.clone();
+                    }
+                    *instances = fresh;
+                    *groups = fresh_groups;
+                }
+            }
+            for report in &outcome.reports {
+                tracing::error!(
+                    target: "tui.home",
+                    "{}",
+                    report.actionable_message()
+                );
+            }
+            outcome.reports
+        };
+        for (profile_name, instances, groups) in &profile_loads {
+            let tree = GroupTree::new_with_groups(instances, groups);
+            group_trees.insert(profile_name.clone(), tree);
+            all_instances.extend(instances.iter().cloned());
         }
 
         // In unified mode there is no single active profile, so config is
@@ -2203,6 +2245,7 @@ impl HomeView {
             pending_group_deletions: HashMap::new(),
             pending_added: HashMap::new(),
             group_trees,
+            legacy_duplicate_reports,
             flat_items: Vec::new(),
             cursor: 0,
             selected_session: None,
@@ -2626,19 +2669,53 @@ impl HomeView {
             self.storages.retain(|k, _| current_profiles.contains(k));
         }
 
-        for (profile_name, storage) in &self.storages {
-            let (mut instances, groups) = storage.load_with_groups()?;
-            for inst in &mut instances {
-                inst.source_profile = profile_name.clone();
-                if let Some(prev) = self.instances.get(&inst.id) {
-                    // Field-ownership rules (generation-governed vs runtime-only)
-                    // live on merge_runtime_from_reload.
-                    inst.merge_runtime_from_reload(prev);
+        // Collect per-profile state without publishing it, so duplicate
+        // detection (#3459) can run journal-guided repairs before anything
+        // reaches the unified map.
+        type ProfileLoads = Vec<(String, Vec<Instance>, Vec<Group>)>;
+        let collect_loads = |storages: &HashMap<String, Storage>,
+                             prev: &indexmap::IndexMap<String, Instance>|
+         -> anyhow::Result<ProfileLoads> {
+            let mut loads = Vec::new();
+            for (profile_name, storage) in storages {
+                let (mut instances, groups) = storage.load_with_groups()?;
+                for inst in &mut instances {
+                    inst.source_profile = profile_name.clone();
+                    if let Some(previous) = prev.get(&inst.id) {
+                        // Field-ownership rules (generation-governed vs
+                        // runtime-only) live on merge_runtime_from_reload.
+                        inst.merge_runtime_from_reload(previous);
+                    }
                 }
+                loads.push((profile_name.clone(), instances, groups));
             }
+            Ok(loads)
+        };
+        let mut loads = collect_loads(&self.storages, &self.instances)?;
+        let loads_view: Vec<(String, Vec<Instance>)> = loads
+            .iter()
+            .map(|(name, instances, _)| (name.clone(), instances.clone()))
+            .collect();
+        let storages_view: Vec<(&str, &Storage)> = self
+            .storages
+            .iter()
+            .map(|(name, storage)| (name.as_str(), storage))
+            .collect();
+        let outcome = crate::session::reconcile_profile_duplicates(&loads_view, &storages_view);
+        if outcome.repaired {
+            // Durable state changed under lock; reload so exactly one row per
+            // session is published.
+            loads = collect_loads(&self.storages, &self.instances)?;
+        }
+        for report in &outcome.reports {
+            tracing::error!(target: "tui.home", "{}", report.actionable_message());
+        }
+        self.legacy_duplicate_reports = outcome.reports;
+
+        for (profile_name, instances, groups) in &loads {
             // Rebuild this profile's tree from disk, preserving any collapsed
             // state that was toggled in-memory but not yet on disk
-            let mut new_tree = GroupTree::new_with_groups(&instances, &groups);
+            let mut new_tree = GroupTree::new_with_groups(instances, groups);
             if let Some(old_tree) = self.group_trees.get(profile_name) {
                 for g in old_tree.get_all_groups() {
                     if g.collapsed {
@@ -2647,7 +2724,7 @@ impl HomeView {
                 }
             }
             self.group_trees.insert(profile_name.clone(), new_tree);
-            all_instances.extend(instances);
+            all_instances.extend(instances.iter().cloned());
         }
 
         // Remove trees for profiles that no longer exist
@@ -5178,8 +5255,9 @@ impl HomeView {
     /// Build the id-keyed `IndexMap` from a `Vec<Instance>` (the storage-load
     /// shape). Duplicate ids across profiles are ambiguous after an interrupted
     /// profile move: selecting either row by iteration order can route lifecycle
-    /// work to the wrong profile. Exclude every copy and fail closed until the
-    /// durable state is reconciled.
+    /// work to the wrong profile. Exclude every copy and fail closed; the
+    /// reload path runs `reconcile_profile_duplicates` first, so only
+    /// legacy duplicates without journal evidence ever reach this state.
     fn build_instances_map(all_instances: Vec<Instance>) -> indexmap::IndexMap<String, Instance> {
         let mut map: indexmap::IndexMap<String, Instance> =
             indexmap::IndexMap::with_capacity(all_instances.len());

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1141,7 +1141,7 @@ impl HomeView {
     fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, layout: PaneLayout) {
         self.list_area = area;
         let profile = self.active_profile_display();
-        let title = match &self.view_mode {
+        let mut title = match &self.view_mode {
             ViewMode::Structured => {
                 compose_list_title("aoe", profile, self.group_by, self.sort_order)
             }
@@ -1155,6 +1155,13 @@ impl HomeView {
                 self.sort_order,
             ),
         };
+        if !self.legacy_duplicate_reports.is_empty() {
+            // Fail-closed surface (#3459): ambiguous copies are hidden from
+            // the list, so without this marker the loss is silent.
+            let count = self.legacy_duplicate_reports.len();
+            let plural = if count == 1 { "" } else { "s" };
+            title.push_str(&format!("  \u{26a0} {count} ambiguous session{plural}"));
+        }
         let (border_color, title_color) = match self.view_mode {
             ViewMode::Structured => (theme.border, theme.title),
             ViewMode::Terminal | ViewMode::Tool(_) => {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20924,7 +20924,10 @@ mod profile_duplicate_reconciliation {
                     group_move_source_path: "work".to_string(),
                     group_move_target_path: "moved".to_string(),
                     group_move_subtree: false,
-                    created_at_epoch_ms: 0,
+                    created_at_epoch_ms: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or_default(),
                 },
                 alpha.sessions_path(),
             )

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20913,18 +20913,21 @@ mod profile_duplicate_reconciliation {
         })
         .unwrap();
         if with_journal {
-            crate::session::record_move_journal(&crate::session::MoveJournalEntry {
-                version: 1,
-                ids: vec![id.clone()],
-                source_profile: "alpha".to_string(),
-                target_profile: "beta".to_string(),
-                source_sessions_path: alpha.sessions_path().to_path_buf(),
-                target_sessions_path: beta.sessions_path().to_path_buf(),
-                group_move_source_path: "work".to_string(),
-                group_move_target_path: "moved".to_string(),
-                group_move_subtree: false,
-                created_at_epoch_ms: 0,
-            })
+            crate::session::record_move_journal(
+                &crate::session::MoveJournalEntry {
+                    version: 1,
+                    ids: vec![id.clone()],
+                    source_profile: "alpha".to_string(),
+                    target_profile: "beta".to_string(),
+                    source_sessions_path: alpha.sessions_path().to_path_buf(),
+                    target_sessions_path: beta.sessions_path().to_path_buf(),
+                    group_move_source_path: "work".to_string(),
+                    group_move_target_path: "moved".to_string(),
+                    group_move_subtree: false,
+                    created_at_epoch_ms: 0,
+                },
+                alpha.sessions_path(),
+            )
             .unwrap();
         }
         (temp, guard, id)

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20882,3 +20882,122 @@ fn every_view_mode_paints_the_same_sunk_row_decoration() {
         }
     }
 }
+
+mod profile_duplicate_reconciliation {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// One session id present in `alpha` and `beta`, plus an optional valid
+    /// move journal claiming alpha -> beta (target published, target wins).
+    fn boot_ambiguous_state(with_journal: bool) -> (TempDir, AppDirGuard, String) {
+        let temp = TempDir::new().unwrap();
+        let guard = setup_test_home(&temp);
+        let alpha = Storage::new_unwatched("alpha").unwrap();
+        let mut inst = Instance::new("moved", "/repo/moved");
+        inst.group_path = "work".to_string();
+        let id = inst.id.clone();
+        alpha
+            .update(|i, g| {
+                i.push(inst.clone());
+                g.push(Group::new("work", "work"));
+                Ok(())
+            })
+            .unwrap();
+        let beta = Storage::new_unwatched("beta").unwrap();
+        beta.update(|i, _| {
+            let mut copy = inst.clone();
+            copy.source_profile = "beta".to_string();
+            i.push(copy);
+            Ok(())
+        })
+        .unwrap();
+        if with_journal {
+            crate::session::record_move_journal(&crate::session::MoveJournalEntry {
+                version: 1,
+                ids: vec![id.clone()],
+                source_profile: "alpha".to_string(),
+                target_profile: "beta".to_string(),
+                source_sessions_path: alpha.sessions_path().to_path_buf(),
+                target_sessions_path: beta.sessions_path().to_path_buf(),
+                group_move_source_path: "work".to_string(),
+                group_move_target_path: "moved".to_string(),
+                group_move_subtree: false,
+                created_at_epoch_ms: 0,
+            })
+            .unwrap();
+        }
+        (temp, guard, id)
+    }
+
+    #[test]
+    #[serial]
+    fn interrupted_move_with_journal_repairs_before_publish() {
+        let (_temp, _guard, id) = boot_ambiguous_state(true);
+
+        let view = HomeView::new(
+            None,
+            AvailableTools::with_tools(&["claude"]),
+            crate::file_watch::FileWatchService::noop(),
+        )
+        .unwrap();
+
+        // The journal arbitrates before the unified map is published, so the
+        // repaired row is usable immediately instead of being excluded.
+        assert_eq!(view.instances.len(), 1, "exactly the winning row publishes");
+        let row = view.instances.get(&id).expect("repaired row present");
+        assert_eq!(row.source_profile, "beta", "target copy wins per journal");
+        assert!(view.legacy_duplicate_reports.is_empty());
+        assert!(
+            Storage::new_unwatched("alpha")
+                .unwrap()
+                .load()
+                .unwrap()
+                .is_empty(),
+            "losing source copy removed on disk"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn legacy_duplicate_stays_excluded_and_is_surfaced() {
+        let (_temp, _guard, id) = boot_ambiguous_state(false);
+
+        let mut view = HomeView::new(
+            None,
+            AvailableTools::with_tools(&["claude"]),
+            crate::file_watch::FileWatchService::noop(),
+        )
+        .unwrap();
+
+        assert!(
+            view.instances.get(&id).is_none(),
+            "without journal evidence every copy stays excluded"
+        );
+        assert_eq!(view.legacy_duplicate_reports.len(), 1);
+        let message = view.legacy_duplicate_reports[0].actionable_message();
+        assert!(message.contains(&id) && message.contains("alpha") && message.contains("beta"));
+
+        // The fail-closed state must be visible, not silent.
+        let theme = crate::tui::styles::load_theme("empire");
+        let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                view.render(f, area, &theme, None, None, None);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        assert!(
+            out.contains("\u{26a0} 1 ambiguous"),
+            "the list title must flag ambiguous sessions.\nFull buffer:\n{out}"
+        );
+    }
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20915,7 +20915,7 @@ mod profile_duplicate_reconciliation {
         if with_journal {
             crate::session::record_move_journal(
                 &crate::session::MoveJournalEntry {
-                    version: 1,
+                    version: crate::session::MOVE_JOURNAL_VERSION,
                     ids: vec![id.clone()],
                     source_profile: "alpha".to_string(),
                     target_profile: "beta".to_string(),


### PR DESCRIPTION
## Description

Cross-profile session moves write the target before removing the source rows, so a process crash between the two leaves the same globally unique session id in two profiles (#3459). #3427 made the TUI fail closed on such duplicates (every ambiguous copy is excluded from the unified map) but left the durable state unreconciled. This PR adds the reconciliation layer underneath that baseline:

**Durable move journal** (src/session/move_journal.rs): one versioned JSON entry per attempted move, stored under the source profile's .move-journal directory next to sessions.json. The new journal directory's profile parent, the entry file, and the journal directory are all synchronised before any mutation, including the external worktree/container effect. Entries are consumed only after the move or repair durability barriers pass. Unusable entries remain for manual inspection with no automatic GC; a consume failure after a durably completed move is logged and self-heals on the next reconciliation. Entries older than 7 days, with post-journal store edits, invalid ids, unreadable data, or unknown versions never arbitrate.

**Journal-guided repair** (reconcile_profile_duplicates in src/session/storage.rs): current-version journals are validated semantically (unique ids, distinct non-aliased endpoints) before locks; arbitration also requires exactly one valid row on each side. Opaque evidence defers all arbitration for the pass. Valid entries run newest-first with filename-nanosecond tie-breaking; unresolved newer intents shadow every older overlapping id transitively across multi-session batches, while any opaque entry or unreadable journal directory defers all arbitration for that reload. Repair holds both profiles' in-process save locks and storage flocks in canonical directory order through the locked target recheck and source commit, then verifies the resolved parents of sessions.json and groups.json before consuming evidence. Source files are backed up under lock with newest-three retention; reload errors preserve fail-closed reports.

**Legacy surfacing**: duplicates without usable evidence (no journal, unreadable file, wrong version) are never arbitrated. They stay excluded from the map, an `actionable_message()` names every copy's profile, store file, and mtime, it lands in the log as an error, and the sidebar list title shows `⚠ N ambiguous session(s)` instead of hiding the loss.

### Order of integration with #3427

#3427 is already merged into this branch's base (`1819e7b4`); this change builds directly on top of it. The fail-closed exclusion from #3427 is preserved verbatim: journal-guided repairs run before the unified map is published, so only legacy duplicates ever reach it. `build_instances_map`'s doc now points at the recovery pass.

### Remaining tranches (explicitly out of this slice)

- Headless daemon asymmetry: reconciliation runs only through TUI new/reload paths. A headless aoe serve process that never opens the TUI can show both copies indefinitely; this PR does not add daemon reconciliation.
- Recovery retention: successful journals are consumed and pre-recovery backups are bounded to the newest three per file. Permanently unusable journal entries have no automatic GC and may be deleted manually after resolving the named duplicate.
- A guided manual-resolution flow for legacy ambiguities (today they surface details + log; resolution is still a hand edit of the named files).
- Web dashboard parity for the ambiguity banner.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The UI delta is one title suffix (`⚠ 1 ambiguous`) asserted by test; no layout change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: crash points are injected inside `Storage::move_instances_to_inner`; a full-binary e2e cannot control those write boundaries. In-module tests inject them deterministically (same rationale as #3427).

New tests:

- Crash-point coverage, one table row per point required by the issue: target write/fsync (`profile-move-target`), source group write/fsync (`profile-move-source-groups`), source session removal (`profile-move-source-sessions`). Each: crash → reload → detection → journal-guided repair → exact final state (single row on the winning side, consistent groups sidecars, backups present, journal consumed), plus idempotence rerun.
- Pre-publication crash: journal exists, nothing was written; source wins by evidence, leaked journal consumed.
- Recovery panic mid-repair: interrupted pass converges on rerun; further reruns are no-ops.
- Legacy ambiguity without journal: surfaced with profiles/paths/mtimes, zero arbitration (sensitive: removing the fail-closed exclusion or the report turns it red).
- Stale-version journal: insufficient evidence, not arbitrated, not consumed.
- TUI startup: journal-guided case publishes exactly one repaired row with `legacy_duplicate_reports` empty; legacy case keeps the row excluded, populates the report, and renders the list-title marker.

Mutation checks performed locally: removing the journal insertion makes the crash-recovery suite red; replacing the #3427 exclusion with iteration-order selection makes both exclusion tests red.
- Chained-journal regression (including equal-ms creation), any-depth group metadata and same-name bystander preservation, journal-before-effect ordering, app-dir lock isolation, journal-directory parent durability, repair fsync retention/retry, typed scan errors, post-repair fail-closed reload fallback, and backup retention are covered by sensitive unit tests.

## Validation

- `cargo fmt --all -- --check`: clean
- cargo clippy --features serve -- -D warnings: clean
- cargo clippy --lib --tests -- -D warnings: clean
- cargo test --features serve: full integration run = 6,715 passed across 24 suites (8 ignored), 0 failed; final sweep cargo test --features serve --lib = 6,450 passed, 2 ignored, 0 failed
- Targeted reconciliation/correction subset: 22 passed, 0 failed; mutation inverses for ordering, parity, effect ordering, durability, reporting, retention, scan separation, and isolation all turn their tests red
- Targeted guards at --test-threads=1: green

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** ox-alpha (Oh My Pi)

**Any Additional AI Details you'd like to share:** Implemented the journal, recovery, TUI wiring, tests, and validation end to end; mutation sensitivity was verified by temporarily reverting each guard and observing red suites.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added durable journals for interrupted cross-profile session moves.
- Added safe, repeatable reconciliation for duplicate sessions and group files.
- Added locking, crash recovery, stale-entry checks, backups, and durability barriers.
- Preserved journal evidence when recovery cannot complete safely.
- Kept unresolved legacy duplicates out of the unified session list.
- Added logs and a TUI warning for ambiguous sessions.
- Added tests for recovery, chained moves, race conditions, storage failures, reload fallback, backup retention, duplicate handling, and UI behavior.

## Benefits

Session moves recover safely after interruptions. The system avoids unsafe repairs when evidence is invalid, stale, incomplete, or conflicting. Recovery remains repeatable and protects data with backups. The TUI reports unresolved duplicates instead of selecting a session silently.

## Further Enhancement

Future work could add direct TUI actions for resolving legacy ambiguities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



