### PR TITLE
ci: make the weekly release PR survive a transient git-cliff failure

### DIFF
--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -129,9 +129,39 @@ jobs:
           # step was the one that missed it.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git cliff --config cliff.toml --tag "v$VERSION" --output CHANGELOG.md
+          set -uo pipefail
+          # git-cliff panics on ANY http error from that metadata walk,
+          # transient 5xx included, and has no internal retry. One blip loses
+          # the whole weekly run and the miss is silent until someone notices
+          # the PR never showed up. Observed 2026-08-28: a 502 on
+          # /commits?page=15 killed an otherwise healthy run, and an immediate
+          # re-dispatch succeeded.
+          for attempt in 1 2 3; do
+            if git cliff --config cliff.toml --tag "v$VERSION" \
+                 --output CHANGELOG.md 2> cliff-stderr.log; then
+              break
+            fi
+            echo "=== git-cliff attempt $attempt failed ==="
+            cat cliff-stderr.log
+            if [ "$attempt" = 3 ]; then
+              echo "::error::git-cliff failed 3 times; see the stderr dumps above"
+              exit 1
+            fi
+            sleep $((attempt * 15))
+          done
           echo "=== CHANGELOG.md head ==="
           head -40 CHANGELOG.md
+          echo "=== cliff stderr ==="
+          cat cliff-stderr.log
+          # Mirror the guard release.yml and prepare-release.yml already carry.
+          # cliff.toml's catch-all parser routes unmatched commits to "Other",
+          # so a parse-error skip means something fell through the safety net.
+          # Without this the weekly PR can open with commits silently missing
+          # from the changelog diff the maintainer is reviewing.
+          if grep -q "skipped due to parse error" cliff-stderr.log; then
+            echo "::error::git-cliff skipped commits due to parse errors. Either fix the offending commit messages or extend cliff.toml's catch-all parser."
+            exit 1
+          fi
 
       - name: Compute changelog since last tag
         id: changelog
@@ -222,3 +252,67 @@ jobs:
             --title "chore: release v${VERSION}" \
             --body-file /tmp/pr-body.md \
             --label release-staging
+
+  notify-on-failure:
+    name: Report a failed weekly run
+    needs: open-release-pr
+    # Only for the scheduled trigger. A workflow_dispatch failure is already in
+    # front of the person who clicked it; a schedule failure is what goes
+    # unnoticed, which is how 2026-08-19 and 08-26 both passed without anyone
+    # spotting that no release PR had opened.
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const label = 'release-automation';
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: 'd93f0b',
+                description: 'Failures in the release automation workflows',
+              });
+            } catch (e) {
+              // Already exists, which is the normal case after the first run.
+            }
+
+            // One open issue at a time. Later failures comment on it rather
+            // than opening a duplicate every Wednesday, so a persistent break
+            // stays a single thread instead of a weekly pile.
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (open.length > 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: open[0].number,
+                body: `The weekly release PR failed again: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: 'Weekly release PR did not open',
+                labels: [label],
+                body: [
+                  `The scheduled \`open-release-pr\` run failed, so no release-staging PR was opened this week.`,
+                  ``,
+                  `Failed run: ${runUrl}`,
+                  ``,
+                  `Re-run it with \`gh workflow run open-release-pr.yml --ref main -f bump=patch\` once the cause is addressed.`,
+                ].join('\n'),
+              });
+            }


### PR DESCRIPTION
## Description
<!-- Describe your changes and the problem they solve -->

Follow-up to #3566, which fixed the rate-limit failure that stopped the weekly release PR from opening. Merging it exposed two more ways the same step can fail, plus the reason nobody noticed for two weeks.

**1. git-cliff has no retry, and panics on any HTTP error.** With the token in place the first dispatch after #3566 merged still died, this time on a transient 502:

```
Status(502, None), url: ".../commits?per_page=100&page=15"
```

An immediate re-dispatch succeeded, so nothing was wrong with the run. One upstream blip is enough to lose the week. This retries three times with backoff (15s, 30s) before failing.

**2. The step was missing the parse-error guard its two siblings have.** `release.yml` and `prepare-release.yml` both capture git-cliff stderr and fail on `skipped due to parse error`, because `cliff.toml`'s catch-all parser is supposed to make that impossible and a skip means something fell through the safety net. `open-release-pr.yml` did not, so it could open a release PR with commits silently absent from the changelog diff the maintainer is reviewing. Mirrored.

**3. A failed scheduled run was silent.** The 2026-08-19 and 08-26 runs both failed and the gap was only found by chasing down the missing PR by hand. Adds a `notify-on-failure` job that opens a single issue labeled `release-automation`, and comments on that existing issue instead of opening a duplicate every Wednesday if the break persists. Scheduled runs only, since a `workflow_dispatch` failure is already in front of whoever clicked it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Workflow-only change; no Rust or web source is touched, so the suites are unaffected and there is no UI surface.

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

There is no harness for workflow YAML in this repo, so the retry loop was extracted from the parsed YAML and exercised locally against a stub `git` binary. All three paths behave:

| Scenario | Result |
| --- | --- |
| Fails twice, succeeds on attempt 3 | absorbed, exit 0, changelog written |
| Fails all 3 attempts | exit 1, `::error::git-cliff failed 3 times` |
| Succeeds but stderr has a parse-error skip | exit 1, `::error::git-cliff skipped commits` |

The workflow YAML parses, and the `github-script` body passes `node --check`.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude Code (Opus 5)


**Any Additional AI Details you'd like to share:**

Opened on @njbrake's behalf, at their request, as follow-up to #3566.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved weekly release reliability by retrying transient `git-cliff` failures.
- Added changelog validation to block release PRs when parsing errors skip commits.
- Added failure notifications that create or update one `release-automation` issue for scheduled workflow failures.
- Added clearer failure logs and workflow links for easier troubleshooting.

## Potential enhancement

- Consider adding automated tests for retry timing, changelog validation, and issue update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->