### PR TITLE
fix(acp): gate the debug-only handshake-failure import

### DIFF
--- a/src/acp/acp_client/mod.rs
+++ b/src/acp/acp_client/mod.rs
@@ -84,10 +84,9 @@ use self::pending::{
     ApprovalResolutionMessage, ElicitationResolutionMessage, PendingResolver, PendingResponders,
 };
 use self::reset::{SESSION_RESET_IN_TASK_TIMEOUT, SESSION_RESET_TIMEOUT};
-use self::runner::{
-    runner_socket_deadline, spawn_runner_detached, take_injected_fresh_handshake_failure,
-    wait_for_socket,
-};
+#[cfg(debug_assertions)]
+use self::runner::take_injected_fresh_handshake_failure;
+use self::runner::{runner_socket_deadline, spawn_runner_detached, wait_for_socket};
 use self::spawn::spawn_subprocess;
 
 /// Top-level ACP client. Owns the subprocess lifetime and pumps events


### PR DESCRIPTION
## Description

The #3593 module split moved `take_injected_fresh_handshake_failure` into `runner.rs`, where it is `#[cfg(debug_assertions)]`, but left the re-import in `acp_client/mod.rs` unconditional. The call site was already gated, so debug builds compiled and anything with debug assertions off failed with E0432: `cargo build --release`, `--profile dev-release`, and the Nix package.

Cachix push has been red on main since #3593 for this reason; the next release build would have failed too.

Verified with `cargo check --profile dev-release --all-features` (the failing configuration) and `cargo check --all-features --all-targets`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: a compile error in a build configuration CI never compiles. The gap is CI coverage, not a test case; no runtime behavior changes.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Diagnosis and fix drafted by Claude Opus 5 through back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Gated the debug-only `take_injected_fresh_handshake_failure` import with `#[cfg(debug_assertions)]`.
- Kept the other runner imports unchanged.
- Prevented `E0432` build failures when debug assertions are disabled.

## Verification

- `cargo check --profile dev-release --all-features`
- `cargo check --all-features --all-targets`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->