### PR TITLE
feat(session): reconcile a stale worktree project_path when the directory moves outside aoe

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -106,6 +106,17 @@ This supports only sessions whose worktree is aoe-managed (`worktree_info.manage
 
 The new directory and branch persist across reload and restart. See #1723 and #1927.
 
+### When the Directory Moves Outside aoe
+
+aoe records a worktree session's directory at creation, so relocating it from another shell leaves that record stale. aoe repairs it from `git worktree list`, matching on the session's branch: at TUI startup, at `aoe serve` startup, and on each CLI workdir edit. If exactly one live worktree checks out the branch, the recorded path is rewritten to it and the session keeps working. If two do, aoe leaves the path alone rather than guessing which checkout is yours.
+
+Two caveats:
+
+- aoe locks the worktrees it creates, so an out-of-band `git worktree move` needs `git worktree unlock <path>` first.
+- A plain `mv` is not recoverable on its own. It leaves git's record naming the old path, which is indistinguishable from a deleted checkout, so aoe reports the worktree as missing and changes nothing. Run `git worktree repair <new-path>` from the repo to bring git's record up to date, and aoe will then find it.
+
+Reconciliation is point-in-time, not a watcher: a directory moved while a TUI or `aoe serve` is already running stays stale for that process until it restarts. See #2002.
+
 ## Configuration
 
 ```toml

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -115,13 +115,18 @@ resolves, or symlink the binary into a standard dir (`/usr/local/bin`,
 ### "Project path no longer exists" banner
 
 The session's working directory was renamed, moved, or deleted out from under
-`aoe serve` (most often a `git worktree move` or a manual `mv`). Two ways to
+`aoe serve` (most often a `git worktree move` or a manual `mv`). Three ways to
 recover:
 
-1. **Restore the directory at the path the banner shows** (e.g.
+1. **Restart `aoe serve`.** For an aoe-managed worktree relocated with
+   `git worktree move`, the daemon repairs `project_path` from
+   `git worktree list` on startup and the banner clears on its own. This does
+   not cover a plain `mv` (see the worktrees guide) and does not happen while
+   the daemon keeps running.
+2. **Restore the directory at the path the banner shows** (e.g.
    `git worktree move <new> <old>`, or recreate the dir), then click **Retry**.
    Transcript continuity is preserved.
-2. **Stop `aoe serve`**, edit `project_path` for this session in
+3. **Stop `aoe serve`**, edit `project_path` for this session in
    `~/.agent-of-empires/profiles/<profile>/sessions.json` to point at the new
    location (update `worktree_info.branch` too if the branch was renamed), then
    start `aoe serve` again. History and `acp_session_id` are preserved; the

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -121,8 +121,9 @@ recover:
 1. **Restart `aoe serve`.** For an aoe-managed worktree relocated with
    `git worktree move`, the daemon repairs `project_path` from
    `git worktree list` on startup and the banner clears on its own. This does
-   not cover a plain `mv` (see the worktrees guide) and does not happen while
-   the daemon keeps running.
+   not cover a plain `mv` (see the worktrees guide), does not happen while the
+   daemon keeps running, and is skipped entirely on a read-only daemon, which
+   never writes `sessions.json`.
 2. **Restore the directory at the path the banner shows** (e.g.
    `git worktree move <new> <old>`, or recreate the dir), then click **Retry**.
    Transcript continuity is preserved.

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1778,6 +1778,19 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         .iter()
         .find(|instance| instance.id == id)
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
+    // Heal a `project_path` left stale by an external `git worktree move`
+    // before the duplicate-identity check and the container gate below derive
+    // anything from it. The tied branch of this command moves the worktree, so
+    // it needs the same repair as the standalone workdir edit; this is a fresh
+    // process per invocation, so no startup sweep has run for it (#2002).
+    let mut inst = inst.clone();
+    if let Err(error) = crate::session::worktree_reconcile::reconcile_and_persist(
+        &storage,
+        &mut inst,
+        &mut Default::default(),
+    ) {
+        tracing::warn!(target: "cli.session", session = %id, "worktree path reconciliation skipped: {error}");
+    }
     let old_title = inst.title.clone();
     let effective_title = args
         .title
@@ -2154,9 +2167,11 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     // against the live parent. Best-effort; a lookup failure just leaves the
     // stale path, which `edit_worktree_workdir` then rejects as before (#2002).
     let mut inst = inst.clone();
-    if let Err(error) =
-        crate::session::worktree_reconcile::reconcile_and_persist(&storage, &mut inst)
-    {
+    if let Err(error) = crate::session::worktree_reconcile::reconcile_and_persist(
+        &storage,
+        &mut inst,
+        &mut Default::default(),
+    ) {
         tracing::warn!(target: "cli.session", session = %id, "worktree path reconciliation skipped: {error}");
     }
     let current_path = inst.project_path.clone();

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -2148,6 +2148,17 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
         .iter()
         .find(|instance| instance.id == id)
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
+    // The recorded path can be stale: someone may have `git worktree move`d the
+    // directory outside aoe. Heal it from git before anything below derives a
+    // target path or a container gate from it, so those decisions are made
+    // against the live parent. Best-effort; a lookup failure just leaves the
+    // stale path, which `edit_worktree_workdir` then rejects as before (#2002).
+    let mut inst = inst.clone();
+    if let Err(error) =
+        crate::session::worktree_reconcile::reconcile_and_persist(&storage, &mut inst)
+    {
+        tracing::warn!(target: "cli.session", session = %id, "worktree path reconciliation skipped: {error}");
+    }
     let current_path = inst.project_path.clone();
     let Some(worktree_info) = inst.worktree_info.clone() else {
         bail!("Session does not use a worktree");

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -77,7 +77,7 @@ pub(crate) use sessions::persist_session_update;
 pub(crate) use sessions::purge_expired_trash;
 // Startup backfill that relocates trashed worktrees; not a route handler.
 #[cfg(feature = "serve")]
-pub(crate) use sessions::reconcile_trashed_worktrees;
+pub(crate) use sessions::{reconcile_trashed_worktrees, reconcile_worktree_paths};
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,
     docker_status, filesystem_home, get_about, get_cityhall_bundle, get_current_theme,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4476,6 +4476,14 @@ pub(crate) async fn reconcile_worktree_paths(state: &Arc<AppState>) {
         // reapplied under the write lock.
         let reconciled = match tokio::task::spawn_blocking(move || {
             let mut instance = snapshot;
+            // An empty profile resolves to the *default* profile rather than
+            // failing, which would aim the persist at another profile's
+            // sessions.json. The compare-and-set inside the reconcile makes
+            // that a no-op, but refuse outright rather than lean on it.
+            anyhow::ensure!(
+                !instance.source_profile.is_empty(),
+                "session has no source profile; refusing worktree path reconciliation"
+            );
             let storage = crate::session::Storage::open_unwatched(&instance.source_profile)?;
             let resolution =
                 crate::session::worktree_reconcile::reconcile_and_persist(&storage, &mut instance)?;

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4435,12 +4435,6 @@ async fn purge_session_artifacts(
     Ok((true, messages))
 }
 
-/// Relocate any trashed managed worktree still sitting in the active dir into
-/// the holding area, and heal a pointer left stale by a crash between the move
-/// and its persist. Backfills rows trashed before relocation existed. Runs
-/// once on daemon startup, best-effort and per-session locked; a failure on one
-/// session logs and moves on. The git move is blocking, so it runs off the
-/// async runtime.
 /// Heal managed worktree sessions whose recorded `project_path` no longer
 /// exists because the directory was moved outside aoe, rewriting it from git's
 /// own worktree listing. Runs once on daemon startup, so every later
@@ -4485,8 +4479,11 @@ pub(crate) async fn reconcile_worktree_paths(state: &Arc<AppState>) {
                 "session has no source profile; refusing worktree path reconciliation"
             );
             let storage = crate::session::Storage::open_unwatched(&instance.source_profile)?;
-            let resolution =
-                crate::session::worktree_reconcile::reconcile_and_persist(&storage, &mut instance)?;
+            let resolution = crate::session::worktree_reconcile::reconcile_and_persist(
+                &storage,
+                &mut instance,
+                &mut Default::default(),
+            )?;
             anyhow::Ok((resolution, instance))
         })
         .await
@@ -4512,6 +4509,12 @@ pub(crate) async fn reconcile_worktree_paths(state: &Arc<AppState>) {
     }
 }
 
+/// Relocate any trashed managed worktree still sitting in the active dir into
+/// the holding area, and heal a pointer left stale by a crash between the move
+/// and its persist. Backfills rows trashed before relocation existed. Runs
+/// once on daemon startup, best-effort and per-session locked; a failure on one
+/// session logs and moves on. The git move is blocking, so it runs off the
+/// async runtime.
 pub(crate) async fn reconcile_trashed_worktrees(state: &Arc<AppState>) {
     let candidates: Vec<(String, String)> = {
         let instances = state.instances.read().await;

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4441,6 +4441,69 @@ async fn purge_session_artifacts(
 /// once on daemon startup, best-effort and per-session locked; a failure on one
 /// session logs and moves on. The git move is blocking, so it runs off the
 /// async runtime.
+/// Heal managed worktree sessions whose recorded `project_path` no longer
+/// exists because the directory was moved outside aoe, rewriting it from git's
+/// own worktree listing. Runs once on daemon startup, so every later
+/// path-derived decision (worker cwd, diff, the rename pre-flight gates) acts
+/// on the live location. See #2002.
+///
+/// The recorded path existing short-circuits the whole pass inside
+/// [`crate::session::worktree_reconcile::reconcile_and_persist`], so a healthy
+/// session costs one `stat` and never shells out to git. Every non-move outcome
+/// leaves the row untouched.
+pub(crate) async fn reconcile_worktree_paths(state: &Arc<AppState>) {
+    let candidates: Vec<String> = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| i.worktree_info.as_ref().is_some_and(|wt| wt.managed_by_aoe))
+            .map(|i| i.id.clone())
+            .collect()
+    };
+    for id in candidates {
+        let lock = state.instance_lock(&id).await;
+        let _guard = lock.lock().await;
+
+        let snapshot = {
+            let instances = state.instances.read().await;
+            match instances.iter().find(|instance| instance.id == id) {
+                Some(instance) => instance.clone(),
+                None => continue,
+            }
+        };
+        // `exists()` and the git listing are blocking filesystem work, so the
+        // whole reconcile runs off the runtime and only the resulting path is
+        // reapplied under the write lock.
+        let reconciled = match tokio::task::spawn_blocking(move || {
+            let mut instance = snapshot;
+            let storage = crate::session::Storage::open_unwatched(&instance.source_profile)?;
+            let resolution =
+                crate::session::worktree_reconcile::reconcile_and_persist(&storage, &mut instance)?;
+            anyhow::Ok((resolution, instance))
+        })
+        .await
+        {
+            Ok(Ok(pair)) => pair,
+            Ok(Err(error)) => {
+                tracing::warn!(target: "http.api.sessions", session = %id, "worktree path reconcile skipped: {error}");
+                continue;
+            }
+            Err(error) => {
+                tracing::warn!(target: "http.api.sessions", session = %id, "worktree path reconcile join failed: {error}");
+                continue;
+            }
+        };
+        let crate::session::worktree_reconcile::WorktreePathResolution::Moved(_) = reconciled.0
+        else {
+            continue;
+        };
+        let mut instances = state.instances.write().await;
+        if let Some(instance) = instances.iter_mut().find(|instance| instance.id == id) {
+            instance.project_path = reconciled.1.project_path;
+        }
+    }
+}
+
 pub(crate) async fn reconcile_trashed_worktrees(state: &Arc<AppState>) {
     let candidates: Vec<(String, String)> = {
         let instances = state.instances.read().await;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1338,6 +1338,9 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 // in the active dir (rows trashed before relocation existed)
                 // and heal any pointer a crash left stale. See #2522.
                 crate::server::api::reconcile_trashed_worktrees(&sweep_state).await;
+                // Same one-shot startup slot: repoint any managed worktree
+                // whose directory was moved outside aoe. See #2002.
+                crate::server::api::reconcile_worktree_paths(&sweep_state).await;
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(60 * 60));
                 interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 loop {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -46,6 +46,7 @@ pub(crate) mod sync;
 pub(crate) mod test_support;
 pub mod trash;
 pub mod worktree_edit;
+pub mod worktree_reconcile;
 
 pub use crate::sound::SoundConfig;
 pub use crate::status_hooks::StatusHookConfig;

--- a/src/session/worktree_reconcile.rs
+++ b/src/session/worktree_reconcile.rs
@@ -1,0 +1,289 @@
+//! Reconcile a managed worktree session's recorded `project_path` against
+//! git's own worktree listing when the directory moved outside aoe (#2002).
+//!
+//! A worktree session records the directory it was created in and nothing
+//! syncs that string afterwards, so a `git worktree move` from another shell
+//! leaves `project_path` naming a directory that no longer exists. git already
+//! knows where the checkout went, keyed by branch, so the repair is a lookup
+//! rather than new bookkeeping.
+//!
+//! Design notes:
+//!   - **Triggered by absence.** The recorded path existing is treated as
+//!     proof it is still the right one, so a healthy row costs one `stat` and
+//!     never shells out. This does not catch a recorded path that survived as
+//!     an unrelated directory; that is not the reported failure and paying a
+//!     git listing per session per load to detect it is not worth it.
+//!   - **Never guesses.** git normally forbids two worktrees on one branch, but
+//!     a `--force`d or hand-edited repo can produce it. Two live candidates
+//!     leave the row alone rather than picking one.
+//!   - **Rewrites a pointer, nothing else.** Unlike the trash relocation in
+//!     [`crate::session::trash`], which moves a directory and therefore needs a
+//!     lifecycle reservation, this only corrects a string to match where git
+//!     already says the checkout is. A plain `Storage::update` is enough.
+//!   - **Reconcile before the caller's pre-flight, never inside the
+//!     operation.** The rename path derives its duplicate-identity check and
+//!     its sandbox-container release from `project_path` before calling
+//!     `edit_worktree_workdir`. Healing inside that call would leave those
+//!     gates computed from the stale path: a stale leaf that happens to equal
+//!     the requested leaf makes `worktree_move_required` false, the container
+//!     is never released, and the `git worktree move` then runs against a live
+//!     bind mount.
+
+use std::path::{Path, PathBuf};
+
+use crate::git::{GitWorktree, WorktreeEntry};
+use crate::session::storage::Storage;
+use crate::session::{Instance, WorktreeInfo};
+
+/// Where a managed worktree session's checkout actually is, relative to the
+/// path the session recorded.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WorktreePathResolution {
+    /// The recorded path is present on disk, or the session is not an
+    /// aoe-managed worktree. Nothing to reconcile.
+    Current,
+    /// Exactly one live worktree checks out the session's branch, at a
+    /// different path than the one recorded.
+    Moved(PathBuf),
+    /// No unique live checkout of the branch was discoverable. Deliberately
+    /// not phrased as "deleted": [`GitWorktree::list_worktrees`] omits linked
+    /// entries whose path it cannot canonicalize, so a removed worktree, a
+    /// dead registration, and a plain `mv` (which leaves git's record naming
+    /// the old path) all land here indistinguishably. If absent and
+    /// inaccessible ever need different handling, the upgrade path is to feed
+    /// the selector a lossless `git worktree list --porcelain` inventory
+    /// instead.
+    Missing,
+    /// More than one live worktree checks out the branch. The recorded path is
+    /// left alone; picking one could point the session at another session's
+    /// checkout.
+    Ambiguous(Vec<PathBuf>),
+}
+
+/// Pick the live worktree that owns `branch`, if there is exactly one.
+///
+/// Split out from the git call so the selection rules are testable without a
+/// repo. Candidates are canonicalized before they are counted, because
+/// `list_worktrees` canonicalizes linked worktrees but leaves the main
+/// worktree's path as configured; on macOS, where `/var` is a symlink to
+/// `/private/var`, comparing those two spellings of one checkout would
+/// otherwise read as [`WorktreePathResolution::Ambiguous`].
+fn select_live_worktree(
+    entries: &[WorktreeEntry],
+    branch: &str,
+    recorded: &Path,
+) -> WorktreePathResolution {
+    let mut candidates: Vec<PathBuf> = entries
+        .iter()
+        .filter(|entry| !entry.is_detached && entry.branch.as_deref() == Some(branch))
+        .filter_map(|entry| entry.path.canonicalize().ok())
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+
+    match candidates.len() {
+        0 => WorktreePathResolution::Missing,
+        1 => {
+            let found = candidates.remove(0);
+            // A recorded path that canonicalizes to the candidate is already
+            // correct even though the raw strings differ (symlinked parents,
+            // a trailing component spelled differently).
+            if recorded.canonicalize().is_ok_and(|r| r == found) {
+                WorktreePathResolution::Current
+            } else {
+                WorktreePathResolution::Moved(found)
+            }
+        }
+        _ => WorktreePathResolution::Ambiguous(candidates),
+    }
+}
+
+/// Resolve where `info`'s checkout is, consulting git only when `recorded` is
+/// absent from disk.
+///
+/// `Err` means git itself could not be consulted, which is deliberately
+/// distinct from [`WorktreePathResolution::Missing`]: a broken repo must not be
+/// logged as "the worktree is gone".
+pub fn resolve_worktree_path(
+    git: &GitWorktree,
+    recorded: &Path,
+    info: &WorktreeInfo,
+) -> crate::git::error::Result<WorktreePathResolution> {
+    if !info.managed_by_aoe || recorded.exists() {
+        return Ok(WorktreePathResolution::Current);
+    }
+    Ok(select_live_worktree(
+        &git.list_worktrees()?,
+        &info.branch,
+        recorded,
+    ))
+}
+
+/// Reconcile one session: on [`WorktreePathResolution::Moved`], rewrite
+/// `inst.project_path` and persist it, so every later path-derived decision
+/// (the rename pre-flight gates, attach, status, diff) sees the live location.
+///
+/// Best-effort by design. Every non-`Moved` outcome, including a git failure,
+/// leaves the row exactly as it was and logs why, mirroring
+/// [`crate::session::trash::reconcile_trashed_location`]. Takes the `Storage`
+/// rather than deriving one from `inst.source_profile`, which only the TUI
+/// populates.
+pub fn reconcile_and_persist(
+    storage: &Storage,
+    inst: &mut Instance,
+) -> anyhow::Result<WorktreePathResolution> {
+    let Some(info) = inst.worktree_info.clone() else {
+        return Ok(WorktreePathResolution::Current);
+    };
+    let recorded = PathBuf::from(&inst.project_path);
+    if !info.managed_by_aoe || recorded.exists() {
+        return Ok(WorktreePathResolution::Current);
+    }
+
+    let git = GitWorktree::new(PathBuf::from(&info.main_repo_path))?;
+    let resolution = resolve_worktree_path(&git, &recorded, &info)?;
+    match &resolution {
+        WorktreePathResolution::Moved(found) => {
+            let id = inst.id.clone();
+            let found_str = found.to_string_lossy().into_owned();
+            storage.update(|instances, _groups| {
+                if let Some(stored) = instances.iter_mut().find(|c| c.id == id) {
+                    stored.project_path = found_str.clone();
+                }
+                Ok(())
+            })?;
+            inst.project_path = found_str;
+            tracing::info!(
+                target: "session.worktree",
+                session = %inst.id,
+                branch = %info.branch,
+                from = %recorded.display(),
+                to = %found.display(),
+                "reconciled worktree path from git after an external move"
+            );
+        }
+        WorktreePathResolution::Missing => tracing::warn!(
+            target: "session.worktree",
+            session = %inst.id,
+            branch = %info.branch,
+            path = %recorded.display(),
+            "recorded worktree path is gone and no live worktree checks out the branch; leaving it alone"
+        ),
+        WorktreePathResolution::Ambiguous(candidates) => tracing::warn!(
+            target: "session.worktree",
+            session = %inst.id,
+            branch = %info.branch,
+            candidates = ?candidates,
+            "several live worktrees check out the branch; refusing to guess which one this session owns"
+        ),
+        WorktreePathResolution::Current => {}
+    }
+    Ok(resolution)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &Path, branch: Option<&str>) -> WorktreeEntry {
+        WorktreeEntry {
+            path: path.to_path_buf(),
+            branch: branch.map(str::to_string),
+            is_detached: false,
+        }
+    }
+
+    #[test]
+    fn select_live_worktree_never_guesses() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("live");
+        let other = dir.path().join("other");
+        let gone = dir.path().join("gone");
+        std::fs::create_dir(&live).unwrap();
+        std::fs::create_dir(&other).unwrap();
+        let canon_live = live.canonicalize().unwrap();
+
+        let cases: Vec<(&str, Vec<WorktreeEntry>, WorktreePathResolution)> = vec![
+            (
+                "the one live checkout of the branch is the new location",
+                vec![entry(&live, Some("feat"))],
+                WorktreePathResolution::Moved(canon_live.clone()),
+            ),
+            (
+                "no entry for the branch",
+                vec![entry(&live, Some("other-branch"))],
+                WorktreePathResolution::Missing,
+            ),
+            (
+                // A registration git kept but whose directory is gone (a plain
+                // `mv`, or a reaped checkout) is not a candidate.
+                "the branch's only entry no longer exists on disk",
+                vec![entry(&gone, Some("feat"))],
+                WorktreePathResolution::Missing,
+            ),
+            (
+                "a detached checkout is never matched",
+                vec![WorktreeEntry {
+                    is_detached: true,
+                    ..entry(&live, Some("feat"))
+                }],
+                WorktreePathResolution::Missing,
+            ),
+            (
+                "branch comparison is exact, not case-folded",
+                vec![entry(&live, Some("Feat"))],
+                WorktreePathResolution::Missing,
+            ),
+            (
+                "an entry with no readable branch is skipped",
+                vec![entry(&live, None)],
+                WorktreePathResolution::Missing,
+            ),
+            (
+                "two live checkouts of one branch are left for a human",
+                vec![entry(&live, Some("feat")), entry(&other, Some("feat"))],
+                WorktreePathResolution::Ambiguous({
+                    let mut both = vec![canon_live.clone(), other.canonicalize().unwrap()];
+                    both.sort();
+                    both
+                }),
+            ),
+            (
+                // `list_worktrees` canonicalizes linked worktrees but not the
+                // main one, so one checkout can arrive under two spellings
+                // wherever a parent is a symlink (every macOS tempdir).
+                "one checkout under two spellings is not ambiguous",
+                vec![entry(&live, Some("feat")), entry(&canon_live, Some("feat"))],
+                WorktreePathResolution::Moved(canon_live.clone()),
+            ),
+        ];
+
+        // `recorded` is the stale path the session carries: absent, hence the
+        // reconcile.
+        let recorded = dir.path().join("stale");
+        for (name, entries, expected) in cases {
+            assert_eq!(
+                select_live_worktree(&entries, "feat", &recorded),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn select_live_worktree_keeps_a_path_that_only_looks_different() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("live");
+        std::fs::create_dir(&live).unwrap();
+        // The row points at the checkout git named, spelled through the
+        // tempdir's symlinked parent. Nothing moved, so nothing is rewritten.
+        assert_eq!(
+            select_live_worktree(
+                &[entry(&live.canonicalize().unwrap(), Some("feat"))],
+                "feat",
+                &live
+            ),
+            WorktreePathResolution::Current
+        );
+    }
+}

--- a/src/session/worktree_reconcile.rs
+++ b/src/session/worktree_reconcile.rs
@@ -113,8 +113,9 @@ pub fn resolve_worktree_path(
 /// Best-effort by design. Every non-`Moved` outcome, including a git failure,
 /// leaves the row exactly as it was and logs why, mirroring
 /// [`crate::session::trash::reconcile_trashed_location`]. Takes the `Storage`
-/// rather than deriving one from `inst.source_profile`, which only the TUI
-/// populates.
+/// rather than deriving one from `inst.source_profile`: `Storage::load` does
+/// not set that field, so on the CLI it is empty, and an empty profile resolves
+/// to the *default* profile rather than failing.
 pub fn reconcile_and_persist(
     storage: &Storage,
     inst: &mut Instance,
@@ -122,6 +123,14 @@ pub fn reconcile_and_persist(
     let Some(info) = inst.worktree_info.clone() else {
         return Ok(WorktreePathResolution::Current);
     };
+    // A trashed session's directory belongs to [`crate::session::trash`], which
+    // relocates the checkout into a holding dir and back and keeps its own
+    // pre-trash marker alongside `project_path`. Both surfaces that run this
+    // pass run the trash reconcile first, and repointing a row it owns (or one
+    // whose relocation it just failed to complete) would fight it.
+    if inst.is_trashed() {
+        return Ok(WorktreePathResolution::Current);
+    }
     let recorded = PathBuf::from(&inst.project_path);
     if !info.managed_by_aoe || recorded.exists() {
         return Ok(WorktreePathResolution::Current);
@@ -133,22 +142,20 @@ pub fn reconcile_and_persist(
         WorktreePathResolution::Moved(found) => {
             let id = inst.id.clone();
             let stale = inst.project_path.clone();
-            let found_str = found.to_string_lossy().into_owned();
+            let new_path = found.to_string_lossy().into_owned();
             // Compare and set. The git lookup runs without holding the storage
             // lock, so a peer process could have renamed or trashed this
             // session in the meantime; its path is fresher than ours and must
             // not be clobbered with a location we resolved from the old one.
             let applied = storage.update(|instances, _groups| {
-                Ok(instances
-                    .iter_mut()
-                    .find(|c| c.id == id)
-                    .is_some_and(|stored| {
-                        let fresh = stored.project_path == stale;
-                        if fresh {
-                            stored.project_path = found_str.clone();
-                        }
-                        fresh
-                    }))
+                let Some(stored) = instances.iter_mut().find(|c| c.id == id) else {
+                    return Ok(false);
+                };
+                if stored.project_path != stale {
+                    return Ok(false);
+                }
+                stored.project_path = new_path.clone();
+                Ok(true)
             })?;
             if !applied {
                 tracing::info!(

--- a/src/session/worktree_reconcile.rs
+++ b/src/session/worktree_reconcile.rs
@@ -63,16 +63,17 @@ pub enum WorktreePathResolution {
 /// Pick the live worktree that owns `branch`, if there is exactly one.
 ///
 /// Split out from the git call so the selection rules are testable without a
-/// repo. Candidates are canonicalized before they are counted, because
+/// repo. Never returns [`WorktreePathResolution::Current`]: the callers
+/// short-circuit on a present recorded path before there is anything to select
+/// between.
+///
+/// Canonicalizing doubles as the liveness filter, since it fails for a path
+/// that is not there, and as the de-duplicator. Both matter:
 /// `list_worktrees` canonicalizes linked worktrees but leaves the main
-/// worktree's path as configured; on macOS, where `/var` is a symlink to
-/// `/private/var`, comparing those two spellings of one checkout would
+/// worktree's path as configured, so on macOS, where `/var` is a symlink to
+/// `/private/var`, one checkout can arrive under two spellings and would
 /// otherwise read as [`WorktreePathResolution::Ambiguous`].
-fn select_live_worktree(
-    entries: &[WorktreeEntry],
-    branch: &str,
-    recorded: &Path,
-) -> WorktreePathResolution {
+fn select_live_worktree(entries: &[WorktreeEntry], branch: &str) -> WorktreePathResolution {
     let mut candidates: Vec<PathBuf> = entries
         .iter()
         .filter(|entry| !entry.is_detached && entry.branch.as_deref() == Some(branch))
@@ -83,17 +84,7 @@ fn select_live_worktree(
 
     match candidates.len() {
         0 => WorktreePathResolution::Missing,
-        1 => {
-            let found = candidates.remove(0);
-            // A recorded path that canonicalizes to the candidate is already
-            // correct even though the raw strings differ (symlinked parents,
-            // a trailing component spelled differently).
-            if recorded.canonicalize().is_ok_and(|r| r == found) {
-                WorktreePathResolution::Current
-            } else {
-                WorktreePathResolution::Moved(found)
-            }
-        }
+        1 => WorktreePathResolution::Moved(candidates.remove(0)),
         _ => WorktreePathResolution::Ambiguous(candidates),
     }
 }
@@ -112,11 +103,7 @@ pub fn resolve_worktree_path(
     if !info.managed_by_aoe || recorded.exists() {
         return Ok(WorktreePathResolution::Current);
     }
-    Ok(select_live_worktree(
-        &git.list_worktrees()?,
-        &info.branch,
-        recorded,
-    ))
+    Ok(select_live_worktree(&git.list_worktrees()?, &info.branch))
 }
 
 /// Reconcile one session: on [`WorktreePathResolution::Moved`], rewrite
@@ -145,14 +132,33 @@ pub fn reconcile_and_persist(
     match &resolution {
         WorktreePathResolution::Moved(found) => {
             let id = inst.id.clone();
+            let stale = inst.project_path.clone();
             let found_str = found.to_string_lossy().into_owned();
-            storage.update(|instances, _groups| {
-                if let Some(stored) = instances.iter_mut().find(|c| c.id == id) {
-                    stored.project_path = found_str.clone();
-                }
-                Ok(())
+            // Compare and set. The git lookup runs without holding the storage
+            // lock, so a peer process could have renamed or trashed this
+            // session in the meantime; its path is fresher than ours and must
+            // not be clobbered with a location we resolved from the old one.
+            let applied = storage.update(|instances, _groups| {
+                Ok(instances
+                    .iter_mut()
+                    .find(|c| c.id == id)
+                    .is_some_and(|stored| {
+                        let fresh = stored.project_path == stale;
+                        if fresh {
+                            stored.project_path = found_str.clone();
+                        }
+                        fresh
+                    }))
             })?;
-            inst.project_path = found_str;
+            if !applied {
+                tracing::info!(
+                    target: "session.worktree",
+                    session = %inst.id,
+                    "worktree path changed under the reconcile; keeping the newer record"
+                );
+                return Ok(WorktreePathResolution::Current);
+            }
+            inst.project_path = found.to_string_lossy().into_owned();
             tracing::info!(
                 target: "session.worktree",
                 session = %inst.id,
@@ -203,7 +209,7 @@ mod tests {
         std::fs::create_dir(&other).unwrap();
         let canon_live = live.canonicalize().unwrap();
 
-        let cases: Vec<(&str, Vec<WorktreeEntry>, WorktreePathResolution)> = vec![
+        let cases = [
             (
                 "the one live checkout of the branch is the new location",
                 vec![entry(&live, Some("feat"))],
@@ -258,32 +264,8 @@ mod tests {
             ),
         ];
 
-        // `recorded` is the stale path the session carries: absent, hence the
-        // reconcile.
-        let recorded = dir.path().join("stale");
         for (name, entries, expected) in cases {
-            assert_eq!(
-                select_live_worktree(&entries, "feat", &recorded),
-                expected,
-                "{name}"
-            );
+            assert_eq!(select_live_worktree(&entries, "feat"), expected, "{name}");
         }
-    }
-
-    #[test]
-    fn select_live_worktree_keeps_a_path_that_only_looks_different() {
-        let dir = tempfile::tempdir().unwrap();
-        let live = dir.path().join("live");
-        std::fs::create_dir(&live).unwrap();
-        // The row points at the checkout git named, spelled through the
-        // tempdir's symlinked parent. Nothing moved, so nothing is rewritten.
-        assert_eq!(
-            select_live_worktree(
-                &[entry(&live.canonicalize().unwrap(), Some("feat"))],
-                "feat",
-                &live
-            ),
-            WorktreePathResolution::Current
-        );
     }
 }

--- a/src/session/worktree_reconcile.rs
+++ b/src/session/worktree_reconcile.rs
@@ -15,7 +15,10 @@
 //!     git listing per session per load to detect it is not worth it.
 //!   - **Never guesses.** git normally forbids two worktrees on one branch, but
 //!     a `--force`d or hand-edited repo can produce it. Two live candidates
-//!     leave the row alone rather than picking one.
+//!     leave the row alone rather than picking one. A lone candidate that
+//!     another session already records is refused for the same reason: git
+//!     only forbids the second worktree while the first registration is live,
+//!     so a pruned session's branch can legally be taken by a later checkout.
 //!   - **Rewrites a pointer, nothing else.** Unlike the trash relocation in
 //!     [`crate::session::trash`], which moves a directory and therefore needs a
 //!     lifecycle reservation, this only corrects a string to match where git
@@ -86,13 +89,16 @@ fn select_live_worktree(
     // Repointing a managed session there would hand its agent the user's
     // primary checkout to work in. Same canonicalize-and-compare guard
     // `crate::git::cleanup::remove_worktree_dir` applies before deleting a
-    // directory.
-    let main = main_repo.canonicalize().ok();
+    // directory, down to falling back on the path as written when it cannot
+    // be canonicalized, so an unresolvable main repo still excludes itself.
+    let main = main_repo
+        .canonicalize()
+        .unwrap_or_else(|_| main_repo.to_path_buf());
     let mut candidates: Vec<PathBuf> = entries
         .iter()
         .filter(|entry| !entry.is_detached && entry.branch.as_deref() == Some(branch))
         .filter_map(|entry| entry.path.canonicalize().ok())
-        .filter(|path| main.as_deref() != Some(path.as_path()))
+        .filter(|path| path != &main)
         .collect();
     candidates.sort();
     candidates.dedup();
@@ -183,11 +189,28 @@ pub fn reconcile_and_persist(
             let id = inst.id.clone();
             let stale = inst.project_path.clone();
             let new_path = found.to_string_lossy().into_owned();
-            // Compare and set. The git lookup runs without holding the storage
-            // lock, so a peer process could have renamed or trashed this
-            // session in the meantime; its path is fresher than ours and must
-            // not be clobbered with a location we resolved from the old one.
+            // Both guards below need the storage lock the git lookup ran
+            // without, so they live inside the update rather than beside it.
+            let mut claimed_by: Option<String> = None;
             let applied = storage.update(|instances, _groups| {
+                // Never adopt a checkout another session already records. git
+                // forbids a second worktree on a branch only while the first
+                // registration is live, so once this session's entry is pruned
+                // a fresh checkout of the branch is legal and the branch-keyed
+                // lookup lands this row on it. Two rows naming one directory
+                // means trashing or deleting the stale one takes the live
+                // one's checkout with it, so leave the stale path alone.
+                if let Some(owner) = instances.iter().find(|c| {
+                    c.id != id
+                        && Path::new(&c.project_path).canonicalize().ok().as_deref()
+                            == Some(found.as_path())
+                }) {
+                    claimed_by = Some(owner.id.clone());
+                    return Ok(false);
+                }
+                // Compare and set: a peer process could have renamed or
+                // trashed this session while the lookup ran, and its path is
+                // fresher than a location we resolved from the old one.
                 let Some(stored) = instances.iter_mut().find(|c| c.id == id) else {
                     return Ok(false);
                 };
@@ -197,6 +220,17 @@ pub fn reconcile_and_persist(
                 stored.project_path = new_path.clone();
                 Ok(true)
             })?;
+            if let Some(owner) = claimed_by {
+                tracing::warn!(
+                    target: "session.worktree",
+                    session = %inst.id,
+                    branch = %info.branch,
+                    owner = %owner,
+                    candidate = %found.display(),
+                    "the only live checkout of the branch already belongs to another session; refusing to adopt it"
+                );
+                return Ok(WorktreePathResolution::Current);
+            }
             if !applied {
                 tracing::info!(
                     target: "session.worktree",

--- a/src/session/worktree_reconcile.rs
+++ b/src/session/worktree_reconcile.rs
@@ -29,6 +29,7 @@
 //!     is never released, and the `git worktree move` then runs against a live
 //!     bind mount.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::git::{GitWorktree, WorktreeEntry};
@@ -73,11 +74,25 @@ pub enum WorktreePathResolution {
 /// worktree's path as configured, so on macOS, where `/var` is a symlink to
 /// `/private/var`, one checkout can arrive under two spellings and would
 /// otherwise read as [`WorktreePathResolution::Ambiguous`].
-fn select_live_worktree(entries: &[WorktreeEntry], branch: &str) -> WorktreePathResolution {
+fn select_live_worktree(
+    entries: &[WorktreeEntry],
+    branch: &str,
+    main_repo: &Path,
+) -> WorktreePathResolution {
+    // The main worktree is never a candidate. `list_worktrees` reports it like
+    // any other entry, and it can legitimately end up on the session's branch
+    // once the linked checkout is gone (`git worktree unlock` plus `prune` plus
+    // `git checkout`, or a single `git checkout --ignore-other-worktrees`).
+    // Repointing a managed session there would hand its agent the user's
+    // primary checkout to work in. Same canonicalize-and-compare guard
+    // `crate::git::cleanup::remove_worktree_dir` applies before deleting a
+    // directory.
+    let main = main_repo.canonicalize().ok();
     let mut candidates: Vec<PathBuf> = entries
         .iter()
         .filter(|entry| !entry.is_detached && entry.branch.as_deref() == Some(branch))
         .filter_map(|entry| entry.path.canonicalize().ok())
+        .filter(|path| main.as_deref() != Some(path.as_path()))
         .collect();
     candidates.sort();
     candidates.dedup();
@@ -89,21 +104,46 @@ fn select_live_worktree(entries: &[WorktreeEntry], branch: &str) -> WorktreePath
     }
 }
 
-/// Resolve where `info`'s checkout is, consulting git only when `recorded` is
-/// absent from disk.
+/// One pass's worth of `git worktree list` results, keyed by main repo path.
 ///
-/// `Err` means git itself could not be consulted, which is deliberately
-/// distinct from [`WorktreePathResolution::Missing`]: a broken repo must not be
-/// logged as "the worktree is gone".
+/// [`GitWorktree::list_worktrees`] opens the repo once for the listing and
+/// again per registered worktree (`get_current_branch`), so N broken sessions
+/// sharing a repo that holds M worktrees would otherwise cost N*(M+1) libgit2
+/// opens. The TUI pays that synchronously before its first paint, and a
+/// worktree-heavy repo makes M large, so the whole sweep shares one cache.
+#[derive(Default)]
+pub struct ReconcileCache(HashMap<String, Vec<WorktreeEntry>>);
+
+impl ReconcileCache {
+    /// The listing for `main_repo`, fetched once per pass.
+    ///
+    /// A failure is not cached: it is nearly always "this repo is unreachable
+    /// right now", and the next session in the same repo should get a fresh
+    /// attempt rather than inherit a stale verdict.
+    fn entries(&mut self, main_repo: &str) -> crate::git::error::Result<&[WorktreeEntry]> {
+        if !self.0.contains_key(main_repo) {
+            let git = GitWorktree::new(PathBuf::from(main_repo))?;
+            self.0.insert(main_repo.to_string(), git.list_worktrees()?);
+        }
+        Ok(&self.0[main_repo])
+    }
+}
+
+/// Resolve where `info`'s checkout is, given git's current worktree listing.
+///
+/// Takes the entries rather than a [`GitWorktree`] so one listing can serve
+/// every session in a repo; obtaining it is [`ReconcileCache`]'s job, which
+/// keeps the "git could not be consulted" failure distinct from
+/// [`WorktreePathResolution::Missing`] by surfacing it before this is called.
 pub fn resolve_worktree_path(
-    git: &GitWorktree,
+    entries: &[WorktreeEntry],
     recorded: &Path,
     info: &WorktreeInfo,
-) -> crate::git::error::Result<WorktreePathResolution> {
+) -> WorktreePathResolution {
     if !info.managed_by_aoe || recorded.exists() {
-        return Ok(WorktreePathResolution::Current);
+        return WorktreePathResolution::Current;
     }
-    Ok(select_live_worktree(&git.list_worktrees()?, &info.branch))
+    select_live_worktree(entries, &info.branch, Path::new(&info.main_repo_path))
 }
 
 /// Reconcile one session: on [`WorktreePathResolution::Moved`], rewrite
@@ -119,6 +159,7 @@ pub fn resolve_worktree_path(
 pub fn reconcile_and_persist(
     storage: &Storage,
     inst: &mut Instance,
+    cache: &mut ReconcileCache,
 ) -> anyhow::Result<WorktreePathResolution> {
     let Some(info) = inst.worktree_info.clone() else {
         return Ok(WorktreePathResolution::Current);
@@ -136,8 +177,7 @@ pub fn reconcile_and_persist(
         return Ok(WorktreePathResolution::Current);
     }
 
-    let git = GitWorktree::new(PathBuf::from(&info.main_repo_path))?;
-    let resolution = resolve_worktree_path(&git, &recorded, &info)?;
+    let resolution = resolve_worktree_path(cache.entries(&info.main_repo_path)?, &recorded, &info);
     match &resolution {
         WorktreePathResolution::Moved(found) => {
             let id = inst.id.clone();
@@ -212,8 +252,10 @@ mod tests {
         let live = dir.path().join("live");
         let other = dir.path().join("other");
         let gone = dir.path().join("gone");
+        let main_repo = dir.path().join("main-repo");
         std::fs::create_dir(&live).unwrap();
         std::fs::create_dir(&other).unwrap();
+        std::fs::create_dir(&main_repo).unwrap();
         let canon_live = live.canonicalize().unwrap();
 
         let cases = [
@@ -269,10 +311,29 @@ mod tests {
                 vec![entry(&live, Some("feat")), entry(&canon_live, Some("feat"))],
                 WorktreePathResolution::Moved(canon_live.clone()),
             ),
+            (
+                // The main repo can be left on the branch once the linked
+                // checkout is gone. Selecting it would point the session at
+                // the user's primary checkout.
+                "the main worktree on the branch is never selected",
+                vec![entry(&main_repo, Some("feat"))],
+                WorktreePathResolution::Missing,
+            ),
+            (
+                // Nor does excluding it turn a real relocation into an
+                // ambiguity.
+                "the main worktree does not make a real move ambiguous",
+                vec![entry(&main_repo, Some("feat")), entry(&live, Some("feat"))],
+                WorktreePathResolution::Moved(canon_live.clone()),
+            ),
         ];
 
         for (name, entries, expected) in cases {
-            assert_eq!(select_live_worktree(&entries, "feat"), expected, "{name}");
+            assert_eq!(
+                select_live_worktree(&entries, "feat", &main_repo),
+                expected,
+                "{name}"
+            );
         }
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2099,6 +2099,22 @@ impl HomeView {
                     );
                 }
             }
+            // Heal a managed worktree whose directory was moved outside aoe
+            // (a `git worktree move` from another shell): rewrite project_path
+            // from git so attach, status, diff, and rename all act on the live
+            // location instead of failing. Only rows whose recorded path is
+            // already gone cost anything. See #2002.
+            for instance in &mut instances {
+                if let Err(error) =
+                    crate::session::worktree_reconcile::reconcile_and_persist(&storage, instance)
+                {
+                    tracing::warn!(
+                        target: "tui.home",
+                        session = %instance.id,
+                        "worktree path reconciliation skipped: {error}",
+                    );
+                }
+            }
             // Clear expired lifecycle reservations only while holding the same
             // per-instance flock used by live transitions.
             let ttl = crate::session::Instance::LIFECYCLE_RESERVATION_TTL;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2104,10 +2104,13 @@ impl HomeView {
             // from git so attach, status, diff, and rename all act on the live
             // location instead of failing. Only rows whose recorded path is
             // already gone cost anything. See #2002.
+            let mut reconcile_cache = crate::session::worktree_reconcile::ReconcileCache::default();
             for instance in &mut instances {
-                if let Err(error) =
-                    crate::session::worktree_reconcile::reconcile_and_persist(&storage, instance)
-                {
+                if let Err(error) = crate::session::worktree_reconcile::reconcile_and_persist(
+                    &storage,
+                    instance,
+                    &mut reconcile_cache,
+                ) {
                     tracing::warn!(
                         target: "tui.home",
                         session = %instance.id,

--- a/tests/integration/worktree_integration.rs
+++ b/tests/integration/worktree_integration.rs
@@ -476,3 +476,187 @@ fn edit_workdir_rejects_invalid_cases_without_partial_changes() {
     assert!(matches!(err, WorktreeEditError::NotManaged));
     assert!(old_path.exists());
 }
+
+// --- Reconciling a stale project_path (#2002) ---
+
+use agent_of_empires::session::worktree_reconcile::{
+    reconcile_and_persist, resolve_worktree_path, WorktreePathResolution,
+};
+
+/// Run a git subcommand in `repo` the way a user in another shell would,
+/// bypassing aoe entirely.
+fn git_in(repo: &std::path::Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// An external `git worktree move` is discovered from git's own listing, and
+/// the recorded path is repaired in storage so the rename that would otherwise
+/// fail with `SourceMissing` proceeds against the relocated directory.
+///
+/// `#[serial]` because `Storage` resolves its app dir from the process-global
+/// `HOME`.
+#[test]
+#[serial]
+fn reconcile_heals_a_worktree_moved_outside_aoe() {
+    let (repo_dir, _repo, _config_dir) = setup_test_environment();
+    let temp_home = TempDir::new().unwrap();
+    std::env::set_var("HOME", temp_home.path());
+    let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
+
+    let created = repo_dir.path().join("recorded-name");
+    git_wt
+        .create_worktree("recorded-name", &created, true, None)
+        .unwrap();
+    let info = managed_info("recorded-name", repo_dir.path());
+
+    let mut instance = Instance::new("Moved Session", created.to_str().unwrap());
+    instance.worktree_info = Some(info.clone());
+    let storage = Storage::new_unwatched("worktree-reconcile-profile").unwrap();
+    let seeded = vec![instance.clone()];
+    storage
+        .update(|i, g| {
+            *i = seeded.to_vec();
+            *g = GroupTree::new_with_groups(&seeded, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    // aoe locks every worktree it creates, so a user relocating one from
+    // another shell has to unlock it first; `git worktree move` refuses a
+    // locked tree.
+    let relocated = repo_dir.path().join("moved-by-hand");
+    git_in(
+        repo_dir.path(),
+        &["worktree", "unlock", created.to_str().unwrap()],
+    );
+    git_in(
+        repo_dir.path(),
+        &[
+            "worktree",
+            "move",
+            created.to_str().unwrap(),
+            relocated.to_str().unwrap(),
+        ],
+    );
+    assert!(!created.exists());
+    assert!(relocated.exists());
+
+    // The pre-reconcile behavior, pinned: `edit_worktree_workdir` is untouched
+    // by the reconcile work, so calling it with the recorded path is exactly
+    // what every surface did before and it still refuses.
+    let before = edit_worktree_workdir(WorktreeEditRequest {
+        worktree_info: &info,
+        current_path: &created,
+        new_name: "settled-name",
+        rename_branch: false,
+    })
+    .unwrap_err();
+    assert!(matches!(before, WorktreeEditError::SourceMissing(_)));
+
+    let mut stale = instance.clone();
+    assert_eq!(
+        reconcile_and_persist(&storage, &mut stale).unwrap(),
+        WorktreePathResolution::Moved(relocated.canonicalize().unwrap())
+    );
+    assert_eq!(
+        std::path::PathBuf::from(&stale.project_path),
+        relocated.canonicalize().unwrap()
+    );
+    // The repair is durable, not just in the caller's copy.
+    let reloaded = storage.load().unwrap();
+    assert_eq!(
+        std::path::PathBuf::from(&reloaded[0].project_path),
+        relocated.canonicalize().unwrap()
+    );
+
+    // The rename that returned SourceMissing before the reconcile now lands,
+    // renaming within the directory's real parent.
+    let outcome = edit_worktree_workdir(WorktreeEditRequest {
+        worktree_info: &info,
+        current_path: std::path::Path::new(&stale.project_path),
+        new_name: "settled-name",
+        rename_branch: false,
+    })
+    .unwrap();
+    assert_eq!(
+        outcome.new_path,
+        relocated
+            .parent()
+            .unwrap()
+            .canonicalize()
+            .unwrap()
+            .join("settled-name")
+    );
+    assert!(outcome.new_path.exists());
+
+    // Reconciling again is a no-op: the recorded path is present, so git is
+    // never consulted.
+    let mut settled = stale.clone();
+    settled.project_path = outcome.new_path.to_string_lossy().into_owned();
+    assert_eq!(
+        reconcile_and_persist(&storage, &mut settled).unwrap(),
+        WorktreePathResolution::Current
+    );
+}
+
+/// What git can and cannot tell us. A bare `mv` leaves git's record naming the
+/// old path, so the new location is not discoverable until the user runs
+/// `git worktree repair`; a deleted checkout is never discoverable. Both leave
+/// the recorded path alone rather than guessing.
+#[test]
+fn resolve_reports_missing_when_git_cannot_place_the_branch() {
+    let (repo_dir, _repo, _config_dir) = setup_test_environment();
+    let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
+
+    let created = repo_dir.path().join("hand-moved");
+    git_wt
+        .create_worktree("hand-moved", &created, true, None)
+        .unwrap();
+    let info = managed_info("hand-moved", repo_dir.path());
+
+    // A bare `mv`: the directory is at its new location but git still points
+    // at the old one, which is indistinguishable from a deletion.
+    let elsewhere = repo_dir.path().join("elsewhere");
+    std::fs::rename(&created, &elsewhere).unwrap();
+    assert_eq!(
+        resolve_worktree_path(&git_wt, &created, &info).unwrap(),
+        WorktreePathResolution::Missing
+    );
+
+    // `git worktree repair` is git's own remedy: once its record catches up,
+    // the same lookup finds the checkout.
+    git_in(
+        repo_dir.path(),
+        &["worktree", "repair", elsewhere.to_str().unwrap()],
+    );
+    assert_eq!(
+        resolve_worktree_path(&git_wt, &created, &info).unwrap(),
+        WorktreePathResolution::Moved(elsewhere.canonicalize().unwrap())
+    );
+
+    // A checkout that is gone for good stays Missing.
+    std::fs::remove_dir_all(&elsewhere).unwrap();
+    assert_eq!(
+        resolve_worktree_path(&git_wt, &created, &info).unwrap(),
+        WorktreePathResolution::Missing
+    );
+
+    // An unmanaged worktree is out of scope and never consults git.
+    let unmanaged = WorktreeInfo {
+        managed_by_aoe: false,
+        ..info.clone()
+    };
+    assert_eq!(
+        resolve_worktree_path(&git_wt, &created, &unmanaged).unwrap(),
+        WorktreePathResolution::Current
+    );
+}

--- a/tests/integration/worktree_integration.rs
+++ b/tests/integration/worktree_integration.rs
@@ -502,14 +502,16 @@ fn git_in(repo: &std::path::Path, args: &[&str]) {
 /// the recorded path is repaired in storage so the rename that would otherwise
 /// fail with `SourceMissing` proceeds against the relocated directory.
 ///
-/// `#[serial]` because `Storage` resolves its app dir from the process-global
-/// `HOME`.
+/// `#[serial]` because `setup_temp_home` mutates the process-global `HOME` and
+/// `XDG_CONFIG_HOME` that `Storage` resolves its app dir from. Setting `HOME`
+/// alone is not enough: on macOS the app dir is `$XDG_CONFIG_HOME/agent-of-empires`
+/// whenever that variable is set, so a bare `HOME` override would write a real
+/// profile dir on any machine that exports it.
 #[test]
 #[serial]
 fn reconcile_heals_a_worktree_moved_outside_aoe() {
     let (repo_dir, _repo, _config_dir) = setup_test_environment();
-    let temp_home = TempDir::new().unwrap();
-    std::env::set_var("HOME", temp_home.path());
+    let _temp_home = crate::common::setup_temp_home();
     let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
 
     let created = repo_dir.path().join("recorded-name");
@@ -612,7 +614,12 @@ fn reconcile_heals_a_worktree_moved_outside_aoe() {
 /// old path, so the new location is not discoverable until the user runs
 /// `git worktree repair`; a deleted checkout is never discoverable. Both leave
 /// the recorded path alone rather than guessing.
+///
+/// `#[serial]` even though this test sets no env var of its own: it shells out
+/// to `git`, which reads `$HOME/.gitconfig`, so it must not overlap a peer that
+/// has pointed `HOME` at a temp dir.
 #[test]
+#[serial]
 fn resolve_reports_missing_when_git_cannot_place_the_branch() {
     let (repo_dir, _repo, _config_dir) = setup_test_environment();
     let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();

--- a/tests/integration/worktree_integration.rs
+++ b/tests/integration/worktree_integration.rs
@@ -667,3 +667,79 @@ fn resolve_reports_missing_when_git_cannot_place_the_branch() {
         WorktreePathResolution::Current
     );
 }
+
+/// A pruned registration frees the branch, so a later checkout of it belongs to
+/// somebody else. The reconcile refuses that lone candidate rather than pointing
+/// two sessions at one directory, where trashing or deleting the stale row would
+/// take the live row's checkout with it.
+///
+/// `#[serial]` for the same reason as the test above: `setup_temp_home` mutates
+/// the process-global `HOME` and `XDG_CONFIG_HOME` that `Storage` resolves its
+/// app dir from.
+#[test]
+#[serial]
+fn reconcile_refuses_a_checkout_another_session_records() {
+    let (repo_dir, _repo, _config_dir) = setup_test_environment();
+    let _temp_home = crate::common::setup_temp_home();
+    let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
+
+    let stale_dir = repo_dir.path().join("first-session");
+    git_wt
+        .create_worktree("shared-branch", &stale_dir, true, None)
+        .unwrap();
+    let info = managed_info("shared-branch", repo_dir.path());
+
+    // The first checkout is removed by hand and its registration pruned, which
+    // is what lets a second worktree take the branch at all.
+    git_in(
+        repo_dir.path(),
+        &["worktree", "unlock", stale_dir.to_str().unwrap()],
+    );
+    std::fs::remove_dir_all(&stale_dir).unwrap();
+    git_in(repo_dir.path(), &["worktree", "prune"]);
+
+    // A later session (or the user's own shell) checks the branch out again.
+    let live_dir = repo_dir.path().join("second-session");
+    git_in(
+        repo_dir.path(),
+        &[
+            "worktree",
+            "add",
+            live_dir.to_str().unwrap(),
+            "shared-branch",
+        ],
+    );
+    let live_canonical = live_dir.canonicalize().unwrap();
+    // git left the branch discoverable, so the lookup does find a lone
+    // candidate; only the ownership check keeps it from being adopted.
+    assert_eq!(
+        resolve_worktree_path(&git_wt.list_worktrees().unwrap(), &stale_dir, &info),
+        WorktreePathResolution::Moved(live_canonical.clone())
+    );
+
+    let mut stale = Instance::new("First Session", stale_dir.to_str().unwrap());
+    stale.worktree_info = Some(info.clone());
+    let mut live = Instance::new("Second Session", live_canonical.to_str().unwrap());
+    live.worktree_info = Some(info.clone());
+    let storage = Storage::new_unwatched("worktree-reconcile-claimed-profile").unwrap();
+    let seeded = vec![stale.clone(), live.clone()];
+    storage
+        .update(|i, g| {
+            *i = seeded.to_vec();
+            *g = GroupTree::new_with_groups(&seeded, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let mut reconciled = stale.clone();
+    assert_eq!(
+        reconcile_and_persist(&storage, &mut reconciled, &mut Default::default()).unwrap(),
+        WorktreePathResolution::Current
+    );
+    assert_eq!(reconciled.project_path, stale.project_path);
+    let reloaded = storage.load().unwrap();
+    let stale_row = reloaded.iter().find(|i| i.id == stale.id).unwrap();
+    assert_eq!(stale_row.project_path, stale.project_path);
+    let live_row = reloaded.iter().find(|i| i.id == live.id).unwrap();
+    assert_eq!(live_row.project_path, live.project_path);
+}

--- a/tests/integration/worktree_integration.rs
+++ b/tests/integration/worktree_integration.rs
@@ -566,7 +566,7 @@ fn reconcile_heals_a_worktree_moved_outside_aoe() {
 
     let mut stale = instance.clone();
     assert_eq!(
-        reconcile_and_persist(&storage, &mut stale).unwrap(),
+        reconcile_and_persist(&storage, &mut stale, &mut Default::default()).unwrap(),
         WorktreePathResolution::Moved(relocated.canonicalize().unwrap())
     );
     assert_eq!(
@@ -605,7 +605,7 @@ fn reconcile_heals_a_worktree_moved_outside_aoe() {
     let mut settled = stale.clone();
     settled.project_path = outcome.new_path.to_string_lossy().into_owned();
     assert_eq!(
-        reconcile_and_persist(&storage, &mut settled).unwrap(),
+        reconcile_and_persist(&storage, &mut settled, &mut Default::default()).unwrap(),
         WorktreePathResolution::Current
     );
 }
@@ -635,7 +635,7 @@ fn resolve_reports_missing_when_git_cannot_place_the_branch() {
     let elsewhere = repo_dir.path().join("elsewhere");
     std::fs::rename(&created, &elsewhere).unwrap();
     assert_eq!(
-        resolve_worktree_path(&git_wt, &created, &info).unwrap(),
+        resolve_worktree_path(&git_wt.list_worktrees().unwrap(), &created, &info),
         WorktreePathResolution::Missing
     );
 
@@ -646,14 +646,14 @@ fn resolve_reports_missing_when_git_cannot_place_the_branch() {
         &["worktree", "repair", elsewhere.to_str().unwrap()],
     );
     assert_eq!(
-        resolve_worktree_path(&git_wt, &created, &info).unwrap(),
+        resolve_worktree_path(&git_wt.list_worktrees().unwrap(), &created, &info),
         WorktreePathResolution::Moved(elsewhere.canonicalize().unwrap())
     );
 
     // A checkout that is gone for good stays Missing.
     std::fs::remove_dir_all(&elsewhere).unwrap();
     assert_eq!(
-        resolve_worktree_path(&git_wt, &created, &info).unwrap(),
+        resolve_worktree_path(&git_wt.list_worktrees().unwrap(), &created, &info),
         WorktreePathResolution::Missing
     );
 
@@ -663,7 +663,7 @@ fn resolve_reports_missing_when_git_cannot_place_the_branch() {
         ..info.clone()
     };
     assert_eq!(
-        resolve_worktree_path(&git_wt, &created, &unmanaged).unwrap(),
+        resolve_worktree_path(&git_wt.list_worktrees().unwrap(), &created, &unmanaged),
         WorktreePathResolution::Current
     );
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

aoe records a worktree session's directory at creation and nothing syncs that string afterwards. Relocate the directory from another shell and the recorded `project_path` goes stale: attach, status detection, diff, and the workdir rename all act on a path that is not there, and the only fix was hand-editing `sessions.json`. git already knows where the checkout went, keyed by branch, so the repair is a lookup rather than new bookkeeping.

`src/session/worktree_reconcile.rs` resolves a managed session's real location from `git worktree list`. It is triggered by absence: a recorded path that exists is treated as proof it is still correct, so a healthy session costs one `stat` and never shells out to git. Exactly one live checkout of the branch means the path is rewritten and persisted; two mean aoe leaves the row alone rather than guessing which checkout belongs to this session; a git failure stays distinct from "nothing was discoverable" so a broken repo is never logged as a missing worktree. The persist is compare-and-set, because the git lookup runs without the storage lock and a peer process could rename or trash the session in that window.

Wired at the seams where each surface takes its sessions: TUI startup, the daemon's one-shot startup sweep beside the existing trash reconcile, and the CLI workdir edit (a fresh process per invocation, so it has no startup seam of its own). Deliberately **not** wired inside `edit_worktree_workdir`, which was the tempting one-line option. Every caller derives its duplicate-identity check and its sandbox-container release from `project_path` before invoking the edit, so healing inside would leave those gates computed against the stale path: a stale leaf that happens to equal the requested leaf makes `worktree_move_required` false, the container is never released, and the `git worktree move` then runs against a live bind mount.

Two limits are worth knowing and are now documented rather than discovered. aoe locks the worktrees it creates, so an out-of-band `git worktree move` needs `git worktree unlock` first. And a plain `mv` is not recoverable on its own: it leaves git's record naming the old path, which is indistinguishable from a deleted checkout, so aoe reports the worktree missing and changes nothing until `git worktree repair` brings git's record up to date.

Scope I left on the table, deliberately. Reconciliation is point-in-time, not a watcher, so a directory moved while a TUI or `aoe serve` is already running stays stale for that process until it restarts. Closing that gap means reconciling ahead of the pre-flight at the four remaining rename call sites (two TUI, two async server), which wants a shared rename-operation service first rather than four copies of the same ordering. Both CLI entry points are wired, since each runs as a fresh process with no startup seam of its own. No durable "worktree missing" field either: without a watcher a stored flag rots the moment the user restores the directory or runs `git worktree repair`, and the structured view already models this condition as a transient observation via `AcpError::ProjectPathMissing`.

Refs #2002

Not `Closes`: the issue lists three mandatory user stories and this PR ships two. Story 2, a user-visible "worktree missing" state (the issue's proposal C), is deliberately not implemented, for the reason in the paragraph above: without a watcher a durable flag rots the moment the user restores the directory or runs `git worktree repair`, and the structured view already models the condition transiently via `AcpError::ProjectPathMissing`. Today `Missing` and `Ambiguous` only reach `debug.log` through `tracing::warn!`, so the issue stays open to track surfacing them, most likely as a transient `last_error`-style signal rather than a stored field.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a worktree session, note its directory, then from another shell run `git worktree unlock <dir>` and `git worktree move <dir> <new-dir>`. Restart the TUI: the session still previews and attaches, now against `<new-dir>`.
- [ ] Same setup, but instead of restarting the TUI run `aoe session set-worktree-name <session> --name something-else`. It succeeds and renames within the relocated directory's parent, where before it failed with "the current worktree directory does not exist".
- [ ] Same setup with `aoe serve` running: stop it, start it again, and confirm the structured-view session loses its "Project path no longer exists" banner and resumes against the new path.
- [ ] `rm -rf` a worktree session's directory instead of moving it, then run the rename. It still refuses with the worktree-missing message and `sessions.json` is untouched, so a deleted checkout is never silently repointed.
- [ ] Move a worktree directory with a bare `mv` (no `git worktree move`). aoe reports it missing and changes nothing. Then run `git worktree repair <new-dir>` from the repo and restart: the path heals.
- [ ] Confirm a session whose directory never moved is untouched: `sessions.json` is byte-identical across a TUI restart.
- [ ] Confirm the main checkout is never adopted: delete a worktree session's directory, then `git worktree unlock <dir>`, `git worktree prune`, and `git checkout <that-branch>` in the main repo so it is the only live checkout of the branch. Restart the TUI and confirm `project_path` is left alone rather than repointed at the main repo, with a warning in `debug.log`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is covered end to end at the integration layer instead. `tests/integration/worktree_integration.rs` creates a real managed worktree, relocates it with real `git worktree unlock` plus `git worktree move` subprocesses, and asserts the pre-reconcile `SourceMissing` failure, the durable repair, and the rename then succeeding. An e2e test would drive the same code through tmux for a behavior with no new TUI rendering or new CLI surface, at 2s serial on the critical path forever. The second integration test pins what git cannot tell us: bare `mv` reads as missing until `git worktree repair`, and a deleted checkout stays missing. A unit table test covers the selection rules, including two live checkouts on one branch and one checkout arriving under two path spellings.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. The scoping calls are mine: I had it debate variant A against a load-time pass and a durable missing-state field, and the wiring cut, the no-migration decision, and the choice not to touch `edit_worktree_workdir` came out of that. I reviewed each commit and ran the manual steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added automatic repair for stale managed worktree paths after external moves.
- Wired repair into TUI startup, daemon startup, and both CLI rename flows.
- Prevented repair from selecting the main worktree or a checkout recorded by another session.
- Added per-pass caching for Git worktree listings.
- Added tests for moved, deleted, repaired, ambiguous, duplicate, unmanaged, and main-worktree cases.
- Documented recovery steps, lock requirements, read-only daemon behavior, and plain-move limitations.

## Benefits

- External worktree moves usually no longer require manual path updates.
- Repaired paths are available before duplicate and sandbox checks.
- Shared Git lookups reduce repeated work.
- Ambiguous or unsafe matches leave the recorded path unchanged.

## Further enhancement

- Missing and ambiguous worktrees remain transient outcomes. A durable “worktree missing” state is not included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
