### PR TITLE
test(tui): guard crop-cancelled mouse projection

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -1035,7 +1035,9 @@ async fn handle_live_ws(
 fn frame_json(content: &str, cursor: Option<&crate::tmux::PaneCursor>) -> String {
     // The cursor is pane relative while composited content uses the window
     // grid. Emit window-relative coordinates and carry the same origin for
-    // the client's inverse pointer mapping. No pane rectangle means identity.
+    // the client's inverse pointer mapping. Translating before emission also
+    // keeps cursor painting correct in older clients that ignore the origin;
+    // only their pointer mapping degrades. No pane rectangle means identity.
     let pane0 = cursor.and_then(|c| c.composite_pane0);
     let (origin_x, origin_y) = pane0.map_or((0, 0), |p| (p.left, p.top));
     let cursor_value = match cursor {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -7110,6 +7110,8 @@ mod tests {
     /// goes to pane 0 alone, so a pointer over a neighbouring pane must not be
     /// mapped against the full rect: that reported a column past pane 0's right
     /// edge to the agent as though its own pane were window-wide.
+    /// It also round-trips a painted composite cursor cell through mouse mapping,
+    /// pinning the bottom-follow clipping semantics.
     #[test]
     fn composited_preview_maps_the_mouse_into_pane_zero_only() {
         use ratatui::layout::Rect;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -7137,6 +7137,34 @@ mod tests {
         assert!(hover_forward_bytes(&split, pane, 39, 5).is_some());
         assert_eq!(hover_forward_bytes(&split, pane, 40, 5), None);
 
+        // In the bottom-follow layout, the composite's top border row is
+        // clipped before painting: `first_line == pane0.top == 1`. The cursor
+        // mapper adds `top` after its anchor delta, while the mouse rect stays
+        // at the visible output origin. A click on the painted cursor must
+        // round-trip to that cursor's 1-based app cell.
+        let mut bottom_follow = cursor_for(true, true, true);
+        bottom_follow.x = 10;
+        bottom_follow.y = 4;
+        bottom_follow.pane_height = 25;
+        bottom_follow.composite_pane0 = Some(crate::tmux::PaneGeom {
+            left: 0,
+            top: 1,
+            width: 40,
+            height: 24,
+        });
+        let painted = crate::tui::home::render::map_live_preview_cursor(
+            pane,
+            usize::from(pane.height),
+            25,
+            bottom_follow,
+        )
+        .expect("visible pane cursor");
+        assert_eq!(
+            map_pane_cell(mouse_pane_rect(&bottom_follow, pane), painted.x, painted.y,),
+            (bottom_follow.x + 1, bottom_follow.y + 1),
+            "clicking the painted cursor must report the same app cell"
+        );
+
         // A no-mouse full-screen agent gets no page key from a wheel aimed at
         // the neighbour either, but keeps it over pane 0.
         let mut no_mouse = cursor_for(true, false, false);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -123,7 +123,7 @@ const READING_CAPTURE_LINES: u16 = 2000;
 /// cursor.y`; a short capture instead anchors at the top. This keeps the
 /// cursor on the same text row for both the status-row offset (#3515) and the
 /// shorter-pane case (#2742). A hidden or out-of-bounds cursor yields `None`.
-fn map_live_preview_cursor(
+pub(super) fn map_live_preview_cursor(
     output: Rect,
     visible_rows: usize,
     line_count: usize,


### PR DESCRIPTION
## Description

Post-merge follow-up to the maintainer review on #3547 and the TUI pointer residual from #3515.

The common side-by-side `pane-border-status top` layout bottom-follows a composite one row taller than the preview. Its `first_line` therefore equals `pane0.top`, so clipping already cancels the pane origin before mouse mapping. #3547 correctly left `mouse_pane_rect` at the visible output origin, but no committed test protected that non-obvious decision.

Extend the existing composited mouse test with a render-to-input round trip: paint a pane-relative cursor through `map_live_preview_cursor`, feed that screen cell through `mouse_pane_rect` and `map_pane_cell`, and require the same 1-based app cell. A naive `pane.y + rect.top` mutation now fails `(11, 4)` versus `(11, 5)`.

`map_live_preview_cursor` becomes `pub(super)` only so the sibling input test can exercise the real mapper. The WebSocket emission comment also restores why cursor translation happens server-side: older clients that ignore the origin still paint the cursor correctly; only their pointer mapping degrades.

The cancellation is not universal for stacked, non-bottom-aligned, or horizontally moved pane 0 layouts. Those require slice-aware pointer projection and are tracked separately in #3550 rather than expanding this regression-guard PR.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No user-visible behavior changes in this PR; it adds a regression guard and restores design rationale.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The regression is a pure coordinate round trip and is folded into the existing Rust test function, matching the repository's one-test-per-behavior guidance.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --features serve -- -D warnings`
- `cargo clippy --lib --tests -- -D warnings`
- mutation: naive mouse `+top` fails `(11, 4)` versus `(11, 5)`
- focused composited mouse test passes after restore
- focused live cursor tests: 4 passed
- focused `frame_json` contract test passes
- `cargo test --features serve`: 6730 passed, 8 ignored on rerun; the first run's unrelated ACP test flake passed in isolation before the clean full rerun

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** openai-codex/gpt-5.6-sol via Oh My Pi

**Any Additional AI Details you'd like to share:** Two independent validators reconstructed each maintainer review item. A separate reviewer cross-validated the completed patch and the split of the broader pointer residual into #3550.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a regression test for cursor mapping in bottom-follow, side-by-side previews.
- Exposed `map_live_preview_cursor` to sibling modules for testing.
- Restored documentation for server-side cursor translation and older WebSocket clients.
- Prevented incorrect pane offset handling during mouse coordinate mapping.

## Benefits

- Keeps painted cursor positions aligned with application cells.
- Protects against regressions in composited TUI layouts.
- Preserves compatibility with older WebSocket clients.

Broader pointer projection cases remain tracked separately in `#3550`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
