### PR TITLE
fix(tui): align split preview cursor with pane origin

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -21,15 +21,12 @@
 //!   `#{mouse_sgr_flag}`: when the pane is a full-screen mouse app the
 //!   client forwards the wheel to it (as input bytes) instead of widening
 //!   the capture window, since the alternate screen has no scrollback.
-//!   On a composited (split) window the frame also carries `"pane0"`:
-//!   `{"cols":..,"rows":..,"left":..,"top":..}`, pane 0's rectangle within
-//!   the window grid. The cursor is translated onto that grid before it is
-//!   sent, and clients map pointer cells back by subtracting
-//!   `(left, top)` (#3515). Absent on single-pane frames. Clients that
-//!   ignore `left`/`top` still paint the cursor correctly at any origin,
-//!   because the translation already happened here; their mouse forwarding
-//!   is what degrades, back to the one-row shift of #3515 whenever the
-//!   origin is not `(0, 0)`.
+//!   A composited frame also carries `"pane0"` as
+//!   `{"cols":..,"rows":..,"left":..,"top":..}`. Cursor coordinates are
+//!   translated onto the window grid before emission; clients subtract the
+//!   same origin when forwarding pointer cells. Single-pane frames serialize
+//!   `pane0` as `null`. The origin fields are optional for older clients and
+//!   default to zero for frames from older servers.
 //!   `{"type":"size_owner","is_owner":bool}`: whether this client holds
 //!     the session's size-owner lock. Only the owner resizes the shared
 //!     tmux window and may type; a non-owner renders best-effort at the
@@ -1036,13 +1033,9 @@ async fn handle_live_ws(
 /// virtual scroll spacer off `history` and slices the live screen off
 /// the content's last `rows` lines, independent of cursor visibility.
 fn frame_json(content: &str, cursor: Option<&crate::tmux::PaneCursor>) -> String {
-    // On a composited frame the content grid is the whole WINDOW while
-    // `x`/`y` are pane 0 relative; the client paints the cursor by indexing
-    // that grid directly, so translate onto the composite here (#3515).
-    // `composite_pane0` is `None` (or at the origin) on every other frame,
-    // where this is the identity. The origin also rides on `pane0` so the
-    // client's inverse mapping, pointer cell -> pane coordinate, can
-    // subtract it again.
+    // The cursor is pane relative while composited content uses the window
+    // grid. Emit window-relative coordinates and carry the same origin for
+    // the client's inverse pointer mapping. No pane rectangle means identity.
     let pane0 = cursor.and_then(|c| c.composite_pane0);
     let (origin_x, origin_y) = pane0.map_or((0, 0), |p| (p.left, p.top));
     let cursor_value = match cursor {
@@ -1163,7 +1156,7 @@ mod tests {
     #[test]
     fn frame_json_includes_geometry_and_cursor() {
         let cases = [
-            // Unsplit: `pane0` is absent and the cursor is untouched.
+            // Unsplit: `pane0` is null and the cursor is untouched.
             (None, (3, 7), serde_json::Value::Null),
             // Composited with pane 0 at the corner (a borderless split):
             // identity translation, but `pane0` rides with zero origin.
@@ -1182,8 +1175,8 @@ mod tests {
                     "top": 0,
                 }),
             ),
-            // Composited with pane-border-status top: the wire cursor moves
-            // onto the window grid by pane 0's origin (#3515).
+            // Composited with pane-border-status top: move the wire cursor
+            // onto the window grid by pane 0's origin.
             (
                 Some(crate::tmux::PaneGeom {
                     left: 2,

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -11,17 +11,15 @@
 //! Compositing is read-only and changes nothing about input routing, which
 //! stays pinned to `^.0` (#435, #488).
 //!
-//! Known residual: a window row covered by NO pane (a `pane-border-status
+//! Known residual: a window row covered by no pane (a `pane-border-status
 //! top` status line, which tmux draws itself and no capture sees) is filled
-//! with a full-width border rule. Translating the cursor (#3515) does not
-//! remove that row; dropping it would mean rendering a grid shorter than
-//! `window_height` and rebasing every consumer, so the rule stays.
+//! with a full-width border rule. Cursor translation does not remove that row;
+//! dropping it would render fewer than `window_height` rows and rebase every
+//! consumer, so the rule stays.
 
 /// One pane's rectangle within its window, from
-/// `#{pane_left} #{pane_top} #{pane_width} #{pane_height}`. Pub because
-/// pane 0's copy rides on the public [`crate::tmux::PaneCursor::
-/// composite_pane0`] so composited frames can translate between pane
-/// coordinates and the window grid (#3515).
+/// `#{pane_left} #{pane_top} #{pane_width} #{pane_height}`. Public because
+/// [`crate::tmux::PaneCursor::composite_pane0`] exposes it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PaneGeom {
     pub left: u16,
@@ -96,16 +94,10 @@ impl WindowLayout {
         composite_window(self.window_width, self.window_height, &self.panes)
     }
 
-    /// The first pane's rectangle. Pane indices follow layout order, so
-    /// index 0 is the top-left pane and closing it renumbers whichever pane
-    /// takes that corner; the composite therefore paints pane 0's rows at
-    /// `geom.top` and its columns at `geom.left`, which is `(0, 0)` for the
-    /// common layouts but NOT always: a window option like
-    /// `pane-border-status top` reserves a border row above every pane,
-    /// shifting pane 0 down to `top == 1` (#3515). Consumers of the cursor
-    /// must translate by the origin carried on
-    /// [`crate::tmux::PaneCursor::composite_pane0`] rather than assuming the
-    /// window origin.
+    /// The first pane's rectangle. Pane indices follow layout order, but the
+    /// top-left pane can still have a non-zero origin when window chrome
+    /// reserves rows or columns. Keep that origin as geometry, not an assumed
+    /// `(0, 0)`.
     pub(crate) fn first_pane(&self) -> Option<PaneGeom> {
         self.panes.first().map(|p| p.geom)
     }
@@ -366,10 +358,8 @@ mod tests {
 
     #[test]
     fn first_pane_is_the_one_at_the_window_origin() {
-        // tmux orders pane indices by layout, so index 0 is the top-left
-        // pane. Consumers no longer assume that corner paints untranslated:
-        // they translate the cursor by the origin carried on
-        // `composite_pane0` (#3515).
+        // tmux layout order puts pane 0 at the top-left pane position; its
+        // actual origin remains part of the returned geometry.
         let l = layout(
             9,
             1,

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -133,19 +133,14 @@ pub struct PaneCursor {
     /// works while an agent streams. `parse` sets it `true`; only the
     /// cross-probe check downgrades it.
     pub position_reliable: bool,
-    /// Pane 0's rectangle within a COMPOSITED preview window, or `None` when
+    /// Pane 0's rectangle within a composited preview window, or `None` when
     /// the preview shows a single pane.
     ///
-    /// Mouse forwarding maps the hovered cell into the previewed app's
-    /// coordinate space by treating the preview rect as the pane, which holds
-    /// while the two describe the same rectangle. A composite makes the rect
-    /// the whole window while input still goes to pane 0 alone (#435, #488),
-    /// and the cursor stays pane relative over a window-relative grid: with
-    /// `pane-border-status top`, pane 0 starts at `pane_top == 1` and every
-    /// row paints one below the cursor row that indexes it (#3515). So this
-    /// carries the full rectangle, not just the extent: consumers translate
-    /// `x`/`y` onto the composite by adding `(left, top)`, and map pointer
-    /// cells back by subtracting it, clamping to `(width, height)`.
+    /// Composite content uses the window grid while the cursor and input stay
+    /// pane relative. Window chrome can give pane 0 a non-zero origin (#3515),
+    /// so full-window consumers add it to cursor coordinates and subtract it
+    /// from pointer coordinates. A cropped preview must also account for rows
+    /// removed before mapping. Input remains pinned to pane 0 (#435, #488).
     pub composite_pane0: Option<PaneGeom>,
 }
 
@@ -869,16 +864,10 @@ impl Session {
     /// [`capture_window_composited`](Self::capture_window_composited) plus pane
     /// 0's cursor, for the live preview.
     ///
-    /// Pane 0 owns the cursor because it is the pane that receives input; its
-    /// coordinates are pane relative, and the composite they index is the
-    /// whole window, so consumers translate them by pane 0's origin carried
-    /// on [`PaneCursor::composite_pane0`] (#3515). The probe targets `^.0`
-    /// explicitly rather than the window, whose format fields would resolve
-    /// against whichever pane the user happens to have selected.
-    ///
-    /// On a composite the cursor is rebased onto the window's dimensions: the
-    /// renderer anchors it by `pane_height` against the painted line count,
-    /// which is now the whole window rather than one pane.
+    /// The probe targets `^.0`, the pane that receives input, rather than the
+    /// window whose format fields resolve against whichever pane is selected.
+    /// On a composite, `pane_height`/`pane_width` are rebased to the window and
+    /// [`PaneCursor::composite_pane0`] retains pane 0's coordinate frame.
     pub fn capture_window_composited_with_cursor(
         &self,
         lines: usize,
@@ -3351,13 +3340,10 @@ mod tests {
         (left, top, width, height)
     }
 
-    /// #3515: a composited preview paints the whole WINDOW grid while the
-    /// cursor stays pane 0 relative, so the two agree only while pane 0 sits
-    /// at the window origin. `pane-border-status top` shifts pane 0 down to
-    /// `pane_top == 1`, and the invariant must hold there: the composite
-    /// paints the pane's cursor row at `cursor.y + top`, and
-    /// `composite_pane0` carries that real origin. Exercised across the three
-    /// split shapes (horizontal, vertical, stacked).
+    /// A top border row shifts pane 0 down. Across horizontal, vertical, and
+    /// stacked splits, verify that the carried rectangle matches tmux and the
+    /// composite paints the cursor row at `cursor.y + top`; the untranslated
+    /// row assertion keeps the test non-vacuous.
     #[test]
     #[serial_test::serial]
     fn composited_cursor_and_pane0_origin_track_pane_border_offset() {
@@ -3672,7 +3658,7 @@ mod tests {
         assert_eq!(
             (first.left, first.top),
             (0, 0),
-            "pane 0 must sit at the origin in this split; a border-status row would shift it (#3515)"
+            "pane 0 must sit at the origin in this split; a border-status row would shift it"
         );
         // Pane 0 is the agent's, even though pane 1 is the active one.
         assert!(

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -202,12 +202,12 @@ fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
 /// report at all, so it is dropped rather than clamped to the nearest edge,
 /// which would otherwise synthesise a click or hover on pane 0's border.
 ///
-/// Pane 0 usually sits at the window origin, so the sub-rectangle shares the
-/// preview's top-left corner and only its extent differs. A window option
-/// like `pane-border-status top` can shift it down (`pane_top == 1`, #3515);
-/// this mapping still assumes the shared corner, so a composited preview with
-/// a shifted pane 0 clamps against the wrong row. Known residual: the TUI
-/// side of #3515 was never reproduced there.
+/// Pane 0 may have a non-zero origin within the full composite. The TUI
+/// bottom-follows a composite taller than its output, clipping reserved rows
+/// above pane 0 before mouse mapping, so its first visible cell still starts
+/// at `pane.x`/`pane.y`. Mapping a non-bottom-aligned slice would additionally
+/// need that slice's first visible row; adding `rect.top` here alone would
+/// shift input below the displayed pane.
 fn mouse_target_rect(
     cursor: &crate::tmux::PaneCursor,
     pane: ratatui::layout::Rect,

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -949,15 +949,9 @@ fn capture_composited_over_grid(
         return capture_composited(name, lines, forward_empty);
     };
 
-    // The cursor is pane 0's and pane relative, while the painted grid is
-    // the whole window; the two agree only while pane 0 sits at the window
-    // origin, which a `pane-border-status` row breaks (#3515). Consumers are
-    // expected to translate by the origin carried on `composite_pane0`; this
-    // path feeds the TUI preview, whose cursor painting and mouse mapping do
-    // not yet (see `map_live_preview_cursor` and the input.rs residual).
-    // What must be restated here is the frame the cursor is measured
-    // against: the renderer anchors it by `pane_height` against the painted
-    // line count, which is now the whole window rather than one pane.
+    // The sampled cursor stays pane relative after its rows are painted on
+    // the window grid. Rebase only the frame dimensions and carry pane 0's
+    // rectangle so the renderer can add its origin.
     cursor.pane_height = layout.window_height;
     cursor.pane_width = layout.window_width;
     // A composite carries no scrollback (panes have independent histories), so

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -116,28 +116,13 @@ const READING_CAPTURE_LINES: u16 = 2000;
 
 /// Map a tmux pane cursor onto the preview's output rect for live-send.
 ///
-/// `output` is the rect the captured pane text paints into; `visible_rows` is
-/// its height in rows; `line_count` is the parsed capture's line count (the
-/// same value the renderer feeds to `compute_scroll`); `cursor` carries the
-/// pane's `(x, y)` (counted from the top of the visible screen) plus
-/// `pane_height`. The renderer bottom-anchors the capture ONLY when it
-/// overflows `output`; a capture shorter than `output` paints from the top
-/// (`compute_scroll` returns 0). Anchor the cursor the same way so it tracks
-/// the text: a screen row maps to `output.y + (min(line_count, visible_rows) -
-/// pane_height) + cursor.y`. With the pane sized to the output area and a
-/// full-height capture the delta is zero and this is just `output.y +
-/// cursor.y`. When the pane is a row or more shorter than `output` and the
-/// capture doesn't overflow (an alt-screen prompt, or the frame after a
-/// resize), using the bare `visible_rows` here would paint the cursor a row
-/// BELOW the text the user typed (#2742); clamping to `line_count` keeps them
-/// aligned. A hidden cursor, or one that maps outside `output`, yields `None`.
-///
-/// Residual #3515 (TUI side, never reproduced): `y` is pane relative, while
-/// on a COMPOSITED preview the painted grid is the whole window and a
-/// `pane-border-status` row shifts pane 0 down. Indexing that grid with the
-/// untranslated `y` would paint one row high; consumers of
-/// [`crate::tmux::PaneCursor::composite_pane0`] are supposed to translate by
-/// `(left, top)`. This path does not yet.
+/// `cursor.x`/`y` are pane relative. On a composite, add the pane origin
+/// carried by [`crate::tmux::PaneCursor::composite_pane0`]. Vertically the
+/// renderer also bottom-anchors captures that overflow `output`, so the row
+/// formula is `output.y + min(line_count, visible_rows) - pane_height + top +
+/// cursor.y`; a short capture instead anchors at the top. This keeps the
+/// cursor on the same text row for both the status-row offset (#3515) and the
+/// shorter-pane case (#2742). A hidden or out-of-bounds cursor yields `None`.
 fn map_live_preview_cursor(
     output: Rect,
     visible_rows: usize,
@@ -148,8 +133,11 @@ fn map_live_preview_cursor(
         return None;
     }
     let anchor = line_count.min(visible_rows) as i32;
-    let row = output.y as i32 + (anchor - cursor.pane_height as i32) + cursor.y as i32;
-    let col = output.x as i32 + cursor.x as i32;
+    let (left, top) = cursor
+        .composite_pane0
+        .map_or((0, 0), |rect| (rect.left as i32, rect.top as i32));
+    let row = output.y as i32 + (anchor - cursor.pane_height as i32) + top + cursor.y as i32;
+    let col = output.x as i32 + left + cursor.x as i32;
     if row < output.y as i32
         || row >= output.y as i32 + output.height as i32
         || col < output.x as i32
@@ -4203,13 +4191,25 @@ mod tests {
     }
 
     #[test]
-    fn live_cursor_maps_directly_when_pane_matches_output() {
-        // Pane sized to the output area (the steady-state live-send case): the
-        // delta is zero, so cursor (x, y) maps onto output.{x,y} + (x, y). A
-        // full-height capture (line_count >= visible_rows) bottom-anchors.
+    fn live_cursor_maps_single_and_composited_origins() {
         let output = Rect::new(40, 5, 80, 24);
-        let pos = map_live_preview_cursor(output, 24, 200, pane_cursor(3, 2, true, 24));
-        assert_eq!(pos, Some(Position::new(43, 7)));
+
+        // Steady-state single pane: the origin and anchoring delta are zero.
+        let single = map_live_preview_cursor(output, 24, 200, pane_cursor(3, 2, true, 24));
+        assert_eq!(single, Some(Position::new(43, 7)));
+
+        // A top border row makes the composite one row taller than the visible
+        // output and shifts pane 0 down. The anchoring delta clips that row;
+        // adding pane 0's origin puts its pane-relative cursor back on the text.
+        let mut split = pane_cursor(3, 2, true, 25);
+        split.composite_pane0 = Some(crate::tmux::PaneGeom {
+            left: 1,
+            top: 1,
+            width: 79,
+            height: 24,
+        });
+        let composited = map_live_preview_cursor(output, 24, 200, split);
+        assert_eq!(composited, Some(Position::new(44, 7)));
     }
 
     #[test]

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -986,9 +986,7 @@ export function MobileLiveTerminal({
       const visualRow = Math.floor((clientY - gridTop) / lineH) - effectiveSpacerLines;
       const firstScreenLine = Math.max(0, lines.length - screenRows);
       const screenTopVisual = visual.lineStartRow[firstScreenLine] ?? 0;
-      // The hovered cell is on the window grid; the app receives pane 0
-      // coordinates, so the inverse projection subtracts pane 0's origin
-      // (#3515).
+      // Convert the hovered window cell back into pane 0 coordinates.
       return pointerPaneCell(compositeCol, visualRow - screenTopVisual, pane0);
     },
     [charW, lineH, renderCols, screenRows, effectiveSpacerLines, lines.length, visual, frame?.pane0],

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -174,12 +174,25 @@ describe("MobileLiveTerminal wheel forwarding", () => {
     expect(forwardButton.mock.calls[1][1]).toBe(true);
   });
 
-  it("clamps split-window mouse input to pane 0", () => {
-    const { scroller, forwardButton } = renderTerm(
-      frame({ altScreen: true, mouse: true, mouseSgr: true, pane0: { cols: 1, rows: 1 } }),
+  it("maps split-window mouse input into pane 0", () => {
+    const clamped = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true, pane0: { cols: 1, rows: 1 } }));
+    fireEvent.pointerDown(clamped.scroller, { pointerType: "mouse", button: 0, clientX: 500, clientY: 500 });
+    expect(clamped.forwardButton.mock.calls[0]!.slice(4)).toEqual([1, 1]);
+    clamped.unmount();
+
+    const base = renderTerm(
+      frame({ altScreen: true, mouse: true, mouseSgr: true, pane0: { cols: 80, rows: 24, left: 0, top: 0 } }),
     );
-    fireEvent.pointerDown(scroller, { pointerType: "mouse", button: 0, clientX: 500, clientY: 500 });
-    expect(forwardButton.mock.calls[0]!.slice(4)).toEqual([1, 1]);
+    fireEvent.pointerDown(base.scroller, { pointerType: "mouse", button: 0, clientX: 100, clientY: 100 });
+    const baseRow = base.forwardButton.mock.calls[0]![5] as number;
+    base.unmount();
+
+    const offset = renderTerm(
+      frame({ altScreen: true, mouse: true, mouseSgr: true, pane0: { cols: 80, rows: 24, left: 0, top: 1 } }),
+    );
+    fireEvent.pointerDown(offset.scroller, { pointerType: "mouse", button: 0, clientX: 100, clientY: 100 });
+    const offsetRow = offset.forwardButton.mock.calls[0]![5] as number;
+    expect(offsetRow).toBe(baseRow - 1);
   });
 
   it("does NOT forward a click for a normal-screen agent", () => {

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -30,11 +30,8 @@ export interface LiveCursor {
 export interface LivePaneRect {
   cols: number;
   rows: number;
-  /** Pane 0's offset within the composited window grid. A
-   *  `pane-border-status` row pushes every pane down, so the cursor and
-   *  pointer cells the client sees are window-relative while the app speaks
-   *  pane-relative coordinates (#3515). Absent means the origin (pre-fix
-   *  servers, unsplit windows). */
+  /** Optional origin within the composited window grid. Missing fields mean
+   *  `(0, 0)` for compatibility with older frames. */
   left?: number;
   top?: number;
 }

--- a/web/src/lib/__tests__/liveMouse.test.ts
+++ b/web/src/lib/__tests__/liveMouse.test.ts
@@ -103,7 +103,7 @@ describe("pointerPaneCell", () => {
     });
   });
 
-  it("subtracts a non-zero origin (#3515: pane-border-status shifts pane 0 down)", () => {
+  it("subtracts a non-zero pane origin", () => {
     // Composite cell (10, 5) over a pane starting one row down: the app
     // hears its own row 5, not the border row above it.
     expect(pointerPaneCell(10, 5, { cols: 164, rows: 71, left: 0, top: 1 })).toEqual({

--- a/web/src/lib/liveMouse.ts
+++ b/web/src/lib/liveMouse.ts
@@ -91,25 +91,17 @@ export function wheelNotches(
 }
 
 /**
- * The composite line index a frame's cursor points at. Frame content is
- * bottom-anchored to the viewport (`screenRows` lines), so the live edge
- * starts at `lineCount - screenRows`; `cursorY` is already composite-space
- * (the server translates pane 0's row by its origin, #3515). Pure so the
- * cursor mapping is testable without a DOM.
+ * Map a frame cursor onto its bottom-anchored content. `cursorY` already
+ * indexes the composited frame. Pure so the mapping is testable without a DOM.
  */
 export function cursorLineIndex(lineCount: number, screenRows: number, cursorY: number): number {
   return Math.max(0, lineCount - screenRows) + cursorY;
 }
 
 /**
- * Inverse projection for pointer forwarding: map a hovered cell of the
- * composited window grid onto pane 0's 1-based mouse coordinate space.
- * `compositeCol` is 1-based, `compositeRow` is the 0-based composite row
- * under the pointer. Pane 0 may sit away from the window origin (a
- * `pane-border-status` row pushes every pane down one), so subtract the
- * origin the frame reports and clamp to the pane rectangle (#3515). A
- * missing rectangle means pane 0 at the corner, which keeps unsplit and
- * pre-fix frames unchanged.
+ * Map a 1-based column and 0-based row from the composited window grid into
+ * pane 0's 1-based mouse coordinates. Subtract the optional origin, then
+ * clamp to the pane rectangle; missing origin fields mean `(0, 0)`.
  */
 export function pointerPaneCell(
   compositeCol: number,

--- a/web/tests/live-click-forward.spec.ts
+++ b/web/tests/live-click-forward.spec.ts
@@ -81,28 +81,6 @@ test("a click on a bottom-aligned row reports that row to the mouse app", async 
   await expect.poll(() => texts(handle).find((text) => /\x1b\[<0;\d+;\d+M/.test(text))).toMatch(/\x1b\[<0;\d+;2M/);
 });
 
-test("a pane-border-status offset shifts forwarded rows up one (#3515)", async ({ page }) => {
-  const handle = await setup(page);
-  const lines = ["first", "second", ...Array<string>(22).fill("")];
-  handle.pushLiveFrame({
-    content: `${lines.join("\n")}\n`,
-    rows: 24,
-    history: 120,
-    altScreen: true,
-    mouse: true,
-    mouseSgr: true,
-    // Pane 0 starts one composite row down (`pane-border-status top`), so a
-    // click on composite row 1 must report the app's row 1, not 2.
-    pane0: { cols: 80, rows: 24, left: 0, top: 1 },
-  } as Parameters<MockHandle["pushLiveFrame"]>[0]);
-  const secondRow = page.getByText("second", { exact: true });
-  await expect(secondRow).toBeVisible();
-  const box = (await secondRow.boundingBox())!;
-
-  await pointer(page, "pointerdown", box.x + 10, box.y + box.height / 2);
-  await expect.poll(() => texts(handle).find((text) => /\x1b\[<0;\d+;\d+M/.test(text))).toMatch(/\x1b\[<0;\d+;1M/);
-});
-
 test("dragging forwards a motion report (button + 32) per new cell", async ({ page }) => {
   const handle = await setup(page);
   pushFrame(handle, { altScreen: true, mouse: true, mouseSgr: true });


### PR DESCRIPTION
## Description

Follow-up to merged PR #3526 and issue #3515.

The native TUI preview consumes the same composited `PaneCursor` geometry as the web surface, but `map_live_preview_cursor` still indexed the window grid with pane-relative `x`/`y`. With `pane-border-status top`, the bottom-anchor delta clipped the reserved row while the missing pane origin left the hardware cursor one row above its painted prompt.

Add `composite_pane0.left/top` after the bottom-anchor delta. The unsplit case remains an identity because `composite_pane0` is `None`. Mouse geometry is intentionally unchanged: the TUI viewport clips the reserved top row before input mapping, so adding `top` there would move input below the displayed pane.

Also move the pane-offset forwarding permutation from a second mocked Playwright page load into the existing component Vitest, retain the browser baseline for DOM-to-WebSocket wiring, make `PaneCursor::composite_pane0` the canonical coordinate contract, and correct the `pane0: null` protocol wording.

Actual TUI verification after the fix:

- tmux source: `source_cursor=32,4 pane0=0,1,41,33 window=81,34`
- native TUI: hardware cursor row 9; painted prompt row 9
- before the fix, the same geometry placed the hardware cursor on row 8

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No screenshot or recording was produced. The actual TUI was launched in an isolated outer tmux session and verified by exact tmux source, hardware-cursor, and captured prompt coordinates above; the isolated session and scratch state were then removed.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The web production behavior is unchanged. Its pane-offset wiring assertion moved to the existing component Vitest; the existing mocked Playwright baseline still covers real DOM row measurement through WebSocket bytes. Existing coverage-matrix entries already list both surfaces, and matrix validation passes.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the pure cursor mapper is the minimal tier that directly fails when the origin addition is removed; an actual TUI smoke test verifies the integrated surface.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --features serve -- -D warnings`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo test --features serve`: 6692 passed, 8 ignored
- focused TUI cursor tests: 4 passed
- `npm run format:check` and `npm run lint`
- targeted Vitest: 53 passed
- full Vitest with the suite's expected `en_US.UTF-8` locale: 3713 passed
- rebuilt mocked Playwright click-forward spec: 6 passed
- `node tests/validate-coverage-matrix.mjs`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** openai-codex/gpt-5.6-sol via Oh My Pi

**Any Additional AI Details you'd like to share:** Two independent validators reconstructed every published #3526 review finding. Both reproduced the TUI cursor offset on the actual surface; they independently disproved the proposed simple mouse-origin change because viewport clipping cancels that offset. A separate reviewer cross-validated the completed diff before commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed cursor alignment in split native TUI previews.
- Preserved correct behavior for single-pane previews.
- Clarified pane origins and coordinate handling across Rust and web components.
- Added component test coverage for pane-origin and vertical-offset behavior.
- Removed a redundant Playwright regression test.
- Updated protocol and geometry documentation for compatibility and clarity.

## Benefits

The hardware cursor now matches the painted prompt when the top pane border is enabled. Mouse behavior remains unchanged. The updated tests and documentation make coordinate handling easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->