### PR TITLE
fix(acp): default the structured-view agent to claude-code

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -206,7 +206,7 @@ Add a new session
 * `--cmd-override <CMD_OVERRIDE>` — Override the agent binary command
 * `--structured-view` — Render this session in the structured view (ACP-based native rendering) instead of the default terminal view. `aoe add` defaults to the terminal (raw tmux/PTY) so the CLI matches the TUI; pass this (or `--agent`) to opt into the structured rendering. Ignored for tools with no ACP adapter
 * `--agent <AGENT>` — Pick a specific ACP agent for the structured view (e.g., claude-code, codex)
-* `--model <MODEL>` — Override the model used by aoe-agent (e.g., claude-opus-4-7, gpt-5, gemini-2.5-pro). Forwarded to the agent at session start
+* `--model <MODEL>` — Override the model used by the ACP agent (e.g., claude-opus-4-7, gpt-5, gemini-2.5-pro). Forwarded to the agent at session start
 * `--scratch` — Create the session in a fresh scratch directory under `<app_dir>/scratch/<id>/` instead of a project path. The directory is removed when the session is deleted (unless `aoe rm` is given `--keep-scratch`). Mutually exclusive with worktree-related flags
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -205,7 +205,7 @@ Add a new session
 * `--extra-args <EXTRA_ARGS>` — Extra arguments to append after the agent binary
 * `--cmd-override <CMD_OVERRIDE>` — Override the agent binary command
 * `--structured-view` — Render this session in the structured view (ACP-based native rendering) instead of the default terminal view. `aoe add` defaults to the terminal (raw tmux/PTY) so the CLI matches the TUI; pass this (or `--agent`) to opt into the structured rendering. Ignored for tools with no ACP adapter
-* `--agent <AGENT>` — Pick a specific ACP agent for the structured view (e.g., aoe-agent, claude-code)
+* `--agent <AGENT>` — Pick a specific ACP agent for the structured view (e.g., claude-code, codex)
 * `--model <MODEL>` — Override the model used by aoe-agent (e.g., claude-opus-4-7, gpt-5, gemini-2.5-pro). Forwarded to the agent at session start
 * `--scratch` — Create the session in a fresh scratch directory under `<app_dir>/scratch/<id>/` instead of a project path. The directory is removed when the session is deleted (unless `aoe rm` is given `--keep-scratch`). Mutually exclusive with worktree-related flags
 

--- a/docs/development/internals/structured-view.md
+++ b/docs/development/internals/structured-view.md
@@ -116,7 +116,7 @@ Profiles are conservative: an unverified tool surface is omitted rather than gue
 
 ```toml
 [acp]
-default_agent = "aoe-agent"
+default_agent = "claude-code"
 approval_timeout_secs = 300
 destructive_require_double_confirm = true
 max_concurrent_workers = 100

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -29,7 +29,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 | `omp` | `omp acp` (native) | `curl -fsSL https://omp.sh/install \| sh` | provider environment or OMP login |
 | `kimi` | `kimi acp` (native) | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | `kimi login`, or provider env |
 | `prime-agent` | `prime-agent --mode acp` (native) | `curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh \| sh` | `/login` once, or provider env |
-| `aoe-agent` | bundled (Vercel AI SDK 6) | ships with `aoe` | provider env vars |
+| `aoe-agent` | bundled (Vercel AI SDK 6) | not yet packaged; needs a local build of `acp-worker/aoe-agent` (#3553) | provider env vars |
 
 Gemini CLI is deprecated upstream for individual accounts since 2026-06-18. Enterprise and API-key authentication remain valid; Antigravity CLI is the replacement for consumer accounts.
 
@@ -79,7 +79,7 @@ The CLI is the optional path for scripting or headless launches. Unlike the wiza
 ```bash
 aoe acp doctor                              # confirm prerequisites
 aoe add . --cmd claude --structured-view    # structured view for an ACP tool
-aoe add . --agent aoe-agent --model gpt-5   # pick an ACP agent + model (implies structured view)
+aoe add . --agent codex --model gpt-5       # pick an ACP agent + model (implies structured view)
 ```
 
 `--agent` for an uninstalled adapter errors with an install hint; `--structured-view` (no `--agent`) falls back to the terminal view with a warning so the command still succeeds.

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -2,7 +2,7 @@
 
 The **structured view** is the default rendering for AI coding agents in the web dashboard and the native TUI. Instead of a terminal pane (PTY bytes through xterm.js), it renders the agent's structured state directly: plan, tool-call cards, diffs, and approvals. It is mobile-first and scales the same components into a richer multi-pane desktop layout.
 
-It speaks the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP), a JSON-RPC standard for editor-agent communication. aoe is the *client*; the agent (Claude Code, Gemini, the bundled `aoe-agent`, etc.) is the *server*. Any ACP-capable agent uses the structured view by default; a session can opt into the **terminal view** instead, per session, and you can switch at any time. Agents with no ACP adapter always run in the terminal view.
+It speaks the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP), a JSON-RPC standard for editor-agent communication. aoe is the *client*; the agent (Claude Code, Gemini, Codex, etc.) is the *server*. Any ACP-capable agent uses the structured view by default; a session can opt into the **terminal view** instead, per session, and you can switch at any time. Agents with no ACP adapter always run in the terminal view.
 
 ![The structured view rendering an agent's plan, tool-call cards, and a pending approval](assets/structured-view/overview.png)
 
@@ -29,7 +29,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 | `omp` | `omp acp` (native) | `curl -fsSL https://omp.sh/install \| sh` | provider environment or OMP login |
 | `kimi` | `kimi acp` (native) | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | `kimi login`, or provider env |
 | `prime-agent` | `prime-agent --mode acp` (native) | `curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh \| sh` | `/login` once, or provider env |
-| `aoe-agent` | bundled (Vercel AI SDK 6) | not yet packaged; needs a local build of `acp-worker/aoe-agent` (#3553) | provider env vars |
+| `aoe-agent` | in-tree (Vercel AI SDK 6) | not yet packaged; needs a local build of `acp-worker/aoe-agent` (#3553) | provider env vars |
 
 Gemini CLI is deprecated upstream for individual accounts since 2026-06-18. Enterprise and API-key authentication remain valid; Antigravity CLI is the replacement for consumer accounts.
 

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -47,9 +47,10 @@ non-standard location, set `AOE_ACP_NODE=/path/to/node` or configure
 
 ### `aoe acp doctor` says aoe-agent is missing
 
-`aoe-agent` ships with the aoe binary. If the doctor reports it missing, your
-install is incomplete. Reinstall aoe via your package manager (e.g.,
-`brew reinstall aoe`).
+`aoe-agent` is not packaged with the aoe binary yet (#3553). The default
+structured-view agent is `claude-code`; leave `acp.default_agent` on an adapter
+that `aoe acp doctor` reports as installed, or build `acp-worker/aoe-agent`
+yourself and point the registry command at it.
 
 ### `aoe acp doctor` says claude-code adapter is missing
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -15289,7 +15289,7 @@ done
 
         let mut config = env_test_spawn_config(tmp.path().to_path_buf());
         let reg = crate::acp::agent_registry::AgentRegistry::with_defaults();
-        config.spec = reg.get("aoe-agent").expect("aoe-agent registered").clone();
+        config.spec = reg.get("aoe-agent").expect("aoe-agent default").clone();
 
         let mut cmd = std::process::Command::new("/bin/true");
         cmd.env_clear();

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -15289,7 +15289,7 @@ done
 
         let mut config = env_test_spawn_config(tmp.path().to_path_buf());
         let reg = crate::acp::agent_registry::AgentRegistry::with_defaults();
-        config.spec = reg.get("aoe-agent").expect("aoe-agent default").clone();
+        config.spec = reg.get("aoe-agent").expect("aoe-agent registered").clone();
 
         let mut cmd = std::process::Command::new("/bin/true");
         cmd.env_clear();

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -939,13 +939,14 @@ impl<S: BroadcastSink> Supervisor<S> {
     ///      `agent_detect_as` (e.g. a Claude wrapper); resolves to the *base*
     ///      registry key so the base agent's adapter, version gate, env
     ///      allowlist, and `AgentProfile` all apply
-    ///   5. legacy fallback: `claude` for the claude tool, otherwise
-    ///      `aoe-agent` (our bundled multi-provider agent)
+    ///   5. fallback: `claude` for the claude tool, otherwise the resolved
+    ///      `acp.default_agent` setting
     ///
     /// `profile` is the session's source profile (`""` resolves the
     /// user's default) and `project_path` is its working directory;
-    /// both are consulted for step 3 so repo-local `agent_acp_cmd`
-    /// overrides are honored.
+    /// both are consulted for steps 3 and 4 so repo-local `agent_acp_cmd`
+    /// overrides are honored; step 5 reads `acp.default_agent`, which only a
+    /// profile may override (`acp` is not repo-overridable).
     pub async fn pick_agent_for_tool(
         &self,
         tool: &str,
@@ -983,12 +984,32 @@ impl<S: BroadcastSink> Supervisor<S> {
         {
             return base;
         }
-        // Step 5: legacy fallbacks.
+        // Step 5: the claude tool keeps its own registry key; everything else
+        // falls back to the configured default agent.
         if tool == "claude" {
             "claude".into()
         } else {
-            "aoe-agent".into()
+            self.resolved_default_agent(profile, project_path).await
         }
+    }
+
+    /// The session's resolved `acp.default_agent`, or the built-in default if
+    /// the config resolve panics.
+    async fn resolved_default_agent(
+        &self,
+        profile: &str,
+        project_path: &std::path::Path,
+    ) -> String {
+        let profile = profile.to_string();
+        let project_path = project_path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            crate::session::repo_config::resolve_config_with_repo_or_warn(&profile, &project_path)
+                .acp
+                .resolved_default_agent()
+                .to_string()
+        })
+        .await
+        .unwrap_or_else(|_| crate::session::config::DEFAULT_ACP_AGENT.to_string())
     }
 
     /// The registry-backed base key `tool` inherits via `agent_detect_as` in
@@ -4086,6 +4107,40 @@ mod tests {
             assert_eq!(got, None, "{label}: expected silence");
         }
     }
+
+    /// Step 5 of `pick_agent_for_tool` reads `acp.default_agent`, so the
+    /// setting actually selects the agent instead of only being displayed.
+    /// Needs HOME isolation for the config resolve.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn unregistered_tool_falls_back_to_the_configured_default_agent() {
+        let tmp = tempfile::TempDir::with_prefix_in("aoe-default-agent-", "/tmp").unwrap();
+        let _guard = crate::session::test_support::isolate_home(tmp.path());
+        let cfg_path = crate::session::get_app_dir().unwrap().join("config.toml");
+        let sup = Supervisor::new(VecSink::new());
+
+        // (configured acp.default_agent, tool, expected agent)
+        let cases = [
+            (None, "plain-tool", "claude-code"),
+            (None, "claude", "claude"),
+            // A tool with its own registry entry never reaches step 5.
+            (Some("codex"), "opencode", "opencode"),
+            (Some("codex"), "plain-tool", "codex"),
+            (Some("codex"), "claude", "claude"),
+            // A hand-edited blank value resolves to the built-in default.
+            (Some("   "), "plain-tool", "claude-code"),
+        ];
+        for (configured, tool, expected) in cases {
+            let body = match configured {
+                Some(agent) => format!("[acp]\ndefault_agent = \"{agent}\"\n"),
+                None => String::new(),
+            };
+            std::fs::write(&cfg_path, body).unwrap();
+            let got = sup.pick_agent_for_tool(tool, None, "", tmp.path()).await;
+            assert_eq!(got, expected, "default={configured:?} tool={tool}");
+        }
+    }
+
     /// `spawn_inner` would leave them green. Here a full `Supervisor::spawn`
     /// runs a detect_as wrapper against the real claude adapter with an
     /// unwritable working directory: the warning is emitted before any

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -141,8 +141,8 @@ pub struct AddArgs {
     #[arg(long = "structured-view")]
     structured_view: bool,
 
-    /// Pick a specific ACP agent for the structured view (e.g., aoe-agent,
-    /// claude-code).
+    /// Pick a specific ACP agent for the structured view (e.g., claude-code,
+    /// codex).
     #[cfg(feature = "serve")]
     #[arg(long = "agent")]
     agent: Option<String>,
@@ -747,14 +747,15 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         let agent_name = pick_acp_agent_name(
             &registry,
             &config.session,
+            &config.acp,
             &instance.tool,
             instance.agent_name.as_deref(),
         );
         // Capability is judged against the explicit `--agent` (or, with none,
-        // the tool itself), NOT `pick_acp_agent_name`'s aoe-agent fallback:
-        // otherwise every tool would look ACP-capable via the bundled default
-        // and `--structured-view` could never be rejected for a non-ACP tool
-        // (it would silently substitute aoe-agent). Mirrors the server create
+        // the tool itself), NOT `pick_acp_agent_name`'s default-agent fallback:
+        // otherwise every tool would look ACP-capable via that default and
+        // `--structured-view` could never be rejected for a non-ACP tool (it
+        // would silently substitute the default). Mirrors the server create
         // path in `src/server/api/sessions.rs`.
         let capability_key = instance
             .agent_name
@@ -1449,11 +1450,12 @@ fn cleanup_partial_session(
 /// async supervisor. Precedence: explicit override → tool-keyed
 /// registry entry → custom agent with `agent_acp_cmd` → custom agent
 /// inheriting a registry-backed base via `agent_detect_as` (resolves to
-/// the base key) → legacy (`claude` → `claude`, else `aoe-agent`).
+/// the base key) → `claude` for the claude tool, else `acp.default_agent`.
 #[cfg(feature = "serve")]
 fn pick_acp_agent_name(
     registry: &crate::acp::agent_registry::AgentRegistry,
     session: &crate::session::config::SessionConfig,
+    acp: &crate::session::config::AcpConfig,
     tool: &str,
     explicit_override: Option<&str>,
 ) -> String {
@@ -1476,7 +1478,7 @@ fn pick_acp_agent_name(
     if tool == "claude" {
         "claude".into()
     } else {
-        "aoe-agent".into()
+        acp.resolved_default_agent().to_string()
     }
 }
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -865,7 +865,6 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                         "ACP adapter `{}` is not installed or not on $PATH.\n\
                          Install: {}\n\
                          Or run: aoe acp doctor --fix\n\
-                         Or use the bundled fallback: rerun with `--agent aoe-agent`\n\
                          Or use the terminal view: drop --agent / --structured-view.",
                         spec.command,
                         hint

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -147,7 +147,7 @@ pub struct AddArgs {
     #[arg(long = "agent")]
     agent: Option<String>,
 
-    /// Override the model used by aoe-agent (e.g., claude-opus-4-7,
+    /// Override the model used by the ACP agent (e.g., claude-opus-4-7,
     /// gpt-5, gemini-2.5-pro). Forwarded to the agent at session start.
     #[cfg(feature = "serve")]
     #[arg(long = "model")]

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -33,13 +33,14 @@ mod v022_prune_tuning_settings;
 mod v023_clear_structured_container_error;
 mod v024_backfill_detect_as;
 mod v025_reenable_confirm_delete;
+mod v026_repoint_acp_default_agent;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 25;
+const CURRENT_VERSION: u32 = 26;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -173,6 +174,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 25,
         name: "reenable_confirm_delete",
         run: v025_reenable_confirm_delete::run,
+    },
+    Migration {
+        version: 26,
+        name: "repoint_acp_default_agent",
+        run: v026_repoint_acp_default_agent::run,
     },
 ];
 

--- a/src/migrations/v026_repoint_acp_default_agent.rs
+++ b/src/migrations/v026_repoint_acp_default_agent.rs
@@ -1,0 +1,168 @@
+//! Migration v026: repoint a persisted `acp.default_agent = "aoe-agent"`.
+//!
+//! `aoe-agent` is not packaged: nothing builds the registry's
+//! `${aoe_data_dir}/acp-worker/dist/aoe-agent` command (#3553). It was
+//! nonetheless the compiled default, v005 seeded it into `[cockpit]` (renamed
+//! to `[acp]` by v012), and `update_config` re-serializes the whole `Config` on
+//! every write, so nearly every existing install carries an explicit
+//! `default_agent = "aoe-agent"` in its `config.toml`. Now that the setting
+//! actually selects the spawned agent, that persisted value would outrank the
+//! new `claude-code` default forever and pick an agent that cannot start.
+//!
+//! Only the seeded value is rewritten; any other name is a real choice.
+//!
+//! Profile configs are deliberately untouched. They are sparse, holding only
+//! the keys a user actually overrode, so an `aoe-agent` there is a decision.
+//! Repo configs cannot carry `[acp]` at all (see `repo_config`).
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir.join("config.toml"))
+}
+
+/// Inner body so the test can drive the migration end-to-end against a temp
+/// file instead of inlining a near-copy of the production logic.
+pub(crate) fn run_in(path: &Path) -> Result<()> {
+    if !path.exists() {
+        debug!("No global config.toml, nothing to repoint for v026");
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(path)?;
+    // A config that does not parse is skipped rather than aborting startup:
+    // this migration is a default correction, not a load-bearing relocation.
+    let mut doc: toml::Table = match content.parse() {
+        Ok(table) => table,
+        Err(e) => {
+            debug!("failed to parse {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
+
+    let Some(acp) = doc.get_mut("acp").and_then(|s| s.as_table_mut()) else {
+        return Ok(());
+    };
+    if acp.get("default_agent").and_then(|v| v.as_str()) != Some("aoe-agent") {
+        return Ok(());
+    }
+    acp.insert(
+        "default_agent".into(),
+        crate::session::config::DEFAULT_ACP_AGENT.into(),
+    );
+
+    info!(
+        "v026: repointed acp.default_agent away from the unpackaged aoe-agent in {}",
+        path.display()
+    );
+    let new_content = toml::to_string_pretty(&doc)?;
+    crate::session::atomic_write(path, new_content.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, content).unwrap();
+        (dir, path)
+    }
+
+    fn default_agent_after(content: &str) -> Option<String> {
+        let (_dir, path) = write(content);
+        run_in(&path).unwrap();
+        let doc: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        Some(
+            doc.get("acp")?
+                .as_table()?
+                .get("default_agent")?
+                .as_str()?
+                .to_string(),
+        )
+    }
+
+    #[test]
+    fn rewrites_only_the_seeded_aoe_agent() {
+        let cases = [
+            // The serialized old default: the case this migration exists for.
+            (
+                "[acp]\ndefault_agent = \"aoe-agent\"\n",
+                Some("claude-code"),
+            ),
+            // A deliberate choice of any other agent survives.
+            ("[acp]\ndefault_agent = \"codex\"\n", Some("codex")),
+            // Already repointed, by an earlier run or a fresh install.
+            (
+                "[acp]\ndefault_agent = \"claude-code\"\n",
+                Some("claude-code"),
+            ),
+            // An absent key already resolves to the new default.
+            ("[acp]\nreplay_events = 0\n", None),
+            // No [acp] table at all.
+            ("[theme]\nname = \"empire\"\n", None),
+        ];
+        for (content, expected) in cases {
+            assert_eq!(
+                default_agent_after(content).as_deref(),
+                expected,
+                "{content:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_other_settings_and_is_idempotent() {
+        let (_dir, path) = write(
+            "[acp]\ndefault_agent = \"aoe-agent\"\nmax_concurrent_workers = 5\n\n\
+             [theme]\nname = \"rose-pine\"\n",
+        );
+
+        run_in(&path).unwrap();
+        let first = fs::read_to_string(&path).unwrap();
+        let doc: toml::Table = first.parse().unwrap();
+        let acp = doc.get("acp").unwrap().as_table().unwrap();
+        assert_eq!(
+            acp.get("default_agent").and_then(|v| v.as_str()),
+            Some("claude-code")
+        );
+        assert_eq!(
+            acp.get("max_concurrent_workers")
+                .and_then(|v| v.as_integer()),
+            Some(5),
+            "sibling acp settings must survive the rewrite"
+        );
+        assert_eq!(
+            doc.get("theme")
+                .and_then(|t| t.as_table())
+                .and_then(|t| t.get("name"))
+                .and_then(|v| v.as_str()),
+            Some("rose-pine"),
+            "unrelated sections must survive the rewrite"
+        );
+
+        run_in(&path).unwrap();
+        assert_eq!(
+            first,
+            fs::read_to_string(&path).unwrap(),
+            "a second run must not rewrite the file"
+        );
+    }
+
+    /// A missing or unparsable config is skipped, never a startup-aborting
+    /// error: this migration corrects a default, so it must not brick boot.
+    #[test]
+    fn unusable_config_is_a_noop() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(run_in(&dir.path().join("nope.toml")).is_ok());
+
+        let (_dir, path) = write("this is not = = toml");
+        assert!(run_in(&path).is_ok());
+    }
+}

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -238,10 +238,9 @@ fn rate_limit_resume_marker_resets_at(
 
 #[derive(Debug, Deserialize)]
 pub struct SpawnAcpRequest {
-    /// Optional override; falls back to the acp_default_agent
-    /// setting / aoe-agent.
+    /// Optional override; falls back to `Supervisor::pick_agent_for_tool`.
     pub agent: Option<String>,
-    /// Optional model override; forwarded to aoe-agent as
+    /// Optional model override; forwarded to the agent as
     /// AOE_AGENT_MODEL env var.
     pub model: Option<String>,
     /// Optional additional dirs the agent may read/write through

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1929,27 +1929,29 @@ pub async fn acp_enable(
 
     // Verify the tool has an ACP-capable agent. Otherwise there's no
     // agent to spawn and the swap would just produce a dead structured view.
-    // Built-in tools resolve from the registry; a custom agent is valid
-    // when it declares an `agent_acp_cmd` in its profile config.
-    let agent_name = state
-        .acp_supervisor
-        .pick_agent_for_tool(
-            &instance.tool,
-            instance.agent_name.as_deref(),
-            &profile,
-            std::path::Path::new(&instance.project_path),
-        )
-        .await;
-    let registry = state.acp_supervisor.registry_snapshot().await;
-    let resolvable = registry.get(&agent_name).is_some()
-        || state
-            .acp_supervisor
-            .custom_agent_has_acp_cmd(
-                &agent_name,
+    //
+    // Judged against the session's explicit `agent_name` (or, with none, the
+    // tool itself), NOT `pick_agent_for_tool`'s default-agent fallback: that
+    // fallback always resolves to a registry key, so gating on it would accept
+    // every tool and switch a terminal-only session into a structured one
+    // running some other agent. Shares the create path's predicate so the two
+    // cannot drift.
+    let resolvable = {
+        let profile = profile.clone();
+        let project_path = std::path::PathBuf::from(&instance.project_path);
+        let tool = instance.tool.clone();
+        let agent_name = instance.agent_name.clone();
+        tokio::task::spawn_blocking(move || {
+            super::sessions::agent_is_acp_capable(
                 &profile,
-                std::path::Path::new(&instance.project_path),
+                &project_path,
+                &tool,
+                agent_name.as_deref(),
             )
-            .await;
+        })
+        .await
+        .unwrap_or(false)
+    };
     if !resolvable {
         return (
             StatusCode::BAD_REQUEST,
@@ -1963,6 +1965,15 @@ pub async fn acp_enable(
 
     // A real terminal -> acp transition is now committed (the idempotent
     // already-acp and unresolvable-agent cases returned above).
+    let agent_name = state
+        .acp_supervisor
+        .pick_agent_for_tool(
+            &instance.tool,
+            instance.agent_name.as_deref(),
+            &profile,
+            std::path::Path::new(&instance.project_path),
+        )
+        .await;
 
     // Tear down the tmux side. Best-effort: a stale tmux name should
     // not block the swap. Run on a blocking pool worker because each

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -5282,7 +5282,7 @@ fn acp_agent_key<'a>(tool: &'a str, agent_name: Option<&'a str>) -> &'a str {
     agent_name.filter(|s| !s.is_empty()).unwrap_or(tool)
 }
 
-fn agent_is_acp_capable(
+pub(super) fn agent_is_acp_capable(
     profile: &str,
     project_path: &std::path::Path,
     tool: &str,
@@ -8187,6 +8187,30 @@ mod tests {
                 "default",
                 std::path::Path::new("/nonexistent"),
                 "definitely-not-a-real-tool",
+                None,
+            ));
+        }
+
+        /// Why `acp_enable` gates on this predicate and not on
+        /// `pick_agent_for_tool`: the default-agent fallback always names a
+        /// registry entry, so a post-fallback registry lookup reports every
+        /// tool capable and would switch a terminal-only session into a
+        /// structured one running some other agent.
+        #[test]
+        #[serial]
+        fn the_default_agent_fallback_is_not_a_capability_signal() {
+            let _tmp = isolate_app_dir();
+            let fallback = crate::session::config::DEFAULT_ACP_AGENT;
+            assert!(
+                crate::acp::AgentRegistry::with_defaults()
+                    .get(fallback)
+                    .is_some(),
+                "the fallback must be spawnable, which is what makes it useless as a gate"
+            );
+            assert!(!agent_is_acp_capable(
+                "default",
+                std::path::Path::new("/nonexistent"),
+                "plain-tool",
                 None,
             ));
         }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -423,7 +423,8 @@ pub struct AcpConfig {
     )]
     pub offer_structured_in_new_session: bool,
     /// Acp agent used when --agent is not specified (e.g. claude-code,
-    /// codex, aoe-agent).
+    /// codex). Must name an agent that can start: `aoe-agent` is not
+    /// packaged yet (#3553).
     #[serde(default = "default_agent")]
     #[setting(label = "Default agent", widget = "text", validate = "nonempty")]
     pub default_agent: String,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -422,8 +422,8 @@ pub struct AcpConfig {
         widget = "toggle"
     )]
     pub offer_structured_in_new_session: bool,
-    /// Acp agent used when --agent is not specified (e.g. aoe-agent,
-    /// claude-code, gemini).
+    /// Acp agent used when --agent is not specified (e.g. claude-code,
+    /// codex, aoe-agent).
     #[serde(default = "default_agent")]
     #[setting(label = "Default agent", widget = "text", validate = "nonempty")]
     pub default_agent: String,
@@ -646,7 +646,7 @@ impl Default for AcpConfig {
 }
 
 fn default_agent() -> String {
-    "aoe-agent".to_string()
+    "claude-code".to_string()
 }
 fn default_max_workers() -> u32 {
     100

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -645,8 +645,12 @@ impl Default for AcpConfig {
     }
 }
 
+/// Built-in `acp.default_agent`. `aoe-agent` is not packaged yet (#3553), so
+/// the default has to be an adapter `aoe acp doctor --fix` can install.
+pub const DEFAULT_ACP_AGENT: &str = "claude-code";
+
 fn default_agent() -> String {
-    "claude-code".to_string()
+    DEFAULT_ACP_AGENT.to_string()
 }
 fn default_max_workers() -> u32 {
     100
@@ -1483,6 +1487,19 @@ impl AcpAgentDefaults {
 }
 
 impl AcpConfig {
+    /// The agent name a structured-view spawn falls back to when nothing more
+    /// specific applies. A hand-edited config can leave `default_agent` blank
+    /// (the settings layer rejects empty, a file edit does not), which would
+    /// otherwise resolve to `UnknownAgent("")`.
+    pub fn resolved_default_agent(&self) -> &str {
+        let configured = self.default_agent.trim();
+        if configured.is_empty() {
+            DEFAULT_ACP_AGENT
+        } else {
+            configured
+        }
+    }
+
     pub fn acp_defaults_for(&self, agent: &str) -> Option<&AcpAgentDefaults> {
         self.acp_defaults
             .get(agent)


### PR DESCRIPTION
## Description

`acp.default_agent` defaulted to `aoe-agent`, which nothing builds or installs (#3553): the release ships only the `aoe` binary, `adapters.rs` embeds just the three npm adapters, and `acp-worker/.gitignore` ignores `dist/`.

The setting also had no runtime reader. `Supervisor::pick_agent_for_tool` and its sync mirror `pick_acp_agent_name` both hard-coded `aoe-agent` as the non-claude fallback, so flipping the serde default alone would not have changed any spawn.

This flips the default to `claude-code`, threads the resolved setting through both selectors, and corrects the docs and `--agent` help that claim `aoe-agent` ships with the binary.

Wiring the setting needs a migration: v005 seeded `default_agent = "aoe-agent"` into existing installs' configs (renamed to `[acp]` by v012), and a persisted value outranks a serde default. v026 repoints only that seeded value in the global config. Profile configs are sparse, so a value there is a real choice and is left alone; `[acp]` is not repo-overridable.

Packaging and the `command_present` fix stay on #3553.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the selector is covered by a table-driven unit test on `pick_agent_for_tool`, and the migration by unit tests in `v026`. Both are cheaper than a full-binary test and catch the regression.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5 and Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**
The packaging investigation and the original default flip were drafted by Claude Fable 5. The selector wiring, migration, and this description were drafted by Claude Opus 5 during review. The reasoning and decisions are @njbrake's.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: the code and this description were drafted by Claude Fable 5 and Claude Opus 5 via back-and-forth with @njbrake using the Claude Code CLI. The reasoning and decisions are his; the prose is the models'._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Changed the ACP structured-view default agent from `aoe-agent` to `claude-code`.
- Updated agent selection to use the configured `acp.default_agent`.
- Added migration v026 for existing global configurations using `aoe-agent`.
- Preserved explicit profile settings and handled blank defaults safely.
- Corrected ACP capability checks before enabling structured view.
- Updated CLI help, documentation, and troubleshooting guidance.
- Added tests for fallback behavior, capability checks, and migration safety.

## Benefits

Users receive a working default agent without manual configuration. Existing configurations migrate safely, explicit agent choices remain unchanged, and terminal-only sessions are no longer treated as ACP-capable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->