### PR TITLE
perf(tui): stop re-forking capture-pane for an idle preview pane

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -806,6 +806,13 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// capture-pane. Mirrors the Clipboard Pass-through setting, so disabled
     /// mode does not keep a second pipe-pane connection open.
     clipboard_capture_enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Cycle counter, bumped at the top of every worker iteration. The render
+    /// thread reads it to tell "the worker is running and has nothing new"
+    /// (an idle pane: no fork needed) from "the worker is wedged" (fall back
+    /// to the synchronous fork). Publishes cannot answer that on their own:
+    /// the worker dedups unchanged frames, so an idle pane publishes nothing
+    /// for minutes while still cycling.
+    cycles: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl Drop for LiveCaptureWorker {
@@ -1000,6 +1007,8 @@ impl LiveCaptureWorker {
         // Pass-through setting, avoiding an observer before configuration is
         // available for a newly created worker.
         let clipboard_capture_enabled = Arc::new(AtomicBool::new(false));
+        let cycles = Arc::new(AtomicU64::new(0));
+        let cycles_cell = cycles.clone();
         let lines_cell = capture_lines.clone();
         let target_cell = target.clone();
         let slot = latest.clone();
@@ -1070,6 +1079,7 @@ impl LiveCaptureWorker {
                 crate::tmux::composite::WindowLayout,
             )> = None;
             while !stop_flag.load(Ordering::Relaxed) {
+                cycles_cell.fetch_add(1, Ordering::Relaxed);
                 let lines = lines_cell.load(Ordering::Relaxed);
                 // Read the target without holding the lock across the fork:
                 // `set_target` must never wait on a `capture-pane`.
@@ -1407,6 +1417,7 @@ impl LiveCaptureWorker {
             clipboard,
             vt_enabled,
             clipboard_capture_enabled,
+            cycles,
         }
     }
 
@@ -1534,6 +1545,15 @@ impl LiveCaptureWorker {
     /// Take the newest capture the worker has produced since the last
     /// call, if any. Returns `None` when nothing new has arrived (the
     /// render loop then keeps the current preview).
+    /// Snapshot of the worker's cycle counter. Two reads a moment apart that
+    /// differ mean the capture loop is running; identical reads across more
+    /// than a cycle's worth of time mean it is wedged (or stopped). The render
+    /// thread uses this to decide whether "no new frame" can be trusted as
+    /// "nothing changed".
+    pub(in crate::tui) fn cycles(&self) -> u64 {
+        self.cycles.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     pub(in crate::tui) fn take_latest(&self) -> Option<String> {
         self.latest.lock().ok().and_then(|mut guard| guard.take())
     }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1545,6 +1545,10 @@ impl LiveCaptureWorker {
     /// Take the newest capture the worker has produced since the last
     /// call, if any. Returns `None` when nothing new has arrived (the
     /// render loop then keeps the current preview).
+    pub(in crate::tui) fn take_latest(&self) -> Option<String> {
+        self.latest.lock().ok().and_then(|mut guard| guard.take())
+    }
+
     /// Snapshot of the worker's cycle counter. Two reads a moment apart that
     /// differ mean the capture loop is running; identical reads across more
     /// than a cycle's worth of time mean it is wedged (or stopped). The render
@@ -1552,10 +1556,6 @@ impl LiveCaptureWorker {
     /// "nothing changed".
     pub(in crate::tui) fn cycles(&self) -> u64 {
         self.cycles.load(std::sync::atomic::Ordering::Relaxed)
-    }
-
-    pub(in crate::tui) fn take_latest(&self) -> Option<String> {
-        self.latest.lock().ok().and_then(|mut guard| guard.take())
     }
 
     /// The newest cursor for the worker's CURRENT target pane, or `None`

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -668,6 +668,17 @@ pub struct HomeView {
     /// at, so the reconcile can tell when the displayed pane changed and
     /// retarget. `None` before the first preview or when nothing is selected.
     pub(super) preview_capture_target: Option<String>,
+    /// Last observed `LiveCaptureWorker::cycles` value and when it was seen,
+    /// so the render thread can tell a running worker with nothing new (an
+    /// idle pane) from a wedged one. `None` before the first observation and
+    /// after every retarget.
+    ///
+    /// This gates the synchronous fallback fork. Without it the 250ms idle
+    /// poll re-forked `capture-pane` on the render thread to re-read content
+    /// the worker had already reported unchanged: measured at 10-50ms per
+    /// fork against a 429x113 terminal, one to three whole frame budgets
+    /// burned every 250ms of simply looking at an idle session.
+    pub(super) preview_worker_pulse: Option<(u64, std::time::Instant)>,
     /// Notified by the capture worker thread when it has fresh, changed
     /// content. The event loop selects on this to repaint without
     /// busy-polling; an idle pane (no new content) never wakes it.
@@ -2344,6 +2355,7 @@ impl HomeView {
             live_send_worker: None,
             preview_capture_worker: None,
             preview_capture_target: None,
+            preview_worker_pulse: None,
             preview_wake: std::sync::Arc::new(tokio::sync::Notify::new()),
             live_send_last_resize: None,
             live_send_pending_leader: false,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2300,8 +2300,9 @@ impl HomeView {
         // `sync_preview_capture_worker` in `render_preview`) keeps fresh
         // content flowing on its own thread; `apply_worker_capture` below
         // just applies the newest it has produced. The synchronous fork via
-        // `refresh_preview_cache_core` remains only as the cold-start /
-        // worker-empty fallback (its 250ms gate still applies there). This
+        // `refresh_preview_cache_core` remains as the cold-start fallback,
+        // plus the wedged-worker and trust-ceiling paths in `idle_poll_due`;
+        // a worker that is merely idle no longer trips it. This
         // moves the per-frame capture cost (~8.5ms on macOS, ~90% of a
         // frame; the `tui.render` `capture_us` trace measures it) off the
         // render thread for every view, not just agent live-send.
@@ -2426,8 +2427,8 @@ impl HomeView {
                 // "session looks gone" signal the non-live path uses).
                 let same_session = s.preview_cache.session_id.as_deref() == Some(id);
                 // Composited in BOTH modes, matching what the worker publishes.
-                // This fallback also runs on every idle refresh (the worker
-                // dedups unchanged frames, so it has nothing to hand over), so a
+                // This fallback still runs behind a live worker (the trust
+                // ceiling, and any stall past `WORKER_PULSE_TIMEOUT`), so a
                 // pane-0-only capture here would clobber the worker's composite
                 // a beat after each keystroke and leave the split visible for
                 // only one frame at a time. On an unsplit window this returns

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -181,6 +181,46 @@ fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
 /// worker's bottom-anchored live frames would shift the content out from under
 /// the user: the read position gets yanked toward the tail as output streams,
 /// or the drag anchors slide off their text. Frozen, wheel-scroll stays smooth
+/// and a drag-select tracks exactly the cells under the pointer.
+fn preview_frozen(scroll_offset: u16, has_selection: bool) -> bool {
+    scroll_offset > 0 || has_selection
+}
+
+/// Idle-poll cadence for the preview cache, in ms. The synchronous
+/// `capture-pane` fallback fires no more often than this.
+const PREVIEW_REFRESH_MS: u128 = 250;
+
+/// Ceiling on how long the capture worker may be the sole source of truth.
+///
+/// The 250ms poll was incidentally a self-healing authoritative refresh: it
+/// overwrote the cache with real `capture-pane` output four times a second, so
+/// any divergence between the worker's picture of the pane and tmux's was
+/// repaired before anyone saw it. Suppressing it removes that net for the one
+/// failure a cycle counter cannot see, a worker that cycles at full rate while
+/// being confidently wrong (its VT grid stably diverged, so `last_captured`
+/// matches every cycle and nothing publishes). This restores the self-heal at
+/// one fortieth of the old fork rate, which keeps essentially all of the win.
+const WORKER_TRUST_CEILING_MS: u128 = 10_000;
+
+/// Whether the idle poll should pay for a synchronous `capture-pane`.
+///
+/// Three ways it does not:
+/// - inside the cadence, which is the pre-existing throttle;
+/// - while frozen (reading scrollback or holding a selection), because a fresh
+///   bottom-anchored snapshot would shift the held content out from under the
+///   reader or the drag. Session change, resize, and the reading grow refresh
+///   through their own clauses regardless;
+/// - while the capture worker is pulsing, because it publishes every change,
+///   so a fork here could only re-read identical bytes at 10-50ms on the
+///   render thread. That suppression expires at [`WORKER_TRUST_CEILING_MS`],
+///   so a worker that is wrong rather than wedged still gets corrected.
+fn idle_poll_due(frozen: bool, idle_elapsed_ms: u128, worker_covers_idle: bool) -> bool {
+    if frozen || idle_elapsed_ms <= PREVIEW_REFRESH_MS {
+        return false;
+    }
+    !worker_covers_idle || idle_elapsed_ms > WORKER_TRUST_CEILING_MS
+}
+
 /// How an observed capture-worker cycle counter folds into a liveness verdict,
 /// given the previous observation. Returns `(is_pulsing, new_observation)`.
 ///
@@ -213,11 +253,6 @@ fn worker_pulse_step(
 /// capture fork inside a cycle can add tens of ms, so one slow cycle must not
 /// trip this.
 const WORKER_PULSE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1500);
-
-/// and a drag-select tracks exactly the cells under the pointer.
-fn preview_frozen(scroll_offset: u16, has_selection: bool) -> bool {
-    scroll_offset > 0 || has_selection
-}
 
 /// Decide whether the cached capture window still covers the requested scroll.
 /// Returns true when the cache must be re-captured because the visible window
@@ -2001,9 +2036,12 @@ impl HomeView {
     /// (#1501); the terminal/tool wrappers use it when the instance has gone
     /// away, matching the original "only write inside `if let Some(inst)`".
     ///
-    /// `force` bypasses the idle throttle; the agent passes `in_live` here so
-    /// every render refreshes the preview in live-send mode (see the throttle
-    /// note in `refresh_preview_cache_if_needed`), the others pass `false`.
+    /// `force` bypasses the idle throttle. All four wrappers pass `false`
+    /// today, so it is inert defensive code; the doc used to claim the agent
+    /// passed `in_live` here to refresh every render in live-send mode, which
+    /// has not been true at any call site. Live-send does not need it: on the
+    /// fast cadence `apply_worker_capture` has a fresh frame nearly every
+    /// render and returns before this is reached.
     fn refresh_preview_cache_core(
         &mut self,
         width: u16,
@@ -2012,35 +2050,35 @@ impl HomeView {
         select: fn(&mut Self) -> &mut super::PreviewCache,
         capture: impl FnOnce(&Self, &str, usize) -> Option<String>,
     ) {
-        const PREVIEW_REFRESH_MS: u128 = 250;
         let Some(id) = self.selected_session.clone() else {
             return;
         };
         let scroll_offset = self.preview_scroll_offset;
         let frozen = self.preview_is_frozen();
         let visible_rows = self.preview_visible_rows;
-        // Only the idle timer is suppressed by a healthy worker; a live-send
-        // `force`, a session change, a resize, and a scroll that outgrew the
-        // cache all still fork, because none of those are answered by "the
-        // worker had no new frame".
-        let worker_covers_idle = !force && self.worker_is_pulsing();
+        // Only the idle timer is suppressed by a pulsing worker. A session
+        // change, a resize, and a scroll that outgrew the cache all still
+        // fork, because none of those are answered by "the worker had no new
+        // frame". `force` is inert defensive code: every caller passes
+        // `false`, so live-send is covered by the suppression rather than
+        // exempt from it, and it does not need an exemption because on the
+        // fast cadence `apply_worker_capture` almost always has a fresh frame
+        // to hand over and returns before this.
+        let worker_covers_idle = !force && self.observe_worker_pulse();
 
         let cache = select(self);
+        let idle_elapsed = cache.last_refresh.elapsed().as_millis();
         let needs_refresh = force
             || cache.session_id.as_ref() != Some(&id)
             || cache.dimensions != (width, height)
-            || capture_window_stale(frozen, cache.captured_lines, height, visible_rows, scroll_offset)
-            // While frozen (reading scrollback or holding a selection) the idle
-            // poll must not re-capture: a fresh bottom-anchored snapshot would
-            // shift the held content out from under the reader or the drag.
-            // Session change, resize, and the reading grow still refresh.
-            //
-            // A pulsing worker also suppresses it: the worker publishes every
-            // change, so re-forking `capture-pane` here could only re-read
-            // identical bytes, at 10-50ms on the render thread.
-            || (!frozen
-                && !worker_covers_idle
-                && cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS);
+            || capture_window_stale(
+                frozen,
+                cache.captured_lines,
+                height,
+                visible_rows,
+                scroll_offset,
+            )
+            || idle_poll_due(frozen, idle_elapsed, worker_covers_idle);
         if !needs_refresh {
             return;
         }
@@ -2164,16 +2202,18 @@ impl HomeView {
         preview_frozen(self.preview_scroll_offset, self.preview_selection.is_some())
     }
 
-    /// Whether the capture worker is demonstrably running for the pane on
+    /// Fold this frame's observation of the capture worker's cycle counter in,
+    /// and report whether the worker is demonstrably running for the pane on
     /// screen, so "the worker handed over nothing" can be read as "nothing
-    /// changed" rather than "nobody is capturing".
+    /// changed" rather than "nobody is capturing". Takes `&mut self` because
+    /// the observation it compares against is the state it updates.
     ///
     /// Liveness comes from the worker's cycle counter, not from its publishes:
     /// it dedups unchanged frames, so an idle pane publishes nothing for
     /// minutes while the loop keeps running. Decision lives in the pure
     /// [`worker_pulse_step`] helper so it is unit-tested away from a live
     /// worker thread.
-    fn worker_is_pulsing(&mut self) -> bool {
+    pub(super) fn observe_worker_pulse(&mut self) -> bool {
         let Some(worker) = self.preview_capture_worker.as_ref() else {
             self.preview_worker_pulse = None;
             return false;
@@ -4185,6 +4225,37 @@ mod tests {
     // by `preview_visible_rows_equal_output_area_with_info_shown` in
     // `home/tests.rs`, which renders a real frame and asserts
     // `preview_visible_rows == preview_pane_area.height`.
+
+    /// The idle-poll gate itself. A pulsing worker suppresses the fork, but
+    /// only up to the trust ceiling, so a worker that is confidently wrong
+    /// rather than wedged still gets corrected (njbrake on #3559).
+    #[test]
+    fn idle_poll_due_suppresses_a_pulsing_worker_only_until_the_trust_ceiling() {
+        let past_cadence = PREVIEW_REFRESH_MS + 1;
+        let past_ceiling = WORKER_TRUST_CEILING_MS + 1;
+        // (frozen, elapsed_ms, worker_covers_idle, expected)
+        let cases = [
+            // Inside the cadence: the pre-existing throttle, worker or not.
+            (false, PREVIEW_REFRESH_MS, false, false),
+            (false, PREVIEW_REFRESH_MS, true, false),
+            // Past the cadence with no trustworthy worker: fork, as before.
+            (false, past_cadence, false, true),
+            // Past the cadence with a pulsing worker: this is the whole fix.
+            (false, past_cadence, true, false),
+            // Past the ceiling: the self-heal fires even while pulsing.
+            (false, past_ceiling, true, true),
+            // Frozen wins over everything; the reader's content must not move.
+            (true, past_cadence, false, false),
+            (true, past_ceiling, false, false),
+        ];
+        for (frozen, elapsed, covered, expected) in cases {
+            assert_eq!(
+                idle_poll_due(frozen, elapsed, covered),
+                expected,
+                "frozen={frozen} elapsed={elapsed} covered={covered}"
+            );
+        }
+    }
 
     /// The gate that keeps `capture-pane` off the render thread on an idle
     /// pane. Advancing cycles prove the worker is running, an unmoved

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -181,6 +181,39 @@ fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
 /// worker's bottom-anchored live frames would shift the content out from under
 /// the user: the read position gets yanked toward the tail as output streams,
 /// or the drag anchors slide off their text. Frozen, wheel-scroll stays smooth
+/// How an observed capture-worker cycle counter folds into a liveness verdict,
+/// given the previous observation. Returns `(is_pulsing, new_observation)`.
+///
+/// A counter that advanced proves the loop is running. An unchanged counter is
+/// inconclusive rather than dead: a render can easily land between two worker
+/// cycles, so the previous observation stays trusted until
+/// [`WORKER_PULSE_TIMEOUT`] has passed with no movement, at which point the
+/// worker is treated as wedged and the caller falls back to the synchronous
+/// fork.
+///
+/// With no prior observation there is nothing to compare, so the first call
+/// records one and reports not-pulsing: a cold start should fork once anyway.
+fn worker_pulse_step(
+    cycles: u64,
+    prior: Option<(u64, std::time::Instant)>,
+    now: std::time::Instant,
+) -> (bool, Option<(u64, std::time::Instant)>) {
+    match prior {
+        None => (false, Some((cycles, now))),
+        Some((seen, _)) if cycles != seen => (true, Some((cycles, now))),
+        Some((seen, at)) => (
+            now.saturating_duration_since(at) < WORKER_PULSE_TIMEOUT,
+            Some((seen, at)),
+        ),
+    }
+}
+
+/// How long an unmoved worker cycle counter stays trusted. Generous against
+/// the worker's own cadence: it cycles at most every 250ms when idle, and a
+/// capture fork inside a cycle can add tens of ms, so one slow cycle must not
+/// trip this.
+const WORKER_PULSE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1500);
+
 /// and a drag-select tracks exactly the cells under the pointer.
 fn preview_frozen(scroll_offset: u16, has_selection: bool) -> bool {
     scroll_offset > 0 || has_selection
@@ -1986,6 +2019,11 @@ impl HomeView {
         let scroll_offset = self.preview_scroll_offset;
         let frozen = self.preview_is_frozen();
         let visible_rows = self.preview_visible_rows;
+        // Only the idle timer is suppressed by a healthy worker; a live-send
+        // `force`, a session change, a resize, and a scroll that outgrew the
+        // cache all still fork, because none of those are answered by "the
+        // worker had no new frame".
+        let worker_covers_idle = !force && self.worker_is_pulsing();
 
         let cache = select(self);
         let needs_refresh = force
@@ -1996,7 +2034,13 @@ impl HomeView {
             // poll must not re-capture: a fresh bottom-anchored snapshot would
             // shift the held content out from under the reader or the drag.
             // Session change, resize, and the reading grow still refresh.
-            || (!frozen && cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS);
+            //
+            // A pulsing worker also suppresses it: the worker publishes every
+            // change, so re-forking `capture-pane` here could only re-read
+            // identical bytes, at 10-50ms on the render thread.
+            || (!frozen
+                && !worker_covers_idle
+                && cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS);
         if !needs_refresh {
             return;
         }
@@ -2077,6 +2121,9 @@ impl HomeView {
                 worker.set_target(desired.clone().unwrap_or_default());
             }
             self.preview_capture_target = desired;
+            // The new pane has no observed cycle history, so the first refresh
+            // for it goes through the synchronous cold-start fork.
+            self.preview_worker_pulse = None;
             // New pane under the pointer: drop the hover dedup cell so a
             // stationary pointer still reports its cell to the new agent.
             self.hover_forward_cell = None;
@@ -2115,6 +2162,29 @@ impl HomeView {
     /// is unit-tested away from a live `HomeView`.
     fn preview_is_frozen(&self) -> bool {
         preview_frozen(self.preview_scroll_offset, self.preview_selection.is_some())
+    }
+
+    /// Whether the capture worker is demonstrably running for the pane on
+    /// screen, so "the worker handed over nothing" can be read as "nothing
+    /// changed" rather than "nobody is capturing".
+    ///
+    /// Liveness comes from the worker's cycle counter, not from its publishes:
+    /// it dedups unchanged frames, so an idle pane publishes nothing for
+    /// minutes while the loop keeps running. Decision lives in the pure
+    /// [`worker_pulse_step`] helper so it is unit-tested away from a live
+    /// worker thread.
+    fn worker_is_pulsing(&mut self) -> bool {
+        let Some(worker) = self.preview_capture_worker.as_ref() else {
+            self.preview_worker_pulse = None;
+            return false;
+        };
+        let (pulsing, observation) = worker_pulse_step(
+            worker.cycles(),
+            self.preview_worker_pulse,
+            std::time::Instant::now(),
+        );
+        self.preview_worker_pulse = observation;
+        pulsing
     }
 
     fn apply_worker_capture(
@@ -4115,6 +4185,41 @@ mod tests {
     // by `preview_visible_rows_equal_output_area_with_info_shown` in
     // `home/tests.rs`, which renders a real frame and asserts
     // `preview_visible_rows == preview_pane_area.height`.
+
+    /// The gate that keeps `capture-pane` off the render thread on an idle
+    /// pane. Advancing cycles prove the worker is running, an unmoved
+    /// counter is trusted until the timeout, and no prior observation forks
+    /// once by design.
+    #[test]
+    fn worker_pulse_step_trusts_a_running_worker_and_gives_up_on_a_wedged_one() {
+        let t0 = std::time::Instant::now();
+        let within = t0 + WORKER_PULSE_TIMEOUT - std::time::Duration::from_millis(1);
+        let past = t0 + WORKER_PULSE_TIMEOUT;
+
+        // Cold start: nothing to compare against, so fork once and record.
+        assert_eq!(worker_pulse_step(7, None, t0), (false, Some((7, t0))));
+
+        // Counter moved: the loop is running, so an empty handover means
+        // "unchanged" and the idle fork is suppressed.
+        assert_eq!(
+            worker_pulse_step(8, Some((7, t0)), within),
+            (true, Some((8, within)))
+        );
+
+        // Unmoved but recent: a render landed between two worker cycles. The
+        // observation must NOT be re-stamped, or repeated renders would keep
+        // pushing the deadline out and a wedged worker would never be caught.
+        assert_eq!(
+            worker_pulse_step(7, Some((7, t0)), within),
+            (true, Some((7, t0)))
+        );
+
+        // Unmoved past the timeout: treat as wedged and fall back to the fork.
+        assert_eq!(
+            worker_pulse_step(7, Some((7, t0)), past),
+            (false, Some((7, t0)))
+        );
+    }
 
     fn pane_cursor(x: u16, y: u16, visible: bool, pane_height: u16) -> crate::tmux::PaneCursor {
         crate::tmux::PaneCursor {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -21065,3 +21065,57 @@ mod profile_duplicate_reconciliation {
         );
     }
 }
+
+/// The two guards on the idle-fork suppression that survived deletion with a
+/// green suite (njbrake on #3559). Driven against a REAL spawned worker
+/// because the mutants that matter are in the wiring, not in the pure
+/// `worker_pulse_step` helper: deleting the retarget reset, which is the one
+/// place a missed path leaves a genuinely stale preview, and deleting the
+/// pulse plumbing entirely.
+#[test]
+fn observe_worker_pulse_needs_a_moving_counter_and_resets_on_retarget() {
+    let mut env = create_test_env_empty();
+
+    // No worker: nothing can be trusted, and the observation stays cleared.
+    assert!(!env.view.observe_worker_pulse());
+    assert!(env.view.preview_worker_pulse.is_none());
+
+    env.view.preview_capture_worker = Some(crate::tui::home::live_send::LiveCaptureWorker::spawn(
+        std::sync::Arc::new(tokio::sync::Notify::new()),
+    ));
+
+    // First observation has no history to compare, so a cold start forks.
+    assert!(
+        !env.view.observe_worker_pulse(),
+        "the first observation must not suppress the cold-start fork"
+    );
+    assert!(env.view.preview_worker_pulse.is_some());
+
+    // The loop cycles on its own; wait for the counter to move rather than
+    // sleeping a fixed window, since the first iteration forks tmux.
+    let mut pulsing = false;
+    for _ in 0..100 {
+        if env.view.observe_worker_pulse() {
+            pulsing = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(
+        pulsing,
+        "a running worker must be observed pulsing, so the idle fork is suppressed"
+    );
+
+    // Retarget: the new pane has no observed history, so its cold-start fork
+    // must not be suppressed by the previous pane's pulse.
+    env.view
+        .sync_preview_capture_worker(Some("aoe_test_pulse_retarget".to_string()));
+    assert!(
+        env.view.preview_worker_pulse.is_none(),
+        "a retarget must clear the pulse observation"
+    );
+    assert!(
+        !env.view.observe_worker_pulse(),
+        "the retargeted pane must fork once before the pulse is trusted again"
+    );
+}


### PR DESCRIPTION
## Description

The home view re-forked `tmux capture-pane` **on the render thread** every 250ms while previewing an idle session, to re-read bytes it had already been told were unchanged.

The preview's off-thread `LiveCaptureWorker` exists precisely so that fork stays off the render thread, but it dedups unchanged frames. An idle pane therefore hands over nothing, `apply_worker_capture` returns `false`, and the render path falls through to the synchronous fallback in `refresh_preview_cache_core` , whose 250ms idle timer then forks. The existing comment there already noted the fallback "runs on every idle refresh"; what wasn't visible is what that costs on the render thread.

Measured from the `tui.render` trace on a 429x113 terminal, home view, `live=false`:

```
frame_ms=65  capture_us=51086   <- worst observed
frame_ms=45  capture_us=33392
frame_ms=35  capture_us=21494
frame_ms=20  capture_us=0       <- same view, no fallback fork
```

`capture_us` was up to **80% of the frame**, so every ~250ms spent *dwelling* on a selection cost one to three whole 16ms budgets re-reading identical output.

**What this does not fix, to be precise about the scope:** arrowing to a different session changes `selected_session`, which trips the `cache.session_id != Some(&id)` clause , deliberately left forking. So every arrow-key press still pays a full synchronous `capture-pane`. This fixes dwelling, not moving between selections.

The worker cannot prove liveness by publishing , an idle pane publishes nothing for minutes while its loop keeps cycling , so it now bumps a cycle counter every iteration. The render path suppresses the **idle poll only** while that counter advances, and falls back to the fork if it stalls for 1.5s (a wedged or stopped worker must not freeze the preview). Cold start, session change, resize, and a scroll past the cache all still fork, since none of those are answered by "the worker had no new frame".

A 10s trust ceiling forces the fork regardless of pulse. The 250ms poll was incidentally a self-healing authoritative refresh, and a cycle counter cannot detect a worker that pulses at full rate while being *wrong* rather than wedged; the ceiling restores that self-heal at one fortieth of the old fork rate.

`Refs #3554`, but I'd now say it is **unlikely to be that reporter's regression**: an archived or trashed selection never reaches the capture path at all (`render_preview` returns into the archived/trashed placeholder first), their 600 rows are mostly those, and their bisect window (1.14.1 → 1.15.0) is far newer than this 250ms poll. Keep #3554 open.

### Remaining, not addressed here

The same trace shows a ~20ms floor with `capture_us=0` , widget build plus ratatui diff at 429x113 (48k cells). That caps the view near 45fps and wants its own investigation.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot: the rendered output is byte-identical, only its cost changes. Verified by hand against a real store (23 live sessions, 61 stored) with the `tui.render` trace on: `capture_us` drops to ~0 on home frames and frame times settle at the ~20ms floor.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: what changed is whether a fork happens, and asserting "no subprocess was spawned this frame" from the e2e harness is not something it can observe. The decision itself is extracted into the pure `worker_pulse_step` helper (same pattern as the existing `preview_frozen` / `passive_resize_step` helpers in this file) and tabled by `worker_pulse_step_trusts_a_running_worker_and_gives_up_on_a_wedged_one`, which covers cold start, an advancing counter, an unmoved-but-recent counter (and that the observation is *not* re-stamped, or a wedged worker would never be caught), and the timeout. The rendering paths it gates are already covered by the existing `tui::home::render` suite (64 tests, passing unchanged).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus)

**Any Additional AI Details you'd like to share:**

Found by enabling the existing `tui.render` trace (`[logging.targets] "tui.render" = "trace"`) against a real store and reading the `capture_us` breakdown on over-budget frames. Worth noting the trace paid for itself here: the frame accounting was already in the code, just filtered out at the default `info` level.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents repeated idle `tmux capture-pane` calls on the TUI render thread.
- Tracks `LiveCaptureWorker` progress with a cycle counter.
- Uses synchronous capture when the worker stalls, changes target, or requires an immediate refresh.
- Resets worker progress tracking after retargeting.
- Adds tests for worker progress and idle capture decisions.

## Benefits

- Reduces render-thread work during idle previews.
- Keeps preview output unchanged.
- Preserves reliable updates for cold starts, session changes, resizes, scrolling, stalled workers, and forced refreshes.

## Technical details

`HomeView` records the latest worker pulse. Idle capture stays suppressed while the worker progresses. A 1.5-second timeout detects stalled workers. A 10-second trust ceiling provides a self-healing fallback. Synchronous capture remains enabled for required refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->