### PR TITLE
refactor(tui): drop the inert force parameter from the preview refresh core

### DIFF
--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2026,8 +2026,8 @@ impl HomeView {
     /// Shared core for the four `refresh_*_preview_cache_if_needed` methods.
     /// They all run the same needs-refresh gate (session id / dimensions /
     /// scroll-exceeds / 250ms timer) and the same capture, cache-update, and
-    /// scroll-clamp body; they differ only in which cache field they target,
-    /// where the capture comes from, and whether live-send forces a refresh.
+    /// scroll-clamp body; they differ only in which cache field they target
+    /// and where the capture comes from.
     ///
     /// `select` is called twice: once for the gate, once to write the result.
     /// `capture` runs between those two borrows so it can take a shared `&self`
@@ -2035,18 +2035,10 @@ impl HomeView {
     /// the agent uses that for its live-send preserve-last-good kill switch
     /// (#1501); the terminal/tool wrappers use it when the instance has gone
     /// away, matching the original "only write inside `if let Some(inst)`".
-    ///
-    /// `force` bypasses the idle throttle. All four wrappers pass `false`
-    /// today, so it is inert defensive code; the doc used to claim the agent
-    /// passed `in_live` here to refresh every render in live-send mode, which
-    /// has not been true at any call site. Live-send does not need it: on the
-    /// fast cadence `apply_worker_capture` has a fresh frame nearly every
-    /// render and returns before this is reached.
     fn refresh_preview_cache_core(
         &mut self,
         width: u16,
         height: u16,
-        force: bool,
         select: fn(&mut Self) -> &mut super::PreviewCache,
         capture: impl FnOnce(&Self, &str, usize) -> Option<String>,
     ) {
@@ -2059,17 +2051,15 @@ impl HomeView {
         // Only the idle timer is suppressed by a pulsing worker. A session
         // change, a resize, and a scroll that outgrew the cache all still
         // fork, because none of those are answered by "the worker had no new
-        // frame". `force` is inert defensive code: every caller passes
-        // `false`, so live-send is covered by the suppression rather than
-        // exempt from it, and it does not need an exemption because on the
-        // fast cadence `apply_worker_capture` almost always has a fresh frame
-        // to hand over and returns before this.
-        let worker_covers_idle = !force && self.observe_worker_pulse();
+        // frame". Live-send is covered by the suppression rather than exempt
+        // from it, and needs no exemption: on the fast cadence
+        // `apply_worker_capture` almost always has a fresh frame to hand over
+        // and returns before this.
+        let worker_covers_idle = self.observe_worker_pulse();
 
         let cache = select(self);
         let idle_elapsed = cache.last_refresh.elapsed().as_millis();
-        let needs_refresh = force
-            || cache.session_id.as_ref() != Some(&id)
+        let needs_refresh = cache.session_id.as_ref() != Some(&id)
             || cache.dimensions != (width, height)
             || capture_window_stale(
                 frozen,
@@ -2411,7 +2401,6 @@ impl HomeView {
         self.refresh_preview_cache_core(
             width,
             height,
-            false,
             |s| &mut s.preview_cache,
             |s, id, capture_lines| {
                 let in_live = s
@@ -2465,7 +2454,6 @@ impl HomeView {
         self.refresh_preview_cache_core(
             width,
             height,
-            false,
             |s| &mut s.terminal_preview_cache,
             |s, id, capture_lines| {
                 s.get_instance(id).map(|inst| {
@@ -2494,7 +2482,6 @@ impl HomeView {
         self.refresh_preview_cache_core(
             width,
             height,
-            false,
             |s| &mut s.container_terminal_preview_cache,
             |s, id, capture_lines| {
                 s.get_instance(id).map(|inst| {
@@ -2528,7 +2515,6 @@ impl HomeView {
         self.refresh_preview_cache_core(
             width,
             height,
-            false,
             |s| &mut s.tool_preview_cache,
             |s, id, capture_lines| {
                 s.get_instance(id).map(|inst| {


### PR DESCRIPTION
## Description

Follow-up to #3559, which is where this was noticed.

`refresh_preview_cache_core` takes a `force: bool` that bypasses the idle
throttle. No caller has ever set it: all four wrappers
(`refresh_preview_cache_if_needed`, and the terminal / container-terminal /
tool variants) pass `false`. #3559 established that while correcting the
doc on it, which had claimed the agent passed `in_live` here to refresh on
every render in live-send mode; that has not been true at any call site.
That PR documented the parameter as inert rather than deleting it, so the
perf change stayed in scope. This is the deletion.

AGENTS.md: "Never add `#[allow(dead_code)]` or write fields/functions that
nothing reads. [...] if it stops being used, remove it." The compiler
cannot see this one, since `false` is a real argument, so nothing flagged
it.

Removed: the parameter, the four `false` arguments, the `force ||` disjunct
in `needs_refresh`, and the `!force &&` guard on `worker_covers_idle`. The
two comments that explained the parameter keep the part that still matters,
which is why live-send needs no exemption from the worker-pulse suppression
(on the fast cadence `apply_worker_capture` almost always has a fresh frame
and returns before the core is reached).

Net 8 insertions, 22 deletions, one file.

**No behavior change.** Every caller already took the `false` path, so both
clauses evaluated identically before and after: `force ||` was always
`false ||`, and `!force &&` was always `true &&`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot: nothing rendered changes, and no code path changes which
branch it takes.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Deleting an argument that every caller already passed as `false` cannot
change behavior, so there is no new behavior to write a regression test
for, and a test asserting the parameter is gone would just restate the
signature. The gate itself is already covered: `idle_poll_due` and
`worker_pulse_step` are table-tested in `tui::home::render`, and
`observe_worker_pulse_needs_a_moving_counter_and_resets_on_retarget` drives
the wiring against a real spawned worker. All 810 `tui::home` tests pass
unchanged.

Verified locally: `cargo fmt --check` clean, `cargo clippy --all-targets`
shows only the pre-existing `items_after_test_module` in
`src/process/macos.rs`, `cargo test --lib` is 4742 passed / 0 failed.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:**

Surfaced during review of #3559 as a nit, then split out rather than folded
in, since removing a pre-existing parameter is not part of a perf fix.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the unused `force` parameter from `refresh_preview_cache_core`.
- Updated all four callers to remove the unused `false` argument.
- Simplified refresh conditions without changing behavior.
- Retained the worker-pulse comments.

## Benefits

- Reduces unnecessary code and improves readability.
- Aligns the implementation with its actual behavior.
- Formatting, Clippy, and library tests passed, including 4,742 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->