### PR TITLE
fix(test): unbreak the macOS lib suite and de-race the live session-list reads

### DIFF
--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1871,6 +1871,9 @@ mod tests {
         std::fs::create_dir(&real_parent).unwrap();
         let linked_parent = dir.path().join("linked");
         std::os::unix::fs::symlink(&real_parent, &linked_parent).unwrap();
+        // macOS hands out temp dirs under `/var`, itself a symlink to
+        // `/private/var`, so the expectation has to be canonical too.
+        let real_parent = real_parent.canonicalize().unwrap();
         let from = linked_parent.join("old");
         std::fs::create_dir(&from).unwrap();
         let to = linked_parent.join("new");

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4422,7 +4422,7 @@ async fn purge_session_artifacts(
         // reload cannot slip between them. See invariant 8 on
         // `reload_state_instances_from_disk`.
         state
-            .delete_epoch
+            .mutation_epoch
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
     state.instance_locks.write().await.remove(id);

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4296,7 +4296,11 @@ async fn purge_session_artifacts(
         crate::session::deletion::PurgeReservation::Rejected(result) => {
             return match result.disposition {
                 crate::session::deletion::DeletionDisposition::AlreadyGone => {
-                    state.instances.write().await.retain(|row| row.id != id);
+                    remove_instance(
+                        &mut *state.instances.write().await,
+                        id,
+                        &state.mutation_epoch,
+                    );
                     state.instance_locks.write().await.remove(id);
                     Ok((true, result.messages))
                 }
@@ -4337,8 +4341,14 @@ async fn purge_session_artifacts(
             Err(result) => *result,
             Ok(committed) => {
                 // Remove the local mirror before awaiting ACP so the reconciler
-                // cannot surface a durable row that no longer exists.
-                state.instances.write().await.retain(|row| row.id != id);
+                // cannot surface a durable row that no longer exists. Bumps the
+                // epoch under the same lock: the ACP teardown below is slow, and
+                // a reload landing inside it would otherwise restore the row.
+                remove_instance(
+                    &mut *state.instances.write().await,
+                    id,
+                    &state.mutation_epoch,
+                );
 
                 // The worker may still use the worktree, so ACP teardown stays
                 // ahead of sidecar cleanup. The durable row is already gone.
@@ -4412,18 +4422,15 @@ async fn purge_session_artifacts(
     }
 
     {
-        let mut instances = state.instances.write().await;
-        instances.retain(|i| i.id != id);
         // The row is now gone from both disk and memory, so any reloader still
         // carrying a `sessions.json` snapshot that predates either removal must
-        // drop it rather than fold the deleted row back in. Bump while still
-        // holding the `instances` write lock: a reloader checks the epoch under
-        // that same lock, so the removal and the bump land as one step and a
-        // reload cannot slip between them. See invariant 8 on
-        // `reload_state_instances_from_disk`.
-        state
-            .mutation_epoch
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        // drop it rather than fold the deleted row back in. `remove_instance`
+        // bumps while still holding the `instances` write lock: a reloader
+        // checks the epoch under that same lock, so the removal and the bump
+        // land as one step and a reload cannot slip between them. See
+        // invariant 8 on `reload_state_instances_from_disk`.
+        let mut instances = state.instances.write().await;
+        remove_instance(&mut instances, id, &state.mutation_epoch);
     }
     state.instance_locks.write().await.remove(id);
     if let Some(entry) = recent_entry {
@@ -5275,6 +5282,35 @@ pub(crate) fn upsert_instance(
         *existing = instance;
     } else {
         instances.push(instance);
+    }
+}
+
+/// Remove `id` from the live registry, bumping `mutation_epoch` when a row was
+/// actually removed.
+///
+/// The delete path removes a row from `state.instances` in three places: the
+/// `AlreadyGone` short-circuit, the structured purge's early mirror removal
+/// (which then awaits ACP teardown before the handler finishes), and the final
+/// commit block. Every one of them has to bump, and has to bump while the
+/// caller still holds the `instances` write lock, because a reloader compares
+/// the epoch under that same lock. A removal that skips the bump leaves a
+/// window where a disk reload carrying a pre-delete snapshot rebuilds
+/// `state.instances` from it and puts the deleted row back, so
+/// `GET /api/sessions` lists a session the user just deleted.
+///
+/// Bumping only on an actual removal keeps the final commit block from
+/// spending an epoch when the early removal already took the row; if a stale
+/// reload DID restore it in between, the retain here finds it, removes it
+/// again, and bumps as it should.
+pub(crate) fn remove_instance(
+    instances: &mut Vec<crate::session::Instance>,
+    id: &str,
+    mutation_epoch: &std::sync::atomic::AtomicU64,
+) {
+    let before = instances.len();
+    instances.retain(|i| i.id != id);
+    if instances.len() != before {
+        mutation_epoch.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
@@ -7667,6 +7703,43 @@ pub async fn serve_session_artifact(Path((id, path)): Path<(String, String)>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `remove_instance` is the only way a row leaves `state.instances` on the
+    /// delete path, so the epoch bump has to be tied to an actual removal
+    /// rather than to reaching the call. Bumping unconditionally would spend
+    /// an epoch on the final commit block after the structured purge's early
+    /// removal already took the row, dropping a reload that was perfectly
+    /// valid; not bumping at all leaves the window a stale reload uses to put
+    /// a deleted row back.
+    #[test]
+    fn remove_instance_bumps_the_epoch_only_when_it_removes_a_row() {
+        let epoch = std::sync::atomic::AtomicU64::new(0);
+        let read = || epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let mut instances = vec![
+            Instance::new("keep", "/tmp/keep"),
+            Instance::new("doomed", "/tmp/doomed"),
+        ];
+        let doomed_id = instances[1].id.clone();
+
+        remove_instance(&mut instances, &doomed_id, &epoch);
+        assert_eq!(read(), 1, "a real removal bumps");
+        assert_eq!(
+            instances
+                .iter()
+                .map(|i| i.title.as_str())
+                .collect::<Vec<_>>(),
+            vec!["keep"]
+        );
+
+        // The structured purge reaches the final commit block after its early
+        // removal already took the row. Nothing left to remove, nothing to
+        // invalidate, so no epoch is spent.
+        remove_instance(&mut instances, &doomed_id, &epoch);
+        assert_eq!(read(), 1, "a no-op removal does not bump");
+
+        remove_instance(&mut instances, "never-existed", &epoch);
+        assert_eq!(read(), 1, "an unknown id does not bump");
+    }
     fn build_rename_test_state(
         persisted: Vec<Instance>,
         cached: Vec<Instance>,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -398,14 +398,20 @@ pub struct AppState {
     /// transitions to `Status::Error` for up to 8 seconds while the agent
     /// is still settling. Periodically GC'd by a background task.
     pub recently_restarted: crate::session::recovery::RecentlyRestarted,
-    /// Bumped once per committed session removal, after the row is gone from
-    /// both `sessions.json` and `instances`. A reloader reads it before its
-    /// disk read and hands the value back to
+    /// Bumped once per committed membership change of the session set: a
+    /// removal, after the row is gone from both `sessions.json` and
+    /// `instances`, and a creation, after the row is in both. A reloader
+    /// reads it before its disk read and hands the value back to
     /// `reload_state_instances_from_disk`, which drops the reload when the
-    /// value moved: the disk snapshot it is carrying predates a delete, so
-    /// folding it in would resurrect the removed row. See invariant 8 on that
-    /// function.
-    pub delete_epoch: std::sync::atomic::AtomicU64,
+    /// value moved: the disk snapshot it is carrying predates the mutation,
+    /// so folding it in would resurrect a removed row or drop a created one.
+    /// See invariant 8 on that function.
+    ///
+    /// Membership only. A field edit on an existing row does not bump, because
+    /// the per-id merge already reconciles those; the epoch exists for the
+    /// two cases the merge cannot see, where the id itself is absent from one
+    /// side.
+    pub mutation_epoch: Arc<std::sync::atomic::AtomicU64>,
     /// Ids whose startup-recovery cascade is scheduled but not yet complete.
     /// Phase A seeds it; each Phase B worker drains its id on completion. The
     /// background refresher walks it to keep queued candidates' marks in
@@ -911,12 +917,14 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let instance_locks = Arc::new(RwLock::new(std::collections::HashMap::new()));
     let idempotency_locks = Arc::new(RwLock::new(std::collections::HashMap::new()));
     let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let mutation_epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
     #[cfg(feature = "serve")]
     let session_service = Arc::new(session_service::SessionService::new(
         Arc::clone(&instances),
         Arc::clone(&instance_locks),
         Arc::clone(&file_watch),
         Arc::clone(&telemetry_session_creates),
+        Arc::clone(&mutation_epoch),
         acp_supervisor.clone(),
         acp_event_store.clone(),
     ));
@@ -926,6 +934,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         Arc::clone(&instance_locks),
         Arc::clone(&file_watch),
         Arc::clone(&telemetry_session_creates),
+        Arc::clone(&mutation_epoch),
     ));
 
     // the daemon serves fine without plugin workers.
@@ -1223,7 +1232,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             crate::session::conversation_summary::MAX_CONCURRENT,
         ),
         recently_restarted: crate::session::recovery::new_recently_restarted(),
-        delete_epoch: std::sync::atomic::AtomicU64::new(0),
+        mutation_epoch: Arc::clone(&mutation_epoch),
         recovery_pending: crate::session::recovery::new_recovery_pending(),
         cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
             // Seed with an already-stale timestamp so the first request
@@ -3296,19 +3305,23 @@ fn skip_tmux_decision_for_structured(inst: &mut Instance) -> bool {
 //    scrape can briefly carry the prior status; it self-corrects on
 //    the next 2s tick. Polling is canonical (invariant 6) so this is
 //    acceptable.
-// 8. Every caller must read `state.delete_epoch` BEFORE its disk read and
+// 8. Every caller must read `state.mutation_epoch` BEFORE its disk read and
 //    pass that value as `read_epoch`. `fresh` is a snapshot of
 //    `sessions.json`, and `*current = merged` below replaces
-//    `state.instances` wholesale, so a delete that commits between the
-//    read and this call would otherwise be undone: the deleted row is
-//    still in `fresh` and comes straight back. The epoch check drops such
-//    a reload rather than resurrecting the row. Dropping ids missing from
+//    `state.instances` wholesale, so a membership change that commits
+//    between the read and this call would otherwise be undone. It cuts both
+//    ways. A delete: the removed row is still in `fresh` and comes straight
+//    back. A create: the new row is absent from `fresh`, and since `merged`
+//    is built exclusively from `fresh`, the wholesale replace drops the row
+//    the create just put in `state.instances`, so `GET /api/sessions` loses
+//    it until the next tick re-reads disk. The epoch check drops such a
+//    reload rather than applying either. Dropping ids missing from
 //    `prior_by_id` is NOT an alternative; that is also how a session
 //    created by another process (the CLI, a peer daemon) legitimately
 //    enters `state.instances`. The comparison happens under the
-//    `state.instances` write lock, and the delete bumps under that same
-//    lock, so the two are ordered against each other; comparing before
-//    taking the lock reopens the race one lock acquisition later.
+//    `state.instances` write lock, and both the delete and the create bump
+//    under that same lock, so they are ordered against each other; comparing
+//    before taking the lock reopens the race one lock acquisition later.
 
 /// Reload `state.instances` by merging caller-supplied `fresh` against the
 /// prior in-memory snapshot per id, then reapplying the acp overlay.
@@ -3358,26 +3371,30 @@ pub(crate) async fn reload_state_instances_from_disk(
 
     let mut current = state.instances.write().await;
 
-    // Invariant 8: `fresh` predates a committed delete, so folding it in would
-    // put the removed row back. Drop the whole reload rather than filter it:
-    // the next poll tick re-reads disk 2s from now and converges, and a delete
-    // is rare enough that losing one tick of status updates costs nothing.
+    // Invariant 8: `fresh` predates a committed create or delete, so folding it
+    // in would put a removed row back, or drop a created one. Drop the whole
+    // reload rather than filter it: the next poll tick re-reads disk 2s from
+    // now and converges, and both mutations are rare enough (each one is a
+    // user action) that losing one tick of status updates costs nothing.
     //
     // Read under the `instances` write lock, and before `drain_from` empties
-    // `current`, so this is atomic against the delete. Checking before taking
-    // the lock leaves a hole: a reload could pass the check, park on the lock,
-    // let a delete take the lock, remove the row and bump, then wake and write
-    // its stale snapshot over the removal. The delete bumps inside the same
-    // lock scope for the same reason. No memory ordering closes that gap; it
+    // `current`, so this is atomic against the mutation. Checking before
+    // taking the lock leaves a hole: a reload could pass the check, park on
+    // the lock, let a delete take the lock, remove the row and bump, then wake
+    // and write its stale snapshot over the removal. Symmetrically for a
+    // create, whose row is missing from the stale snapshot entirely. Both
+    // mutations bump inside the same lock scope for the same reason. No memory ordering closes that gap; it
     // is a check-then-act race, so the check has to happen under the lock that
     // orders the two writers.
-    let current_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+    let current_epoch = state
+        .mutation_epoch
+        .load(std::sync::atomic::Ordering::SeqCst);
     if current_epoch != read_epoch {
         tracing::debug!(
             target: "server.file_watch",
             read_epoch,
             current_epoch,
-            "dropping a disk reload whose snapshot predates a session delete"
+            "dropping a disk reload whose snapshot predates a session create or delete"
         );
         return;
     }
@@ -3910,7 +3927,9 @@ async fn disk_watcher_consumer(state: Arc<AppState>) {
         let started = std::time::Instant::now();
         // Invariant 8: read before the disk read, so a delete committing
         // during it invalidates this snapshot.
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
         let file_watch_for_load = state.file_watch.clone();
         let loaded = match tokio::task::spawn_blocking(move || {
             load_all_instances(&file_watch_for_load)
@@ -4567,7 +4586,9 @@ async fn status_poll_loop(state: Arc<AppState>) {
         // scrape that follows it can block for seconds when the tmux server is
         // unreachable, which is exactly when a concurrent delete has time to
         // land and this tick's snapshot goes stale.
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
         let updated = tokio::task::spawn_blocking(move || {
             let mut instances = load_all_instances(&file_watch_for_poll).unwrap_or_default();
             seed_unknown_tracking(&mut instances, &prev_unknown_tracking);
@@ -6151,12 +6172,14 @@ pub mod test_support {
         let instance_locks = Arc::new(RwLock::new(HashMap::new()));
         let idempotency_locks = Arc::new(RwLock::new(HashMap::new()));
         let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let mutation_epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let file_watch = FileWatchService::noop();
         let session_service = Arc::new(session_service::SessionService::new(
             Arc::clone(&instances),
             Arc::clone(&instance_locks),
             Arc::clone(&file_watch),
             Arc::clone(&telemetry_session_creates),
+            Arc::clone(&mutation_epoch),
             supervisor.clone(),
             event_store.clone(),
         ));
@@ -6186,7 +6209,7 @@ pub mod test_support {
                 crate::session::conversation_summary::MAX_CONCURRENT,
             ),
             recently_restarted: crate::session::recovery::new_recently_restarted(),
-            delete_epoch: std::sync::atomic::AtomicU64::new(0),
+            mutation_epoch: Arc::clone(&mutation_epoch),
             recovery_pending: crate::session::recovery::new_recovery_pending(),
             cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
                 refreshed_at: std::time::Instant::now(),
@@ -6293,7 +6316,9 @@ pub mod test_support {
         fresh: Vec<Instance>,
         live_worker_records: Vec<(crate::process::worker_registry::WorkerRecord, String)>,
     ) {
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
         super::reload_state_instances_from_disk(
             state,
             fresh,
@@ -6309,7 +6334,9 @@ pub mod test_support {
         fresh: Vec<Instance>,
         live_worker_records: Vec<(crate::process::worker_registry::WorkerRecord, String)>,
     ) {
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
         super::reload_state_instances_from_disk(
             state,
             fresh,
@@ -8876,7 +8903,9 @@ mod tests {
 
         // Invariant 8: capture the epoch BEFORE the disk read, the order every
         // production caller uses.
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
         let file_watch = state.file_watch.clone();
         let fresh = tokio::task::spawn_blocking(move || load_all_instances(&file_watch))
             .await
@@ -8925,7 +8954,7 @@ mod tests {
         // The delete already committed: `doomed` is gone from memory, and the
         // epoch moved to say so.
         state
-            .delete_epoch
+            .mutation_epoch
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         reload_state_instances_from_disk(
@@ -8951,6 +8980,78 @@ mod tests {
         assert_eq!(titles, vec!["survivor".to_string()]);
     }
 
+    // The mirror image of the delete case, and the reason `mutation_epoch` is
+    // not named `delete_epoch`. `create_session` persists the new row to
+    // `sessions.json` and only then upserts it into `state.instances`
+    // (`upsert_instance`). A poll tick whose disk read STARTED before that
+    // persist carries a `fresh` without the new row, and since the merge
+    // rebuilds `state.instances` exclusively from `fresh`, the wholesale
+    // replace drops the session the create just inserted. `GET /api/sessions`
+    // then loses it until the next tick re-reads disk 2s later. Observed as a
+    // live Playwright failure: `wizard-scratch-launch` polled until the
+    // session appeared, and the very next `GET /api/sessions` returned `[]`.
+    #[tokio::test]
+    async fn a_reload_predating_a_create_does_not_drop_the_new_row() {
+        let existing = Instance::new("existing", "/tmp/existing");
+        let created = Instance::new("created", "/tmp/created");
+        // What a reloader read from disk before the create persisted.
+        let stale_snapshot = vec![existing.clone()];
+
+        // The create already committed: `created` is in memory (and on disk),
+        // and the epoch moved to say so.
+        let state = test_support::build_test_app_state(vec![existing.clone(), created.clone()]);
+        state
+            .mutation_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        reload_state_instances_from_disk(
+            &state,
+            stale_snapshot.clone(),
+            Vec::new(),
+            StatusSource::DiskOnly,
+            0,
+        )
+        .await;
+
+        let titles: Vec<String> = state
+            .instances
+            .read()
+            .await
+            .iter()
+            .map(|i| i.title.clone())
+            .collect();
+        assert!(
+            titles.contains(&"created".to_string()),
+            "a created session must survive a pre-create snapshot: {titles:?}"
+        );
+
+        // And the converse, which is what the create path's bump buys: hand
+        // the same stale snapshot a matching epoch, as if the create had never
+        // bumped, and the row is gone. This is the pre-fix behaviour, pinned so
+        // the bump cannot be dropped as redundant.
+        let unbumped = test_support::build_test_app_state(vec![existing.clone(), created.clone()]);
+        reload_state_instances_from_disk(
+            &unbumped,
+            stale_snapshot,
+            Vec::new(),
+            StatusSource::DiskOnly,
+            0,
+        )
+        .await;
+        let titles: Vec<String> = unbumped
+            .instances
+            .read()
+            .await
+            .iter()
+            .map(|i| i.title.clone())
+            .collect();
+        assert_eq!(
+            titles,
+            vec!["existing".to_string()],
+            "without the epoch bump the reload drops the created row"
+        );
+    }
+
     // The epoch comparison has to be atomic against the delete, not merely
     // ordered by `SeqCst`. Comparing before taking the `instances` write lock
     // leaves a check-then-act race: a reload passes the check, parks on the
@@ -8969,7 +9070,9 @@ mod tests {
         let stale_snapshot = vec![doomed.clone(), survivor.clone()];
 
         let state = test_support::build_test_app_state(vec![survivor.clone()]);
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
 
         // Hold the lock the reload needs, so it cannot get past it.
         let guard = state.instances.write().await;
@@ -8992,7 +9095,7 @@ mod tests {
         // The delete commits while the reload is parked: row out, epoch up.
         // Both happen before the lock is released, mirroring the real purge.
         state
-            .delete_epoch
+            .mutation_epoch
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         drop(guard);
 
@@ -9020,7 +9123,9 @@ mod tests {
         let known = Instance::new("known", "/tmp/known");
         let created_elsewhere = Instance::new("created-elsewhere", "/tmp/elsewhere");
         let state = test_support::build_test_app_state(vec![known.clone()]);
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
 
         reload_state_instances_from_disk(
             &state,
@@ -9085,7 +9190,9 @@ mod tests {
 
         // Invariant 8: capture the epoch BEFORE the disk read, the order every
         // production caller uses.
-        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let read_epoch = state
+            .mutation_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
         let file_watch = state.file_watch.clone();
         let fresh = tokio::task::spawn_blocking(move || load_all_instances(&file_watch))
             .await

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -160,6 +160,13 @@ pub struct SessionService {
     /// Opt-in telemetry create counter, shared with
     /// `AppState.telemetry_session_creates`.
     pub telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
+    /// Session-set membership epoch, shared with `AppState.mutation_epoch`.
+    /// Bumped under the `instances` write lock once a create is in both
+    /// `sessions.json` and `instances`, so a disk reload still carrying a
+    /// snapshot from before the create drops itself instead of replacing
+    /// `instances` with a `fresh` that never had the new row. See invariant 8
+    /// on `reload_state_instances_from_disk`.
+    pub mutation_epoch: Arc<std::sync::atomic::AtomicU64>,
     /// Owns the per-session ACP agent subprocesses, shared with
     /// `AppState.acp_supervisor`.
     #[cfg(feature = "serve")]
@@ -252,6 +259,7 @@ impl SessionService {
         instance_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
         file_watch: Arc<crate::file_watch::FileWatchService>,
         telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
+        mutation_epoch: Arc<std::sync::atomic::AtomicU64>,
         acp_supervisor: Arc<
             crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>,
         >,
@@ -262,6 +270,7 @@ impl SessionService {
             instance_locks,
             file_watch,
             telemetry_session_creates,
+            mutation_epoch,
             acp_supervisor,
             acp_event_store,
             create_in_flight: std::sync::Mutex::new(HashMap::new()),
@@ -276,12 +285,14 @@ impl SessionService {
         instance_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
         file_watch: Arc<crate::file_watch::FileWatchService>,
         telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
+        mutation_epoch: Arc<std::sync::atomic::AtomicU64>,
     ) -> Self {
         Self {
             instances,
             instance_locks,
             file_watch,
             telemetry_session_creates,
+            mutation_epoch,
             create_in_flight: std::sync::Mutex::new(HashMap::new()),
             pending_drains: std::sync::Mutex::new(std::collections::HashSet::new()),
             persist_locks: RwLock::new(HashMap::new()),

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -486,6 +486,20 @@ pub(crate) async fn spawn_structured_session(
             };
             let mut instances = service.instances.write().await;
             crate::server::api::sessions::upsert_instance(&mut instances, instance);
+            // The row is now in both `sessions.json` (persisted above) and
+            // `instances`, so any reloader still carrying a snapshot that
+            // predates the persist must drop it rather than replace
+            // `instances` with a `fresh` the new row was never in. Bump while
+            // still holding the `instances` write lock, for the same reason
+            // the delete path does: a reloader checks the epoch under that
+            // same lock, so the insert and the bump land as one step. Without
+            // this, a `status_poll_loop` tick whose disk read started before
+            // the persist drops the session from `GET /api/sessions` until the
+            // next tick re-reads disk. See invariant 8 on
+            // `reload_state_instances_from_disk`.
+            service
+                .mutation_epoch
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             drop(instances);
 
             // Count the create for the opt-in telemetry trend counter. Bounded
@@ -635,5 +649,43 @@ pub(crate) async fn spawn_structured_session(
         }
         Ok(Err(e)) => Err(e),
         Err(e) => Err(anyhow::Error::new(SessionBuildPanicked(e.to_string()))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The create path must bump `mutation_epoch` while it still holds the
+    /// `instances` write lock. A reloader compares the epoch under that same
+    /// lock, so the insert and the bump have to land as one step; bumping
+    /// after `drop(instances)` reopens the window a reload can slip into and
+    /// silently drops the new session from `GET /api/sessions` for a tick.
+    ///
+    /// Source-level rather than behavioural: reaching the bump needs a real
+    /// spawn (tmux pane, worktree, agent subprocess), and the failure mode is
+    /// a future edit moving the bump out of the lock scope, which this
+    /// catches. The reload side is covered behaviourally in
+    /// `server::tests::a_reload_predating_a_create_does_not_drop_the_new_row`.
+    #[test]
+    fn the_create_bumps_the_mutation_epoch_under_the_instances_lock() {
+        // Whitespace-normalised so rustfmt's line wrapping cannot change the
+        // result: the point is the ordering, not how it is laid out.
+        let source = include_str!("session_spawn.rs");
+        let normalised: String = source.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let lock = normalised
+            .find("let mut instances = service.instances.write().await;")
+            .expect("the create path takes the instances write lock");
+        let bump = normalised[lock..]
+            .find(".mutation_epoch .fetch_add(1, std::sync::atomic::Ordering::SeqCst);")
+            .expect("the create path bumps mutation_epoch after the upsert");
+        let unlock = normalised[lock..]
+            .find("drop(instances);")
+            .expect("the create path releases the instances write lock");
+
+        assert!(
+            bump < unlock,
+            "mutation_epoch must be bumped before drop(instances), so the insert \
+             and the bump are atomic against a concurrent reload"
+        );
     }
 }

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -186,6 +186,31 @@ export async function listSessions(
 }
 
 /**
+ * Poll `GET /api/sessions` until at least one session is present, and
+ * return the snapshot the poll settled on. The list is a cache the
+ * daemon reconciles on a 2s tick (see `waitForView` below), so a fresh
+ * `listSessions()` issued right after a poll that already saw the
+ * session can come back empty; reading the array from inside the poll
+ * removes that second, racy fetch.
+ */
+export async function waitForSessions(
+  baseUrl: string,
+  timeout = 15_000,
+): Promise<Awaited<ReturnType<typeof listSessions>>> {
+  let settled: Awaited<ReturnType<typeof listSessions>> = [];
+  await expect
+    .poll(
+      async () => {
+        settled = await listSessions(baseUrl);
+        return settled.length;
+      },
+      { timeout },
+    )
+    .toBeGreaterThan(0);
+  return settled;
+}
+
+/**
  * Poll `GET /api/sessions` until the given session's `view` reaches
  * `expected`. The sessions list is a cache the daemon reconciles on a
  * 2s tick, so a disk snapshot taken just before an endpoint's write

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -204,7 +204,11 @@ export async function waitForSessions(
         settled = await listSessions(baseUrl);
         return settled.length;
       },
-      { timeout },
+      {
+        timeout,
+        intervals: [100, 200, 400],
+        message: `at least one session should appear in GET /api/sessions within ${timeout}ms`,
+      },
     )
     .toBeGreaterThan(0);
   return settled;

--- a/web/tests/live/palette-scratch-launch.spec.ts
+++ b/web/tests/live/palette-scratch-launch.spec.ts
@@ -6,7 +6,7 @@
 
 import { basename, dirname } from "node:path";
 import { test, expect } from "../helpers/liveTest";
-import { listSessions } from "../helpers/aoeServe";
+import { waitForSessions } from "../helpers/aoeServe";
 
 const PALETTE_PLACEHOLDER = "Search actions, sessions, settings…";
 
@@ -32,13 +32,7 @@ test("palette 'New scratch session' opens the wizard and launches a scratch sess
 
   await page.keyboard.press("ControlOrMeta+Enter");
 
-  await expect
-    .poll(async () => (await listSessions(serve.baseUrl)).length, {
-      timeout: 15_000,
-    })
-    .toBeGreaterThan(0);
-
-  const sessions = await listSessions(serve.baseUrl);
+  const sessions = await waitForSessions(serve.baseUrl);
   expect(sessions).toHaveLength(1);
   const session = sessions[0]!;
   expect(session.scratch).toBe(true);

--- a/web/tests/live/wizard-acp-create-session.spec.ts
+++ b/web/tests/live/wizard-acp-create-session.spec.ts
@@ -4,7 +4,7 @@
 // Setup docs now promise. Closes #1841.
 
 import { test, expect } from "@playwright/test";
-import { listSessions, spawnAoeServe, waitForView } from "../helpers/aoeServe";
+import { listSessions, spawnAoeServe, waitForSessions, waitForView } from "../helpers/aoeServe";
 import { waitForStructuredView } from "../helpers/acp";
 
 test("wizard with Use structured view on creates a structured_view session", async ({ page }, testInfo) => {
@@ -40,13 +40,7 @@ test("wizard with Use structured view on creates a structured_view session", asy
 
     // Server-side: one session exists and is persisted with structured_view
     // true, the behavior the rewritten docs describe.
-    await expect
-      .poll(async () => (await listSessions(serve.baseUrl)).length, {
-        timeout: 15_000,
-      })
-      .toBeGreaterThan(0);
-
-    const sessions = await listSessions(serve.baseUrl);
+    const sessions = await waitForSessions(serve.baseUrl);
     expect(sessions).toHaveLength(1);
     await waitForView(serve.baseUrl, sessions[0]!.id, "structured");
   } finally {

--- a/web/tests/live/wizard-acp-create-session.spec.ts
+++ b/web/tests/live/wizard-acp-create-session.spec.ts
@@ -4,7 +4,7 @@
 // Setup docs now promise. Closes #1841.
 
 import { test, expect } from "@playwright/test";
-import { listSessions, spawnAoeServe, waitForSessions, waitForView } from "../helpers/aoeServe";
+import { spawnAoeServe, waitForSessions, waitForView } from "../helpers/aoeServe";
 import { waitForStructuredView } from "../helpers/acp";
 
 test("wizard with Use structured view on creates a structured_view session", async ({ page }, testInfo) => {
@@ -77,7 +77,7 @@ test("wizard auto-approve starts Codex in full-access mode", async ({ page }, te
     await waitForStructuredView(page);
     await expect(page.getByRole("button", { name: /Agent \(full access\)/ }).first()).toBeVisible({ timeout: 15_000 });
 
-    const sessions = await listSessions(serve.baseUrl);
+    const sessions = await waitForSessions(serve.baseUrl);
     expect(sessions).toHaveLength(1);
     expect(sessions[0]!.tool).toBe("codex");
     expect(sessions[0]!.yolo_mode).toBe(true);

--- a/web/tests/live/wizard-scratch-delete-cleans-tempdir.spec.ts
+++ b/web/tests/live/wizard-scratch-delete-cleans-tempdir.spec.ts
@@ -4,7 +4,7 @@
 
 import { existsSync } from "node:fs";
 import { test as base, expect } from "@playwright/test";
-import { listSessions, spawnAoeServe } from "../helpers/aoeServe";
+import { listSessions, spawnAoeServe, waitForSessions } from "../helpers/aoeServe";
 
 base("deleting a scratch session removes its scratch dir", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -23,13 +23,7 @@ base("deleting a scratch session removes its scratch dir", async ({ page }, test
     await wizard.getByRole("switch", { name: "Skip project folder" }).click();
     await wizard.getByRole("button", { name: /Launch session/ }).click();
 
-    await expect
-      .poll(async () => (await listSessions(serve.baseUrl)).length, {
-        timeout: 15_000,
-      })
-      .toBeGreaterThan(0);
-
-    const [created] = await listSessions(serve.baseUrl);
+    const [created] = await waitForSessions(serve.baseUrl);
     const sessionId = created!.id as string;
     const projectPath = created!.project_path as string;
     expect(existsSync(projectPath)).toBe(true);

--- a/web/tests/live/wizard-scratch-launch.spec.ts
+++ b/web/tests/live/wizard-scratch-launch.spec.ts
@@ -4,7 +4,7 @@
 
 import { basename, dirname } from "node:path";
 import { test as base, expect } from "@playwright/test";
-import { spawnAoeServe, waitForSessions } from "../helpers/aoeServe";
+import { listSessions, spawnAoeServe, waitForSessions } from "../helpers/aoeServe";
 
 base("scratch happy path: launch creates a scratch-dir session", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -39,6 +39,19 @@ base("scratch happy path: launch creates a scratch-dir session", async ({ page }
     // is "the parent dir is named scratch", expressed cross-platform.
     const projectPath = session.project_path as string;
     expect(basename(dirname(projectPath))).toBe("scratch");
+
+    // The row must STAY listed, not merely show up once. A `status_poll_loop`
+    // tick whose disk read started before the create persisted carries a
+    // snapshot without the new session, and the reload rebuilds the list
+    // wholesale from that snapshot, so the row used to vanish for a tick and
+    // a second read returned []. The server drops such a reload now
+    // (`mutation_epoch`). Span more than one 2s tick so a regression here is
+    // caught rather than merely made invisible by reading only once.
+    const deadline = Date.now() + 3_000;
+    while (Date.now() < deadline) {
+      await page.waitForTimeout(250);
+      expect(await listSessions(serve.baseUrl)).toHaveLength(1);
+    }
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/wizard-scratch-launch.spec.ts
+++ b/web/tests/live/wizard-scratch-launch.spec.ts
@@ -4,7 +4,7 @@
 
 import { basename, dirname } from "node:path";
 import { test as base, expect } from "@playwright/test";
-import { listSessions, spawnAoeServe } from "../helpers/aoeServe";
+import { spawnAoeServe, waitForSessions } from "../helpers/aoeServe";
 
 base("scratch happy path: launch creates a scratch-dir session", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -30,13 +30,7 @@ base("scratch happy path: launch creates a scratch-dir session", async ({ page }
     // whose parent directory basename is "scratch" (the harness isolates
     // the app dir under a per-worker temp tree, so we assert structure
     // rather than absolute location).
-    await expect
-      .poll(async () => (await listSessions(serve.baseUrl)).length, {
-        timeout: 15_000,
-      })
-      .toBeGreaterThan(0);
-
-    const sessions = await listSessions(serve.baseUrl);
+    const sessions = await waitForSessions(serve.baseUrl);
     expect(sessions).toHaveLength(1);
     const session = sessions[0]!;
     expect(session.scratch).toBe(true);


### PR DESCRIPTION
## Description

Main has been red on the **Tests** workflow for every commit for at least two days. Two distinct problems, both in test code:

**1. `Cargo Test (macos)` fails 100% of runs (the actual blocker).**
`git::worktree::tests::worktree_move_observation_canonicalizes_symlinked_parents` (added in #3457) compares the output of `canonicalize_move_endpoint` against a raw `tempfile::tempdir()` path. On macOS that temp dir lives under `/var`, which is itself a symlink to `/private/var`, so the two sides can never be equal:

```
left:  "/private/var/folders/df/.../T/.tmpkg7IXg/real/old"
right: "/var/folders/df/.../T/.tmpkg7IXg/real/old"
```

Linux CI is unaffected because `/tmp` is real there. Fix: canonicalize `real_parent` before building the expectation, so both sides are canonical on either platform. Production code is untouched, `canonicalize_move_endpoint` was behaving correctly.

**2. `Playwright (live)` flakes on the session list (~8% of runs) — and the server race behind it.**

`wizard-scratch-launch` failed with `expect(sessions).toHaveLength(1)` receiving `[]`, on the line *after* an `expect.poll` had already observed a session.

The first version of this PR treated that as a test-side read-ordering issue. @jerome-benoit correctly pushed back: it is a real server-side race, and the helper was hiding it. It is now fixed properly.

`reload_state_instances_from_disk` builds `merged` exclusively from the caller's `fresh` disk snapshot and then does `*current = merged` (`src/server/mod.rs:3432`), so a reload carries no memory of rows it never saw. `create_session` persists the new row to `sessions.json` **before** upserting it in-memory (documented on `upsert_instance`, `src/server/api/sessions.rs:5262`). So a `status_poll_loop` tick whose disk read started before that persist has a `fresh` without the new row, and the wholesale replace drops the session the create just inserted. `GET /api/sessions` loses it until the next tick re-reads disk 2s later. `delete_epoch` did not cover this: no delete occurred.

The fix reuses the existing mechanism rather than adding a parallel one:

- `delete_epoch` becomes `mutation_epoch`; it guards session-set **membership** in both directions, not deletes only. Field doc and invariant 8 updated.
- The create path bumps it (`src/server/session_spawn.rs:488`) under the `instances` write lock the upsert already holds, so the insert and the bump land as one step against a concurrent reload, exactly as the delete path does at `sessions.rs:4424`.
- Threaded through `SessionService` as a shared `Arc`, same pattern as `telemetry_session_creates`.

On the test side, `waitForSessions()` returns the snapshot the poll settled on (removing the second racy fetch) across five specs, and `wizard-scratch-launch` now asserts the row **stays** listed across more than one 2s poll tick rather than only that it appeared.

New coverage, both mutation-checked:

| Test | Fails when |
| --- | --- |
| `a_reload_predating_a_create_does_not_drop_the_new_row` | the epoch comparison is disabled |
| `the_create_bumps_the_mutation_epoch_under_the_instances_lock` | the bump moves after `drop(instances)` |

The first also pins the pre-fix outcome, so the bump cannot later be removed as redundant.

### Known remaining flake, not fixed here

`acp-stories/queue-follow-up-with-nav` failed once in the last 25 main runs. That one is **not** a test-side race: the attached `debug.log` stops dead at `18:54:56.9` while the test ran until `18:55:22`, the fake agent log shows only a single `session/prompt`, and the page snapshot shows `Network error sending prompt: Failed to fetch` plus `Structured view worker stopped`. The serve daemon went away mid-test. That deserves its own investigation rather than a timeout bump here, so it is deliberately left alone.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Verified locally on macOS with the exact command the failing job runs:

```
cargo test --features serve,e2e-tests --lib --bins
# 6417 passed, 2 ignored   <- was 6414 passed; 1 failed on main
cargo fmt --check      # clean
cargo clippy --all-features  # clean
cd web && npx tsc --noEmit && npm run format:check && npm run lint  # all clean
```

The four live specs are left for CI to run.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/`
- [ ] Skipped a test, because:

`wizard-scratch-launch.spec.ts` gained a real regression assertion for the stale-create race (the session must stay listed across more than one poll tick). No `coverage-matrix.json` entry: the matrix tracks dashboard flows, and no flow changed. The server fix's primary coverage is the two Rust tests above.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Both changes are fixes to existing tests. The macOS fix restores a regression test that was already asserting the right behavior; the live-spec change removes a racy read.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**
Failure triage across 25 main runs, root-causing, and the fixes were done with Claude Code. Playwright trace artifacts were downloaded and inspected to separate the test-side race from the daemon-death flake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed a macOS worktree test that failed because temporary paths can use `/var` or `/private/var`.
- Added `waitForSessions()` to centralize session polling and improve timeout diagnostics.
- Updated live tests to use settled session snapshots and reduce duplicated polling logic.
- Fixed a server race that could restore deleted sessions or remove newly created sessions during stale disk reloads.
- Improved test coverage for session creation, deletion, and reload ordering.

## Technical details

- Replaced deletion-only tracking with shared `mutation_epoch` protection for session creation and deletion.
- Routed session removals through a shared helper that updates the mutation epoch.
- The separate `queue-follow-up-with-nav` daemon failure remains unresolved for future investigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
