### PR TITLE
feat(tui): render the row-badge plugin slot in the remote-home picker

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -366,6 +366,11 @@ id = "my_pane"
 | `composer-action` | per-session | A button beside the ACP composer controls (requires `api_version >= 8`). |
 | `notification` | n/a | A transient notification pushed via `ui.notify`; gated by the `notifications` capability, not a slot declaration. |
 
+The native TUI's daemon-connected session picker renders `row-badge` and
+`row-column` as tone-colored text, sharing one bounded column between them. A
+badge carrying only an `icon` renders nothing there, since a lucide name has no
+terminal glyph: send `text` for a badge that should be visible in a terminal.
+
 ### Pane payload
 
 A `pane` entry renders a dockable tool-window. The worker pushes it with

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -963,6 +963,79 @@ mod tests {
     }
 
     #[test]
+    fn row_badge_cells_read_both_payload_forms() {
+        // One badge payload and the cells it must yield. Covers the single
+        // badge form, the `items` list, and every shape that renders nothing.
+        let cases: [(serde_json::Value, &[(&str, Option<Tone>)]); 9] = [
+            // Single badge: text and tone kept, the web-only fields dropped.
+            (
+                json!({"text": "open", "tone": "success", "icon": "git-pull-request",
+                       "href": "https://example.test/1", "tooltip": "dropped"}),
+                &[("open", Some(Tone::Success))],
+            ),
+            // Items keep snapshot order and carry their own tones.
+            (
+                json!({"items": [{"text": "draft"}, {"text": "2 checks", "tone": "warn"}]}),
+                &[("draft", None), ("2 checks", Some(Tone::Warn))],
+            ),
+            // The documented "clear the row" form.
+            (json!({"items": []}), &[]),
+            // `items` present selects the list form, so the entry's own text
+            // is not a fallback: a plugin clearing the row means it.
+            (json!({"text": "stale", "items": []}), &[]),
+            (
+                json!({"text": "outer", "items": [{"text": "inner"}]}),
+                &[("inner", None)],
+            ),
+            // Malformed `items` clears the row rather than quietly rendering
+            // the other form.
+            (json!({"text": "stale", "items": 7}), &[]),
+            // A lucide name has no terminal glyph, so an icon-only badge
+            // yields nothing; its text-carrying neighbours still render.
+            (json!({"icon": "git-pull-request"}), &[]),
+            (
+                json!({"items": [{"icon": "check"}, {"text": "kept"}, {"text": "  "}, {"text": 7}]}),
+                &[("kept", None)],
+            ),
+            // An unreadable tone degrades to neutral rather than dropping text.
+            (
+                json!({"text": "kept", "tone": "chartreuse"}),
+                &[("kept", None)],
+            ),
+        ];
+        for (payload, expected) in cases {
+            let snap = pane_snapshot(json!([
+                {"plugin_id": "gh", "slot": "row-badge", "id": "pr",
+                 "session_id": "s1", "payload": payload}
+            ]));
+            let expected: Vec<(String, Option<Tone>)> = expected
+                .iter()
+                .map(|(t, tone)| ((*t).to_string(), *tone))
+                .collect();
+            assert_eq!(row_badge_cells(&snap, "s1"), expected);
+        }
+    }
+
+    #[test]
+    fn row_badge_cells_read_this_session_and_slot_only() {
+        let snap = pane_snapshot(json!([
+            {"plugin_id": "gh", "slot": "row-badge", "id": "pr", "session_id": "s1",
+             "payload": {"text": "mine"}},
+            {"plugin_id": "gh", "slot": "row-badge", "id": "pr", "session_id": "s2",
+             "payload": {"text": "theirs"}},
+            {"plugin_id": "gh", "slot": "row-badge", "id": "pr",
+             "payload": {"text": "global"}},
+            {"plugin_id": "gh", "slot": "row-column", "id": "col", "session_id": "s1",
+             "payload": {"text": "column"}}
+        ]));
+        assert_eq!(
+            row_badge_cells(&snap, "s1"),
+            vec![("mine".to_string(), None)]
+        );
+        assert!(row_badge_cells(&snap, "s3").is_empty());
+    }
+
+    #[test]
     fn row_column_cells_ignore_other_slots() {
         let snap = pane_snapshot(json!([
             {"plugin_id": "a", "slot": "row-badge", "id": "b", "session_id": "s1",

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -4,9 +4,9 @@
 //! `StatusBar` (global) and `DetailBadge` (per-session) text, tone-colored,
 //! plus `Notification` toasts, and `Pane` (per session) and `HomePane` (global)
 //! blocks in a toggleable overlay (#2467); the remote-home picker shows
-//! `RowColumn` text per session row
-//! (#2948). Icons, tooltips, hrefs, and the
-//! `Card`/`RowBadge`/`SortKey`/`FilterFacet` slots have no TUI surface here and
+//! `RowBadge` (#2947) and `RowColumn` (#2948) text per session row.
+//! Icons, tooltips, hrefs, and the
+//! `Card`/`SortKey`/`FilterFacet` slots have no TUI surface here and
 //! are ignored.
 //!
 //! Kept side-effect-free so the render layer can borrow the snapshot and so the
@@ -72,6 +72,35 @@ pub fn row_column_cells(snapshot: &UiSnapshot, session_id: &str) -> Vec<(String,
     session_entries(snapshot, UiSlot::RowColumn, session_id)
         .filter_map(|e| entry_text(e).map(|t| (t.to_string(), entry_tone(e))))
         .collect()
+}
+
+/// This session's `RowBadge` chips as `(text, tone)`, in snapshot order
+/// (#2947). One entry is either a single badge or a list of them under `items`,
+/// so the picker row can show several chips the way the web sidebar does.
+///
+/// The presence of `items` selects the list form: the documented `items: []`
+/// clears the row rather than falling back to the entry's own `text`, and a
+/// malformed `items` clears it too rather than silently rendering the other
+/// form. A badge carrying only an `icon` yields nothing, since a lucide name
+/// has no terminal glyph and a generic stand-in would keep the badge's presence
+/// while dropping which state it meant. `tooltip` and `href` have no terminal
+/// surface either; opening the `href` is tracked as #2528.
+pub fn row_badge_cells(snapshot: &UiSnapshot, session_id: &str) -> Vec<(String, Option<Tone>)> {
+    session_entries(snapshot, UiSlot::RowBadge, session_id)
+        .flat_map(|e| match e.payload.get("items") {
+            Some(items) => items
+                .as_array()
+                .map(|items| items.iter().filter_map(badge_cell).collect())
+                .unwrap_or_default(),
+            None => badge_cell(&e.payload).into_iter().collect::<Vec<_>>(),
+        })
+        .collect()
+}
+
+/// One badge's renderable `(text, tone)`, from either a whole `row-badge`
+/// payload or one element of its `items` list: the two carry the same fields.
+fn badge_cell(badge: &Value) -> Option<(String, Option<Tone>)> {
+    Some((block_str(badge, "text")?.to_string(), block_tone(badge)))
 }
 
 /// Map a tone to a foreground style against the active theme. `None` (no tone)
@@ -697,7 +726,8 @@ fn section_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'stati
     out
 }
 
-/// The block's tone, if it carries a valid one.
+/// The tone of a pane block or a `row-badge` payload, if it carries a valid
+/// one. Both spell the field the same way.
 fn block_tone(block: &Value) -> Option<Tone> {
     block
         .get("tone")
@@ -711,8 +741,9 @@ fn value_tone(block: &Value) -> Option<Tone> {
         .and_then(|v| serde_json::from_value::<Tone>(v.clone()).ok())
 }
 
-/// A trimmed, non-empty string field, or `None`. Defensive against a malformed
-/// or schema-skewed block so the renderer never panics on plugin data.
+/// A trimmed, non-empty string field of a plugin-authored object, or `None`.
+/// Defensive against a malformed or schema-skewed payload so the renderer never
+/// panics on plugin data.
 fn block_str<'a>(block: &'a Value, key: &str) -> Option<&'a str> {
     block
         .get(key)

--- a/src/tui/remote_home/render.rs
+++ b/src/tui/remote_home/render.rs
@@ -342,6 +342,11 @@ mod tests {
                "session_id": session_id, "payload": {"text": text}})
     }
 
+    fn row_badge(session_id: &str, payload: serde_json::Value) -> serde_json::Value {
+        json!({"plugin_id": "gh", "slot": "row-badge", "id": "pr",
+               "session_id": session_id, "payload": payload})
+    }
+
     /// Screen column where `needle` starts on the first row carrying it. Indexes
     /// the per-cell strings from `rows`, one character per painted cell, so it is
     /// a real column: a byte offset would be skewed by the multi-byte `▸ `
@@ -490,6 +495,85 @@ mod tests {
         let (cells, width) = row_column_cells(&state, "s1", PLUGIN_REGION_MAX_WIDTH);
         assert_eq!(cells.len(), 1);
         assert_eq!(width, PLUGIN_REGION_MAX_WIDTH);
+    }
+
+    #[test]
+    fn row_shows_the_plugin_row_badge_text_before_the_column() {
+        let state = state_with(
+            &["s1"],
+            json!([
+                row_column("s1", "CI failing"),
+                row_badge("s1", json!({"text": "draft", "tone": "warn"}))
+            ]),
+        );
+        let painted = rows(&state);
+        assert!(painted.iter().any(|l| l.contains("draft")), "{painted:?}");
+        // Badges sit left of the column, matching the web's row line.
+        assert!(column_of(&painted, "draft") < column_of(&painted, "CI failing"));
+    }
+
+    #[test]
+    fn badges_share_the_plugin_region_instead_of_widening_it() {
+        // A badge plus a column wordy enough to have filled the region alone.
+        let long = "x".repeat(PLUGIN_REGION_MAX_WIDTH + 10);
+        let state = state_with(
+            &["s1"],
+            json!([
+                row_badge("s1", json!({"text": "draft"})),
+                row_column("s1", &long)
+            ]),
+        );
+        let painted = rows(&state);
+        assert!(painted.iter().any(|l| l.contains("draft")), "{painted:?}");
+        // The 41-cell prefix, the whole region, and the gap before the path:
+        // the badge took its cells from the column, not from the path, which
+        // starts exactly where a badge-free capped column leaves it.
+        assert_eq!(
+            column_of(&painted, "/tmp/s1"),
+            41 + PLUGIN_REGION_MAX_WIDTH + 2
+        );
+    }
+
+    #[test]
+    fn badge_free_rows_leave_the_whole_region_to_the_column() {
+        let long = "x".repeat(PLUGIN_REGION_MAX_WIDTH + 10);
+        let state = state_with(&["s1"], json!([row_column("s1", &long)]));
+        let (_, width) = row_column_cells(&state, "s1", PLUGIN_REGION_MAX_WIDTH);
+        assert_eq!(width, PLUGIN_REGION_MAX_WIDTH);
+    }
+
+    #[test]
+    fn badge_column_pads_so_the_path_stays_aligned() {
+        // s2 has no badge; both rows must start the path at the same column.
+        let state = state_with(
+            &["s1", "s2"],
+            json!([row_badge("s1", json!({"text": "changes requested"}))]),
+        );
+        let painted = rows(&state);
+        assert_eq!(
+            column_of(&painted, "/tmp/s1"),
+            column_of(&painted, "/tmp/s2")
+        );
+    }
+
+    #[test]
+    fn cleared_and_icon_only_badges_reserve_no_width() {
+        // Both render nothing, so the path sits where it does with no entries.
+        for payload in [json!({"items": []}), json!({"icon": "git-pull-request"})] {
+            let state = state_with(&["s1"], json!([row_badge("s1", payload.clone())]));
+            assert_eq!(column_of(&rows(&state), "/tmp/s1"), 41, "{payload}");
+        }
+    }
+
+    #[test]
+    fn long_badge_text_is_capped_to_the_badge_budget() {
+        let long = "b".repeat(ROW_BADGE_MAX_WIDTH + 20);
+        let state = state_with(&["s1"], json!([row_badge("s1", json!({"text": long}))]));
+        let (cells, width) = row_badge_cells(&state, "s1");
+        assert_eq!(width, ROW_BADGE_MAX_WIDTH);
+        assert!(cells[0].0.ends_with('\u{2026}'));
+        let painted = rows(&state);
+        assert!(painted.iter().any(|l| l.contains("/tmp/s1")), "{painted:?}");
     }
 
     #[test]

--- a/src/tui/remote_home/render.rs
+++ b/src/tui/remote_home/render.rs
@@ -16,40 +16,47 @@ use crate::tui::styles::{has_min_contrast, Theme};
 
 const SELECTED_ROW_CONTRAST_RATIO: f32 = 3.0;
 
-/// Widest a plugin's `row-column` cell may grow, in terminal cells, so a chatty
-/// plugin cannot push the project path off the row. Matches the title column's
-/// budget.
-const ROW_COLUMN_MAX_WIDTH: usize = 24;
+/// Widest the whole plugin region may grow, in terminal cells: the `row-badge`
+/// chips, the `row-column` cells, and the gap between the two groups. One shared
+/// cap rather than one per slot because the row already spends 41 cells on the
+/// highlight symbol, title, and status before any plugin content, so a second
+/// independent 24-cell group would push the project path past the right edge of
+/// an 80-column terminal instead of merely squeezing it.
+const PLUGIN_REGION_MAX_WIDTH: usize = 24;
 
-/// Gap between two plugins' cells inside the same column.
-const ROW_COLUMN_GAP: &str = "  ";
+/// Slice of the region the `row-badge` chips may claim, leaving the rest to the
+/// wordier `row-column` text. Badges are terse state markers ("draft",
+/// "approved"), so they need far less room than a status sentence.
+const ROW_BADGE_MAX_WIDTH: usize = 10;
 
-/// One plugin's `row-column` text plus the tone to paint it in.
-type RowColumnCell = (String, Option<Tone>);
+/// Gap between two plugins' cells inside a group, and between the two groups.
+const PLUGIN_COLUMN_GAP: &str = "  ";
+
+/// One plugin's cell text plus the tone to paint it in.
+type PluginCell = (String, Option<Tone>);
 
 /// A session's cells and the display width they occupy together.
-type MeasuredCells = (Vec<RowColumnCell>, usize);
+type MeasuredCells = (Vec<PluginCell>, usize);
 
-/// One session's `row-column` cells, truncated to the shared budget, plus the
-/// display width they occupy. Separate from rendering so the column width can be
-/// computed across every listed session before any row is painted: every row
-/// pads to that one width, so a session with no cell leaves a blank of the same
-/// size instead of shifting the path column (#2948). Returns width 0 when no
-/// plugin pushed anything, which keeps the row identical to before this slot
-/// rendered at all.
+/// One session's cells for a slot, truncated to `budget`, plus the display width
+/// they occupy. Separate from rendering so a group's width can be computed
+/// across every listed session before any row is painted: every row pads to that
+/// one width, so a session with no cell leaves a blank of the same size instead
+/// of shifting the path column (#2948). Returns width 0 when no plugin pushed
+/// anything, which keeps the row identical to before these slots rendered at
+/// all.
 ///
 /// Budgets in terminal cells, not chars: plugin text is arbitrary, and a wide
 /// glyph (an emoji status marker, CJK) paints two cells while counting as one
-/// char, which would under-measure the column and shift the path after all.
-fn row_column_cells(state: &RemoteHomeState, session_id: &str) -> MeasuredCells {
-    let mut budget = ROW_COLUMN_MAX_WIDTH;
+/// char, which would under-measure the group and shift the path after all.
+fn measured_cells(cells: Vec<PluginCell>, mut budget: usize) -> MeasuredCells {
     let mut width = 0;
-    let mut cells = Vec::new();
-    for (text, tone) in plugin_ui::row_column_cells(&state.plugin_ui, session_id) {
-        let gap = if cells.is_empty() {
+    let mut kept = Vec::new();
+    for (text, tone) in cells {
+        let gap = if kept.is_empty() {
             0
         } else {
-            UnicodeWidthStr::width(ROW_COLUMN_GAP)
+            UnicodeWidthStr::width(PLUGIN_COLUMN_GAP)
         };
         // Needs room for the gap plus at least one cell of text, else the
         // remaining plugins are dropped rather than rendered as a bare gap.
@@ -64,9 +71,61 @@ fn row_column_cells(state: &RemoteHomeState, session_id: &str) -> MeasuredCells 
         let len = UnicodeWidthStr::width(text.as_str()).min(budget - gap);
         width += gap + len;
         budget -= gap + len;
-        cells.push((text, tone));
+        kept.push((text, tone));
     }
-    (cells, width)
+    (kept, width)
+}
+
+/// This session's `row-badge` chips, measured against the badge sub-cap.
+fn row_badge_cells(state: &RemoteHomeState, session_id: &str) -> MeasuredCells {
+    measured_cells(
+        plugin_ui::row_badge_cells(&state.plugin_ui, session_id),
+        ROW_BADGE_MAX_WIDTH,
+    )
+}
+
+/// This session's `row-column` cells, measured against whatever the badges left
+/// of the shared region.
+fn row_column_cells(state: &RemoteHomeState, session_id: &str, budget: usize) -> MeasuredCells {
+    measured_cells(
+        plugin_ui::row_column_cells(&state.plugin_ui, session_id),
+        budget,
+    )
+}
+
+/// Paint one group's cells and pad them out to `group_width`, then the gap that
+/// separates the group from what follows. A zero-width group paints nothing, so
+/// a picker with no plugin entries keeps its original row layout.
+fn push_group(
+    spans: &mut Vec<Span<'static>>,
+    measured: &MeasuredCells,
+    group_width: usize,
+    theme: &Theme,
+    is_selected: bool,
+) {
+    if group_width == 0 {
+        return;
+    }
+    let (cells, width) = measured;
+    for (i, (text, tone)) in cells.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw(PLUGIN_COLUMN_GAP));
+        }
+        let style = plugin_ui::tone_style(*tone, theme);
+        spans.push(Span::styled(
+            text.clone(),
+            if is_selected {
+                selected_row_style(style, theme)
+            } else {
+                style
+            },
+        ));
+    }
+    spans.push(Span::raw(format!(
+        "{:pad$}{PLUGIN_COLUMN_GAP}",
+        "",
+        pad = group_width - width
+    )));
 }
 
 fn selected_row_style(style: Style, theme: &Theme) -> Style {
@@ -137,13 +196,28 @@ fn render_list(frame: &mut Frame, area: Rect, theme: &Theme, state: &RemoteHomeS
         frame.render_widget(para, area);
         return;
     }
-    // Measure every row's plugin cells first so they all pad to one width.
-    let plugin_cells: Vec<MeasuredCells> = state
+    // Measure every row's plugin cells first so they all pad to one width. The
+    // badges go first and eat into the shared region, so the column's budget is
+    // whatever they leave: with no badges anywhere the column still gets the
+    // whole region and the row renders exactly as it did before #2947.
+    let badge_cells: Vec<MeasuredCells> = state
         .sessions
         .iter()
-        .map(|s| row_column_cells(state, &s.id))
+        .map(|s| row_badge_cells(state, &s.id))
         .collect();
-    let plugin_width = plugin_cells.iter().map(|(_, w)| *w).max().unwrap_or(0);
+    let badge_width = badge_cells.iter().map(|(_, w)| *w).max().unwrap_or(0);
+    let column_budget = if badge_width == 0 {
+        PLUGIN_REGION_MAX_WIDTH
+    } else {
+        PLUGIN_REGION_MAX_WIDTH
+            .saturating_sub(badge_width + UnicodeWidthStr::width(PLUGIN_COLUMN_GAP))
+    };
+    let column_cells: Vec<MeasuredCells> = state
+        .sessions
+        .iter()
+        .map(|s| row_column_cells(state, &s.id, column_budget))
+        .collect();
+    let column_width = column_cells.iter().map(|(_, w)| *w).max().unwrap_or(0);
     let items: Vec<ListItem> = state
         .sessions
         .iter()
@@ -167,25 +241,22 @@ fn render_list(frame: &mut Frame, area: Rect, theme: &Theme, state: &RemoteHomeS
                 ),
                 Span::styled(format!("{:<10}  ", s.status), readable(status_style)),
             ];
-            if plugin_width > 0 {
-                let (cells, width) = &plugin_cells[idx];
-                for (i, (text, tone)) in cells.iter().enumerate() {
-                    if i > 0 {
-                        spans.push(Span::raw(ROW_COLUMN_GAP));
-                    }
-                    spans.push(Span::styled(
-                        text.clone(),
-                        readable(plugin_ui::tone_style(*tone, theme)),
-                    ));
-                }
-                // Pad to the shared width, then the inter-column gap, so the
-                // path starts at the same screen column on every row.
-                spans.push(Span::raw(format!(
-                    "{:width$}{ROW_COLUMN_GAP}",
-                    "",
-                    width = plugin_width - width
-                )));
-            }
+            // Each group pads to its shared width, then the gap, so the path
+            // starts at the same screen column on every row.
+            push_group(
+                &mut spans,
+                &badge_cells[idx],
+                badge_width,
+                theme,
+                is_selected,
+            );
+            push_group(
+                &mut spans,
+                &column_cells[idx],
+                column_width,
+                theme,
+                is_selected,
+            );
             spans.push(Span::styled(s.project_path.clone(), readable(path_style)));
             ListItem::new(Line::from(spans))
         })
@@ -344,10 +415,10 @@ mod tests {
 
     #[test]
     fn long_plugin_text_is_capped_so_the_path_survives() {
-        let long = "x".repeat(ROW_COLUMN_MAX_WIDTH + 20);
+        let long = "x".repeat(PLUGIN_REGION_MAX_WIDTH + 20);
         let state = state_with(&["s1"], json!([row_column("s1", &long)]));
-        let (cells, width) = row_column_cells(&state, "s1");
-        assert_eq!(width, ROW_COLUMN_MAX_WIDTH);
+        let (cells, width) = row_column_cells(&state, "s1", PLUGIN_REGION_MAX_WIDTH);
+        assert_eq!(width, PLUGIN_REGION_MAX_WIDTH);
         assert!(cells[0].0.ends_with('…'));
         let painted = rows(&state);
         assert!(painted.iter().any(|l| l.contains("/tmp/s1")), "{painted:?}");
@@ -360,8 +431,8 @@ mod tests {
         let wide = "検査失敗検査失敗検査失敗中";
         assert_eq!(wide.chars().count(), 13);
         let state = state_with(&["s1"], json!([row_column("s1", wide)]));
-        let (cells, width) = row_column_cells(&state, "s1");
-        assert!(width <= ROW_COLUMN_MAX_WIDTH, "{width} cells");
+        let (cells, width) = row_column_cells(&state, "s1", PLUGIN_REGION_MAX_WIDTH);
+        assert!(width <= PLUGIN_REGION_MAX_WIDTH, "{width} cells");
         assert!(cells[0].0.ends_with('…'));
         // And the painted column still lines up with a cell-less row. The four
         // CJK chars paint 8 cells, so the path starts 8 + 2 columns past the 41
@@ -390,13 +461,13 @@ mod tests {
             ]),
         );
         for id in ["s1", "s2"] {
-            let (cells, width) = row_column_cells(&state, id);
-            assert!(width <= ROW_COLUMN_MAX_WIDTH, "{id}: {width} cells");
+            let (cells, width) = row_column_cells(&state, id, PLUGIN_REGION_MAX_WIDTH);
+            assert!(width <= PLUGIN_REGION_MAX_WIDTH, "{id}: {width} cells");
             let painted: usize = cells
                 .iter()
                 .map(|(t, _)| UnicodeWidthStr::width(t.as_str()))
                 .sum::<usize>()
-                + ROW_COLUMN_GAP.len() * cells.len().saturating_sub(1);
+                + PLUGIN_COLUMN_GAP.len() * cells.len().saturating_sub(1);
             assert_eq!(painted, width, "{id}: measured width must match painted");
         }
         // The cap holds, so the path still renders and stays aligned.
@@ -412,13 +483,13 @@ mod tests {
         let state = state_with(
             &["s1"],
             json!([
-                row_column("s1", &"y".repeat(ROW_COLUMN_MAX_WIDTH)),
+                row_column("s1", &"y".repeat(PLUGIN_REGION_MAX_WIDTH)),
                 row_column("s1", "dropped")
             ]),
         );
-        let (cells, width) = row_column_cells(&state, "s1");
+        let (cells, width) = row_column_cells(&state, "s1", PLUGIN_REGION_MAX_WIDTH);
         assert_eq!(cells.len(), 1);
-        assert_eq!(width, ROW_COLUMN_MAX_WIDTH);
+        assert_eq!(width, PLUGIN_REGION_MAX_WIDTH);
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A plugin filling the `row-badge` slot (the GitHub plugin's PR badge) rendered tone-colored chips on the web sidebar and nothing at all on the native session picker. That was the most visible half of the "the GitHub plugin isn't shown in the TUI" gap. This renders those badges on each row of the daemon-connected remote-home picker.

No host or fetch work was needed: #2948 already pulls the plugin UI snapshot alongside the session list, so this is a selector plus rendering. `plugin_ui::row_badge_cells` reads the slot's two payload forms (a single badge, or an `items` list), and the picker paints the result as a tone-colored group left of the existing `row-column` group, matching the web's left-to-right order.

The one design call worth flagging: **badges share a single 24-column plugin region with `row-column` rather than claiming a second column of their own.** The row already spends 41 columns on the highlight symbol, title, and status before any plugin content, and `row-column` may take 24 more. A second independent 24-column group would have put the project path at column 85, off the right edge of an 80-column terminal, rather than merely squeezing it. Sharing the region means badges take their cells from the column, never from the path, and a picker with no badges anywhere still gives `row-column` the full 24 and renders byte-identical to today. There is a regression test for each half of that.

Two smaller calls, both deliberate deviations from the issue body, both argued out with a `/debate` consult:

- **Icon-only badges render nothing.** The issue suggested a compact marker. A lucide icon name is what carries the meaning (success, draft, warning); a bullet preserves only "something exists" while discarding which state it was, so three icon-only badges would paint `•••` that can be read as the wrong status. The web renders nothing when it cannot resolve an icon, and the TUI already drops unsupported icons elsewhere. A plugin that wants terminal visibility should send text.
- **No terminal-width-responsive budgeting.** Deriving the region from `area.width` would also require rewriting the title and status columns to be terminal-cell-aware (they count chars today), which is a layout change unrelated to this slot. The shared region already guarantees the path never sits further right than it does on `main`, so responsive budgeting is a separate hardening concern.

`items: []` clears the row as documented, and a malformed `items` clears it too rather than silently falling back to the entry's own `text`. `tooltip` and `href` have no terminal surface; opening a badge's `href` is #2528.

Closes #2947

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With a daemon running and the GitHub plugin attached, open the native picker (`AOE_DAEMON_URL=... aoe`) and confirm a session whose branch has an open PR shows a tone-colored badge between the status and the project path, matching what the web sidebar shows for that session.
- [ ] Confirm a session with no open PR renders unchanged: no empty artifact, and its project path starts at the same screen column as the badged row's.
- [ ] Detach the plugin (or run against a daemon with no plugins) and confirm the picker rows look exactly as they did before this PR, with no reserved blank column.
- [ ] Narrow the terminal toward 80 columns with both a badge and a `row-column` entry present and confirm the project path is still visible; the badge should eat into the column text, not the path.
- [ ] Stop the daemon and press `r` and confirm the badges clear while the session list itself stays intact.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is fully reachable from the cheaper tier that #2948 established for this exact render path. 6 ratatui `TestBackend` tests paint the real picker and assert the badge text, its position left of the column, path alignment across badged and unbadged rows, the region-sharing invariant, and the zero-width cases; 2 table-driven selector tests cover all 9 payload shapes. A live-daemon e2e would add roughly 10 to 28s to a strictly serial suite to re-assert what those already fail on. Per AGENTS.md, cheapest tier that can actually fail.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult between two models on the width budgeting and the icon-only question. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added `row-badge` rendering to the daemon-connected remote-home picker.
- Rendered badge text with tone colors and shared a 24-cell region with `row-column`.
- Preserved project-path alignment and avoided layout shifts when badges are absent.
- Added handling for empty, malformed, icon-only, and oversized badge content.
- Added selector, rendering, alignment, and width regression tests.
- Documented TUI support and badge limitations.

## Benefits
Users can now see session badges, such as GitHub pull request status, in the native TUI. The picker keeps its layout stable across sessions.

## Further enhancement
Icon rendering, tooltips, links, and browser actions remain unsupported in the TUI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->