### PR TITLE
ci: give git-cliff a token in the weekly release PR workflow

### DIFF
--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -121,6 +121,13 @@ jobs:
       - name: Update CHANGELOG.md
         env:
           VERSION: ${{ steps.next.outputs.version }}
+          # cliff.toml enables [remote.github], so git-cliff pages the closed-PR
+          # list to resolve commit -> PR -> author. Unauthenticated that is
+          # capped at 60/hr on a shared runner IP, and the repo is now past 2100
+          # closed PRs (22 pages), so the walk 403s and panics partway through.
+          # release.yml and prepare-release.yml already pass this token; this
+          # step was the one that missed it.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git cliff --config cliff.toml --tag "v$VERSION" --output CHANGELOG.md
           echo "=== CHANGELOG.md head ==="


### PR DESCRIPTION
## Description
<!-- Describe your changes and the problem they solve -->

The weekly release-staging PR has not been opened since 2026-08-12. The schedule is firing fine; the job dies at the `Update CHANGELOG.md` step:

```
thread 'main' panicked at git-cliff-core/src/changelog.rs:493:18:
Could not get github metadata: HttpClientError(reqwest::Error { kind: Status(403, None),
url: "https://api.github.com/repos/agent-of-empires/agent-of-empires/pulls?per_page=100&page=22&state=closed" })
```

`cliff.toml` enables `[remote.github]`, so git-cliff pages the closed-PR list to resolve commit -> PR -> author. That step passed no token, so the calls went out unauthenticated against the 60/hr shared-runner-IP limit. The repo is now at 2192 closed PRs, which is exactly 22 pages at `per_page=100`, and the walk 403s on the last one.

Nothing in the workflow or the tool changed. The 2026-08-12, 08-19 and 08-26 runs all installed the same `git-cliff 2.13.1`, and `cliff.toml` has not been touched since June. The repo simply grew past what an unauthenticated caller can page through. 08-12 squeaked by, 08-19 and 08-26 did not. The manual `workflow_dispatch` on 08-21 that produced v1.15.0 won the same quota race.

`release.yml` and `prepare-release.yml` already set `GITHUB_TOKEN` on their git-cliff steps for exactly this reason; `open-release-pr.yml` was the one that missed it. This aligns it with its siblings, which raises the ceiling to 5000/hr.

Noted but deliberately out of scope: this step also lacks the `skipped due to parse error` guard that the other two git-cliff steps carry. Worth a follow-up, but keeping this PR to the one line that unbreaks the schedule.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Workflow-only change; no Rust or web source is touched, so the suites are unaffected and there is no UI surface. The step comment carries the why.

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

The real verification is the next scheduled run, or a `workflow_dispatch` on this branch once merged.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude Code (Opus 5)


**Any Additional AI Details you'd like to share:**

Diagnosed from the failing run logs and opened on @njbrake's behalf, at their request.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the weekly release workflow to provide `GITHUB_TOKEN` to git-cliff.
- Authenticated GitHub API requests prevent rate-limit failures during changelog generation.
- This aligns the workflow with the token configuration used by other release workflows.

## Benefits

- Improves reliability as the repository grows.
- Raises the GitHub API limit from 60 to 5,000 requests per hour for this workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->