### PR TITLE
fix(serve): mark structured sessions unread when an ACP turn ends

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4299,6 +4299,9 @@ struct PassiveTransitionDecision {
     /// intra-doc link that would degrade to literal text under
     /// `cargo doc`).
     patch: Option<crate::session::PassiveStatusPatch>,
+    /// Always `false` for structured / ACP sessions: `should_mark_acp_unread`,
+    /// driven off the live ACP turn-end event, is the sole producer of their
+    /// automatic mark. See the gate in `decide_passive_transition`.
     mark_unread: bool,
 }
 
@@ -4306,9 +4309,9 @@ struct PassiveTransitionDecision {
 /// `status` differs from the tick's `prev` snapshot. The full
 /// contract lives on the return type at [`PassiveTransitionDecision`]:
 /// `patch: None` for structured / ACP sessions (the ACP overlay is the
-/// sole authority), and `mark_unread: true` only on genuine
-/// Running -> Idle when unread is enabled and the row is not already
-/// unread.
+/// sole authority), and `mark_unread: true` only on a genuine
+/// Running -> Idle for a *terminal* session when unread is enabled and the
+/// row is not already unread.
 fn decide_passive_transition(
     inst: &Instance,
     old_status: Status,
@@ -4316,7 +4319,14 @@ fn decide_passive_transition(
 ) -> PassiveTransitionDecision {
     let patch =
         (!inst.is_structured()).then(|| crate::session::PassiveStatusPatch::from_instance(inst));
+    // Structured rows are excluded for the same reason as the patch: the poll
+    // loop has no authority over a paneless row, and since #3162 one never
+    // reaches here anyway (it compares equal to `prev`, so `observed_transitions`
+    // does not report it). `should_mark_acp_unread`, driven off the live ACP
+    // `Stopped` event, is the sole producer for them; the gate is what stops a
+    // later change to this loop from quietly re-marking from two daemon paths.
     let mark_unread = unread_enabled
+        && !inst.is_structured()
         && old_status == Status::Running
         && inst.status == Status::Idle
         && !inst.unread;
@@ -5621,7 +5631,7 @@ async fn acp_event_listener(state: Arc<AppState>) {
 
         // Acquire `instances` once for both branches. Releases before
         // the (potentially blocking) sessions.json save.
-        let profile_to_save = {
+        let (profile_to_save, unread_profile) = {
             let mut instances = state.instances.write().await;
             let Some(inst) = instances.iter_mut().find(|i| i.id == frame.session_id) else {
                 continue;
@@ -5630,9 +5640,74 @@ async fn acp_event_listener(state: Arc<AppState>) {
                 continue;
             }
 
+            // Snapshotting around the call is exactly "the transition
+            // `apply_status_intent` actually applied": it assigns `status` in
+            // one place and every rejected or no-op path (the trashed /
+            // Deleting / Creating guard, the Stopped guard, the ineligible
+            // HealError guard, `status == target`) leaves it untouched. We hold
+            // the write lock across both reads, so nothing else can move it in
+            // between. A future refactor that makes `apply_status_intent`
+            // assign `status` more than once has to revisit this.
+            let old_status = inst.status;
             apply_status_intent(inst, status_intent, &state.status_tx);
-            apply_acp_session_change(inst, &frame.session_id, acp_change.as_ref())
+            let unread_profile =
+                should_mark_acp_unread(inst, old_status, crate::session::unread_enabled())
+                    .then(|| inst.source_profile.clone());
+
+            (
+                apply_acp_session_change(inst, &frame.session_id, acp_change.as_ref()),
+                unread_profile,
+            )
         };
+
+        // The turn just finished, so the row takes the automatic unread mark.
+        // This is the sole producer of it for a structured row. The tmux poll
+        // loop has no authority over a paneless one, which is why #3162 stopped
+        // it reporting phantom transitions for them and so left this gap; the
+        // TUI's passive path is gated off them to keep the boolean single-writer.
+        //
+        // The write has to be durable. `reload_state_instances_from_disk` rebases
+        // every row on the disk row on each 2s tick and `merge_runtime_fields`
+        // does not carry `unread`, so an in-memory-only mark is gone within two
+        // seconds. Memory is mirrored only after the write lands, the same
+        // ordering `flush_passive_transition_writes` uses (#2755) and for the
+        // same reason: a mark that exists only in daemon memory is served over
+        // `/api/sessions`, mirrored into the TUI, and then silently dropped by
+        // the next reload.
+        //
+        // Deliberately not folded into the `profile_to_save` save below:
+        // `derive_acp_session_change` yields nothing for `Event::Stopped`, so an
+        // identity change and a turn-end can never arrive on the same event and
+        // there is no atomicity to win.
+        //
+        // No per-instance lock. A concurrent `PATCH /api/sessions/:id/unread`
+        // clear cannot be lost to this write: `should_mark_acp_unread` requires
+        // the row to be read at decision time, and until the mirror below runs
+        // it still reads as read everywhere, so the reactive clears (the
+        // dashboard's active-session effect, the TUI's unread dwell) cannot have
+        // fired yet. A clear racing this window is therefore a no-op on an
+        // already-read row, and marking after it is the chronologically correct
+        // outcome: the turn did finish afterwards.
+        if let Some(profile) = unread_profile {
+            let persist_id = frame.session_id.clone();
+            let persisted = api::persist_session_update(
+                profile,
+                "acp turn-end unread",
+                state.file_watch.clone(),
+                move |instances| {
+                    if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
+                        inst.mark_unread();
+                    }
+                },
+            )
+            .await;
+            if persisted.is_ok() {
+                let mut instances = state.instances.write().await;
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == frame.session_id) {
+                    inst.mark_unread();
+                }
+            }
+        }
 
         // Persist `acp_session_id` to disk if the field changed.
         // Sync FS (file copy + JSON write) goes through spawn_blocking
@@ -5791,6 +5866,32 @@ pub(crate) fn apply_status_intent(
         new: target,
         at: now,
     });
+}
+
+/// Whether a structured row whose ACP status just moved should take the
+/// automatic unread mark, i.e. whether its turn just finished.
+///
+/// `inst` is the row *after* [`apply_status_intent`] ran and `old_status` is
+/// the snapshot taken before it. The predicate is deliberately byte-identical
+/// to the one in [`decide_passive_transition`] and in the TUI's
+/// `apply_status_update`, so "a turn just finished" means the same thing on
+/// every surface.
+///
+/// `Running -> Idle` is the whole edge. An approval or elicitation excursion
+/// comes back through `Set(Running)` (`ApprovalResolved` /
+/// `ElicitationResolved`) before the turn's `Stopped`, so an answered-then-
+/// completed turn still ends on this edge and needs no case of its own. A
+/// direct `Waiting -> Idle` means the turn stopped while still blocked on the
+/// user, who is by construction present for it. Every `Stopped` reason maps to
+/// `Idle`, so a rate-limit park marks unread too; that is the same policy
+/// terminal sessions get, and a parked session does want attention.
+#[cfg(feature = "serve")]
+fn should_mark_acp_unread(inst: &Instance, old_status: Status, unread_enabled: bool) -> bool {
+    unread_enabled
+        && inst.is_structured()
+        && old_status == Status::Running
+        && inst.status == Status::Idle
+        && !inst.unread
 }
 
 /// Fold a derived `AcpSessionChange` into an `Instance`. Returns the
@@ -7888,6 +7989,127 @@ mod tests {
             !decision.mark_unread,
             "already-unread sessions must not re-mark"
         );
+
+        // #3181: a structured row's turn-end mark belongs to the live ACP
+        // listener (`should_mark_acp_unread`), so the poll loop must not also
+        // produce it. Paired with
+        // `tick_reports_no_transition_for_a_structured_phantom` above, which
+        // covers the other half: the tick never even reports such a row, so a
+        // read structured session cannot be re-marked seconds after the user
+        // read it (the #3162 defect).
+        let mut structured = Instance::new("acp-session", "/tmp/test");
+        structured.view = crate::session::View::Structured;
+        structured.status = Status::Idle;
+        let decision = decide_passive_transition(&structured, Status::Running, true);
+        assert!(
+            !decision.mark_unread,
+            "structured turn-end unread is owned by the acp event listener"
+        );
+    }
+
+    /// #3181: the automatic mark's predicate for a structured row, driven off
+    /// the live ACP turn-end event. One table rather than a test per case, per
+    /// the repo's compile-cost rule.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn should_mark_acp_unread_only_on_a_structured_running_to_idle_turn_end() {
+        // (name, structured, old_status, new_status, unread_enabled, already_unread, expected)
+        let cases = [
+            (
+                "turn finished",
+                true,
+                Status::Running,
+                Status::Idle,
+                true,
+                false,
+                true,
+            ),
+            // The turn stopped while still blocked on the user, who is by
+            // construction present for it; an answered approval comes back
+            // through Running first, so this is not the answered-then-completed
+            // path.
+            (
+                "still blocked on the user",
+                true,
+                Status::Waiting,
+                Status::Idle,
+                true,
+                false,
+                false,
+            ),
+            (
+                "crashed, not finished",
+                true,
+                Status::Running,
+                Status::Error,
+                true,
+                false,
+                false,
+            ),
+            (
+                "turn starting",
+                true,
+                Status::Idle,
+                Status::Running,
+                true,
+                false,
+                false,
+            ),
+            (
+                "no transition applied",
+                true,
+                Status::Running,
+                Status::Running,
+                true,
+                false,
+                false,
+            ),
+            (
+                "feature off",
+                true,
+                Status::Running,
+                Status::Idle,
+                false,
+                false,
+                false,
+            ),
+            // Re-marking would churn the flock once per turn, and would undo a
+            // read the user has not been given a new turn to earn.
+            (
+                "already unread",
+                true,
+                Status::Running,
+                Status::Idle,
+                true,
+                true,
+                false,
+            ),
+            // Terminal rows stay with the tmux poll loop's
+            // `decide_passive_transition`.
+            (
+                "terminal row, owned elsewhere",
+                false,
+                Status::Running,
+                Status::Idle,
+                true,
+                false,
+                false,
+            ),
+        ];
+        for (name, structured, old, new, enabled, already_unread, expected) in cases {
+            let mut inst = Instance::new(name, "/tmp/test");
+            if structured {
+                inst.view = crate::session::View::Structured;
+            }
+            // The helper reads the row *after* `apply_status_intent` ran.
+            inst.status = new;
+            inst.unread = already_unread;
+            assert_eq!(
+                should_mark_acp_unread(&inst, old, enabled),
+                expected,
+                "{name}"
+            );
+        }
     }
 
     // #2755 (follow-up to #2729): the poller must not strand an in-memory

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -595,17 +595,7 @@ impl AppState {
     /// `RwLock` is only held long enough to insert/lookup the `Arc<Mutex>`;
     /// the caller awaits the inner mutex without holding the map lock.
     pub async fn instance_lock(&self, id: &str) -> Arc<tokio::sync::Mutex<()>> {
-        {
-            let guard = self.instance_locks.read().await;
-            if let Some(lock) = guard.get(id) {
-                return lock.clone();
-            }
-        }
-        let mut guard = self.instance_locks.write().await;
-        guard
-            .entry(id.to_string())
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone()
+        instance_lock_in(&self.instance_locks, id).await
     }
 
     /// Get or create the per-idempotency-key serialization mutex. Same
@@ -5343,12 +5333,34 @@ async fn acp_event_listener(state: Arc<AppState>) {
             // reconcile on the next event; a missed acp_session_id
             // means at most one restart loses context. Far better to
             // continue than to exit the listener entirely.
+            //
+            // The unread mark does NOT self-heal like status does: it is
+            // edge-triggered on `Running -> Idle`, so a dropped `Stopped` would
+            // lose it for good and no later event would reproduce it. The
+            // events are durable, recorded before broadcast, so replay the
+            // structured rows from the event log before continuing.
             Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
                 tracing::warn!(
                     target: "acp.event_listener",
                     skipped,
                     "broadcast lagged; status and acp_session_id may briefly desync"
                 );
+                let recovered = recover_structured_unread_after_lag(
+                    &state.instances,
+                    &state.acp_event_store,
+                    &state.instance_locks,
+                    state.file_watch.clone(),
+                    &state.status_tx,
+                )
+                .await;
+                if recovered > 0 {
+                    tracing::info!(
+                        target: "acp.event_listener",
+                        skipped,
+                        recovered,
+                        "replayed turn-end unread marks missed by the lagged frames"
+                    );
+                }
                 continue;
             }
             // Closed: AppState dropped (shutdown). Exit cleanly.
@@ -5680,33 +5692,18 @@ async fn acp_event_listener(state: Arc<AppState>) {
         // identity change and a turn-end can never arrive on the same event and
         // there is no atomicity to win.
         //
-        // No per-instance lock. A concurrent `PATCH /api/sessions/:id/unread`
-        // clear cannot be lost to this write: `should_mark_acp_unread` requires
-        // the row to be read at decision time, and until the mirror below runs
-        // it still reads as read everywhere, so the reactive clears (the
-        // dashboard's active-session effect, the TUI's unread dwell) cannot have
-        // fired yet. A clear racing this window is therefore a no-op on an
-        // already-read row, and marking after it is the chronologically correct
-        // outcome: the turn did finish afterwards.
+        // `persist_and_mirror_unread` owns the lock and commit-check ordering;
+        // see its docstring for why both are load-bearing.
         if let Some(profile) = unread_profile {
-            let persist_id = frame.session_id.clone();
-            let persisted = api::persist_session_update(
-                profile,
-                "acp turn-end unread",
+            let lock = state.instance_lock(&frame.session_id).await;
+            persist_and_mirror_unread(
+                &state.instances,
+                &lock,
                 state.file_watch.clone(),
-                move |instances| {
-                    if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
-                        inst.mark_unread();
-                    }
-                },
+                &frame.session_id,
+                profile,
             )
             .await;
-            if persisted.is_ok() {
-                let mut instances = state.instances.write().await;
-                if let Some(inst) = instances.iter_mut().find(|i| i.id == frame.session_id) {
-                    inst.mark_unread();
-                }
-            }
         }
 
         // Persist `acp_session_id` to disk if the field changed.
@@ -5868,6 +5865,27 @@ pub(crate) fn apply_status_intent(
     });
 }
 
+/// Get or create the per-instance serialization mutex in `locks`. Free function
+/// rather than only an [`AppState`] method so the ACP turn-end unread writers
+/// can take the *same* lock a REST handler takes without needing an `AppState`
+/// (which has no test constructor). See [`AppState::instance_lock`].
+async fn instance_lock_in(
+    locks: &RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    id: &str,
+) -> Arc<tokio::sync::Mutex<()>> {
+    {
+        let guard = locks.read().await;
+        if let Some(lock) = guard.get(id) {
+            return lock.clone();
+        }
+    }
+    let mut guard = locks.write().await;
+    guard
+        .entry(id.to_string())
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+}
+
 /// Whether a structured row whose ACP status just moved should take the
 /// automatic unread mark, i.e. whether its turn just finished.
 ///
@@ -5892,6 +5910,149 @@ fn should_mark_acp_unread(inst: &Instance, old_status: Status, unread_enabled: b
         && old_status == Status::Running
         && inst.status == Status::Idle
         && !inst.unread
+}
+
+/// Write the automatic unread mark for `id` to its profile store, then mirror it
+/// into daemon memory. Returns whether the mark actually landed.
+///
+/// Takes primitives rather than [`AppState`] so it is reachable from tests
+/// (`AppState` has no test constructor).
+///
+/// Ordering rules, both of which cost correctness if dropped:
+///
+/// 1. **Under `instance_lock`.** The same mutex `PATCH /api/sessions/:id/unread`
+///    takes, held across both the write and the mirror. Without it a clear can
+///    land between them and leave disk read while memory says unread, and the
+///    user's explicit mark-read loses to a mark it happened after. Holding it
+///    makes the two orderings the only ones possible, and both are correct: a
+///    clear before this marks (the turn genuinely finished afterwards), a clear
+///    after this wins (the user read it afterwards).
+/// 2. **Only mirror a committed mutation.** `persist_session_update` reports
+///    `Ok` for a write whose closure matched no row, so `profile` going stale
+///    (a concurrent profile move) would otherwise mark memory off a successful
+///    no-op on the *old* profile, and the next reload would drop the
+///    notification. The flag reports whether the owning row was really mutated.
+///
+/// A stale-profile write is not retried. The row is left read rather than
+/// half-marked, the turn's mark is simply lost, and the move is rare enough that
+/// a re-resolve loop is not worth the added failure surface here.
+#[cfg(feature = "serve")]
+async fn persist_and_mirror_unread(
+    instances: &RwLock<Vec<Instance>>,
+    instance_lock: &tokio::sync::Mutex<()>,
+    file_watch: Arc<crate::file_watch::FileWatchService>,
+    id: &str,
+    profile: String,
+) -> bool {
+    let _guard = instance_lock.lock().await;
+    let marked = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let marked_in_closure = marked.clone();
+    let persist_id = id.to_string();
+    let persisted = api::persist_session_update(
+        profile.clone(),
+        "acp turn-end unread",
+        file_watch,
+        move |instances| {
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
+                inst.mark_unread();
+                marked_in_closure.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        },
+    )
+    .await;
+    if persisted.is_err() {
+        return false;
+    }
+    if !marked.load(std::sync::atomic::Ordering::SeqCst) {
+        tracing::debug!(
+            target: "acp.event_listener",
+            session = %id,
+            profile = %profile,
+            "turn-end unread write found no row in that profile store (moved?); \
+             not mirroring so memory cannot disagree with disk"
+        );
+        return false;
+    }
+    let mut instances = instances.write().await;
+    if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+        inst.mark_unread();
+    }
+    true
+}
+
+/// Re-derive every structured row's status from the durable event log after the
+/// ACP broadcast dropped frames, marking any row whose turn ended while we were
+/// not listening. Returns the number of rows marked.
+///
+/// `acp_events_tx` is a `broadcast` of [`ACP_CHANNEL_CAPACITY`], and a lagged
+/// receiver is told only *how many* frames it missed, never which. Status
+/// tolerated that because it is level-triggered: any later event re-derives the
+/// right value. The unread mark is edge-triggered, so a dropped `Stopped` loses
+/// it permanently, and nothing else would ever produce it.
+///
+/// The events themselves are durable (recorded before broadcast), so the log is
+/// the recovery source. `latest_seed_status_event` is the same query
+/// `seed_acp_statuses` uses at boot, and for the same reason: it returns the
+/// most recent *lifecycle* event, which is exactly the frame whose loss matters.
+///
+/// This deliberately does NOT reuse `seed_acp_statuses`, despite the shared
+/// shape, because the two differ on both points that matter:
+///
+/// - **Boot must not mark.** Its replay re-reads history, so a `Stopped` from
+///   before the restart would re-mark a row the user has already read, on every
+///   restart. Here a `Stopped` under a still-`Running` memory status is evidence
+///   of a turn that ended during this daemon's life and was missed.
+/// - **Boot lifts a stale `Stopped`**, because a persisted `Stopped` from a
+///   daemon that died mid-turn would otherwise trap the dot grey. Mid-run a
+///   `Stopped` in memory is a deliberate stop, so `apply_status_intent`'s guard
+///   should keep it.
+#[cfg(feature = "serve")]
+async fn recover_structured_unread_after_lag(
+    instances: &RwLock<Vec<Instance>>,
+    event_store: &crate::acp::event_store::EventStore,
+    instance_locks: &RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    file_watch: Arc<crate::file_watch::FileWatchService>,
+    status_tx: &broadcast::Sender<StatusChange>,
+) -> usize {
+    let ids: Vec<String> = instances
+        .read()
+        .await
+        .iter()
+        .filter(|i| i.is_structured())
+        .map(|i| i.id.clone())
+        .collect();
+    let unread_enabled = crate::session::unread_enabled();
+    let mut marked = 0usize;
+    for id in ids {
+        let Some(event) = event_store.latest_seed_status_event(&id) else {
+            continue;
+        };
+        let Some(intent) = derive_acp_status(&event) else {
+            continue;
+        };
+        // Same snapshot-around-apply as the live path, so "the transition that
+        // was actually applied" means the same thing in both.
+        let unread_profile = {
+            let mut guard = instances.write().await;
+            let Some(inst) = guard.iter_mut().find(|i| i.id == id) else {
+                continue;
+            };
+            if !inst.is_structured() {
+                continue;
+            }
+            let old_status = inst.status;
+            apply_status_intent(inst, Some(intent), status_tx);
+            should_mark_acp_unread(inst, old_status, unread_enabled)
+                .then(|| inst.source_profile.clone())
+        };
+        if let Some(profile) = unread_profile {
+            let lock = instance_lock_in(instance_locks, &id).await;
+            if persist_and_mirror_unread(instances, &lock, file_watch.clone(), &id, profile).await {
+                marked += 1;
+            }
+        }
+    }
+    marked
 }
 
 /// Fold a derived `AcpSessionChange` into an `Instance`. Returns the
@@ -8110,6 +8271,251 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    /// Seed `profile`'s store with `rows`, so a persist closure has a matching
+    /// id to mark. Mirrors the shape used by the `flush_passive_transition_*`
+    /// tests above.
+    #[cfg(feature = "serve")]
+    fn seed_profile_store(profile: &str, rows: Vec<Instance>) {
+        crate::session::Storage::new_unwatched(profile)
+            .expect("storage")
+            .update(move |instances, _groups| {
+                *instances = rows;
+                Ok(())
+            })
+            .expect("seed write");
+    }
+
+    #[cfg(feature = "serve")]
+    fn load_profile_row(profile: &str, id: &str) -> Option<Instance> {
+        crate::session::Storage::new_unwatched(profile)
+            .expect("storage")
+            .load()
+            .expect("load")
+            .into_iter()
+            .find(|i| i.id == id)
+    }
+
+    /// The commit-check half of `persist_and_mirror_unread`: memory is mirrored
+    /// only when the write actually mutated the owning row.
+    ///
+    /// The second call is the profile-move case a reviewer raised on #3530.
+    /// `persist_session_update` reports `Ok` for a write whose closure matched
+    /// nothing, so mirroring on `is_ok()` alone would mark memory off a
+    /// successful no-op against a profile the row no longer lives in, and the
+    /// next disk reload would silently drop the notification.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn persist_and_mirror_unread_mirrors_only_a_committed_mutation() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialized test; no other test mutates HOME concurrently.
+        unsafe { std::env::set_var("HOME", temp.path()) };
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+
+        let owning = "acp-unread-owner";
+        let mut inst = Instance::new("acp-session", "/tmp/acp");
+        inst.view = crate::session::View::Structured;
+        inst.source_profile = owning.to_string();
+        let id = inst.id.clone();
+        seed_profile_store(owning, vec![inst.clone()]);
+        // The profile the row is *not* in. Created empty, so the write there
+        // succeeds while matching nothing.
+        seed_profile_store("acp-unread-stale", Vec::new());
+
+        let instances = RwLock::new(vec![inst]);
+        let lock = tokio::sync::Mutex::new(());
+
+        // Stale profile: write succeeds, matches no row, so nothing is mirrored.
+        let landed = persist_and_mirror_unread(
+            &instances,
+            &lock,
+            crate::file_watch::FileWatchService::noop(),
+            &id,
+            "acp-unread-stale".to_string(),
+        )
+        .await;
+        assert!(!landed, "a no-op write must not report the mark as landed");
+        assert!(
+            !instances.read().await[0].unread,
+            "memory must not be marked off a write that matched no row"
+        );
+        assert!(
+            !load_profile_row(owning, &id).expect("row").unread,
+            "the owning profile's row must be untouched by a stale-profile write"
+        );
+
+        // Owning profile: the mark lands on disk first, then in memory.
+        let landed = persist_and_mirror_unread(
+            &instances,
+            &lock,
+            crate::file_watch::FileWatchService::noop(),
+            &id,
+            owning.to_string(),
+        )
+        .await;
+        assert!(landed);
+        assert!(
+            load_profile_row(owning, &id).expect("row").unread,
+            "the mark must be durable"
+        );
+        assert!(
+            instances.read().await[0].unread,
+            "memory must mirror the committed mark"
+        );
+    }
+
+    /// A failed write must not strand a memory-only mark, the #2755 rule that
+    /// `flush_passive_transition_defers_unread_until_persist_ok` locks for the
+    /// tmux poller. Separate test rather than a row in the one above because it
+    /// needs the store deliberately broken.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn persist_and_mirror_unread_skips_the_mirror_on_a_failed_write() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialized test; no other test mutates HOME concurrently.
+        unsafe { std::env::set_var("HOME", temp.path()) };
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+
+        let profile = "acp-unread-write-failure";
+        // Making `sessions.json` a directory makes the read-modify-write fail.
+        let dir = crate::session::get_profile_dir(profile).expect("profile dir");
+        std::fs::create_dir_all(dir.join("sessions.json")).expect("sessions.json dir");
+
+        let mut inst = Instance::new("acp-session", "/tmp/acp");
+        inst.view = crate::session::View::Structured;
+        inst.source_profile = profile.to_string();
+        let id = inst.id.clone();
+        let instances = RwLock::new(vec![inst]);
+        let lock = tokio::sync::Mutex::new(());
+
+        let landed = persist_and_mirror_unread(
+            &instances,
+            &lock,
+            crate::file_watch::FileWatchService::noop(),
+            &id,
+            profile.to_string(),
+        )
+        .await;
+
+        assert!(!landed);
+        assert!(
+            !instances.read().await[0].unread,
+            "a failed persist must not leave a phantom in-memory unread mark"
+        );
+    }
+
+    /// Lag replay, the other finding on #3530: the ACP broadcast tells a lagged
+    /// receiver only how many frames it missed, never which, so a dropped
+    /// `Stopped` would lose the turn-end mark permanently (unlike status, which
+    /// is level-triggered and re-derives from any later event). The events are
+    /// durable, so recovery reads the log.
+    ///
+    /// Three rows in one pass, all with a durable `Stopped` as their latest
+    /// lifecycle event, so the discriminator is the row rather than the event:
+    /// only the structured row still sitting at `Running` represents a turn that
+    /// ended unobserved.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn recover_structured_unread_after_lag_marks_only_a_missed_turn_end() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialized test; no other test mutates HOME concurrently.
+        unsafe { std::env::set_var("HOME", temp.path()) };
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+        crate::session::set_unread_enabled(true);
+
+        let profile = "acp-unread-lag-replay";
+
+        // The turn ended while the listener was lagged: memory still says
+        // Running, the log already has the Stopped we never saw.
+        let mut missed = Instance::new("acp-missed", "/tmp/acp");
+        missed.view = crate::session::View::Structured;
+        missed.source_profile = profile.to_string();
+        missed.status = Status::Running;
+
+        // Already reconciled: the Stopped was observed, so there is no
+        // transition left to apply and no second mark to make.
+        let mut already = Instance::new("acp-already-idle", "/tmp/acp");
+        already.view = crate::session::View::Structured;
+        already.source_profile = profile.to_string();
+        already.status = Status::Idle;
+
+        // A terminal row is not this producer's to touch at all.
+        let mut terminal = Instance::new("tmux-row", "/tmp/tmux");
+        terminal.source_profile = profile.to_string();
+        terminal.status = Status::Running;
+
+        let (missed_id, already_id, terminal_id) =
+            (missed.id.clone(), already.id.clone(), terminal.id.clone());
+        let rows = vec![missed.clone(), already.clone(), terminal.clone()];
+        seed_profile_store(profile, rows.clone());
+
+        let db = temp.path().join("acp-events.db");
+        let store = crate::acp::event_store::EventStore::open(&db, 1000).expect("event store");
+        for id in [&missed_id, &already_id, &terminal_id] {
+            store
+                .record(
+                    id,
+                    1,
+                    &crate::acp::Event::Stopped {
+                        reason: "prompt_complete".into(),
+                    },
+                )
+                .expect("record stopped");
+        }
+
+        let instances = RwLock::new(rows);
+        let locks = RwLock::new(std::collections::HashMap::new());
+        let (status_tx, _rx) = broadcast::channel(16);
+
+        let marked = recover_structured_unread_after_lag(
+            &instances,
+            &store,
+            &locks,
+            crate::file_watch::FileWatchService::noop(),
+            &status_tx,
+        )
+        .await;
+
+        assert_eq!(marked, 1, "only the missed turn-end is a fresh mark");
+
+        let guard = instances.read().await;
+        let row = |id: &str| guard.iter().find(|i| i.id == id).expect("row").clone();
+
+        let missed = row(&missed_id);
+        assert_eq!(
+            missed.status,
+            Status::Idle,
+            "replay applies the missed Stopped"
+        );
+        assert!(missed.unread, "and marks the turn that ended unobserved");
+        assert!(
+            load_profile_row(profile, &missed_id).expect("row").unread,
+            "the replayed mark must be durable, not memory-only"
+        );
+
+        assert!(
+            !row(&already_id).unread,
+            "an already-reconciled row has no transition left, so no second mark"
+        );
+        assert_eq!(
+            row(&terminal_id).status,
+            Status::Running,
+            "a terminal row is left entirely to the tmux poller"
+        );
+        assert!(!row(&terminal_id).unread);
     }
 
     // #2755 (follow-up to #2729): the poller must not strand an in-memory

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8518,6 +8518,98 @@ mod tests {
         assert!(!row(&terminal_id).unread);
     }
 
+    /// End to end over `acp_event_listener` itself, the path that actually
+    /// closes #3181. The predicate table and the TUI ownership tests all pass
+    /// even if the snapshot is taken *after* `apply_status_intent`, the persist
+    /// is dropped, or the mirror is reordered, because none of them run the
+    /// listener. This one drives a real `Event::Stopped` frame through the
+    /// broadcast and asserts both halves of the write.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn acp_event_listener_marks_a_finished_turn_unread_on_disk_and_in_memory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialized test; no other test mutates HOME concurrently.
+        unsafe { std::env::set_var("HOME", temp.path()) };
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+        crate::session::set_unread_enabled(true);
+
+        let profile = "acp-listener-turn-end";
+        let mut inst = Instance::new("acp-session", "/tmp/acp");
+        inst.view = crate::session::View::Structured;
+        inst.source_profile = profile.to_string();
+        // Mid-turn, so the incoming Stopped is a real Running -> Idle edge.
+        inst.status = Status::Running;
+        let id = inst.id.clone();
+        seed_profile_store(profile, vec![inst.clone()]);
+
+        let state = test_support::build_test_app_state(vec![inst]);
+        let listener = tokio::spawn(acp_event_listener(state.clone()));
+
+        // A broadcast only reaches receivers that subscribed before the send,
+        // and the spawned listener subscribes as its first act. Wait for that
+        // rather than racing it; nothing else in this test subscribes, so the
+        // count reaching 1 is precisely "the listener is listening".
+        for _ in 0..500 {
+            if state.acp_events_tx.receiver_count() > 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        assert!(
+            state.acp_events_tx.receiver_count() > 0,
+            "listener never subscribed"
+        );
+
+        // The turn ends.
+        state
+            .acp_events_tx
+            .send(AcpBroadcastFrame {
+                session_id: id.clone(),
+                seq: 1,
+                event: Arc::new(crate::acp::Event::Stopped {
+                    reason: "prompt_complete".into(),
+                }),
+            })
+            .expect("listener is subscribed");
+
+        // The listener owns the write, so poll rather than sleeping a fixed
+        // interval: the persist is a real flock'd file write. Wait on the
+        // *mirror*, which is the last step, so this cannot abort the listener
+        // in between the disk write and the mirror and then blame the mirror.
+        let mut mirrored = false;
+        for _ in 0..500 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            if state
+                .instances
+                .read()
+                .await
+                .iter()
+                .any(|i| i.id == id && i.unread)
+            {
+                mirrored = true;
+                break;
+            }
+        }
+        listener.abort();
+
+        assert!(
+            mirrored,
+            "daemon memory must mirror the mark, so /api/sessions reports it"
+        );
+        assert!(
+            load_profile_row(profile, &id).is_some_and(|i| i.unread),
+            "and the mark must be durable, which is the #3181 fix; a memory-only \
+             mark is dropped by the next reload"
+        );
+        let instances = state.instances.read().await;
+        let row = instances.iter().find(|i| i.id == id).expect("row present");
+        assert_eq!(row.status, Status::Idle, "the Stopped applied");
+    }
+
     // #2755 (follow-up to #2729): the poller must not strand an in-memory
     // unread mark on a persist that never landed. `flush_passive_transition_writes`
     // applies the mark to the live vec only after `persist_session_update`

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3310,13 +3310,16 @@ impl HomeView {
                     // marks them off the live ACP turn-end event and persists it
                     // there (#3181). Marking here too would be a second writer of
                     // the same boolean for no gain, and `is_live_target` cannot
-                    // even earn its keep on one: live-send needs a tmux pane
-                    // (`LiveSendState.tmux_name`) and a structured row has none,
-                    // so the exemption is always inert for them. What clears the
-                    // mark for a structured row the user is actually reading is
-                    // `tick_unread_dwell`, which re-checks `is_unread()` every
-                    // tick and so picks up a daemon-written mark on the row under
-                    // the cursor.
+                    // even earn its keep on one: `start_live_send` returns `None`
+                    // outright for `is_structured()` (`home/input.rs`, matched by
+                    // the guard in `app.rs`), so the exemption is always inert for
+                    // them. Note it is that explicit guard which makes it inert,
+                    // not the absence of a pane: a structured row can own paired
+                    // terminal and tool panes, so `LiveSendTarget` alone would not
+                    // rule live-send out. What clears the mark for a structured
+                    // row the user is actually reading is `tick_unread_dwell`,
+                    // which re-checks `is_unread()` every tick and so picks up a
+                    // daemon-written mark on the row under the cursor.
                     let should_mark_unread = crate::session::unread_enabled()
                         && !structured
                         && old == Status::Running

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3129,13 +3129,13 @@ impl HomeView {
     }
 
     /// Fold one daemon-sourced structured status into the shared apply path,
-    /// so sounds, status hooks, and unread marking behave exactly as they do
-    /// for a tmux-derived transition. The `sessions.json` status patch is the
-    /// one deliberate exception: this path only handles structured rows, and
-    /// `persist_passive_status_transition` skips the passive status patch for
-    /// `is_structured()` (only the unread mark persists there), since a
-    /// structured row's status is a daemon-side overlay with no durable owner.
-    /// See #3201.
+    /// so sounds and status hooks fire exactly as they do for a tmux-derived
+    /// transition. Persistence is the deliberate exception: this path only
+    /// handles structured rows, and nothing about one is the TUI's to write, so
+    /// `persist_passive_status_transition` returns early for `is_structured()`.
+    /// The status is a daemon-side overlay with no durable owner (#3201), and
+    /// the automatic unread mark is the daemon's too, written from the live ACP
+    /// turn-end event (#3181).
     ///
     /// The row is re-checked against `is_structured()` here rather than
     /// trusted from the wire: the daemon's `view` and the local row's could
@@ -3302,9 +3302,23 @@ impl HomeView {
                     // Skip when already unread (the mark is a no-op) so a
                     // re-finishing session doesn't churn the flock once
                     // per turn.
-                    let already_unread =
-                        self.get_instance(&update.id).is_some_and(|i| i.is_unread());
+                    let (already_unread, structured) = self
+                        .get_instance(&update.id)
+                        .map(|i| (i.is_unread(), i.is_structured()))
+                        .unwrap_or((false, false));
+                    // Structured rows are the daemon's: `should_mark_acp_unread`
+                    // marks them off the live ACP turn-end event and persists it
+                    // there (#3181). Marking here too would be a second writer of
+                    // the same boolean for no gain, and `is_live_target` cannot
+                    // even earn its keep on one: live-send needs a tmux pane
+                    // (`LiveSendState.tmux_name`) and a structured row has none,
+                    // so the exemption is always inert for them. What clears the
+                    // mark for a structured row the user is actually reading is
+                    // `tick_unread_dwell`, which re-checks `is_unread()` every
+                    // tick and so picks up a daemon-written mark on the row under
+                    // the cursor.
                     let should_mark_unread = crate::session::unread_enabled()
+                        && !structured
                         && old == Status::Running
                         && new_status == Status::Idle
                         && !is_live_target
@@ -6847,7 +6861,8 @@ impl HomeView {
     /// `mark_unread` folds the Running -> Idle unread mark into the same
     /// `Storage::update` call instead of a second flock round-trip on the
     /// same row in the same tick, matching the daemon's per-tick batching
-    /// shape in `status_poll_loop`.
+    /// shape in `status_poll_loop`. Terminal rows only; see the
+    /// `is_structured()` return below.
     pub(super) fn persist_passive_status_transition(&self, id: &str, mark_unread: bool) {
         let Some(inst) = self.instances.get(id) else {
             return;
@@ -6855,32 +6870,31 @@ impl HomeView {
         let Some(storage) = self.storages.get(&inst.source_profile) else {
             return;
         };
-        // Structured rows are not durable: their status is a daemon-side
-        // overlay rebuilt from live worker state (`apply_acp_overlay_inplace`)
-        // and re-derived at daemon boot by `seed_acp_statuses`. The daemon's
-        // own passive writer gates the status patch on exactly this predicate
+        // A structured row has nothing for the TUI to persist, so bail before
+        // taking the flock at all.
+        //
+        // Its status is not durable: that is a daemon-side overlay rebuilt from
+        // live worker state (`apply_acp_overlay_inplace`) and re-derived at
+        // daemon boot by `seed_acp_statuses`, and the daemon's own passive
+        // writer gates the patch on exactly this predicate
         // (`decide_passive_transition` returns `patch: None` for
-        // `is_structured()`, `server/mod.rs`). Persisting it here would strand
-        // a row at `Running` or `Error` with no producer left to heal it once
-        // the daemon is gone, since the tmux poller now bails on structured
-        // rows (`status_poller.rs`); this is the #3201 regression from #3170.
-        // The unread mark is deliberately NOT gated: the daemon marks a
-        // structured row unread on a Running -> Idle turn (its `mark_unread` is
-        // not gated on `is_structured`), so mirroring it here keeps the two
-        // producers symmetric.
-        let structured = inst.is_structured();
-        // Pure optimization, not a correctness gate: a structured row with
-        // nothing to mark unread has no patch and no unread write, so skip the
-        // empty-write flock round-trip entirely.
-        if structured && !mark_unread {
+        // `is_structured()`, `server/mod.rs`). Persisting it here would strand a
+        // row at `Running` or `Error` with no producer left to heal it once the
+        // daemon is gone, since the tmux poller now bails on structured rows
+        // (`status_poller.rs`); this is the #3201 regression from #3170.
+        //
+        // Its unread mark is not ours either, as of #3181: the daemon writes it
+        // from the live ACP turn-end event (`should_mark_acp_unread`), and the
+        // caller's predicate is gated on `!structured` to match. So `mark_unread`
+        // is only ever `false` here for a structured row and this return is
+        // total, not an optimization.
+        if inst.is_structured() {
             return;
         }
-        let patch = (!structured).then(|| crate::session::PassiveStatusPatch::from_instance(inst));
+        let patch = crate::session::PassiveStatusPatch::from_instance(inst);
         if let Err(e) = storage.update(|insts, _groups| {
             if let Some(disk) = insts.iter_mut().find(|i| i.id == id) {
-                if let Some(patch) = &patch {
-                    disk.merge_passive_status_patch(id, patch);
-                }
+                disk.merge_passive_status_patch(id, &patch);
                 if mark_unread {
                     disk.mark_unread();
                 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -20130,32 +20130,13 @@ mod daemon_status_apply_tests {
         );
     }
 
-    /// A structured row's turn-end is the daemon's to record, both halves of
-    /// it, so the TUI writes neither field.
+    /// A structured row's turn-end is the daemon's to record, both halves of it,
+    /// so the TUI writes neither field: the status is a daemon-side overlay with
+    /// no durable owner (#3201), and the unread mark is written durably by the
+    /// live ACP turn-end path (`should_mark_acp_unread`, #3181).
     ///
-    /// The status half is #3201: it is a daemon-side overlay with no durable
-    /// owner, and persisting it here strands a row at `Running` with nothing
-    /// left to heal it once the daemon is gone.
-    ///
-    /// The unread half is #3181. This test previously asserted the opposite,
-    /// on the rationale that `decide_passive_transition`'s `mark_unread` was
-    /// ungated so the daemon persisted the mark too and the TUI was merely
-    /// mirroring it. That rationale was already false when it was written:
-    /// since #3162 a structured row compares equal to `prev`, so
-    /// `observed_transitions` never reports one and the poll loop never
-    /// reached that predicate. The TUI was the only writer, which is why the
-    /// mark was missing for anyone not running a TUI home view. The daemon now
-    /// writes it durably from the live ACP turn-end event
-    /// (`should_mark_acp_unread`), so mirroring here would make the TUI a
-    /// second writer of one boolean.
-    ///
-    /// The restart-stranding fear the old rationale named is handled, and by
-    /// the correct owner: `apply_daemon_status_update` is fed only by
-    /// `DaemonStatusPoller`, so reaching this code at all proves a daemon is
-    /// live, and that same daemon produced this `Running -> Idle` reading and
-    /// persisted the mark alongside it. The TUI picks the mark up from disk on
-    /// its next reload; `merge_from_tui` has no `unread` arm, so its own saves
-    /// cannot clobber it.
+    /// The mark still reaches this row, from disk on the next reload;
+    /// `merge_from_tui` has no `unread` arm, so a TUI save cannot clobber it.
     #[test]
     #[serial]
     fn tui_persists_neither_status_nor_unread_for_a_structured_turn_end() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -19927,6 +19927,30 @@ mod daemon_status_apply_tests {
 
     #[test]
     #[serial]
+    fn daemon_status_does_not_mark_a_structured_turn_end_unread() {
+        // #3181: the daemon writes that mark itself, durably, from the live ACP
+        // turn-end event (`should_mark_acp_unread`). Marking here as well would
+        // make the TUI a second writer of the same boolean, and the exemption
+        // that would have justified keeping it (`!is_live_target`) is inert on a
+        // structured row anyway, since live-send needs a tmux pane. The row
+        // still picks the mark up: it arrives through the daemon's disk write.
+        crate::session::set_unread_enabled(true);
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Running);
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Idle));
+
+        let inst = env.view.get_instance(&id).expect("row still present");
+        assert_eq!(inst.status, Status::Idle, "the turn-end still applies");
+        assert!(
+            !inst.is_unread(),
+            "the structured turn-end mark is the daemon's to write"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn daemon_status_ignores_a_terminal_row() {
         // The tmux poller owns terminal rows. Letting the daemon's copy through
         // would give them two producers fighting on alternating cycles.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -19927,30 +19927,6 @@ mod daemon_status_apply_tests {
 
     #[test]
     #[serial]
-    fn daemon_status_does_not_mark_a_structured_turn_end_unread() {
-        // #3181: the daemon writes that mark itself, durably, from the live ACP
-        // turn-end event (`should_mark_acp_unread`). Marking here as well would
-        // make the TUI a second writer of the same boolean, and the exemption
-        // that would have justified keeping it (`!is_live_target`) is inert on a
-        // structured row anyway, since live-send needs a tmux pane. The row
-        // still picks the mark up: it arrives through the daemon's disk write.
-        crate::session::set_unread_enabled(true);
-        let mut env = create_test_env_empty();
-        let id = structured_row(&mut env, Status::Running);
-
-        env.view
-            .apply_daemon_status_update(update(&id, Status::Idle));
-
-        let inst = env.view.get_instance(&id).expect("row still present");
-        assert_eq!(inst.status, Status::Idle, "the turn-end still applies");
-        assert!(
-            !inst.is_unread(),
-            "the structured turn-end mark is the daemon's to write"
-        );
-    }
-
-    #[test]
-    #[serial]
     fn daemon_status_ignores_a_terminal_row() {
         // The tmux poller owns terminal rows. Letting the daemon's copy through
         // would give them two producers fighting on alternating cycles.
@@ -20154,16 +20130,35 @@ mod daemon_status_apply_tests {
         );
     }
 
-    /// #3201, the deliberately-ungated half: the status patch is skipped
-    /// for a structured row, but the unread mark still lands, mirroring the
-    /// daemon (`decide_passive_transition` gates only `patch` on
-    /// `is_structured()`; its `mark_unread` is ungated and
-    /// `flush_passive_transition_writes` persists it). A future refactor that
-    /// gates unread the same way it gates status would strand structured rows
-    /// as read across a restart; this locks against it.
+    /// A structured row's turn-end is the daemon's to record, both halves of
+    /// it, so the TUI writes neither field.
+    ///
+    /// The status half is #3201: it is a daemon-side overlay with no durable
+    /// owner, and persisting it here strands a row at `Running` with nothing
+    /// left to heal it once the daemon is gone.
+    ///
+    /// The unread half is #3181. This test previously asserted the opposite,
+    /// on the rationale that `decide_passive_transition`'s `mark_unread` was
+    /// ungated so the daemon persisted the mark too and the TUI was merely
+    /// mirroring it. That rationale was already false when it was written:
+    /// since #3162 a structured row compares equal to `prev`, so
+    /// `observed_transitions` never reports one and the poll loop never
+    /// reached that predicate. The TUI was the only writer, which is why the
+    /// mark was missing for anyone not running a TUI home view. The daemon now
+    /// writes it durably from the live ACP turn-end event
+    /// (`should_mark_acp_unread`), so mirroring here would make the TUI a
+    /// second writer of one boolean.
+    ///
+    /// The restart-stranding fear the old rationale named is handled, and by
+    /// the correct owner: `apply_daemon_status_update` is fed only by
+    /// `DaemonStatusPoller`, so reaching this code at all proves a daemon is
+    /// live, and that same daemon produced this `Running -> Idle` reading and
+    /// persisted the mark alongside it. The TUI picks the mark up from disk on
+    /// its next reload; `merge_from_tui` has no `unread` arm, so its own saves
+    /// cannot clobber it.
     #[test]
     #[serial]
-    fn daemon_status_persists_the_unread_mark_but_not_the_status_for_structured() {
+    fn tui_persists_neither_status_nor_unread_for_a_structured_turn_end() {
         crate::session::set_unread_enabled(true);
         let mut env = create_test_env_empty();
         let id = structured_row(&mut env, Status::Running);
@@ -20171,9 +20166,16 @@ mod daemon_status_apply_tests {
             .save()
             .expect("seed the structured row on disk as read/Running");
 
-        // A finished turn (Running -> Idle) marks the row unread.
+        // A finished turn (Running -> Idle).
         env.view
             .apply_daemon_status_update(update(&id, Status::Idle));
+
+        let inst = env.view.get_instance(&id).expect("row still present");
+        assert_eq!(inst.status, Status::Idle, "the turn-end still applies");
+        assert!(
+            !inst.is_unread(),
+            "the structured turn-end mark is the daemon's to write, not ours"
+        );
 
         let rows = env.view.storages.get("test").unwrap().load().unwrap();
         let disk = rows.iter().find(|i| i.id == id).expect("disk row present");
@@ -20183,8 +20185,8 @@ mod daemon_status_apply_tests {
             "structured status must not be passively persisted (#3201)"
         );
         assert!(
-            disk.is_unread(),
-            "the unread mark must still persist for a structured row, mirroring the daemon (#3201)"
+            !disk.is_unread(),
+            "structured unread must not be passively persisted either (#3181)"
         );
     }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`session.unread_indicator` is on by default and promises, at `src/session/config.rs`, that "a session whose turn just finished is painted in the theme's unread color until you open it." Structured (ACP) sessions largely did not get that.

To be precise, because #3181's title and an earlier draft of this description both overstated it: a TUI home view running next to a daemon *did* mark these rows, via `apply_daemon_status_update`. What got nothing was every other case, which is most of them. A dashboard-only user, since that path is inside the TUI's home loop. Anyone with no TUI running. Any turn shorter than the 1s `DAEMON_STATUS_REFRESH_INTERVAL`, since the poller has to catch both sides of the edge. And `/api/sessions` never reported the mark at all, because it lived in TUI memory rather than the daemon's.

Both existing producers of the automatic mark hang off the tmux status pipeline, and a structured session does not travel through it. The daemon's `decide_passive_transition` is only reached for a row that `observed_transitions` reported, and since #3162 a structured row always compares equal to `prev` there. That is correct rather than a regression: the poll loop has no authority over a paneless row, and the transitions it used to report for one were phantoms that re-marked a row seconds after the user read it. A structured session's lifecycle runs on ACP events into `apply_status_intent`, which was never taught the unread concern.

So the live ACP listener learns it. It snapshots the row's status around `apply_status_intent` and marks on `Running -> Idle`, the same predicate the two tmux-side sites already use. Snapshotting is exactly "the transition that was actually applied": `apply_status_intent` assigns `status` in one place and every rejected or no-op path leaves it untouched, and the write lock is held across both reads. That avoids changing its signature, which matters because `seed_acp_statuses` shares the function at daemon boot to replay the latest on-disk lifecycle event; marking there would re-mark from history on every restart.

The write is durable rather than in-memory. `reload_state_instances_from_disk` rebases every row on the freshly loaded disk row on each 2s poll tick, and `merge_runtime_fields` does not carry `unread`, so a memory-only mark would be gone within two seconds. Memory is mirrored only after the write lands, the #2755 ordering, so a mark disk never accepted is not served over `/api/sessions`, mirrored into the TUI, and then silently dropped by the next reload.

Ownership is then made single-writer. `decide_passive_transition` is gated on `!is_structured()`; it is unreachable for a structured row today, but the gate stops a later change to the poll loop from quietly re-marking one from a second daemon path. The TUI's predicate is gated too: `apply_daemon_status_update` (#3170, #3201) folds a structured row's daemon-sourced status through the same `apply_status_update` path a tmux transition takes, so the TUI's mark has in fact been firing for structured rows, and the daemon writing the mark itself makes that a second writer of one boolean.

Nothing is lost on the suppression or clear side, which is what settles the issue's three open questions:

- **`Running -> Idle` is the whole edge.** An approval or elicitation excursion comes back through `Set(Running)` (`ApprovalResolved` / `ElicitationResolved`) before the turn's `Stopped`, so an answered-then-completed turn still ends on this edge and needs no case of its own. The only edge missed is a direct `Waiting -> Idle`, which means the turn stopped while still blocked on a user who is by construction present for it. Keeping the predicate byte-identical across all three sites means "a turn just finished" means one thing everywhere.
- **The mark must be durable**, per the 2s disk rebase above. Not a preference.
- **No server-side suppression.** `AppState::web_active_within` is a *global* any-dashboard-focused boolean with no per-session dimension, so using it would suppress session B's mark because a dashboard is focused on session A. Both clients already clear reactively: the dashboard's active-session effect in `web/src/App.tsx` (whose own comment covers "having it open when its turn finishes"), and the TUI's `tick_unread_dwell`, which re-reads `is_unread()` every tick and so picks up a daemon-written mark on the row under the cursor. The TUI exemption that might have argued for keeping its own mark, `!is_live_target`, is inert on a structured row regardless, because `start_live_send` returns early on `is_structured()` (`src/tui/home/input.rs:6158`, with a matching guard at `src/tui/app.rs:3616`). The absence of a pane is not the reason: a structured row can still have a paired terminal or tool pane.

The write and the mirror happen under the same `instance_lock` that `PATCH /api/sessions/:id/unread` takes, and only a write that actually mutated the owning row is mirrored. An earlier revision of this PR did neither, on the reasoning that the mark was invisible until mirrored. Review showed that reasoning was wrong in both directions: `persist_session_update` lands the disk write *before* the mirror, and the TUI reads `unread` from disk on its watcher-driven reload, so the mark is visible in that window; and `persist_session_update` reports `Ok` for a write whose closure matched nothing, so a stale profile could mark memory off a successful no-op.

A dropped broadcast frame is also recovered. `acp_events_tx` holds 256 frames and tells a lagged receiver only how many it missed, never which. Status tolerated that by being level-triggered, but the unread mark is edge-triggered, so a dropped `Stopped` lost it permanently. Since ACP events are recorded before they are broadcast, the `Lagged` arm now replays the structured rows from the durable log.

Closes #3181

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo test --features serve` is 6378 passed / 1 failed locally, and the one failure is
`git::worktree::tests::worktree_move_observation_canonicalizes_symlinked_parents`, a macOS
`/private/var` vs `/var` tmpdir-symlink assertion in a file this PR does not touch. Confirmed
pre-existing by running it against the untouched pre-fix tree, where it fails identically.
`cargo fmt --all -- --check`, `cargo clippy -- -D warnings` (CI's exact invocation),
`cargo clippy --features serve -- -D warnings`, and
`cargo check --no-default-features --lib --bins --tests` are all clean.

No `docs/` change: `grep -rn unread docs/` is empty, and the promise this makes true already lives in the `session.unread_indicator` doc comment. No new config field, so no settings parity. No stored-data change, so no migration.

## How to test

- [ ] With `aoe serve` running and `session.unread_indicator` on (the default), open the dashboard, start a turn in a structured session, then switch to a different session. When the turn finishes, the first session's sidebar row paints unread.
- [ ] Open that row. It clears, and stays clear across several 2s poll ticks (this is what the old phantom-transition behavior got wrong).
- [ ] Restart `aoe serve` while a structured row is unread. The marker is still there, so it is genuinely on disk rather than in daemon memory.
- [ ] Sit *on* a structured session in the dashboard while its turn finishes. No unread dot appears.
- [ ] With the TUI home view open next to the daemon, let a structured turn finish on a row you are not sitting on. The row paints unread there too, and dwelling on it clears it.
- [ ] Set `session.unread_indicator = false`, **restart `aoe serve`**, finish a structured turn, and confirm nothing is marked. The restart is required and is pre-existing behavior, not something this PR changes: the daemon reads the flag once at startup (`src/server/mod.rs`, "read once at startup; a config change needs a restart to take effect"). Without it the daemon still writes the mark, though both render surfaces gate on their own live copy of the flag so nothing paints.
- [ ] Confirm terminal (tmux) sessions still mark unread on turn end exactly as before.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

Zero `web/` files change. The dashboard-side behavior the issue asks about (a session open in front of you is not left unread) is the pre-existing clear-on-view effect in `App.tsx`, and its render half already has Vitest coverage in `SessionRowTriage.test.tsx` ("suppresses the unread dot on the active row").

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: driving this end to end needs a live `aoe serve` plus the fake ACP agent to run a turn to completion, the 10-28s e2e tier, to assert one boolean that the unit tests already pin from both sides. Covered instead by:

  - `should_mark_acp_unread_only_on_a_structured_running_to_idle_turn_end`, a table over the daemon's predicate (8 cases: the turn-end edge, `Waiting -> Idle`, `Running -> Error`, turn start, no-transition-applied, feature off, already-unread, and a terminal row).
  - `tui_persists_neither_status_nor_unread_for_a_structured_turn_end`, which locks the TUI ownership gate on both the in-memory and the on-disk half. This is the retargeted `daemon_status_persists_the_unread_mark_but_not_the_status_for_structured`; see the third commit for why its old assertion was resting on a premise that #3162 had already invalidated.
  - the existing `decide_passive_transition_marks_unread_only_on_running_to_idle` table, which gains the structured case, deliberately alongside `tick_reports_no_transition_for_a_structured_phantom` so the #3162 fix and this one are locked together.

  - `acp_event_listener_marks_a_finished_turn_unread_on_disk_and_in_memory`, added after review. Both reviewers independently flagged that nothing exercised the listener, so the fix's own wiring was the one untested path and a future refactor of it would reintroduce the bug against a green suite. This one drives a real `Event::Stopped` frame through the broadcast and asserts the mark on disk and in memory.
  - `persist_and_mirror_unread_mirrors_only_a_committed_mutation` and `..._skips_the_mirror_on_a_failed_write`, covering the profile-move no-op and the failed write.
  - `recover_structured_unread_after_lag_marks_only_a_missed_turn_end`, covering a lagged `Running -> Stopped` against an already-reconciled row and a terminal row.

  Each new assertion was checked for the red direction rather than assumed. `tui_persists_neither_status_nor_unread_for_a_structured_turn_end` fails on the pre-fix tree on the mark assertion itself, not on setup. The listener test was verified against the exact hypothetical raised in review: moving the `old_status` snapshot to after `apply_status_intent` leaves the predicate table green and fails only that test.

  One residual gap, stated rather than papered over: the clear interleaving is now unrepresentable rather than tested. Holding `instance_lock` across the write and the mirror means a `PATCH /unread` clear cannot land between them, so a test for it would be asserting `tokio::sync::Mutex` rather than this code. A stale-profile write is also not retried; the mark is dropped rather than half-applied, which is a deliberate call given how rare a move mid-turn-end is.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement`)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction, with a two-round design debate between two external models to pressure-test the three open questions in the issue. I made the design calls, reviewed each commit, and ran the manual test steps. Two of the issue's own proposals were revised against what the code actually does: the issue says the TUI has no ACP status path, which #3170/#3201 made stale, and the durability question resolves to "required" rather than "preferred" because of the 2s disk rebase.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- ACP sessions now become unread when a turn changes from `Running` to `Idle`.
- The unread state is saved to disk and updated in memory only after a successful save.
- Event-log recovery restores unread updates when live ACP events are delayed or missed.
- Tmux and TUI paths no longer duplicate unread marking for structured sessions.
- Tests cover persistence, recovery, locking, listener behavior, and disabled-feature cases.

## Benefits

This keeps unread status consistent across restarts and event delays. It also prevents duplicate updates from competing session owners.

## Further enhancement

The behavior for turns that change from `Waiting` to `Idle` remains open for future clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
