### PR TITLE
fix(acp): classify aoe-agent task calls as think and drop AOE_AGENT's false claude claims

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -272,6 +272,14 @@ jobs:
       - name: Run Vitest with coverage
         working-directory: web
         run: npm run test:unit -- --coverage --reporter=default --reporter=junit --outputFile.junit=test-report.junit.xml
+      # The bundled aoe-agent ACP adapter is a separate npm package with its
+      # own node:test suite (transcript round-tripping, tool-kind mapping).
+      # Nothing ran it before, so both of its test files could rot unnoticed;
+      # it rides this job because Node is already set up here. Seconds to run,
+      # and it is deliberately not part of the coverage upload below.
+      - name: aoe-agent adapter tests
+        working-directory: acp-worker/aoe-agent
+        run: npm ci && npm test
       # Vitest's v8 coverage reporter emits LCOV paths relative to the
       # vitest cwd (web/), so SF: lines read "SF:src/...". Codecov
       # matches file paths against the PR diff, which uses repo-root

--- a/acp-worker/aoe-agent/src/index.ts
+++ b/acp-worker/aoe-agent/src/index.ts
@@ -22,6 +22,7 @@ import { openai } from "@ai-sdk/openai";
 import { google } from "@ai-sdk/google";
 import { z } from "zod";
 import { appendTurn, loadTranscript } from "./transcript.ts";
+import { classifyKind } from "./toolKind.ts";
 
 const DEFAULT_MODEL = "claude-opus-4-7";
 
@@ -266,19 +267,6 @@ function buildTools(sessionId: string, client: acp.AgentContext) {
       },
     }),
   };
-}
-
-function classifyKind(toolName: string): acp.ToolKind {
-  switch (toolName) {
-    case "Read":
-      return "read";
-    case "Write":
-      return "edit";
-    case "Bash":
-      return "execute";
-    default:
-      return "other";
-  }
 }
 
 function serialiseToolOutput(output: unknown): Record<string, unknown> {

--- a/acp-worker/aoe-agent/src/toolKind.ts
+++ b/acp-worker/aoe-agent/src/toolKind.ts
@@ -6,22 +6,25 @@
 
 import type * as acp from "@agentclientprotocol/sdk";
 
+// Matched case-insensitively, the way opencode's mapper normalises before
+// its switch. The names below are how `buildTools` registers them, but a
+// model picks the casing, and a mismatch here only costs a wrong card.
 export function classifyKind(toolName: string): acp.ToolKind {
-  switch (toolName) {
-    case "Read":
+  switch (toolName.toLowerCase()) {
+    case "read":
       return "read";
-    case "Write":
+    case "write":
       return "edit";
-    case "Bash":
+    case "bash":
       return "execute";
     // `task` is not in `buildTools`, but models trained against harnesses
     // that do have a subagent tool call it anyway; two such calls landed in
-    // the wild (#1904). The AI SDK cannot execute it, so no subagent runs.
-    // This only fixes how the call renders: `think` matches what
-    // claude-agent-acp and opencode >=1.16.0 report for the same name,
-    // which puts it on the think card instead of the generic one.
+    // the wild (#1904). The AI SDK answers each one with a NoSuchToolError,
+    // so no subagent runs and the call always fails. `think` matches what
+    // claude-agent-acp and opencode >=1.16.0 report for the same name; the
+    // think card falls through to the error body on a failure, so the
+    // NoSuchToolError text stays visible.
     case "task":
-    case "Task":
       return "think";
     default:
       return "other";

--- a/acp-worker/aoe-agent/src/toolKind.ts
+++ b/acp-worker/aoe-agent/src/toolKind.ts
@@ -1,0 +1,29 @@
+/**
+ * Tool-name to ACP `ToolKind` mapping for the structured view's card
+ * dispatch. Its own module so it is testable: `index.ts` calls `main()` at
+ * module scope, so importing it from a test would connect to stdio.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+
+export function classifyKind(toolName: string): acp.ToolKind {
+  switch (toolName) {
+    case "Read":
+      return "read";
+    case "Write":
+      return "edit";
+    case "Bash":
+      return "execute";
+    // `task` is not in `buildTools`, but models trained against harnesses
+    // that do have a subagent tool call it anyway; two such calls landed in
+    // the wild (#1904). The AI SDK cannot execute it, so no subagent runs.
+    // This only fixes how the call renders: `think` matches what
+    // claude-agent-acp and opencode >=1.16.0 report for the same name,
+    // which puts it on the think card instead of the generic one.
+    case "task":
+    case "Task":
+      return "think";
+    default:
+      return "other";
+  }
+}

--- a/acp-worker/aoe-agent/test/toolKind.test.ts
+++ b/acp-worker/aoe-agent/test/toolKind.test.ts
@@ -10,7 +10,10 @@ test("maps the tool palette and the unregistered task tool", () => {
     // Regression for #1904: `task` used to fall through to "other", which
     // rendered a generic card instead of the think card.
     ["task", "think"],
+    // The model picks the casing, so every arm is matched case-insensitively.
     ["Task", "think"],
+    ["TASK", "think"],
+    ["bash", "execute"],
     // Anything the adapter does not know still falls through.
     ["WebFetch", "other"],
     ["", "other"],

--- a/acp-worker/aoe-agent/test/toolKind.test.ts
+++ b/acp-worker/aoe-agent/test/toolKind.test.ts
@@ -1,0 +1,21 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyKind } from "../src/toolKind.ts";
+
+test("maps the tool palette and the unregistered task tool", () => {
+  const cases: [string, string][] = [
+    ["Read", "read"],
+    ["Write", "edit"],
+    ["Bash", "execute"],
+    // Regression for #1904: `task` used to fall through to "other", which
+    // rendered a generic card instead of the think card.
+    ["task", "think"],
+    ["Task", "think"],
+    // Anything the adapter does not know still falls through.
+    ["WebFetch", "other"],
+    ["", "other"],
+  ];
+  for (const [name, expected] of cases) {
+    assert.equal(classifyKind(name), expected, name);
+  }
+});

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -293,19 +293,43 @@ pub const PRIME_AGENT: AgentProfile = AgentProfile {
     yolo_mode_id: None,
 };
 
-/// aoe's own multi-provider agent. Treated as Claude-equivalent
-/// for now (Vercel AI SDK 7 with Claude as one of the providers); the
-/// claude_capabilities subset is the safest reference until aoe-agent
-/// has its own conventions.
+/// aoe's own multi-provider agent (Vercel AI SDK 7), at
+/// `acp-worker/aoe-agent/src/index.ts`. Every field below is read off that
+/// source, which is a much smaller surface than Claude's: three tools
+/// (Read, Write, Bash), no `_meta` on any event, no plan mode, no
+/// ScheduleWakeup, no heartbeats, and a `session/set_mode` that is a stub
+/// returning `{}`. It used to inherit `..CLAUDE`, which claimed all of
+/// those; the structured view then advertised subagent indentation and a
+/// mode picker the adapter cannot honor. See #1904.
 pub const AOE_AGENT: AgentProfile = AgentProfile {
     key: "aoe-agent",
-    // Deliberately NOT inherited from CLAUDE: aoe-agent is multi-provider, and
-    // nobody has checked whether its clear rotates an observable session id the
-    // way claude-agent-acp fails to. Driving a reset on an adapter that already
-    // handles the alias natively would double-reset it, so it stays on the
-    // forward path until someone verifies it.
-    clear_requires_driven_reset: false,
-    ..CLAUDE
+    // The adapter sets no `_meta` on its tool_call notifications at all, so
+    // there is no namespace to look up and child tool calls cannot be linked
+    // to a parent. Populate this only once the adapter emits linkage.
+    parent_meta_namespaces: &[],
+    clear_aliases: &["/clear"],
+    // Same defect class as codex-acp: the adapter has no clear handler of any
+    // kind, so a forwarded `/clear` is answered as an ordinary prompt and the
+    // model keeps its whole history while AoE draws a clear divider. Driving
+    // the reset via `session/new` mints an id we can persist and does reset
+    // the in-memory history.
+    //
+    // Known hole: the adapter reseeds from `${AOE_ARTIFACT_DIR}/transcript.jsonl`
+    // on `session/load`, and that file still holds the pre-clear turns, so a
+    // worker restart after a clear resurrects the cleared context. Fixing that
+    // means truncating the transcript on reset, tracked separately.
+    clear_requires_driven_reset: true,
+    // No ExitPlanMode tool and no mode channel; no ScheduleWakeup or cron
+    // tools. Synthesising Plan or WakeupScheduled events here would fire on
+    // nothing.
+    supports_exit_plan_mode: false,
+    supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
+    // `session/set_mode` is `() => ({})`: it accepts any id and changes
+    // nothing, and the adapter advertises no modes. Claiming Claude's
+    // `bypassPermissions` made YOLO look applied when nothing was gated by
+    // the adapter at all, so keep it a documented no-op.
+    yolo_mode_id: None,
 };
 
 /// Permissive default for unknown registry keys: no claude-specific
@@ -422,7 +446,9 @@ mod tests {
             resolve("claude-code").yolo_mode_id,
             Some("bypassPermissions")
         );
-        assert_eq!(resolve("aoe-agent").yolo_mode_id, Some("bypassPermissions"));
+        // aoe-agent's `session/set_mode` is a stub that accepts any id and
+        // gates nothing, so it advertises no bypass mode (#1904).
+        assert_eq!(resolve("aoe-agent").yolo_mode_id, None);
         // Regression for #1142 and the @agentclientprotocol/codex-acp
         // migration: codex's bypass preset is `agent-full-access`, not
         // Claude's `bypassPermissions` or the old Zed adapter's `full-access`.
@@ -470,19 +496,18 @@ mod tests {
     /// text-forward path leaves the new conversation unresumable across a
     /// worker restart. Both need AoE to mint the id itself.
     ///
-    /// `aoe-agent` must NOT inherit claude's answer here even though it
-    /// inherits the rest of the profile via `..CLAUDE`: it is a different
-    /// multi-provider adapter whose clear semantics nobody has verified. The
-    /// assertion below is what stops a future `..CLAUDE` edit from silently
-    /// flipping it. Same standard for the unverified `/new` mappings
-    /// (opencode, omp, kimi), which keep the old behavior until observed.
+    /// `aoe-agent` lands in the same bucket as codex, for codex's reason
+    /// rather than claude's: its adapter source handles no slash command at
+    /// all, so a forwarded `/clear` reaches the model as an ordinary prompt
+    /// and the conversation keeps its full history (#1904). Same standard for
+    /// the unverified `/new` mappings (opencode, omp, kimi), which keep the
+    /// old behavior until observed.
     #[test]
     fn clear_requires_driven_reset_for_codex_and_claude() {
-        for profile in [&CODEX, &CLAUDE, &CLAUDE_CODE] {
+        for profile in [&CODEX, &CLAUDE, &CLAUDE_CODE, &AOE_AGENT] {
             assert!(profile.clear_requires_driven_reset, "{}", profile.key);
         }
         for profile in [
-            &AOE_AGENT,
             &OPENCODE,
             &GEMINI,
             &VIBE,
@@ -527,6 +552,18 @@ mod tests {
         // Opencode's parent linkage convention is unverified; even if the
         // wire carries the value, we don't claim it until observed.
         assert!(OPENCODE.parent_tool_use_id_from_meta(&Some(meta)).is_none());
+
+        // aoe-agent emits no `_meta` on any tool_call notification, so even
+        // claude's own namespace must not resolve for it (#1904). It used to,
+        // via `..CLAUDE`, which promised linkage the adapter never sends.
+        let mut claude_meta = serde_json::Map::new();
+        claude_meta.insert(
+            "claudeCode".to_string(),
+            serde_json::json!({ "parentToolUseId": "tc-parent-7" }),
+        );
+        assert!(AOE_AGENT
+            .parent_tool_use_id_from_meta(&Some(claude_meta))
+            .is_none());
     }
 
     #[test]
@@ -571,10 +608,13 @@ mod tests {
 
     #[test]
     fn capability_flags_only_set_for_claude_family() {
-        for profile in [&CLAUDE, &CLAUDE_CODE, &AOE_AGENT] {
+        for profile in [&CLAUDE, &CLAUDE_CODE] {
             assert!(profile.supports_exit_plan_mode);
             assert!(profile.supports_wakeup_tools);
         }
+        // `aoe-agent` sits with the others despite bundling Claude as one of
+        // its providers: the adapter's own tool palette is Read/Write/Bash,
+        // with no ExitPlanMode and no ScheduleWakeup to synthesise from (#1904).
         for profile in [
             &CODEX,
             &OPENCODE,
@@ -584,6 +624,7 @@ mod tests {
             &OMP,
             &KIMI,
             &PRIME_AGENT,
+            &AOE_AGENT,
             &DEFAULT,
         ] {
             assert!(!profile.supports_exit_plan_mode, "{}", profile.key);

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -612,8 +612,8 @@ mod tests {
             assert!(profile.supports_exit_plan_mode);
             assert!(profile.supports_wakeup_tools);
         }
-        // `aoe-agent` sits with the others despite bundling Claude as one of
-        // its providers: the adapter's own tool palette is Read/Write/Bash,
+        // `aoe-agent` sits with the non-Claude group despite bundling Claude
+        // as one of its providers: the adapter's tool palette is Read/Write/Bash,
         // with no ExitPlanMode and no ScheduleWakeup to synthesise from (#1904).
         for profile in [
             &CODEX,

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -1103,7 +1103,21 @@ function FetchToolCard({ tool, result }: Props) {
 
 /* ── think ──────────────────────────────────────────────────────── */
 
-function ThinkToolCard({ tool }: Props) {
+function ThinkToolCard({ tool, result }: Props) {
+  // A think call's substance normally lives somewhere other than the card:
+  // in streamed child tool calls, or in a returned report. The quiet
+  // one-line card is right for that. A *failed* one inverts it, the error
+  // is all there is, and this card has nowhere to put it. Fall through to
+  // the generic card, which auto-expands on error and prints the text.
+  //
+  // aoe-agent makes this the common case rather than an edge: `task` is not
+  // in its palette, so the AI SDK answers every call with a NoSuchToolError
+  // naming the tools that do exist, which is the one message a user needs
+  // to see. A claude or opencode Task can fail too, and was equally silent
+  // before this branch. See #1904.
+  if (statusFor(result) === "err") {
+    return <GenericToolCard tool={tool} result={result} />;
+  }
   return (
     <div className="my-1 flex items-center gap-2 px-3 py-1 text-xs italic text-text-muted">
       <Sparkles className="h-3 w-3 text-text-dim" />

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -311,7 +311,22 @@ function renderToolCard(tool: ToolCall, result: ActivityRow | undefined, profile
     case "fetch":
       return <FetchToolCard tool={tool} result={result} />;
     case "think":
-      return <ThinkToolCard tool={tool} result={result} />;
+      // A think call's substance normally lives somewhere other than the card:
+      // in streamed child tool calls, or in a returned report. The quiet
+      // one-line ThinkToolCard is right for that. A *failed* one inverts it,
+      // the error is all there is, and that card renders no error body, so
+      // route failures to the generic card instead.
+      //
+      // aoe-agent makes this the common case rather than an edge: `task` is
+      // not in its palette, so the AI SDK answers every call with a
+      // NoSuchToolError naming the tools that do exist, which is the one
+      // message a user needs to see. A claude or opencode Task can fail too,
+      // and was equally silent before this branch. See #1904.
+      return statusFor(result) === "err" ? (
+        <GenericToolCard tool={tool} result={result} />
+      ) : (
+        <ThinkToolCard tool={tool} result={result} />
+      );
     default:
       return <GenericToolCard tool={tool} result={result} />;
   }
@@ -1103,21 +1118,7 @@ function FetchToolCard({ tool, result }: Props) {
 
 /* ── think ──────────────────────────────────────────────────────── */
 
-function ThinkToolCard({ tool, result }: Props) {
-  // A think call's substance normally lives somewhere other than the card:
-  // in streamed child tool calls, or in a returned report. The quiet
-  // one-line card is right for that. A *failed* one inverts it, the error
-  // is all there is, and this card has nowhere to put it. Fall through to
-  // the generic card, which auto-expands on error and prints the text.
-  //
-  // aoe-agent makes this the common case rather than an edge: `task` is not
-  // in its palette, so the AI SDK answers every call with a NoSuchToolError
-  // naming the tools that do exist, which is the one message a user needs
-  // to see. A claude or opencode Task can fail too, and was equally silent
-  // before this branch. See #1904.
-  if (statusFor(result) === "err") {
-    return <GenericToolCard tool={tool} result={result} />;
-  }
+function ThinkToolCard({ tool }: Props) {
   return (
     <div className="my-1 flex items-center gap-2 px-3 py-1 text-xs italic text-text-muted">
       <Sparkles className="h-3 w-3 text-text-dim" />

--- a/web/src/components/acp/__tests__/ToolCards.test.tsx
+++ b/web/src/components/acp/__tests__/ToolCards.test.tsx
@@ -189,6 +189,25 @@ describe("ToolCard dispatch by kind", () => {
     expect(container.textContent).toContain("Reasoning");
   });
 
+  it("falls through to the error body for a failed think card", () => {
+    // The quiet think card has nowhere to render a failure, so a failed one
+    // used to show its name and nothing else. aoe-agent's `task` is never in
+    // its palette, so every call fails with a NoSuchToolError naming the
+    // tools that do exist, and that text is the whole point. See #1904.
+    const tool = toolWith({ kind: "think", name: "task", args_preview: JSON.stringify({ description: "delegate" }) });
+    const { container } = render(
+      <ToolCard
+        tool={tool}
+        result={errorRow(
+          "AI_NoSuchToolError: Model tried to call unavailable tool 'task'. Available tools: Read, Write, Bash.",
+        )}
+      />,
+    );
+    expect(container.textContent).toContain("failed");
+    expect(container.textContent).toContain("unavailable tool 'task'");
+    expect(container.textContent).toContain("Available tools: Read, Write, Bash.");
+  });
+
   it("renders the generic fallback for an unrecognised kind", () => {
     const tool = toolWith({
       kind: "weird",

--- a/web/src/lib/agentProfiles.test.ts
+++ b/web/src/lib/agentProfiles.test.ts
@@ -55,6 +55,25 @@ describe("resolveAgentProfile", () => {
     expect(p.parentMetaNamespaces).toEqual([]);
   });
 
+  it("aoe-agent claims no claude specials despite bundling claude as a provider", () => {
+    // Regression for #1904: this profile used to spread CLAUDE, so the view
+    // advertised subagent indentation, the claude specialised cards, and the
+    // legacy mode picker for an adapter whose surface is Read / Write / Bash.
+    const p = resolveAgentProfile("aoe-agent");
+    expect(p.capabilities).toEqual({
+      todos: false,
+      skills: false,
+      wakeup: false,
+      subagents: false,
+      legacyModeFallback: false,
+      heartbeatKeepalives: false,
+    });
+    expect(p.parentMetaNamespaces).toEqual([]);
+    expect(p.specialTitles).toEqual({ skillNames: [], scheduleNames: [], harnessNames: [] });
+    // No subagent card by wire name either: nothing actually runs.
+    expect(isSubagentToolName("task", p)).toBe(false);
+  });
+
   it("omp uses its native ACP clear boundary without guessed capabilities", () => {
     const p = resolveAgentProfile("omp");
     expect(p.capabilities.todos).toBe(false);

--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -331,9 +331,29 @@ const PRIME_AGENT: AgentProfile = {
   specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
+// aoe's own multi-provider agent (Vercel AI SDK 7), at
+// `acp-worker/aoe-agent/src/index.ts`. It used to spread CLAUDE, which claimed
+// the whole claude specials set; the adapter's actual surface is three tools
+// (Read, Write, Bash) reported with real ToolKinds, no `_meta` on any
+// notification, no TodoWrite / Skill / ScheduleWakeup, no mode channel, and no
+// heartbeats. Everything below is off rather than guessed, so tools land on
+// the generic kind path. Its `task` calls arrive as `kind: "think"` from the
+// adapter itself, so they need no alias here. See #1904.
 const AOE_AGENT: AgentProfile = {
-  ...CLAUDE,
   key: "aoe-agent",
+  subagentToolNames: [],
+  capabilities: {
+    todos: false,
+    skills: false,
+    wakeup: false,
+    subagents: false,
+    legacyModeFallback: false,
+    heartbeatKeepalives: false,
+  },
+  parentMetaNamespaces: [],
+  mcpPrefixes: ["mcp__"],
+  aliases: {},
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
 /** Permissive fallback for unknown agent keys: kind-only dispatch with


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Partial progress on #1904. Two of its three slices, A and C; slice B stays out because it is `blocked:upstream`.

`aoe-agent`'s `classifyKind` only recognised `Read`, `Write` and `Bash`, so every other tool name fell through to `kind: "other"` and landed on the generic tool card. Models trained against harnesses that ship a subagent tool call `task` anyway, which is how two of them landed in session `2934dc8c87804072`. `claude-agent-acp` and `opencode` >= 1.16.0 both report `think` for that name, so `aoe-agent` now matches them and the call renders on the think card.

Worth being precise about what that does and does not fix: `buildTools` registers exactly Read, Write and Bash, so the AI SDK cannot execute a `task` call at all. No subagent runs, and no child tool calls stream. This is a rendering fix. Real subagent support needs a `task` tool in the palette plus slice B's `_meta` linkage, and B is gated on [anomalyco/opencode#30557](https://github.com/anomalyco/opencode/issues/30557) per the issue thread.

Slice C is the larger half. Both `AOE_AGENT` profiles, server and frontend, inherited Claude's profile wholesale (`..CLAUDE` / `...CLAUDE`). Read against the adapter source, almost every inherited field was false: it emits no `_meta` on any notification, has no ExitPlanMode or ScheduleWakeup tool, sends no heartbeat keepalives, and its `session/set_mode` is a stub that returns `{}` and gates nothing. So the structured view was advertising subagent indentation it could never render, the Claude specialised cards, and a Default/Plan/AcceptEdits/Yolo mode picker whose selections the adapter silently discarded. Every field is now stated explicitly with the source fact behind it, so a later `..CLAUDE` edit cannot quietly re-inherit a claim.

Two decisions inside slice C worth flagging for review:

- **`clear_requires_driven_reset` flips to `true`.** The issue left this field "tbd". The adapter handles no slash command at all, so a forwarded `/clear` reached the model as an ordinary prompt: the conversation kept its whole history while AoE drew a clear divider. That is codex-acp's defect exactly, so it takes codex-acp's remedy. One hole remains, commented at the field rather than fixed here: `session/load` reseeds from `${AOE_ARTIFACT_DIR}/transcript.jsonl`, which still holds the pre-clear turns, so a worker restart after a clear resurrects the cleared context. Fixing that means truncating the transcript on reset, which is a separate change.
- **`yolo_mode_id` drops to `None`, and this is not a security loosening.** `bypassPermissions` is still in `TRUSTED_MODE_TABLE` in `src/plugin/automation_policy.rs`, so it classifies `Unattended` regardless of the profile. The profile field only stopped claiming a bypass mode the adapter does not advertise.

`subagentToolNames` stays empty on purpose. That field (#3070) renders a childless subagent card for an off-protocol subagent that really ran, which is opencode's case. `aoe-agent` has no `task` tool, so nothing runs and the card would be inventing a subagent.

**Separate follow-up I did not touch, but noticed while reading:** `is_reviewed("aoe-agent")` is `true`, which classifies an omitted mode as `Interactive` on the assumption the adapter prompts for approval. `aoe-agent` never sends `session/request_permission`; AoE's own `fs/*` and `terminal/*` handlers gate it server-side instead. That is a security-policy call in #2897's territory, not a rendering fix, so it wants its own issue.

Refs #1904

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view session with `--agent aoe-agent` and a non-Claude model, prompt it into something multi-step, and confirm any `task` call the model emits renders as a think card rather than a generic "other" card.
- [ ] In the same session, open the mode picker: it should now be absent rather than offering Default / Plan / Accept-edits / Yolo, since the adapter advertises no modes and ignored every selection.
- [ ] Send `/clear` in an `aoe-agent` session, then ask the agent about something from before the clear. It should not remember it. Before this change it did, while the timeline showed a clear divider.
- [ ] Known limitation to confirm, not a regression: after that `/clear`, stop the worker (`aoe acp stop <session>`) and prompt again. The pre-clear context comes back, because the adapter reseeds from its on-disk transcript. Commented at the profile field.
- [ ] Confirm a Claude session is untouched: subagent indentation, TodoWrite / Skill cards, and the mode picker all still work as before.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --features serve --all-targets`, and `cargo test --features serve` are clean, except for one pre-existing macOS-only failure unrelated to this diff: `git::worktree::tests::worktree_move_observation_canonicalizes_symlinked_parents` compares a `tempfile::tempdir()` path against a canonicalized one, and macOS resolves `/var` to `/private/var`. Verified failing at the base commit `fb0e7af` in a detached worktree, and this diff does not touch `src/git/`. Web side: `npx vitest run` (3716 pass), `npm run format:check`, `npm run lint`, `npx tsc -b` all clean.

No `docs/` change. The feature matrix in `docs/structured-view.md` puts `aoe-agent` in the "Other ACP" column, which is already marked as either adapter-dependent or unsupported for every capability this PR turns off, so nothing there becomes wrong.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a Playwright test, because: the change is in a pure data table (`web/src/lib/agentProfiles.ts`), covered by a Vitest regression test in `agentProfiles.test.ts` that asserts the whole capability set and fails on a re-spread of `CLAUDE`. `coverage-matrix.json` already maps that file to that spec, and `validate-coverage-matrix.mjs` passes. A live Playwright spec proving the aoe-agent mode picker is gone would need a fake adapter advertising no modes, which is worth having but is a harness addition rather than part of this fix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Regression tests, each verified red before the fix and green after:

- `acp-worker/aoe-agent/test/toolKind.test.ts`: table over the tool palette plus `task` / `Task`. `classifyKind` moved into its own `src/toolKind.ts` to get a test seam at all, since `index.ts` calls `main()` at module scope and importing it from a test would connect to stdio. Note this package's `npm test` is not wired into CI today (neither is its existing `transcript.test.ts`); run it with `cd acp-worker/aoe-agent && npm test`.
- `src/acp/agent_profiles.rs`: three existing tests pinned the old claim and now pin the new one (`capability_flags_only_set_for_claude_family`, `yolo_mode_id_is_adapter_specific`, `clear_requires_driven_reset_for_codex_and_claude`). The last one carried a doc comment arguing aoe-agent must *not* inherit Claude's answer here, so it is rewritten to state the new reason rather than just moved. Added an assertion that Claude's own `_meta` namespace does not resolve for aoe-agent.
- `web/src/lib/agentProfiles.test.ts`: asserts the full capability object, `parentMetaNamespaces`, `specialTitles`, and that `isSubagentToolName("task", …)` is false.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I scoped the PR to slices A and C and made the two judgment calls it surfaced (extracting a test seam for `classifyKind`, and driving the clear reset rather than dropping the alias). I reviewed each commit and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `aoe-agent` rendering for `task` calls, regardless of letter case.
- Failed think calls now display their error messages.
- Removed unsupported Claude capabilities from the server and web `AOE_AGENT` profiles.
- Added server-driven `/clear` reset handling.
- Added regression tests and CI coverage for the adapter.

## Benefits

- Tool activity renders correctly.
- Unavailable tools no longer fail silently.
- The profile exposes only supported capabilities.
- Tests reduce the risk of future regressions.

## Technical details

- `task` calls map to the `think` kind for rendering only.
- `subagentToolNames` remains empty because `aoe-agent` does not execute subagents.
- `/clear` uses a driven reset and documents transcript-reload limitations.
- Slice B remains blocked upstream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->