### PR TITLE
fix(tui): translate the live preview cursor and mouse by pane 0's origin

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -202,12 +202,10 @@ fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
 /// report at all, so it is dropped rather than clamped to the nearest edge,
 /// which would otherwise synthesise a click or hover on pane 0's border.
 ///
-/// Pane 0 usually sits at the window origin, so the sub-rectangle shares the
-/// preview's top-left corner and only its extent differs. A window option
-/// like `pane-border-status top` can shift it down (`pane_top == 1`, #3515);
-/// this mapping still assumes the shared corner, so a composited preview with
-/// a shifted pane 0 clamps against the wrong row. Known residual: the TUI
-/// side of #3515 was never reproduced there.
+/// Pane 0 does not always sit at the window origin: a window option like
+/// `pane-border-status top` reserves a border row above every pane and shifts
+/// it to `pane_top == 1` (#3515), so the sub-rectangle carries pane 0's origin
+/// as well as its extent and a pointer over the border row falls outside it.
 fn mouse_target_rect(
     cursor: &crate::tmux::PaneCursor,
     pane: ratatui::layout::Rect,
@@ -235,16 +233,24 @@ fn mouse_target_rect(
 /// is deliberately not position-gated so a gesture that began on pane 0 still
 /// completes, and those events need a clamped coordinate even after the pointer
 /// has wandered off pane 0.
+///
+/// The origin is what [`map_pane_cell`] subtracts to reach the app's own
+/// coordinates, so it must be pane 0's corner within the preview rather than
+/// the preview's: painting the cursor ADDS the origin (see
+/// `map_live_preview_cursor`) while forwarding a pointer removes it again.
+/// The extent is clamped to what is left of the preview past that corner, so a
+/// pane 0 wider or taller than the area it is shown in cannot admit cells
+/// outside the rect.
 fn mouse_pane_rect(
     cursor: &crate::tmux::PaneCursor,
     pane: ratatui::layout::Rect,
 ) -> ratatui::layout::Rect {
     match cursor.composite_pane0 {
         Some(rect) => ratatui::layout::Rect {
-            x: pane.x,
-            y: pane.y,
-            width: rect.width.min(pane.width),
-            height: rect.height.min(pane.height),
+            x: pane.x.saturating_add(rect.left),
+            y: pane.y.saturating_add(rect.top),
+            width: rect.width.min(pane.width.saturating_sub(rect.left)),
+            height: rect.height.min(pane.height.saturating_sub(rect.top)),
         },
         None => pane,
     }
@@ -7170,24 +7176,68 @@ mod tests {
         );
     }
 
-    /// A pane 0 extent larger than the preview rect (the window is bigger than
-    /// the area it is being shown in, e.g. an attached client keeping its own
-    /// size) must clamp to the rect rather than admitting cells outside it.
+    /// Pane 0's sub-rectangle within the preview: it starts at pane 0's own
+    /// origin (#3515: `pane-border-status top` puts it a row below the
+    /// preview's corner) and its extent clamps to whatever is left of the
+    /// preview past that corner, so a window bigger than the area it is shown
+    /// in (an attached client keeping its own size) cannot admit cells outside
+    /// the rect.
     #[test]
-    fn composite_pane_rect_clamps_to_the_preview() {
+    fn composite_pane_rect_carries_the_origin_and_clamps_to_the_preview() {
         use ratatui::layout::Rect;
         let pane = Rect::new(2, 3, 20, 10);
-        let mut cursor = cursor_for(true, true, true);
-        cursor.composite_pane0 = Some(crate::tmux::PaneGeom {
+        // (pane 0's rect, the sub-rectangle it must produce inside `pane`).
+        let cases = [
+            // Oversized pane 0 at the corner: clamps to the whole preview.
+            ((0, 0, 999, 999), Rect::new(2, 3, 20, 10)),
+            // A borderless split: origin at the corner, extent honoured.
+            ((0, 0, 8, 6), Rect::new(2, 3, 8, 6)),
+            // `pane-border-status top`: one row down, and the height clamp
+            // must shrink with it or the rect would run past the preview.
+            ((0, 1, 8, 9), Rect::new(2, 4, 8, 9)),
+            ((0, 1, 999, 999), Rect::new(2, 4, 20, 9)),
+            // Both axes, oversized: `left` shrinks the width the same way.
+            ((3, 1, 999, 999), Rect::new(5, 4, 17, 9)),
+        ];
+        for (geom, want) in cases {
+            let mut cursor = cursor_for(true, true, true);
+            cursor.composite_pane0 = Some(crate::tmux::PaneGeom {
+                left: geom.0,
+                top: geom.1,
+                width: geom.2,
+                height: geom.3,
+            });
+            assert_eq!(mouse_pane_rect(&cursor, pane), want, "{geom:?}");
+        }
+
+        // The origin is honoured by the containment test too: with pane 0 at
+        // the preview's corner, a cell above/left of the rect is outside.
+        let mut corner = cursor_for(true, true, true);
+        corner.composite_pane0 = Some(crate::tmux::PaneGeom {
             left: 0,
             top: 0,
             width: 999,
             height: 999,
         });
-        assert_eq!(mouse_pane_rect(&cursor, pane), pane);
-        // And the origin is honoured: a cell above/left of the rect is outside.
-        assert_eq!(mouse_target_rect(&cursor, pane, 1, 3), None);
-        assert!(mouse_target_rect(&cursor, pane, 2, 3).is_some());
+        assert_eq!(mouse_target_rect(&corner, pane, 1, 3), None);
+        assert!(mouse_target_rect(&corner, pane, 2, 3).is_some());
+
+        // #3515: a border-status row belongs to no pane, so a pointer on it is
+        // dropped rather than forwarded as pane 0's first row, and the row
+        // below it reports the app's own row 1 instead of row 2.
+        let mut shifted = cursor_for(true, true, true);
+        shifted.mouse_all = true;
+        shifted.composite_pane0 = Some(crate::tmux::PaneGeom {
+            left: 0,
+            top: 1,
+            width: 20,
+            height: 9,
+        });
+        assert_eq!(hover_forward_bytes(&shifted, pane, 2, 3), None);
+        assert_eq!(
+            hover_forward_bytes(&shifted, pane, 2, 4).as_deref(),
+            Some(b"\x1b[<35;1;1M".as_slice())
+        );
     }
 
     /// The fix for #2407: a full-screen pane with no mouse tracking must

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -951,13 +951,13 @@ fn capture_composited_over_grid(
 
     // The cursor is pane 0's and pane relative, while the painted grid is
     // the whole window; the two agree only while pane 0 sits at the window
-    // origin, which a `pane-border-status` row breaks (#3515). Consumers are
-    // expected to translate by the origin carried on `composite_pane0`; this
-    // path feeds the TUI preview, whose cursor painting and mouse mapping do
-    // not yet (see `map_live_preview_cursor` and the input.rs residual).
-    // What must be restated here is the frame the cursor is measured
-    // against: the renderer anchors it by `pane_height` against the painted
-    // line count, which is now the whole window rather than one pane.
+    // origin, which a `pane-border-status` row breaks (#3515). Consumers
+    // translate by the origin carried on `composite_pane0`: this path feeds
+    // the TUI preview, where `map_live_preview_cursor` adds it to paint and
+    // `mouse_pane_rect` removes it again to forward a pointer. What must be
+    // restated here is the frame the cursor is measured against: the renderer
+    // anchors it by `pane_height` against the painted line count, which is now
+    // the whole window rather than one pane.
     cursor.pane_height = layout.window_height;
     cursor.pane_width = layout.window_width;
     // A composite carries no scrollback (panes have independent histories), so

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -132,12 +132,13 @@ const READING_CAPTURE_LINES: u16 = 2000;
 /// BELOW the text the user typed (#2742); clamping to `line_count` keeps them
 /// aligned. A hidden cursor, or one that maps outside `output`, yields `None`.
 ///
-/// Residual #3515 (TUI side, never reproduced): `y` is pane relative, while
-/// on a COMPOSITED preview the painted grid is the whole window and a
-/// `pane-border-status` row shifts pane 0 down. Indexing that grid with the
-/// untranslated `y` would paint one row high; consumers of
-/// [`crate::tmux::PaneCursor::composite_pane0`] are supposed to translate by
-/// `(left, top)`. This path does not yet.
+/// On a COMPOSITED preview the painted grid is the whole window while `(x, y)`
+/// stay pane 0 relative, so they are translated by the origin carried on
+/// [`crate::tmux::PaneCursor::composite_pane0`] before being anchored: a
+/// `pane-border-status top` row shifts pane 0 to `top == 1`, and indexing the
+/// composite with the untranslated `y` painted the cursor one row high
+/// (#3515). The origin is `(0, 0)` on an unsplit preview and on any split
+/// whose pane 0 sits at the corner, where this is the identity.
 fn map_live_preview_cursor(
     output: Rect,
     visible_rows: usize,
@@ -147,9 +148,12 @@ fn map_live_preview_cursor(
     if !cursor.visible {
         return None;
     }
+    let (origin_x, origin_y) = cursor
+        .composite_pane0
+        .map_or((0, 0), |p| (p.left as i32, p.top as i32));
     let anchor = line_count.min(visible_rows) as i32;
-    let row = output.y as i32 + (anchor - cursor.pane_height as i32) + cursor.y as i32;
-    let col = output.x as i32 + cursor.x as i32;
+    let row = output.y as i32 + (anchor - cursor.pane_height as i32) + cursor.y as i32 + origin_y;
+    let col = output.x as i32 + cursor.x as i32 + origin_x;
     if row < output.y as i32
         || row >= output.y as i32 + output.height as i32
         || col < output.x as i32
@@ -4256,6 +4260,42 @@ mod tests {
             map_live_preview_cursor(output, 24, 23, pane_cursor(0, 0, true, 23)),
             Some(Position::new(0, 0)),
         );
+    }
+
+    /// #3515: on a composited preview the painted grid is the whole window
+    /// while the cursor stays pane 0 relative, so it is translated by pane 0's
+    /// origin before anchoring. `pane-border-status top` is the trigger in the
+    /// wild (it shifts pane 0 to `top == 1`); the zero-origin rows are the
+    /// ones that must not move, since an unsplit preview is the common case.
+    #[test]
+    fn live_cursor_translates_by_pane_zero_origin_on_a_composite() {
+        let output = Rect::new(40, 5, 80, 24);
+        // (pane 0's rect, expected position) for a cursor at pane cell (3, 2)
+        // over a 24-row composite that fills the output.
+        let cases = [
+            // Unsplit: no composite at all, the pre-#3515 mapping verbatim.
+            (None, Position::new(43, 7)),
+            // A borderless split: pane 0 IS at the corner, so still identity.
+            (Some((0, 0, 40, 24)), Position::new(43, 7)),
+            // `pane-border-status top`: one row down, nothing sideways.
+            (Some((0, 1, 40, 23)), Position::new(43, 8)),
+            // Both axes, to pin that `left` is not silently ignored.
+            (Some((2, 1, 38, 23)), Position::new(45, 8)),
+        ];
+        for (geom, want) in cases {
+            let mut cursor = pane_cursor(3, 2, true, 24);
+            cursor.composite_pane0 = geom.map(|(left, top, width, height)| crate::tmux::PaneGeom {
+                left,
+                top,
+                width,
+                height,
+            });
+            assert_eq!(
+                map_live_preview_cursor(output, 24, 200, cursor),
+                Some(want),
+                "{geom:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Second half of #3515. #3526 fixed the web live terminal and carried pane 0's full rectangle through `PaneCursor::composite_pane0`, but deliberately left the TUI preview alone because that side was never reproduced. Both sites were marked as a known residual instead, and the review of #3526 called this out as the one thing left open. The geometry the fix needs has been on the struct since #3526, so this takes the other half.

The defect is the same one, in the same shape: on a composited (split) preview the painted grid is the whole WINDOW while pane 0's cursor stays pane relative. The two agree only while pane 0 sits at the window origin, and `pane-border-status top` (Claude Code's subagent split sets it) shifts pane 0 to `pane_top == 1`.

Two sites, moving in **opposite** directions, exactly as on the web side:

- `map_live_preview_cursor` (`src/tui/home/render.rs`) indexed the composite with an untranslated `y`, painting the caret one row above the input line. It now **adds** the origin before anchoring. The anchoring math is linear in the composite row index, so this stays correct whether the capture is top anchored or bottom anchored.
- `mouse_pane_rect` (`src/tui/home/input.rs`) built pane 0's sub-rectangle at the preview's corner rather than pane 0's. That rectangle is both the origin `map_pane_cell` subtracts and the extent it clamps to, so a forwarded pointer reported the app a row it never saw, and `mouse_target_rect`'s containment gate admitted the border row as pane 0's first row. It now starts at the origin, which **removes** it again on the way out.

The extent clamp needed changing too, which is not obvious from the two-line description: with the rectangle shifted to `pane.y + top`, clamping the height to `pane.height` lets an oversized pane 0 run one row past the preview's bottom edge. The clamp is now against `pane.height.saturating_sub(top)` (and likewise for width and `left`). There is a mutation check for this specific case below.

Also checked and deliberately not changed: `forward_hover_to_preview` keys its dedup off `map_pane_cell(pane, ..)` against the full preview rect rather than the pane 0 target rect. That is a different rect for a different purpose, and it stays injective on screen cells inside pane 0 both before and after this change, so it does not double count.

The residual comments at all three sites (`render.rs`, `input.rs`, `live_send.rs`) no longer describe a residual and were rewritten to state the actual contract.

No behavior changes for an unsplit preview or for any split whose pane 0 sits at the corner: the origin is `(0, 0)` there and both paths are the identity.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No screenshot: the change is two coordinate functions, and the thing it moves (the terminal caret's cell) is not something a tmux pane capture records, so a TUI recording would show an identical screen either way. The guarantees rest on the unit tests plus the mutation checks below.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The web half landed in #3526 and nothing here touches `web/`. No `web/tests/coverage-matrix.json` entry is implicated.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: both behaviors are pure coordinate functions with no observable e2e surface. The caret's cell is terminal state, not pane content, so `capture_screen()` cannot see it, and a forwarded mouse report goes out to the agent rather than onto the screen. An e2e test would stand up a real tmux split for roughly 2s of serial critical path and still assert nothing about the thing that changed. Unit tests at the function level catch both, and I mutation verified that they do.

Tests added, following the one-test-per-behavior rule with permutations as rows:

- `render.rs`, `live_cursor_translates_by_pane_zero_origin_on_a_composite` (new, table of 4): unsplit (`None`), a borderless split at the corner, `pane-border-status top`, and both axes together. The two zero-origin rows are the regression guard for the common case.
- `input.rs`, `composite_pane_rect_carries_the_origin_and_clamps_to_the_preview` (rewrote the existing `composite_pane_rect_clamps_to_the_preview` into a table of 5 rather than adding a test fn): origin placement plus the shrunk extent clamp on both axes, keeping the original oversized-pane-0 case as row 1. It also keeps the existing containment assertions and adds two byte-level ones, that a pointer on the border row is dropped rather than forwarded as pane 0's row 1, and that the row below it reports the app's own row 1.

`composited_preview_maps_the_mouse_into_pane_zero_only` and the other three `live_cursor_*` tests were left untouched and still pass, which is the unsplit and zero-origin regression evidence.

### Mutation checks

Each half reverted in turn, confirming the new tests actually go red.

1. Reverted the `render.rs` translation:

```
live_cursor_translates_by_pane_zero_origin_on_a_composite panicked:
assertion `left == right` failed: Some((0, 1, 40, 23))
  left: Some(Position { x: 43, y: 7 })
 right: Some(Position { x: 43, y: 8 })
test result: FAILED. 4 passed; 1 failed
```

That is the #3515 symptom exactly: one row high. The two zero-origin rows stayed green.

2. Reverted `mouse_pane_rect`'s origin:

```
composite_pane_rect_carries_the_origin_and_clamps_to_the_preview panicked:
assertion `left == right` failed: (0, 1, 8, 9)
  left: Rect { x: 2, y: 3, width: 8, height: 9 }
 right: Rect { x: 2, y: 4, width: 8, height: 9 }
```

3. Kept the origin but left the extent clamp against the full `pane.height`, the subtle half:

```
composite_pane_rect_carries_the_origin_and_clamps_to_the_preview panicked:
assertion `left == right` failed: (0, 1, 999, 999)
  left: Rect { x: 2, y: 4, width: 20, height: 10 }
 right: Rect { x: 2, y: 4, width: 20, height: 9 }
```

The rectangle runs a row past the preview's bottom edge, which is why the clamp had to shrink with the origin.

### Checks

- `cargo fmt --all -- --check` clean.
- `cargo clippy --features serve -- -D warnings` clean. `--all-targets` reports 5 pre-existing errors, all in `src/acp/supervisor.rs`, `src/acp/background_agent.rs`, `src/session/smart_rename.rs`, and `src/process/macos.rs`. None in `src/tui/`, so this adds none.
- `cargo test --features serve` green, exit 0, 6413 lib tests, no failures in any target.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:** This came out of reviewing #3526, where the TUI residual was the one open item. The fix, the tests, and the mutation checks above were run locally against real builds rather than reasoned about; the mutation output quoted is verbatim.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed live preview cursor and mouse coordinate handling for split panes.
- Preserved pane 0’s actual position, including borders and shifted origins.
- Clamped mouse dimensions to the visible preview area.
- Added regression tests for split layouts, coordinate translation, borders, and bounds.
- Updated related cursor documentation.

## Benefits

Unsplit previews and splits at the window origin remain unchanged. Split-pane input now targets the correct preview location and stays within visible bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->