### PR TITLE
docs: ask changes to prune the comments they touch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ For web commands and tests, read `web/AGENTS.md`.
 - Keep comments short and precise. Add one only when the code cannot clearly express a
   non-obvious reason or invariant; do not restate code or preserve
   implementation history.
+- Leave the comments around a change shorter than you found them: prune
+  narration, repeated rationale, and implementation history as you touch them.
 - Add standalone documentation only for a durable user workflow, public
   contract, or cross-cutting invariant. Keep implementation details with the
   code; do not add feature inventories, rollout history, or duplicate guides.


### PR DESCRIPTION
## Description

Comments explaining a change tend to pile up one reasonable-looking line at a time, and the least useful of them restate what the diff, the commit, or the issue already says. Nothing prompts anyone to remove them, so they accumulate and go stale quietly. This asks every change to leave the prose around it a little shorter, which spreads the cleanup across normal work instead of saving it for an occasional sweep like #3574.

Two lines under Code rules, beside the existing "keep comments short and precise" bullet.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: N/A, no UI changes

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Prompted by reviewing an agent-authored PR whose own comment volume was the problem this rule describes.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `AGENTS.md` with guidance to shorten comments when contributors modify nearby code.
- The guidance asks contributors to remove narration, repeated rationale, and outdated implementation history.

## Benefits

- Keeps comments focused and easier to maintain.
- Reduces stale or redundant documentation during normal development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->