### PR TITLE
chore: make git blame work across the instance.rs split

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,7 @@
 
 # oxfmt 80 -> 120 line width
 1f1a33396d189a596d29404df074b22e11646721
+
+# instance.rs split into src/session/instance/
+# Only helps files that predate it: use `git blame -C -C` inside the new modules.
+7f0fb177140efe82e2390991e22a322eecd6ea76


### PR DESCRIPTION
## Description

Follow-up to #3587.

`--ignore-rev` does nothing for the 24 new modules. They did not exist before `7f0fb177`, so blame has no earlier revision to fall back to:

```
$ git blame --ignore-rev 7f0fb177 -L 20,24 src/session/instance/flags.rs
7f0fb1771 (Nathan Brake 2026-08-30 20) /// Active`. Used to route a session ...
```

Copy detection traces through the move:

```
$ git blame -C -C -L 20,24 src/session/instance/flags.rs
ec54fdf18 src/session/instance.rs (Jules Lasne 2026-06-28 20) /// Active`. Used to ...
```

The entry still helps the four files predating the split, where a one-line path repoint masks the original author. Both go in, caveat beside the entry.

The same asymmetry applies to every file split in #3573: `.git-blame-ignore-revs` is not what keeps blame useful across them.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording


## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Config file only.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any Additional AI Details you'd like to share:**

Review advice was to add the SHA alone. Testing it showed that entry is inert for the split files, hence the caveat.

- [x] I am an AI Agent filling out this form (check box if true)
