### PR TITLE
fix: preserve utf-8 names when stopping sessions

### DIFF
--- a/src/session/instance/tmux_session.rs
+++ b/src/session/instance/tmux_session.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 pub(super) fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
-    let output = crate::tmux::tmux_command()
+    let output = crate::tmux::tmux_query_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()
         .ok()?;

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -877,22 +877,21 @@ pub fn stop_all_sessions() -> anyhow::Result<usize> {
         .output()
         .map_err(|e| anyhow::anyhow!("tmux list-sessions spawn failed: {e}"))?;
 
+    let mut matched = false;
     let killed = if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         stop_aoe_sessions(stdout.lines(), |name| {
+            matched = true;
             if let Some(pid) = crate::process::get_pane_pid(name) {
                 crate::process::kill_process_tree(pid);
             }
-            tmux_command()
-                .args(["kill-session", "-t", name])
-                .output()
-                .is_ok_and(|result| result.status.success())
+            utils::kill_session_if_present(name).is_ok()
         })
     } else {
         0
     };
 
-    if killed > 0 {
+    if matched {
         refresh_session_cache();
     }
     Ok(killed)

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -872,29 +872,40 @@ fn session_name_from_cache(derived: &str, shape: &NameShape) -> Option<String> {
 /// for a panic button with a handful of sessions; if counts grow, batch the
 /// SIGTERM across all pids, wait once, then SIGKILL survivors.
 pub fn stop_all_sessions() -> anyhow::Result<usize> {
-    let output = tmux_command()
+    let output = tmux_query_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()
         .map_err(|e| anyhow::anyhow!("tmux list-sessions spawn failed: {e}"))?;
 
-    let mut killed = 0;
-    if output.status.success() {
+    let killed = if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        for line in stdout.lines() {
-            if is_aoe_session(line) {
-                if let Some(pid) = crate::process::get_pane_pid(line) {
-                    crate::process::kill_process_tree(pid);
-                }
-                let _ = tmux_command().args(["kill-session", "-t", line]).output();
-                killed += 1;
+        stop_aoe_sessions(stdout.lines(), |name| {
+            if let Some(pid) = crate::process::get_pane_pid(name) {
+                crate::process::kill_process_tree(pid);
             }
-        }
-    }
+            tmux_command()
+                .args(["kill-session", "-t", name])
+                .output()
+                .is_ok_and(|result| result.status.success())
+        })
+    } else {
+        0
+    };
 
     if killed > 0 {
         refresh_session_cache();
     }
     Ok(killed)
+}
+
+fn stop_aoe_sessions<'a>(
+    names: impl Iterator<Item = &'a str>,
+    mut stop: impl FnMut(&str) -> bool,
+) -> usize {
+    names
+        .filter(|name| is_aoe_session(name))
+        .filter(|name| stop(name))
+        .count()
 }
 
 /// Batch-fetch pane metadata for all aoe sessions in a single tmux subprocess call.
@@ -1354,7 +1365,7 @@ fn refresh_pane_meta_cache() {
 }
 
 pub fn get_current_session_name() -> Option<String> {
-    let output = tmux_command()
+    let output = tmux_query_command()
         .args(["display-message", "-p", "#{session_name}"])
         .output()
         .ok()?;
@@ -1609,6 +1620,22 @@ mod tests {
                 .is_some_and(|(_, value)| value.is_none()),
             "LC_ALL must not override LC_MESSAGES=C"
         );
+    }
+
+    #[test]
+    fn stop_aoe_sessions_counts_only_successful_kills() {
+        let successful = format!("{P}unicode_会话");
+        let failed = format!("{P}failed");
+        let names = [successful.as_str(), "unrelated", failed.as_str()];
+        let mut attempted = Vec::new();
+
+        let killed = stop_aoe_sessions(names.into_iter(), |name| {
+            attempted.push(name.to_string());
+            name == successful
+        });
+
+        assert_eq!(attempted, [successful, failed]);
+        assert_eq!(killed, 1);
     }
 
     #[cfg(unix)]

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -479,7 +479,7 @@ impl ContainerTerminalSession {
 pub fn kill_all_terminals_for_id(id: &str) {
     let needle = format!("_{}", truncate_id(id, 8));
 
-    let output = crate::tmux::tmux_command()
+    let output = crate::tmux::tmux_query_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output();
 

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -221,7 +221,7 @@ impl ToolSession {
 pub fn kill_all_tool_sessions_for_id(session_id: &str) {
     let id_suffix = format!("_{}", truncate_id(session_id, 8));
 
-    let output = crate::tmux::tmux_command()
+    let output = crate::tmux::tmux_query_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output();
 


### PR DESCRIPTION
## Description
Use the UTF-8-safe tmux query command when listing sessions for the panic button and when reading the current session name. The stop count now includes only successful `kill-session` calls, and a focused unit test covers Unicode names, ownership filtering, and failed kills.

Closes #3548

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A: no public workflow changed)
- [x] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is covered by the focused pure unit test and existing `tmux_query_command` environment test; tmux is unavailable on this development host.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you would like to share:** Used for codebase navigation, implementation, and test execution.

- [x] I am an AI Agent filling out this form

## Testing

- `cargo fmt --check`
- `cargo test stop_aoe_sessions_counts_only_successful_kills`
- `cargo test tmux_query_command_preserves_ctype_for_session_names`
- `cargo clippy --lib -- -D warnings`
- `cargo test --lib` reached 4,751 passing / 2 ignored; three unrelated tmux-dependent status tests failed because tmux is not installed on this host.
- `cargo clippy --all-targets -- -D warnings` is blocked by the pre-existing `items_after_test_module` warning in `src/process/macos.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserves Unicode session names by using UTF-8-safe tmux queries.
- Applies this handling to session stopping, current-session lookup, terminal sessions, tool sessions, and instance sessions.
- Counts only sessions that stop successfully.
- Refreshes the session cache after matching AOE sessions, including race conditions.
- Adds tests for Unicode names, ownership filtering, and failed session kills.

## Benefits

This prevents incorrect session matching and false success counts in environments without a UTF-8 locale. It also improves cleanup reliability during teardown races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->