### PR TITLE
fix(tmux): stop a parallel refresh clobbering a forced session cache

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1154,7 +1154,11 @@ impl SessionCacheGuard {
 #[cfg(test)]
 impl Drop for SessionCacheGuard {
     fn drop(&mut self) {
-        if let Ok(mut cache) = SESSION_CACHE.write() {
+        // Deregistered under the same lock the restore takes, mirroring
+        // `capture`: a refresh arriving mid-drop is either suppressed or lands
+        // on top of the restored snapshot, never dropped on the floor.
+        let mut cache = SESSION_CACHE.write();
+        if let Ok(cache) = cache.as_mut() {
             cache.data = self.prev_data.take();
             cache.time = self.prev_time;
         }

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -39,6 +39,8 @@ pub mod test_support {
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
@@ -249,6 +251,27 @@ pub struct PaneMetadata {
     pub pane_start_command_is_protected: bool,
 }
 
+#[cfg(test)]
+static FORCED_SESSION_CACHE_GUARDS: AtomicUsize = AtomicUsize::new(0);
+
+/// Whether a test owns [`SESSION_CACHE`] through a live [`SessionCacheGuard`],
+/// in which case [`refresh_session_cache`] must leave the forced snapshot
+/// alone. `#[serial_test::serial]` only orders serial tests against each
+/// other, so a parallel test can already be past its staleness check and
+/// blocked on the `list-sessions` fork when the guard forces a snapshot, then
+/// land its write mid-test. On a host with no tmux server that write is
+/// `data: None`, which reads back as [`SessionExistence::Unknown`] and flips
+/// the status assertion the guard was meant to pin.
+#[cfg(test)]
+fn forced_session_cache_active() -> bool {
+    FORCED_SESSION_CACHE_GUARDS.load(Ordering::SeqCst) > 0
+}
+
+#[cfg(not(test))]
+fn forced_session_cache_active() -> bool {
+    false
+}
+
 static SESSION_CACHE: RwLock<SessionCache> = RwLock::new(SessionCache {
     data: None,
     time: None,
@@ -388,9 +411,14 @@ pub fn refresh_session_cache() -> SessionCacheRefresh {
         "session cache refreshed",
     );
 
+    // Checked under the write lock, which `SessionCacheGuard::capture` also
+    // takes: either the guard registers first and this refresh skips, or this
+    // write lands first and the guard captures it as the state to restore.
     if let Ok(mut cache) = SESSION_CACHE.write() {
-        cache.data = new_data;
-        cache.time = Some(Instant::now());
+        if !forced_session_cache_active() {
+            cache.data = new_data;
+            cache.time = Some(Instant::now());
+        }
     }
     outcome
 }
@@ -1095,7 +1123,10 @@ pub(crate) struct SessionCacheGuard {
 #[cfg(test)]
 impl SessionCacheGuard {
     pub(crate) fn capture() -> Self {
-        let cache = SESSION_CACHE.read().expect("session cache lock");
+        // Write lock, not read: registering the guard and reading the state
+        // to restore must be one step against a concurrent refresh.
+        let cache = SESSION_CACHE.write().expect("session cache lock");
+        FORCED_SESSION_CACHE_GUARDS.fetch_add(1, Ordering::SeqCst);
         Self {
             prev_data: cache.data.clone(),
             prev_time: cache.time,
@@ -1127,6 +1158,7 @@ impl Drop for SessionCacheGuard {
             cache.data = self.prev_data.take();
             cache.time = self.prev_time;
         }
+        FORCED_SESSION_CACHE_GUARDS.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -2032,6 +2064,24 @@ mod tests {
         let name = format!("{P}exists_probe_cache_hit");
         test_inject_session_into_cache(&name);
         assert!(session_exists(&name));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn a_forced_cache_snapshot_survives_a_concurrent_refresh() {
+        // See `forced_session_cache_active`: a refresh a parallel test
+        // started must not land inside a guarded window.
+        let guard = SessionCacheGuard::capture();
+        let name = format!("{P}forced_snapshot_survives_refresh");
+        guard.force_present(&[name.as_str()]);
+
+        refresh_session_cache();
+
+        assert_eq!(
+            probe_session_existence(&name),
+            SessionExistence::Present,
+            "a live SessionCacheGuard must own the snapshot"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes the macOS-only `Cargo Test (macos)` failure in `session::instance::status_update::tests::update_status_probes_the_resolved_name_not_the_title` (red on runs 33319514778, 33320567444, 33323320022).

`SessionCacheGuard` forces `SESSION_CACHE` into a known state, but `refresh_session_cache` is not atomic: it checks staleness, forks `list-sessions`, then writes. A parallel test already blocked on that fork lands its write inside the guarded window. `#[serial]` does not prevent this; it only orders serial tests against each other. On a host with no tmux server that write is `data: None`, which `session_existence_from_cache` reads back as `SessionExistence::Unknown`.

That is the observed failure. The second probe got `Unknown` instead of `Absent`, so the instance stayed `Running` inside the grace window instead of latching `Error`:

```
DEBUG session.store: status 'resolve-r2': tmux server unreachable for 958ns
      (< 4s window, ever_confirmed_present=false), retaining status Running
```

A live guard now suppresses the refresh write. The check happens under the same lock `capture` takes, so guard registration and a concurrent write cannot interleave: either the guard registers first and the refresh skips, or the write lands first and the guard captures it as the state to restore.

Non-test builds compile `forced_session_cache_active` to `false`, so production behavior is unchanged.

## Tests

Added `a_forced_cache_snapshot_survives_a_concurrent_refresh`, which reproduces the clobber deterministically (calls `refresh_session_cache` directly inside a guarded window rather than racing). It fails on `main` with the same `Unknown` vs `Present` mismatch seen on macOS, and passes with the fix.

`cargo test --lib` run three times: 4770 pass. `cargo fmt`, `cargo clippy --all-features`, and `cargo check --features serve` clean.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Diagnosis and fix drafted by Claude Opus 5 through back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents concurrent session-cache refreshes from overwriting a forced `SessionCacheGuard` snapshot.
- Coordinates guard operations and cache writes under the same lock.
- Keeps the lock held during guard deregistration to prevent refresh races.
- Adds a deterministic regression test for the concurrency issue.
- Preserves production behavior outside test builds.

## Benefits

- Makes macOS test runs more reliable.
- Keeps forced cache snapshots stable during concurrent refreshes.
- Improves synchronization without changing runtime behavior.

## Potential follow-up

- Monitor related cache tests for similar concurrency issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->