### PR TITLE
fix: recover from half-closed runner relay

### DIFF
--- a/src/acp/acp_client/connection.rs
+++ b/src/acp/acp_client/connection.rs
@@ -340,10 +340,17 @@ pub(super) async fn run_connection_task<W, R>(
     // new turn that legitimately reuses the prior turn's trailing text under a
     // fresh message_id would be misclassified as a restatement. See #2281.
     let agent_msg_dedup_for_block = agent_msg_dedup.clone();
+    let control_on_close = control_client.clone();
 
     let result = Client
         .builder()
         .name("aoe-acp")
+        .on_close(move |_connection| async move {
+            if let Some(control) = control_on_close {
+                control.shutdown();
+            }
+            Err(acp_internal_error("agent transport closed".into()))
+        })
         .on_receive_notification(
             move |notification: SessionNotification, _cx| {
                 let event_tx = event_tx_for_notif.clone();

--- a/src/acp/acp_client/control.rs
+++ b/src/acp/acp_client/control.rs
@@ -20,8 +20,7 @@ pub(super) struct ShutdownControlOnDrop(pub(super) Option<Arc<DaemonControlClien
 impl Drop for ShutdownControlOnDrop {
     fn drop(&mut self) {
         if let Some(control) = self.0.take() {
-            // SAFETY: `control` keeps this exact socket alive for the call.
-            unsafe { libc::shutdown(control.raw_fd, libc::SHUT_RDWR) };
+            control.shutdown();
         }
     }
 }
@@ -45,6 +44,11 @@ pub(super) struct DaemonControlClient {
 }
 
 impl DaemonControlClient {
+    pub(super) fn shutdown(&self) {
+        // SAFETY: `self` keeps this exact socket alive for the call.
+        unsafe { libc::shutdown(self.raw_fd, libc::SHUT_RDWR) };
+    }
+
     async fn send(&self, body: ControlBody) -> Result<(), AcpError> {
         let mut w = self.write.lock().await;
         control_protocol::write_frame(&mut *w, &body)

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -972,10 +972,12 @@ impl RunnerShared {
         }
         pending.push_back(line.to_vec());
         drop(pending);
-        drop(guard);
+        // Keep replacement attach behind the completion decision so it cannot
+        // set `main_attached` and make `emit_control` discard this completion.
         if let Some(body) = prompt_completed {
             self.emit_control(body).await;
         }
+        drop(guard);
         false
     }
 
@@ -2501,6 +2503,97 @@ mod tests {
             shared.control.lock().await.pending,
             Some(ControlBody::PromptCompleted {
                 prompt_req_id: 9,
+                outcome: PromptOutcome::Completed {
+                    stop_reason: Some("end_turn".into()),
+                },
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_attach_cannot_overtake_failed_prompt_completion() {
+        use std::sync::atomic::Ordering;
+        use tokio::io::AsyncReadExt;
+
+        let shared = Arc::new(RunnerShared::new());
+        let (closed_daemon, failed_runner) = UnixStream::pair().expect("failed relay pair");
+        drop(closed_daemon);
+        let (_failed_read, failed_write) = failed_runner.into_split();
+        *shared.active_outbound.lock().await = Some(failed_write);
+        shared.main_attached.store(true, Ordering::Relaxed);
+        shared
+            .note_prompt_request(
+                br#"{"jsonrpc":"2.0","id":10,"method":"session/prompt","params":{}}"#,
+            )
+            .await;
+
+        let control = shared.control.lock().await;
+        let mut failures = shared.relay_failures.subscribe();
+        let response = br#"{"jsonrpc":"2.0","id":10,"result":{"stopReason":"end_turn"}}
+"#;
+        let delivery = {
+            let shared = Arc::clone(&shared);
+            tokio::spawn(async move { shared.deliver_line(response).await })
+        };
+        failures.changed().await.expect("relay failure signal");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if shared
+                    .pending
+                    .lock()
+                    .await
+                    .back()
+                    .is_some_and(|line| line == response)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("failed response buffered");
+
+        let (replacement_daemon, replacement_runner) =
+            UnixStream::pair().expect("replacement relay pair");
+        let (mut replacement_read, _replacement_write) = replacement_daemon.into_split();
+        let (_runner_read, replacement_write) = replacement_runner.into_split();
+        let (replacement_started_tx, replacement_started_rx) = tokio::sync::oneshot::channel();
+        let replacement = {
+            let shared = Arc::clone(&shared);
+            tokio::spawn(async move {
+                replacement_started_tx
+                    .send(())
+                    .expect("replacement start receiver");
+                shared.install_outbound(replacement_write).await
+            })
+        };
+        replacement_started_rx
+            .await
+            .expect("replacement install task starts");
+        assert!(
+            !replacement.is_finished(),
+            "replacement attach must wait for completion preservation"
+        );
+        assert!(!shared.main_attached.load(Ordering::Relaxed));
+
+        drop(control);
+        assert!(!delivery.await.expect("failed response delivery task"));
+        assert!(replacement
+            .await
+            .expect("replacement install task")
+            .expect("replacement relay installs")
+            .is_none());
+        let mut replayed = vec![0; response.len()];
+        replacement_read
+            .read_exact(&mut replayed)
+            .await
+            .expect("read buffered response");
+        assert_eq!(replayed, response);
+        assert!(shared.main_attached.load(Ordering::Relaxed));
+        assert_eq!(
+            shared.control.lock().await.pending,
+            Some(ControlBody::PromptCompleted {
+                prompt_req_id: 10,
                 outcome: PromptOutcome::Completed {
                     stop_reason: Some("end_turn".into()),
                 },

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -1722,6 +1722,7 @@ async fn handle_connection(
     let mut relay_failed = false;
     loop {
         let read = tokio::select! {
+            biased;
             changed = relay_failures.changed() => {
                 if changed.is_ok() {
                     relay_failed = true;
@@ -2504,6 +2505,61 @@ mod tests {
                     stop_reason: Some("end_turn".into()),
                 },
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_failure_preempts_ready_stale_daemon_frame() {
+        use tokio::io::AsyncReadExt;
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn agent stdin fixture");
+        let agent_stdin = Arc::new(Mutex::new(child.stdin.take().expect("agent stdin")));
+        let mut agent_stdout = child.stdout.take().expect("agent stdout");
+        let shared = Arc::new(RunnerShared::new());
+        let (daemon, runner) = UnixStream::pair().expect("relay socket pair");
+        let handler = tokio::spawn(handle_connection(
+            runner,
+            Arc::clone(&shared),
+            Arc::clone(&agent_stdin),
+            "fixture-session".into(),
+        ));
+
+        tokio::task::yield_now().await;
+        assert!(shared.main_attached.load(Ordering::Relaxed));
+
+        // Mirror relay write failure state, then make the failure notification
+        // and a stale inbound frame ready without yielding to the handler.
+        drop(shared.active_outbound.lock().await.take());
+        shared.main_attached.store(false, Ordering::Relaxed);
+        shared
+            .relay_failures
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
+        let stale = b"stale daemon frame\n";
+        assert_eq!(
+            daemon.try_write(stale).expect("queue stale frame"),
+            stale.len()
+        );
+
+        handler.await.expect("connection handler");
+        drop(daemon);
+        let agent_stdin =
+            Arc::try_unwrap(agent_stdin).unwrap_or_else(|_| panic!("handler retained agent stdin"));
+        drop(agent_stdin.into_inner());
+        let mut forwarded = Vec::new();
+        agent_stdout
+            .read_to_end(&mut forwarded)
+            .await
+            .expect("read agent fixture output");
+        child.wait().await.expect("agent fixture exits");
+        assert!(
+            forwarded.is_empty(),
+            "relay failure must prevent stale daemon input from reaching agent stdin"
         );
     }
 

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -712,6 +712,10 @@ struct RunnerShared {
     /// gap (buffer it for the next control attach). Set/cleared alongside
     /// `active_outbound`.
     main_attached: std::sync::atomic::AtomicBool,
+    /// Advances when the active daemon's relay write half fails. The
+    /// connection reader watches this so a daemon that keeps only its write
+    /// half open cannot pin the sequential accept loop.
+    relay_failures: watch::Sender<u64>,
     /// Runner-owned ACP handshake cache (#2976 Phase B). Populated the
     /// first time a v2 daemon drives `initialize` / `session/new|load|fork`
     /// through the control channel; replayed verbatim on every later
@@ -859,6 +863,7 @@ impl RunnerShared {
             prompt_requests: Mutex::new(HashSet::new()),
             control: Mutex::new(ControlChannel::default()),
             main_attached: std::sync::atomic::AtomicBool::new(false),
+            relay_failures: watch::channel(0).0,
             handshake: Mutex::new(RunnerHandshake::default()),
             next_req_id: AtomicI64::new(RUNNER_REQUEST_ID_BASE),
             pending_client_responses: Mutex::new(HashMap::new()),
@@ -912,17 +917,22 @@ impl RunnerShared {
         // session does not JSON-parse every agent line twice (this on top
         // of `note_daemon_response`). Independent of the byte-relay
         // outbound below, since the control channel is a separate socket.
-        if !self.prompt_requests.lock().await.is_empty() {
+        let prompt_completed = if !self.prompt_requests.lock().await.is_empty() {
             if let Some((id, outcome)) = parse_response(line) {
                 if self.prompt_requests.lock().await.remove(&id) {
-                    self.emit_control(ControlBody::PromptCompleted {
+                    Some(ControlBody::PromptCompleted {
                         prompt_req_id: id,
                         outcome,
                     })
-                    .await;
+                } else {
+                    None
                 }
+            } else {
+                None
             }
-        }
+        } else {
+            None
+        };
 
         // #2979: refresh the cached handshake session when this line answers
         // a daemon-driven relay `session/new` (conversation reset). Gated on
@@ -933,11 +943,21 @@ impl RunnerShared {
         let mut guard = self.active_outbound.lock().await;
         if let Some(out) = guard.as_mut() {
             if out.write_all(line).await.is_ok() && out.flush().await.is_ok() {
+                drop(guard);
+                if let Some(body) = prompt_completed {
+                    self.emit_control(body).await;
+                }
                 return true;
             }
             // Write failure: daemon side closed. Drop the writer and
-            // buffer this line for the next attach.
+            // buffer this line for the next attach. Advance the failure
+            // signal while holding `active_outbound` so the reader cannot
+            // observe a half-updated attachment state.
             *guard = None;
+            self.main_attached
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+            self.relay_failures
+                .send_modify(|generation| *generation = generation.wrapping_add(1));
         }
         // Buffer while STILL holding `active_outbound`. Dropping it before
         // locking `pending` opens a TOCTOU window: a reattaching
@@ -951,6 +971,11 @@ impl RunnerShared {
             pending.pop_front();
         }
         pending.push_back(line.to_vec());
+        drop(pending);
+        drop(guard);
+        if let Some(body) = prompt_completed {
+            self.emit_control(body).await;
+        }
         false
     }
 
@@ -1063,7 +1088,7 @@ impl RunnerShared {
     async fn install_outbound(
         &self,
         mut out: tokio::net::unix::OwnedWriteHalf,
-    ) -> Option<tokio::net::unix::OwnedWriteHalf> {
+    ) -> Result<Option<tokio::net::unix::OwnedWriteHalf>, ()> {
         // Hold `active_outbound` across the whole drain + install so a
         // concurrent `deliver_line` (which locks `active_outbound` first,
         // sees None, then buffers into `pending`) cannot slip a line into
@@ -1080,24 +1105,30 @@ impl RunnerShared {
                 // stays None (via the earlier take), matching the old
                 // behavior of leaving no live writer on a failed attach.
                 pending.push_front(line);
-                return None;
+                self.main_attached
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                self.relay_failures
+                    .send_modify(|generation| *generation = generation.wrapping_add(1));
+                return Err(());
             }
         }
         drop(pending);
         *guard = Some(out);
         self.main_attached
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        prev
+        Ok(prev)
     }
 
-    async fn clear_outbound(&self) {
+    async fn clear_outbound(&self, preserve_completion: bool) {
         *self.active_outbound.lock().await = None;
         self.main_attached
             .store(false, std::sync::atomic::Ordering::Relaxed);
         // A main-relay disconnect starts a no-daemon gap. Drop any
         // completion left un-drained from a prior gap so only the current
         // gap's completion is ever replayed to the next resuming daemon.
-        self.control.lock().await.pending = None;
+        if !preserve_completion {
+            self.control.lock().await.pending = None;
+        }
     }
 
     /// Peek a daemon to agent line: if it is a `session/prompt` request,
@@ -1666,7 +1697,18 @@ async fn handle_connection(
     session_id: String,
 ) {
     let (read_half, write_half) = stream.into_split();
-    let prev = shared.install_outbound(write_half).await;
+    let mut relay_failures = shared.relay_failures.subscribe();
+    let relay_generation = *relay_failures.borrow_and_update();
+    let prev = match shared.install_outbound(write_half).await {
+        Ok(prev) => prev,
+        Err(()) => {
+            shared
+                .cancel_outstanding_requests(&agent_stdin, &session_id)
+                .await;
+            shared.clear_outbound(true).await;
+            return;
+        }
+    };
     if prev.is_some() {
         debug!(
             target: "acp.runner",
@@ -1677,8 +1719,18 @@ async fn handle_connection(
 
     let mut reader = BufReader::with_capacity(STDOUT_READ_BUF, read_half);
     let mut line = Vec::with_capacity(4096);
+    let mut relay_failed = false;
     loop {
-        match read_frame_bounded(&mut reader, &mut line).await {
+        let read = tokio::select! {
+            changed = relay_failures.changed() => {
+                if changed.is_ok() {
+                    relay_failed = true;
+                }
+                break;
+            }
+            read = read_frame_bounded(&mut reader, &mut line) => read,
+        };
+        match read {
             Ok(0) => break, // EOF: daemon closed the connection.
             Ok(_) => {
                 // #2976: once the runner owns the session, answer a relay
@@ -1719,7 +1771,8 @@ async fn handle_connection(
     shared
         .cancel_outstanding_requests(&agent_stdin, &session_id)
         .await;
-    shared.clear_outbound().await;
+    relay_failed |= *relay_failures.borrow() != relay_generation;
+    shared.clear_outbound(relay_failed).await;
 }
 
 enum ControlRead {
@@ -2419,6 +2472,38 @@ mod tests {
         assert!(
             shared.control.lock().await.pending.is_none(),
             "a live main-relay daemon owns the completion; nothing should buffer"
+        );
+    }
+
+    #[tokio::test]
+    async fn prompt_completion_survives_main_relay_write_failure() {
+        use std::sync::atomic::Ordering;
+
+        let shared = RunnerShared::new();
+        let (peer, ours) = tokio::net::UnixStream::pair().unwrap();
+        drop(peer);
+        let (_read, write) = ours.into_split();
+        *shared.active_outbound.lock().await = Some(write);
+        shared.main_attached.store(true, Ordering::Relaxed);
+
+        shared
+            .note_prompt_request(
+                br#"{"jsonrpc":"2.0","id":9,"method":"session/prompt","params":{}}"#,
+            )
+            .await;
+        let response = br#"{"jsonrpc":"2.0","id":9,"result":{"stopReason":"end_turn"}}
+"#;
+        assert!(!shared.deliver_line(response).await);
+
+        assert!(!shared.main_attached.load(Ordering::Relaxed));
+        assert_eq!(
+            shared.control.lock().await.pending,
+            Some(ControlBody::PromptCompleted {
+                prompt_req_id: 9,
+                outcome: PromptOutcome::Completed {
+                    stop_reason: Some("end_turn".into()),
+                },
+            })
         );
     }
 

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -2530,8 +2530,13 @@ mod tests {
             "fixture-session".into(),
         ));
 
-        tokio::task::yield_now().await;
-        assert!(shared.main_attached.load(Ordering::Relaxed));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !shared.main_attached.load(Ordering::Relaxed) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("relay handler installs outbound within timeout");
 
         // Mirror relay write failure state, then make the failure notification
         // and a stale inbound frame ready without yielding to the handler.

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -17,6 +17,7 @@
 #![cfg(feature = "serve")]
 
 use std::io::{Read, Write};
+use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
@@ -221,6 +222,80 @@ fn runner_reports_native_prompt_complete_over_control_socket() {
 
     let _ = child.kill();
     let _ = child.wait();
+}
+
+#[test]
+fn runner_accepts_next_relay_after_outbound_half_close() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    let scratch = Scratch::new("half");
+    let home = scratch.0.join("home");
+    let xdg = scratch.0.join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+
+    let session_id = "shalf001";
+    let workers = app_dir(&home, &xdg).join("acp-workers");
+    let socket = workers.join(format!("{session_id}.sock"));
+    let record = workers.join(format!("{session_id}.json"));
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let _child = KillOnDrop(
+        Command::new(bin)
+            .args([
+                "__acp-runner",
+                "--socket",
+                socket.to_str().unwrap(),
+                "--session-id",
+                session_id,
+                "--agent-name",
+                "fake-agent",
+                "--cwd",
+                home.to_str().unwrap(),
+                "--",
+                "/bin/cat",
+            ])
+            .env("HOME", &home)
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
+            .spawn()
+            .expect("spawn acp runner"),
+    );
+
+    wait_for(&record, "registry record");
+    wait_for(&socket, "relay socket");
+
+    let mut first = UnixStream::connect(&socket).expect("connect first relay");
+    first
+        .shutdown(Shutdown::Read)
+        .expect("half-close first relay input");
+    let failed_line = b"{\"jsonrpc\":\"2.0\",\"method\":\"half-close\"}\n";
+    first.write_all(failed_line).expect("write first relay");
+    first.flush().expect("flush first relay");
+
+    // Keep `first` and therefore its daemon -> runner write side open. The
+    // runner must still leave that connection after cat's echo fails, accept
+    // this relay, replay the complete failed line, and carry new traffic.
+    let mut second = UnixStream::connect(&socket).expect("connect second relay");
+    second
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let fresh_line = b"{\"jsonrpc\":\"2.0\",\"method\":\"fresh\"}\n";
+    second.write_all(fresh_line).expect("write second relay");
+    second.flush().expect("flush second relay");
+
+    let mut received = Vec::new();
+    let mut byte = [0u8; 1];
+    while !received.ends_with(fresh_line) {
+        second
+            .read_exact(&mut byte)
+            .expect("read replay and fresh echo");
+        received.push(byte[0]);
+    }
+    assert!(
+        received.starts_with(failed_line),
+        "failed outbound line must be replayed intact: {received:?}"
+    );
 }
 
 /// Write a length-prefixed control frame (4-byte big-endian length, then

--- a/tests/integration/acp_midturn_resume.rs
+++ b/tests/integration/acp_midturn_resume.rs
@@ -25,8 +25,10 @@ use std::time::{Duration, Instant};
 
 use agent_of_empires::acp::acp_client::AcpClient;
 use agent_of_empires::acp::state::{AcpSessionId, Event};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixListener;
 use tokio::process::Command;
+use tokio::sync::oneshot;
 
 use crate::common::{shim_path, shim_ready};
 
@@ -86,6 +88,91 @@ async fn spawn_shim_socket_bridge_with_preseed(
 
 async fn spawn_shim_socket_bridge() -> (PathBuf, tempfile::TempDir) {
     spawn_shim_socket_bridge_with_preseed(None).await
+}
+
+async fn write_control_frame(stream: &mut tokio::net::UnixStream, body: serde_json::Value) {
+    let body = serde_json::to_vec(&body).unwrap();
+    stream
+        .write_all(&(body.len() as u32).to_be_bytes())
+        .await
+        .unwrap();
+    stream.write_all(&body).await.unwrap();
+}
+
+async fn read_control_frame(stream: &mut tokio::net::UnixStream) -> Option<serde_json::Value> {
+    let mut len = [0u8; 4];
+    match stream.read_exact(&mut len).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return None,
+        Err(e) => panic!("read control frame length: {e}"),
+    }
+    let mut body = vec![0u8; u32::from_be_bytes(len) as usize];
+    stream.read_exact(&mut body).await.unwrap();
+    Some(serde_json::from_slice(&body).unwrap())
+}
+
+/// A minimal v2 runner that completes the control handshake, waits for a
+/// prompt, then closes only its relay write half. Its relay read half stays
+/// open until the daemon closes the paired control connection.
+async fn spawn_half_closing_v2_runner() -> (PathBuf, tempfile::TempDir, oneshot::Receiver<()>) {
+    let temp = tempfile::tempdir().unwrap();
+    let socket_path = temp.path().join("runner.sock");
+    let control_path = agent_of_empires::process::worker::control_socket_sibling(&socket_path);
+    let relay_listener = UnixListener::bind(&socket_path).unwrap();
+    let control_listener = UnixListener::bind(&control_path).unwrap();
+    let (control_closed_tx, control_closed_rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        let (relay, _) = relay_listener.accept().await.unwrap();
+        let (relay_read, relay_write) = relay.into_split();
+        let (mut control, _) = control_listener.accept().await.unwrap();
+
+        write_control_frame(
+            &mut control,
+            serde_json::json!({
+                "kind": "hello",
+                "control_protocol_version": 2,
+                "session_id": "half-close-client"
+            }),
+        )
+        .await;
+        assert_eq!(
+            read_control_frame(&mut control).await.unwrap()["kind"],
+            "attach"
+        );
+        assert_eq!(
+            read_control_frame(&mut control).await.unwrap()["kind"],
+            "initialize"
+        );
+        write_control_frame(
+            &mut control,
+            serde_json::json!({
+                "kind": "initialized",
+                "result": {
+                    "protocolVersion": 1,
+                    "agentCapabilities": {
+                        "loadSession": false,
+                        "promptCapabilities": {}
+                    }
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            read_control_frame(&mut control).await.unwrap()["kind"],
+            "prompt"
+        );
+        drop(relay_write);
+        let _relay_read_stays_open = relay_read;
+        assert!(
+            read_control_frame(&mut control).await.is_none(),
+            "daemon must close the paired control connection on relay EOF"
+        );
+        let _ = control_closed_tx.send(());
+    });
+
+    (socket_path, temp, control_closed_rx)
 }
 
 /// Variant for the watchdog-disarm test: preseeds `session_id` AND tells
@@ -331,4 +418,37 @@ async fn socket_transport_round_trips_prompt_via_attach() {
         "shim should echo received: hello over socket via the socket transport"
     );
     assert!(saw_stopped, "shim should emit Stopped at end of turn");
+}
+
+#[tokio::test]
+async fn incoming_half_close_ends_v2_connection_task() {
+    let (socket_path, _tmp, control_closed) = spawn_half_closing_v2_runner().await;
+    let mut client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        "established-session".into(),
+        false,
+        AcpSessionId("half-close-client".into()),
+        None,
+        "fake-agent".into(),
+        None,
+    )
+    .await
+    .expect("attach to v2 runner");
+
+    client
+        .send_prompt("hold the prompt open", &[])
+        .await
+        .expect("send prompt");
+
+    tokio::time::timeout(Duration::from_secs(5), control_closed)
+        .await
+        .expect("paired control connection stayed open")
+        .expect("control observer dropped");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while client.next_event().await.is_some() {}
+    })
+    .await
+    .expect("AcpClient event channel stayed open after relay EOF");
 }


### PR DESCRIPTION
## Description

Closes #3577.

Treat a one-sided runner relay failure as a connection failure instead of leaving the old handler and ACP foreground alive:

- wake the runner reader when its daemon-bound write half fails, so the accept loop can take a replacement relay;
- mark the main daemon detached and preserve the failed line plus matching prompt completion for reattachment;
- close the paired v2 control socket when ACP incoming transport ends, allowing the existing supervisor recovery path to observe task termination.

No steering message is queued onto the dead transport.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: deterministic runner and ACP integration tests exercise the real UNIX relay/control entrypoints and can isolate a unilateral half-close; the TUI harness cannot.

Regression coverage:

- `cargo test --features serve --test acp_runner_control runner_accepts_next_relay_after_outbound_half_close -- --exact --nocapture`
- `cargo test --features serve --test integration incoming_half_close_ends_v2_connection_task -- --nocapture`
- `cargo test --features serve --lib process::runner::tests::prompt_completion_survives_main_relay_write_failure -- --exact --nocapture`
- `cargo test --features serve --lib process::runner::tests::emit_control_buffers_on_write_failure_even_when_main_attached -- --exact --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Local Rust 1.93 Clippy also reports an inherited `clippy::duplicated_attributes` warning in untouched `src/tui/dialogs/serve.rs`; the exact upstream base CI run is green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you would like to share:** Codex traced the paired runner/daemon lifecycle, implemented the bounded repair, and added deterministic production-entrypoint regressions under operator direction.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved ACP relay recovery after one-sided connection failures.
- Allows the runner to accept a replacement relay.
- Preserves failed output and its matching prompt completion during reattachment.
- Closes paired control connections when ACP transport ends.
- Prevents steering messages from being queued on closed transports.
- Added regression tests for relay replacement, transport shutdown, completion preservation, and control buffering.

## Benefits

These changes prevent ACP sessions from becoming unusable after partial relay failures. They also make recovery deterministic and protect response delivery during reattachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->