### PR TITLE
fix(tmux): preserve UTF-8 session names

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -203,7 +203,10 @@ pub(crate) fn tmux_command() -> Command {
 /// removed so it cannot override that. Global `-u` forces UTF-8 session names
 /// even when the caller has `LC_CTYPE=C` or when `LC_ALL` was the only UTF-8
 /// locale source. Used by the status-query callers (which classify via
-/// [`tmux_no_server_running`]) and by `kill_session_if_present`.
+/// [`tmux_no_server_running`]) and by `kill_session_if_present`. Not folded into
+/// [`tmux_command`]: the interactive attach/switch-client/capture-pane paths must
+/// keep the user's locale, and `-u` would assert UTF-8 to a terminal that may not
+/// be.
 pub(crate) fn tmux_query_command() -> Command {
     let mut cmd = tmux_command();
     cmd.arg("-u");

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -193,19 +193,20 @@ pub(crate) fn tmux_command() -> Command {
     cmd
 }
 
-/// Like [`tmux_command`], but pins `LC_ALL=C` so tmux's connection-failure
+/// Like [`tmux_command`], but pins `LC_MESSAGES=C` so tmux's connection-failure
 /// messages on stderr stay stable English for callers that match them. tmux's
 /// `client.c` prints `error connecting to <socket> (strerror(errno))` for a
 /// non-`ECONNREFUSED` connect failure, and glibc localizes `strerror` by
 /// `LC_MESSAGES`, so on a non-English host the `(No such file or directory)`
-/// ENOENT marker for an absent socket (#3337) would not match. Used by the
-/// status-query callers (which classify via [`tmux_no_server_running`]) and by
-/// `kill_session_if_present`. NOT folded into [`tmux_command`]: the
-/// interactive attach/switch-client/capture-pane paths must keep the user's
-/// locale for UTF-8 and status-bar rendering.
+/// ENOENT marker for an absent socket (#3337) would not match. Keeping the
+/// caller's `LC_CTYPE` matters because `list-sessions` returns names later
+/// passed to locale-preserving tmux commands; `LC_ALL=C` substitutes wide
+/// characters with underscores in those names. Used by the status-query
+/// callers (which classify via [`tmux_no_server_running`]) and by
+/// `kill_session_if_present`.
 pub(crate) fn tmux_query_command() -> Command {
     let mut cmd = tmux_command();
-    cmd.env("LC_ALL", "C");
+    cmd.env("LC_MESSAGES", "C");
     cmd
 }
 
@@ -1463,6 +1464,22 @@ mod tests {
         assert_eq!(args.first().map(|a| a.to_str().unwrap()), Some("-S"));
         assert!(args.get(1).is_some(), "socket path arg present");
         assert_eq!(cmd.get_program().to_str(), Some("tmux"));
+    }
+
+    #[test]
+    fn tmux_query_command_preserves_ctype_for_session_names() {
+        let command = tmux_query_command();
+        let message_locale = command
+            .get_envs()
+            .find(|(key, _)| key.to_str() == Some("LC_MESSAGES"))
+            .and_then(|(_, value)| value.and_then(|value| value.to_str()));
+        assert_eq!(message_locale, Some("C"));
+        assert!(
+            command
+                .get_envs()
+                .all(|(key, _)| key.to_str() != Some("LC_ALL")),
+            "LC_ALL changes LC_CTYPE and corrupts non-ASCII tmux session names"
+        );
     }
 
     #[cfg(unix)]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -206,6 +206,7 @@ pub(crate) fn tmux_command() -> Command {
 /// `kill_session_if_present`.
 pub(crate) fn tmux_query_command() -> Command {
     let mut cmd = tmux_command();
+    cmd.env_remove("LC_ALL");
     cmd.env("LC_MESSAGES", "C");
     cmd
 }
@@ -1477,8 +1478,9 @@ mod tests {
         assert!(
             command
                 .get_envs()
-                .all(|(key, _)| key.to_str() != Some("LC_ALL")),
-            "LC_ALL changes LC_CTYPE and corrupts non-ASCII tmux session names"
+                .find(|(key, _)| key.to_str() == Some("LC_ALL"))
+                .is_some_and(|(_, value)| value.is_none()),
+            "LC_ALL must not override the caller's LC_CTYPE"
         );
     }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -198,14 +198,14 @@ pub(crate) fn tmux_command() -> Command {
 /// `client.c` prints `error connecting to <socket> (strerror(errno))` for a
 /// non-`ECONNREFUSED` connect failure, and glibc localizes `strerror` by
 /// `LC_MESSAGES`, so on a non-English host the `(No such file or directory)`
-/// ENOENT marker for an absent socket (#3337) would not match. Keeping the
-/// caller's `LC_CTYPE` matters because `list-sessions` returns names later
-/// passed to locale-preserving tmux commands; `LC_ALL=C` substitutes wide
-/// characters with underscores in those names. Used by the status-query
-/// callers (which classify via [`tmux_no_server_running`]) and by
-/// `kill_session_if_present`.
+/// ENOENT marker for an absent socket (#3337) would not match. `LC_ALL` is
+/// removed so it cannot override that. Global `-u` forces UTF-8 session names
+/// even when the caller has `LC_CTYPE=C` or when `LC_ALL` was the only UTF-8
+/// locale source. Used by the status-query callers (which classify via
+/// [`tmux_no_server_running`]) and by `kill_session_if_present`.
 pub(crate) fn tmux_query_command() -> Command {
     let mut cmd = tmux_command();
+    cmd.arg("-u");
     cmd.env_remove("LC_ALL");
     cmd.env("LC_MESSAGES", "C");
     cmd
@@ -1470,6 +1470,11 @@ mod tests {
     #[test]
     fn tmux_query_command_preserves_ctype_for_session_names() {
         let command = tmux_query_command();
+        let args: Vec<_> = command.get_args().map(|a| a.to_owned()).collect();
+        assert!(
+            args.iter().any(|a| a.to_str() == Some("-u")),
+            "tmux -u forces UTF-8 names independently of inherited LC_CTYPE"
+        );
         let message_locale = command
             .get_envs()
             .find(|(key, _)| key.to_str() == Some("LC_MESSAGES"))
@@ -1480,7 +1485,7 @@ mod tests {
                 .get_envs()
                 .find(|(key, _)| key.to_str() == Some("LC_ALL"))
                 .is_some_and(|(_, value)| value.is_none()),
-            "LC_ALL must not override the caller's LC_CTYPE"
+            "LC_ALL must not override LC_MESSAGES=C"
         );
     }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -203,10 +203,10 @@ pub(crate) fn tmux_command() -> Command {
 /// removed so it cannot override that. Global `-u` forces UTF-8 session names
 /// even when the caller has `LC_CTYPE=C` or when `LC_ALL` was the only UTF-8
 /// locale source. Used by the status-query callers (which classify via
-/// [`tmux_no_server_running`]) and by `kill_session_if_present`. Not folded into
+/// [`tmux_no_server_running`]) and by `kill_session_if_present`. NOT folded into
 /// [`tmux_command`]: the interactive attach/switch-client/capture-pane paths must
-/// keep the user's locale, and `-u` would assert UTF-8 to a terminal that may not
-/// be.
+/// keep the user's locale for UTF-8 and status-bar rendering, and `-u` would
+/// assert UTF-8 to a terminal that may not be.
 pub(crate) fn tmux_query_command() -> Command {
     let mut cmd = tmux_command();
     cmd.arg("-u");


### PR DESCRIPTION
## Description

`tmux_query_command` used `LC_ALL=C` to keep tmux connection errors parseable. That also forced `LC_CTYPE=C`, so `list-sessions` replaced wide characters in CJK session names with underscores. The cached name then no longer matched the UTF-8 session name used by attach and capture.

Narrowing the override to `LC_MESSAGES=C` and removing inherited `LC_ALL` is not enough on its own: when `LC_CTYPE=C` overrides a UTF-8 `LANG`, or when `LC_ALL` was the caller's only UTF-8 locale, query output still width-substitutes. This adds tmux's global `-u` so query clients emit UTF-8 independently of those locales, while `LC_MESSAGES=C` keeps diagnostics stable English.

Fixes #3536

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- Create a tmux session named `aoe_QA_협업_정리_9f4e4c6a` under a UTF-8 locale.
- `tmux -u list-sessions -F '#{session_name}'` with `LC_CTYPE=C` (or with `LC_ALL` unset and no other UTF-8 locale) returns the Hangul name intact.
- The same command without `-u` emits `aoe_QA___________9f4e4c6a`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR changes tmux status-query locale handling, not a rendered TUI or CLI flow
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

`tmux_query_command_preserves_ctype_for_session_names` covers the command environment at the owning seam: `-u` is present, `LC_MESSAGES=C` stays explicit, and inherited `LC_ALL` is removed.

Verified locally:

- `cargo fmt --check`
- `cargo test tmux_query_command_preserves_ctype --lib`
- `cargo clippy -- -D warnings`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** gpt-5.6-terra via Codex

**Any Additional AI Details you'd like to share:** The locale behavior was reproduced against tmux with a CJK session name, and the resulting patch was independently reviewed.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated tmux queries to preserve UTF-8 session names.
- Set `LC_MESSAGES=C` and removed inherited `LC_ALL` to keep diagnostics stable.
- Added tmux’s global `-u` option for UTF-8 query output.
- Added session liveness snapshots to reduce repeated tmux lookups.
- Added regression tests for UTF-8 handling and liveness behavior.
- Re-exported `PaneGeom` for shared use.

## Benefits

- Prevents non-ASCII session names from becoming unreachable.
- Improves liveness checks.
- Keeps tmux output reliable for parsing.

## Potential enhancement

- Continue monitoring snapshot behavior across tmux server and session state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->