### PR TITLE
fix: capture compressed Codex rollouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "webbrowser",
  "which",
  "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -5889,3 +5890,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # UUID generation
 uuid = { version = "1.23", features = ["v4"] }
+zstd = "0.13"
 
 # Random
 rand = "0.10"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     ripgrep \
     fzf \
     unzip \
+    zstd \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js (required for Codex CLI)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     build-essential \

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -1983,17 +1983,20 @@ pub(crate) fn opencode_poll_fn_sandboxed(
 
 const CODEX_COMMAND_TIMEOUT_SECS: u64 = 5;
 
-/// Shell snippet executed via `docker exec` to enumerate Codex `.jsonl` session
-/// files inside the container. Each file is emitted as a
+/// Shell snippet executed via `docker exec` to enumerate Codex `.jsonl` and
+/// `.jsonl.zst` session files inside the container. Each file is emitted as a
 /// `===CODEX:<unix-mtime>:<basename>===` header followed by the first line of the
 /// file and a `===END===` trailer.
 const CODEX_CONTAINER_LIST_SCRIPT: &str = r#"SESS_DIR="${CODEX_HOME:-$HOME/.codex}/sessions"
 [ -d "$SESS_DIR" ] || exit 0
-find "$SESS_DIR" -name '*.jsonl' -type f | while read -r f; do
+find "$SESS_DIR" -type f \( -name '*.jsonl' -o -name '*.jsonl.zst' \) | while read -r f; do
   ts=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
   bn=$(basename "$f")
   printf '===CODEX:%s:%s===\n' "$ts" "$bn"
-  head -n 1 "$f"
+  case "$f" in
+    *.jsonl.zst) zstd -dc "$f" 2>/dev/null | head -n 1 ;;
+    *) head -n 1 "$f" ;;
+  esac
   printf '\n===END===\n'
 done
 "#;
@@ -5172,10 +5175,11 @@ mod tests {
         let uuid = "cccccccc-cccc-cccc-cccc-cccccccccccc";
         let project_dir = tmp.path().join("test-project");
         std::fs::create_dir_all(&project_dir).unwrap();
-        let jsonl_content = format!(
-            r#"{{"type":"session_meta","payload":{{"cwd":"{}"}}}}"#,
-            project_dir.display()
-        );
+        let jsonl_content = serde_json::json!({
+            "type": "session_meta",
+            "payload": {"cwd": project_dir},
+        })
+        .to_string();
         std::fs::write(
             sessions_dir.join(format!("rollout-2025-03-06T10-30-00-{}.jsonl", uuid)),
             jsonl_content,
@@ -5199,10 +5203,11 @@ mod tests {
         let uuid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
         let project_dir = tmp.path().join("test-project");
         std::fs::create_dir_all(&project_dir).unwrap();
-        let jsonl_content = format!(
-            r#"{{"type":"session_meta","payload":{{"cwd":"{}"}}}}"#,
-            project_dir.display()
-        );
+        let jsonl_content = serde_json::json!({
+            "type": "session_meta",
+            "payload": {"cwd": project_dir},
+        })
+        .to_string();
         let compressed = zstd::stream::encode_all(jsonl_content.as_bytes(), 0).unwrap();
         std::fs::write(
             sessions_dir.join(format!("rollout-2025-03-06T10-30-00-{uuid}.jsonl.zst")),

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2100,6 +2100,7 @@ fn extract_codex_uuid_from_filename(path: &Path) -> Option<String> {
     None
 }
 
+/// Returns whether `path` is a plain or zstd-compressed Codex rollout.
 fn is_codex_rollout(path: &Path) -> bool {
     path.extension().and_then(|e| e.to_str()) == Some("jsonl")
         || path
@@ -2108,6 +2109,7 @@ fn is_codex_rollout(path: &Path) -> bool {
             .is_some_and(|name| name.ends_with(".jsonl.zst"))
 }
 
+/// Opens a Codex rollout, transparently decoding zstd-compressed files.
 fn open_codex_rollout(path: &Path) -> Result<Box<dyn Read>> {
     let file = std::fs::File::open(path)?;
     if path.extension().and_then(|e| e.to_str()) == Some("zst") {

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2001,8 +2001,9 @@ done
 /// Capture session ID from Codex filesystem.
 ///
 /// Walks the Codex sessions directory (including date-partitioned `YYYY/MM/DD/` subdirectories)
-/// for `.jsonl` rollout files and extracts the UUID from the most recent one.
-/// Codex filenames follow the pattern `rollout-<timestamp>-<uuid>.jsonl`.
+/// for `.jsonl` and `.jsonl.zst` rollout files and extracts the UUID from the
+/// most recent one. Codex filenames follow the pattern
+/// `rollout-<timestamp>-<uuid>.jsonl[.zst]`.
 /// Respects `CODEX_HOME` env var, falling back to `~/.codex`.
 pub(crate) fn capture_codex_session_id(
     project_path: &str,
@@ -2034,8 +2035,8 @@ pub(crate) fn capture_codex_session_id(
         if exclusion.contains(&uuid) {
             return None;
         }
-        let file = std::fs::File::open(path).ok()?;
-        let reader = std::io::BufReader::new(file);
+        let reader = open_codex_rollout(path).ok()?;
+        let reader = std::io::BufReader::new(reader);
         let first_line = std::io::BufRead::lines(reader).next()?.ok()?;
         let cwd = parse_codex_cwd_from_json(&first_line, &uuid)?;
         let cwd_matches = std::fs::canonicalize(&cwd)
@@ -2086,6 +2087,7 @@ fn parse_codex_cwd_from_json(line: &str, filename_uuid: &str) -> Option<String> 
 /// The UUID is the last 36 characters of the stem (before `.jsonl`).
 fn extract_codex_uuid_from_filename(path: &Path) -> Option<String> {
     let stem = path.file_stem()?.to_str()?;
+    let stem = stem.strip_suffix(".jsonl").unwrap_or(stem);
     if stem.len() >= 36 {
         let candidate = &stem[stem.len() - 36..];
         if Uuid::parse_str(candidate).is_ok() {
@@ -2095,10 +2097,28 @@ fn extract_codex_uuid_from_filename(path: &Path) -> Option<String> {
     None
 }
 
+fn is_codex_rollout(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+        || path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".jsonl.zst"))
+}
+
+fn open_codex_rollout(path: &Path) -> Result<Box<dyn Read>> {
+    let file = std::fs::File::open(path)?;
+    if path.extension().and_then(|e| e.to_str()) == Some("zst") {
+        Ok(Box::new(zstd::stream::read::Decoder::new(file)?))
+    } else {
+        Ok(Box::new(file))
+    }
+}
+
 /// Recursively collect Codex session `.jsonl` files, descending into date-partitioned dirs.
 ///
 /// Directories whose names are all ASCII digits (e.g. `2025`, `03`, `06`) are treated as
-/// date components and recursed into. Files ending in `.jsonl` are collected as session entries.
+/// date components and recursed into. Files ending in `.jsonl` or `.jsonl.zst` are collected as
+/// session entries.
 pub(crate) fn collect_codex_sessions(
     dir: &Path,
     entries: &mut Vec<(PathBuf, std::time::SystemTime)>,
@@ -2111,7 +2131,7 @@ pub(crate) fn collect_codex_sessions(
             if name_str.chars().all(|c| c.is_ascii_digit()) {
                 collect_codex_sessions(&path, entries)?;
             }
-        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+        } else if is_codex_rollout(&path) {
             let modified = entry
                 .metadata()
                 .and_then(|m| m.modified())
@@ -5166,6 +5186,33 @@ mod tests {
 
         let result = capture_codex_session_id(project_dir.to_str().unwrap(), &HashSet::new());
         assert!(result.is_ok());
+        assert_eq!(result.unwrap(), uuid);
+    }
+
+    #[test]
+    #[serial]
+    fn test_codex_capture_reads_compressed_rollout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let uuid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+        let project_dir = tmp.path().join("test-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let jsonl_content = format!(
+            r#"{{"type":"session_meta","payload":{{"cwd":"{}"}}}}"#,
+            project_dir.display()
+        );
+        let compressed = zstd::stream::encode_all(jsonl_content.as_bytes(), 0).unwrap();
+        std::fs::write(
+            sessions_dir.join(format!("rollout-2025-03-06T10-30-00-{uuid}.jsonl.zst")),
+            compressed,
+        )
+        .unwrap();
+
+        let _guard = EnvGuard::set(&[("CODEX_HOME", tmp.path())]);
+
+        let result = capture_codex_session_id(project_dir.to_str().unwrap(), &HashSet::new());
         assert_eq!(result.unwrap(), uuid);
     }
 


### PR DESCRIPTION
## Summary

Codex compresses aged rollout files from `.jsonl` to `.jsonl.zst`, but session capture only enumerated and opened `.jsonl` files. As a result, resumable compressed sessions were invisible to project session detection.

This change:

- recognizes `.jsonl.zst` rollout files during recursive Codex session collection;
- transparently decodes compressed rollouts when reading their metadata header;
- preserves the existing `.jsonl` behavior and UUID extraction;
- adds a regression test using a real temporary `CODEX_HOME` and compressed rollout.

## Testing

- `cargo test --locked --lib test_codex_capture_reads_compressed_rollout` (Linux Docker): passed
- `cargo test --locked --lib test_collect_codex_sessions` (Linux Docker): 2 passed
- `rustfmt --edition 2021 --check src/session/capture.rs`: passed
- `git diff --check`: passed

The focused tests were run in a Linux Docker container because the repository's Windows target contains existing Unix-only code paths. The container used the repository's pinned lockfile and no external service or API key.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [x] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: 

**TUI / CLI (e2e test)**

- [ ] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is isolated to the Codex filesystem capture helper and is covered by a deterministic unit test using a temporary `CODEX_HOME`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:** Codex prepared the focused implementation and tests; all changes and validation results are included above.

- [x] I am an AI Agent filling out this form (check box is true)

Closes #3281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added support for recursively discovered compressed `.jsonl.zst` Codex rollout files.
- Added transparent decompression while preserving plain `.jsonl` support and UUID extraction.
- Updated container scanning to read compressed rollout metadata.
- Added the `zstd` dependency and Docker package.
- Added a regression test for compressed rollouts with a temporary `CODEX_HOME`.

## Benefits

Codex session capture now works with both plain and compressed rollout files.

## Further enhancement

Add tests for invalid or corrupted compressed rollout files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->