### PR TITLE
chore: make git blame work across the three hotspot splits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -11,3 +11,12 @@
 # instance.rs split into src/session/instance/
 # Only helps files that predate it: use `git blame -C -C` inside the new modules.
 7f0fb177140efe82e2390991e22a322eecd6ea76
+
+# acp_client.rs split into src/acp/acp_client/
+f197ae07c9c64fcec1520948266e4b4f98cd23a0
+
+# server/mod.rs split into per-concern modules under src/server/
+8827701d98ad839c31a17d6b0f962504417b0348
+
+# tui/home/mod.rs split into per-concern modules under src/tui/home/
+d649c3d9d70637f2105c3f6cf99fb144895aea39


### PR DESCRIPTION
## Description

Three recent commits moved code between files without changing it, so `git blame` on any line in the new modules points at the move instead of at the change that actually wrote the line. This adds those three commits to the list `git blame` knows to skip over, so blame walks past them to the real author. It changes no code and no behaviour.

The three revs are #3593 (`acp_client.rs`), #3594 (`server/mod.rs`), and #3595 (`tui/home/mod.rs`), together 34,366 lines moved. Same treatment #3590 gave the `instance.rs` split, and the same caveat applies: this only helps files that predate a split. Inside the new modules, use `git blame -C -C` to follow a line back through the move.

Part of #3573.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No code changes; the file is data for `git blame`, read only when a developer opts in with `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any Additional AI Details you'd like to share:**

Each rev was read back from the merged commit on `main` and verified to exist and to be the right split.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added three split commits to `.git-blame-ignore-revs`.
- Updated blame settings for reorganizations involving `acp_client.rs`, `server/mod.rs`, and `tui/home/mod.rs`.
- This change affects blame history only. It does not change code or behavior.

## Benefits

`git blame` now skips 34,366 moved lines from these reorganizations, which makes history easier to review. Use `git blame -C -C` inside the new modules to trace the original lines.

## Technical details

- Added 9 lines to `.git-blame-ignore-revs`.
- Added comments for each ignored commit.
- No public declarations changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->