### PR TITLE
perf(tui): cut idle subprocess churn and render-thread capture forks

### DIFF
--- a/src/containers/stats.rs
+++ b/src/containers/stats.rs
@@ -24,10 +24,12 @@ pub struct ContainerStats {
 pub type StatsMap = HashMap<String, ContainerStats>;
 
 /// `docker stats --no-stream` re-samples every running container to compute a
-/// CPU delta, which costs ~2s on a host running a couple dozen sandboxes. That
-/// cannot ride the 1s metrics cadence, so the refresh runs on its own thread
-/// and callers read whatever the last completed pass left behind.
-const STATS_TTL: Duration = Duration::from_secs(5);
+/// CPU delta, which costs ~2s on a host running a dozen sandboxes. That cannot
+/// ride the 1s metrics cadence, so the refresh runs on its own thread and
+/// callers read whatever the last completed pass left behind. At 5s the
+/// command was in flight ~40% of the time; 15s keeps per-row sandbox figures
+/// live enough for a health strip.
+const STATS_TTL: Duration = Duration::from_secs(15);
 
 struct Cache {
     map: Arc<StatsMap>,

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -87,7 +87,48 @@ pub(crate) struct MetricsSampler {
     last_at: Option<Instant>,
     last_host_cpu: Option<(u64, u64)>,
     last_process_cpu: HashMap<(u32, u64), f64>,
-    last_pane_pids: HashMap<String, u32>,
+    last_pane_roots: PaneRoots,
+}
+
+/// Pane metadata from the last successful `list-panes -a`, with the start
+/// identity of every root pid as seen in the process snapshot taken alongside
+/// it. A tick whose `list-panes` fails reuses the map, and the identity check
+/// keeps a pid that exited and was recycled during the outage from seeding a
+/// process-tree walk.
+#[derive(Default)]
+struct PaneRoots {
+    panes: HashMap<String, crate::tmux::PaneMetadata>,
+    start_ids: HashMap<u32, u64>,
+}
+
+impl PaneRoots {
+    fn capture(
+        panes: HashMap<String, crate::tmux::PaneMetadata>,
+        processes: &[ProcessRecord],
+    ) -> Self {
+        let pids: HashSet<u32> = panes.values().filter_map(|meta| meta.pane_pid).collect();
+        let start_ids = processes
+            .iter()
+            .filter(|p| pids.contains(&p.pid))
+            .map(|p| (p.pid, p.start_id))
+            .collect();
+        Self { panes, start_ids }
+    }
+
+    /// The live root pid of `inst`'s agent pane: resolved against this same
+    /// snapshot (a renamed session still matches), not dead, and still the
+    /// process it was when the snapshot was taken.
+    fn root_for(&self, inst: &Instance, by_pid: &HashMap<u32, &ProcessRecord>) -> Option<u32> {
+        let derived = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        let name = crate::tmux::resolve_agent_session_name_in(&self.panes, &inst.id, &derived);
+        let meta = self.panes.get(&name)?;
+        if meta.pane_dead {
+            return None;
+        }
+        let pid = meta.pane_pid?;
+        let record = by_pid.get(&pid)?;
+        (self.start_ids.get(&pid) == Some(&record.start_id)).then_some(pid)
+    }
 }
 
 impl MetricsSampler {
@@ -111,20 +152,14 @@ impl MetricsSampler {
         let processes = process_snapshot();
         // One `list-panes -a` for every pane root, instead of one
         // `display-message` per session. `Err` means tmux could not answer, not
-        // that there are no panes, so the previous map stands for that tick. A
-        // dead pane's pid has exited, and the OS may already have handed it to
-        // something unrelated, so it must not seed a process-tree walk.
+        // that there are no panes, so the previous snapshot stands for that tick.
         if let Ok(panes) = crate::tmux::batch_pane_metadata() {
-            self.last_pane_pids = panes
-                .into_iter()
-                .filter(|(_, meta)| !meta.pane_dead)
-                .filter_map(|(name, meta)| Some((name, meta.pane_pid?)))
-                .collect();
+            self.last_pane_roots = PaneRoots::capture(panes, &processes);
         }
         let agents = aggregate_agents(
             instances,
             &processes,
-            &self.last_pane_pids,
+            &self.last_pane_roots,
             elapsed,
             &self.last_process_cpu,
         );
@@ -224,7 +259,7 @@ fn host_figures(
 fn aggregate_agents(
     instances: &[Instance],
     processes: &[ProcessRecord],
-    pane_pids: &HashMap<String, u32>,
+    roots: &PaneRoots,
     elapsed: Option<f64>,
     previous: &HashMap<(u32, u64), f64>,
 ) -> Vec<AgentMetric> {
@@ -274,13 +309,9 @@ fn aggregate_agents(
         .then(crate::containers::stats::cached_stats)
         .unwrap_or_default();
     for inst in &eligible {
-        let session_name = crate::tmux::Session::resolve_name(&inst.id, &inst.title);
-        let Some(&root) = pane_pids.get(&session_name) else {
+        let Some(root) = roots.root_for(inst, &by_pid) else {
             continue;
         };
-        if !by_pid.contains_key(&root) {
-            continue;
-        }
         let mut stack = vec![root];
         let mut pids = Vec::new();
         while let Some(pid) = stack.pop() {
@@ -410,5 +441,51 @@ fn process_snapshot() -> Vec<ProcessRecord> {
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(pid: u32, start_id: u64) -> ProcessRecord {
+        ProcessRecord {
+            pid,
+            ppid: 1,
+            start_id,
+            rss_bytes: 0,
+            cpu_seconds: 0.0,
+        }
+    }
+
+    fn pane(pid: Option<u32>, dead: bool) -> crate::tmux::PaneMetadata {
+        crate::tmux::PaneMetadata {
+            pane_dead: dead,
+            pane_current_command: None,
+            pane_start_command_is_protected: false,
+            pane_pid: pid,
+        }
+    }
+
+    #[test]
+    fn root_for_requires_a_live_pane_whose_pid_kept_its_identity() {
+        let inst = Instance::new("metrics-root", "/tmp/metrics-root");
+        let name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        let snapshot = [record(100, 7)];
+        // (pane, current processes, expected)
+        let cases = [
+            (pane(Some(100), false), vec![record(100, 7)], Some(100)),
+            // The pane died and its pid was handed to something else.
+            (pane(Some(100), false), vec![record(100, 8)], None),
+            (pane(Some(100), false), vec![], None),
+            (pane(Some(100), true), vec![record(100, 7)], None),
+            (pane(None, false), vec![record(100, 7)], None),
+        ];
+        for (meta, processes, expected) in cases {
+            let roots = PaneRoots::capture(HashMap::from([(name.clone(), meta)]), &snapshot);
+            let by_pid: HashMap<u32, &ProcessRecord> =
+                processes.iter().map(|p| (p.pid, p)).collect();
+            assert_eq!(roots.root_for(&inst, &by_pid), expected);
+        }
     }
 }

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -108,7 +108,23 @@ impl MetricsSampler {
         });
 
         let processes = process_snapshot();
-        let agents = aggregate_agents(instances, &processes, elapsed, &self.last_process_cpu);
+        // One `list-panes -a` for every pane root, instead of one
+        // `display-message` per session.
+        let pane_pids: HashMap<String, u32> = crate::tmux::batch_pane_metadata()
+            .map(|panes| {
+                panes
+                    .into_iter()
+                    .filter_map(|(name, meta)| Some((name, meta.pane_pid?)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let agents = aggregate_agents(
+            instances,
+            &processes,
+            &pane_pids,
+            elapsed,
+            &self.last_process_cpu,
+        );
         let counts = AgentCounts {
             agents: agents.len(),
             procs: agents.iter().filter_map(|a| a.procs).sum(),
@@ -205,6 +221,7 @@ fn host_figures(
 fn aggregate_agents(
     instances: &[Instance],
     processes: &[ProcessRecord],
+    pane_pids: &HashMap<String, u32>,
     elapsed: Option<f64>,
     previous: &HashMap<(u32, u64), f64>,
 ) -> Vec<AgentMetric> {
@@ -253,13 +270,9 @@ fn aggregate_agents(
         || sandboxed_worker)
         .then(crate::containers::stats::cached_stats)
         .unwrap_or_default();
-    let alive = crate::session::recovery::orphaned_agents_alive(&eligible);
-    for (inst, is_alive) in eligible.iter().zip(alive) {
-        if !is_alive {
-            continue;
-        }
+    for inst in &eligible {
         let session_name = crate::tmux::Session::resolve_name(&inst.id, &inst.title);
-        let Some(root) = crate::process::get_pane_pid(&session_name) else {
+        let Some(&root) = pane_pids.get(&session_name) else {
             continue;
         };
         if !by_pid.contains_key(&root) {

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -87,6 +87,7 @@ pub(crate) struct MetricsSampler {
     last_at: Option<Instant>,
     last_host_cpu: Option<(u64, u64)>,
     last_process_cpu: HashMap<(u32, u64), f64>,
+    last_pane_pids: HashMap<String, u32>,
 }
 
 impl MetricsSampler {
@@ -109,19 +110,21 @@ impl MetricsSampler {
 
         let processes = process_snapshot();
         // One `list-panes -a` for every pane root, instead of one
-        // `display-message` per session.
-        let pane_pids: HashMap<String, u32> = crate::tmux::batch_pane_metadata()
-            .map(|panes| {
-                panes
-                    .into_iter()
-                    .filter_map(|(name, meta)| Some((name, meta.pane_pid?)))
-                    .collect()
-            })
-            .unwrap_or_default();
+        // `display-message` per session. `Err` means tmux could not answer, not
+        // that there are no panes, so the previous map stands for that tick. A
+        // dead pane's pid has exited, and the OS may already have handed it to
+        // something unrelated, so it must not seed a process-tree walk.
+        if let Ok(panes) = crate::tmux::batch_pane_metadata() {
+            self.last_pane_pids = panes
+                .into_iter()
+                .filter(|(_, meta)| !meta.pane_dead)
+                .filter_map(|(name, meta)| Some((name, meta.pane_pid?)))
+                .collect();
+        }
         let agents = aggregate_agents(
             instances,
             &processes,
-            &pane_pids,
+            &self.last_pane_pids,
             elapsed,
             &self.last_process_cpu,
         );

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -338,7 +338,7 @@ pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, O
                 Some(value) => value,
                 None => {
                     repaired += 1;
-                    get_hidden_env(name, key)
+                    get_hidden_env_uncached(name, key)
                 }
             };
             (name.to_string(), value)

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -278,58 +278,59 @@ fn invalidate_cache_entry(session_name: &str, key: &str) {
     }
 }
 
-/// Get hidden environment variables from multiple sessions in a single tmux command
+/// First character of the marker line each batched segment prints ahead of
+/// its `show-environment` output. A segment that fails (variable unset,
+/// session gone) then leaves its block empty instead of shifting every later
+/// line onto the wrong session.
+const BATCH_MARKER: char = '\u{1f}';
+
+/// Get a hidden environment variable from multiple sessions in one tmux
+/// command, returning `(session_name, value)` in input order.
 ///
-/// Attempts to batch-read from all sessions with a single command. Falls back to
-/// sequential reads if the batch command fails.
-///
-/// Returns a vector of (session_name, value) tuples in the same order as input.
+/// tmux runs every `;`-separated segment even after one fails and exits
+/// non-zero if any did, so the exit status is ignored and stdout is parsed by
+/// marker. Falls back to sequential reads only when no marker came back.
 pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, Option<String>)> {
     if session_names.is_empty() {
         return Vec::new();
     }
-
-    // Build a batch tmux command: each segment needs the full
-    // `show-environment -h` prefix since `;` is a command separator.
     let mut args: Vec<String> = Vec::new();
     for (i, session_name) in session_names.iter().enumerate() {
         if i > 0 {
             args.push(";".to_string());
         }
-        args.push("show-environment".to_string());
-        args.push("-h".to_string());
-        args.push("-t".to_string());
-        args.push(session_name.to_string());
-        args.push(key.to_string());
+        args.extend([
+            "display-message".to_string(),
+            "-p".to_string(),
+            "-t".to_string(),
+            session_name.to_string(),
+            format!("{BATCH_MARKER}{}", session_name.replace('#', "##")),
+            ";".to_string(),
+            "show-environment".to_string(),
+            "-h".to_string(),
+            "-t".to_string(),
+            session_name.to_string(),
+            key.to_string(),
+        ]);
     }
-
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let output = crate::tmux::tmux_command().args(&str_args).output();
-
     let fallback = || {
         session_names
             .iter()
             .map(|name| (name.to_string(), get_hidden_env(name, key)))
             .collect()
     };
-
     let results = match output {
-        Ok(out) if out.status.success() => {
+        Ok(out) => {
             let stdout = String::from_utf8_lossy(&out.stdout);
             parse_batch_output(&stdout, session_names).unwrap_or_else(|| {
-                tracing::debug!(target: "tmux.command", 
-                    "Batch env parse failed (line count mismatch for {} sessions), falling back to sequential reads",
-                    session_names.len()
+                tracing::debug!(target: "tmux.command",
+                    "Batch tmux show-environment returned no markers (exit {}), falling back to sequential reads",
+                    out.status
                 );
                 fallback()
             })
-        }
-        Ok(out) => {
-            tracing::debug!(target: "tmux.command",
-                "Batch tmux show-environment failed (exit {}), falling back to sequential reads",
-                out.status
-            );
-            fallback()
         }
         Err(ref e) => {
             tracing::debug!(target: "tmux.command",
@@ -357,34 +358,38 @@ pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, O
     results
 }
 
-/// Parse output from batch show-environment command.
-///
-/// Each session's output is on a separate line in the format "KEY=VALUE" or "-KEY".
-/// If the number of output lines does not match the number of sessions (e.g. due to
-/// tmux error lines), returns `None` so the caller can fall back to sequential reads.
+/// Parse marker-delimited batch output into per-session values, in input
+/// order. A session whose block is missing, empty, or `-KEY` (unset) reads as
+/// `None`. Returns `None` when no marker came back at all, so the caller can
+/// fall back to sequential reads.
 fn parse_batch_output(
     output: &str,
     session_names: &[&str],
 ) -> Option<Vec<(String, Option<String>)>> {
-    let lines: Vec<&str> = output.lines().collect();
-    if lines.len() != session_names.len() {
+    let mut values: HashMap<&str, String> = HashMap::new();
+    let mut current: Option<&str> = None;
+    let mut saw_marker = false;
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(name) = line.strip_prefix(BATCH_MARKER) {
+            saw_marker = true;
+            current = session_names.iter().copied().find(|n| *n == name);
+            continue;
+        }
+        let Some(name) = current else { continue };
+        if let Some((_, val)) = line.split_once('=').filter(|_| !line.starts_with('-')) {
+            values.insert(name, val.to_string());
+        }
+    }
+    if !saw_marker {
         return None;
     }
-    let mut results = Vec::new();
-
-    for (i, session_name) in session_names.iter().enumerate() {
-        let line = lines[i].trim();
-        let value = if line.starts_with('-') {
-            None
-        } else if let Some((_, val)) = line.split_once('=') {
-            Some(val.to_string())
-        } else {
-            None
-        };
-        results.push((session_name.to_string(), value));
-    }
-
-    Some(results)
+    Some(
+        session_names
+            .iter()
+            .map(|name| (name.to_string(), values.remove(name)))
+            .collect(),
+    )
 }
 
 #[cfg(test)]
@@ -488,56 +493,58 @@ mod tests {
         clear_env_cache();
     }
 
-    #[test]
-    fn test_parse_key_value() {
-        let output = "AOE_INSTANCE_ID=abc123";
-        let result = parse_batch_output(output, &["test_session"]).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].0, "test_session");
-        assert_eq!(result[0].1, Some("abc123".to_string()));
+    fn marked(name: &str, body: &str) -> String {
+        format!("{BATCH_MARKER}{name}\n{body}")
     }
 
     #[test]
-    fn test_parse_unset_key() {
-        let output = "-AOE_INSTANCE_ID";
-        let result = parse_batch_output(output, &["test_session"]).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].0, "test_session");
-        assert_eq!(result[0].1, None);
+    fn test_parse_batch_output_attributes_by_marker() {
+        let m = BATCH_MARKER;
+        // (output, sessions, expected values)
+        let cases = vec![
+            (
+                marked("s1", "AOE_INSTANCE_ID=abc123\n"),
+                &["s1"][..],
+                vec![Some("abc123")],
+            ),
+            (marked("s1", "-AOE_INSTANCE_ID\n"), &["s1"][..], vec![None]),
+            (
+                marked("s1", "KEY=value=with=equals\n"),
+                &["s1"][..],
+                vec![Some("value=with=equals")],
+            ),
+            // The regression: a session lacking the variable prints nothing
+            // between its marker and the next, and must not shift the rest.
+            (
+                format!("{m}s1\nAOE_INSTANCE_ID=abc123\n{m}s2\n{m}s3\nAOE_INSTANCE_ID=xyz789\n"),
+                &["s1", "s2", "s3"][..],
+                vec![Some("abc123"), None, Some("xyz789")],
+            ),
+            // A block for a session that was not asked about is ignored.
+            (
+                format!("{m}other\nAOE_INSTANCE_ID=nope\n{m}s1\nAOE_INSTANCE_ID=abc\n"),
+                &["s1"][..],
+                vec![Some("abc")],
+            ),
+            (
+                format!("  {m}s1  \n  AOE_INSTANCE_ID=value123  \n"),
+                &["s1"][..],
+                vec![Some("value123")],
+            ),
+        ];
+        for (output, sessions, expected) in cases {
+            let result = parse_batch_output(&output, sessions).unwrap();
+            let names: Vec<&str> = result.iter().map(|(n, _)| n.as_str()).collect();
+            assert_eq!(names, sessions, "order for {output:?}");
+            let values: Vec<Option<&str>> = result.iter().map(|(_, v)| v.as_deref()).collect();
+            assert_eq!(values, expected, "values for {output:?}");
+        }
     }
 
     #[test]
-    fn test_parse_multiple_sessions() {
-        let output = "AOE_INSTANCE_ID=abc123\n-AOE_INSTANCE_ID\nAOE_INSTANCE_ID=xyz789";
-        let result = parse_batch_output(output, &["session1", "session2", "session3"]).unwrap();
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].1, Some("abc123".to_string()));
-        assert_eq!(result[1].1, None);
-        assert_eq!(result[2].1, Some("xyz789".to_string()));
-    }
-
-    #[test]
-    fn test_parse_value_with_equals() {
-        let output = "KEY=value=with=equals";
-        let result = parse_batch_output(output, &["test_session"]).unwrap();
-        assert_eq!(result[0].1, Some("value=with=equals".to_string()));
-    }
-
-    #[test]
-    fn test_parse_line_count_mismatch_returns_none() {
-        let output = "";
-        assert!(parse_batch_output(output, &["session1", "session2"]).is_none());
-
-        let output = "VAL1\nVAL2\nVAL3";
-        assert!(parse_batch_output(output, &["session1"]).is_none());
-    }
-
-    #[test]
-    fn test_parse_whitespace_handling() {
-        let output = "  AOE_INSTANCE_ID=value123  \n  -AOE_INSTANCE_ID  ";
-        let result = parse_batch_output(output, &["session1", "session2"]).unwrap();
-        assert_eq!(result[0].1, Some("value123".to_string()));
-        assert_eq!(result[1].1, None);
+    fn test_parse_batch_output_without_markers_returns_none() {
+        assert!(parse_batch_output("", &["s1", "s2"]).is_none());
+        assert!(parse_batch_output("AOE_INSTANCE_ID=abc\n", &["s1"]).is_none());
     }
 
     #[test]

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -279,17 +279,20 @@ fn invalidate_cache_entry(session_name: &str, key: &str) {
 }
 
 /// First character of the marker line each batched segment prints ahead of
-/// its `show-environment` output. A segment that fails (variable unset,
-/// session gone) then leaves its block empty instead of shifting every later
-/// line onto the wrong session.
+/// its `show-environment` output, so a block that is empty (the session has
+/// no hidden vars) cannot shift every later line onto the wrong session.
 const BATCH_MARKER: char = '\u{1f}';
 
 /// Get a hidden environment variable from multiple sessions in one tmux
 /// command, returning `(session_name, value)` in input order.
 ///
-/// tmux runs every `;`-separated segment even after one fails and exits
-/// non-zero if any did, so the exit status is ignored and stdout is parsed by
-/// marker. Falls back to sequential reads only when no marker came back.
+/// tmux ABORTS a `;`-separated command list at the first command that fails,
+/// so no segment may fail: each one queries the session's whole hidden
+/// environment (`show-environment -h` with no variable exits 0 even when the
+/// variable, or every variable, is unset) rather than the single key, and the
+/// key is picked out of the marked block. A session that disappears mid-batch
+/// still truncates the run, so any session whose marker never came back is
+/// re-read sequentially instead of being reported as unset.
 pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, Option<String>)> {
     if session_names.is_empty() {
         return Vec::new();
@@ -310,36 +313,44 @@ pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, O
             "-h".to_string(),
             "-t".to_string(),
             session_name.to_string(),
-            key.to_string(),
         ]);
     }
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let output = crate::tmux::tmux_command().args(&str_args).output();
-    let fallback = || {
-        session_names
-            .iter()
-            .map(|name| (name.to_string(), get_hidden_env(name, key)))
-            .collect()
-    };
-    let results = match output {
+    let mut covered = match output {
         Ok(out) => {
             let stdout = String::from_utf8_lossy(&out.stdout);
-            parse_batch_output(&stdout, session_names).unwrap_or_else(|| {
-                tracing::debug!(target: "tmux.command",
-                    "Batch tmux show-environment returned no markers (exit {}), falling back to sequential reads",
-                    out.status
-                );
-                fallback()
-            })
+            parse_batch_output(&stdout, session_names, key)
         }
         Err(ref e) => {
             tracing::debug!(target: "tmux.command",
                 "Batch tmux show-environment error: {}, falling back to sequential reads",
                 e
             );
-            fallback()
+            HashMap::new()
         }
     };
+    let mut repaired = 0usize;
+    let results: Vec<(String, Option<String>)> = session_names
+        .iter()
+        .map(|name| {
+            let value = match covered.remove(name) {
+                Some(value) => value,
+                None => {
+                    repaired += 1;
+                    get_hidden_env(name, key)
+                }
+            };
+            (name.to_string(), value)
+        })
+        .collect();
+    if repaired > 0 {
+        tracing::debug!(target: "tmux.command",
+            "Batch tmux show-environment covered {} of {} sessions; read the rest sequentially",
+            session_names.len() - repaired,
+            session_names.len()
+        );
+    }
 
     if let Ok(mut cache) = ENV_CACHE.write() {
         let entries = cache.entries.get_or_insert_with(HashMap::new);
@@ -358,38 +369,35 @@ pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, O
     results
 }
 
-/// Parse marker-delimited batch output into per-session values, in input
-/// order. A session whose block is missing, empty, or `-KEY` (unset) reads as
-/// `None`. Returns `None` when no marker came back at all, so the caller can
-/// fall back to sequential reads.
-fn parse_batch_output(
+/// Parse marker-delimited batch output into `key`'s value per session.
+///
+/// Only sessions whose marker line came back are present in the map: an entry
+/// is the authoritative reading for that session (`None` = the key is unset),
+/// while an ABSENT session is one the run never reached and the caller must
+/// read separately. `-KEY` (explicitly removed) reads as unset.
+fn parse_batch_output<'a>(
     output: &str,
-    session_names: &[&str],
-) -> Option<Vec<(String, Option<String>)>> {
-    let mut values: HashMap<&str, String> = HashMap::new();
+    session_names: &[&'a str],
+    key: &str,
+) -> HashMap<&'a str, Option<String>> {
+    let prefix = format!("{key}=");
+    let mut values: HashMap<&str, Option<String>> = HashMap::new();
     let mut current: Option<&str> = None;
-    let mut saw_marker = false;
     for line in output.lines() {
         let line = line.trim();
         if let Some(name) = line.strip_prefix(BATCH_MARKER) {
-            saw_marker = true;
             current = session_names.iter().copied().find(|n| *n == name);
+            if let Some(name) = current {
+                values.entry(name).or_insert(None);
+            }
             continue;
         }
         let Some(name) = current else { continue };
-        if let Some((_, val)) = line.split_once('=').filter(|_| !line.starts_with('-')) {
-            values.insert(name, val.to_string());
+        if let Some(value) = line.strip_prefix(&prefix) {
+            values.insert(name, Some(value.to_string()));
         }
     }
-    if !saw_marker {
-        return None;
-    }
-    Some(
-        session_names
-            .iter()
-            .map(|name| (name.to_string(), values.remove(name)))
-            .collect(),
-    )
+    values
 }
 
 #[cfg(test)]
@@ -500,51 +508,68 @@ mod tests {
     #[test]
     fn test_parse_batch_output_attributes_by_marker() {
         let m = BATCH_MARKER;
-        // (output, sessions, expected values)
+        let key = "AOE_INSTANCE_ID";
+        // (output, sessions, expected per session: None = not covered by the
+        // run at all, Some(None) = covered and unset)
         let cases = vec![
             (
                 marked("s1", "AOE_INSTANCE_ID=abc123\n"),
                 &["s1"][..],
-                vec![Some("abc123")],
+                vec![Some(Some("abc123"))],
             ),
-            (marked("s1", "-AOE_INSTANCE_ID\n"), &["s1"][..], vec![None]),
+            // Covered but unset: the block is empty, or holds other keys only.
+            (marked("s1", ""), &["s1"][..], vec![Some(None)]),
             (
-                marked("s1", "KEY=value=with=equals\n"),
+                marked("s1", "AOE_CAPTURED_SESSION_ID=other\n"),
                 &["s1"][..],
-                vec![Some("value=with=equals")],
+                vec![Some(None)],
             ),
-            // The regression: a session lacking the variable prints nothing
-            // between its marker and the next, and must not shift the rest.
+            (
+                marked("s1", "-AOE_INSTANCE_ID\n"),
+                &["s1"][..],
+                vec![Some(None)],
+            ),
+            (
+                marked("s1", "AOE_INSTANCE_ID=value=with=equals\n"),
+                &["s1"][..],
+                vec![Some(Some("value=with=equals"))],
+            ),
+            // A session lacking the variable must not shift the rest.
             (
                 format!("{m}s1\nAOE_INSTANCE_ID=abc123\n{m}s2\n{m}s3\nAOE_INSTANCE_ID=xyz789\n"),
                 &["s1", "s2", "s3"][..],
-                vec![Some("abc123"), None, Some("xyz789")],
+                vec![Some(Some("abc123")), Some(None), Some(Some("xyz789"))],
             ),
+            // The regression: tmux aborts the list at a failing segment, so
+            // sessions past it produce no marker and must read as uncovered
+            // (the caller re-reads them) rather than as unset.
+            (
+                format!("{m}s1\nAOE_INSTANCE_ID=abc123\n"),
+                &["s1", "s2"][..],
+                vec![Some(Some("abc123")), None],
+            ),
+            (String::new(), &["s1", "s2"][..], vec![None, None]),
+            ("AOE_INSTANCE_ID=abc\n".to_string(), &["s1"][..], vec![None]),
             // A block for a session that was not asked about is ignored.
             (
                 format!("{m}other\nAOE_INSTANCE_ID=nope\n{m}s1\nAOE_INSTANCE_ID=abc\n"),
                 &["s1"][..],
-                vec![Some("abc")],
+                vec![Some(Some("abc"))],
             ),
             (
                 format!("  {m}s1  \n  AOE_INSTANCE_ID=value123  \n"),
                 &["s1"][..],
-                vec![Some("value123")],
+                vec![Some(Some("value123"))],
             ),
         ];
         for (output, sessions, expected) in cases {
-            let result = parse_batch_output(&output, sessions).unwrap();
-            let names: Vec<&str> = result.iter().map(|(n, _)| n.as_str()).collect();
-            assert_eq!(names, sessions, "order for {output:?}");
-            let values: Vec<Option<&str>> = result.iter().map(|(_, v)| v.as_deref()).collect();
-            assert_eq!(values, expected, "values for {output:?}");
+            let parsed = parse_batch_output(&output, sessions, key);
+            let got: Vec<Option<Option<&str>>> = sessions
+                .iter()
+                .map(|name| parsed.get(name).map(|v| v.as_deref()))
+                .collect();
+            assert_eq!(got, expected, "values for {output:?}");
         }
-    }
-
-    #[test]
-    fn test_parse_batch_output_without_markers_returns_none() {
-        assert!(parse_batch_output("", &["s1", "s2"]).is_none());
-        assert!(parse_batch_output("AOE_INSTANCE_ID=abc\n", &["s1"]).is_none());
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -247,6 +247,7 @@ pub struct PaneMetadata {
     pub pane_dead: bool,
     pub pane_current_command: Option<String>,
     pub pane_start_command_is_protected: bool,
+    pub pane_pid: Option<u32>,
 }
 
 static SESSION_CACHE: RwLock<SessionCache> = RwLock::new(SessionCache {
@@ -913,7 +914,7 @@ pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
             "list-panes",
             "-a",
             "-F",
-            "#{session_name}|#{pane_index}|#{pane_dead}|#{pane_current_command}|#{pane_start_command}",
+            "#{session_name}|#{pane_index}|#{pane_dead}|#{pane_current_command}|#{pane_start_command}|#{pane_pid}",
         ])
         .output();
 
@@ -1020,7 +1021,7 @@ fn parse_pane_metadata(output: &str) -> HashMap<String, PaneMetadata> {
             Some(pane_index),
             Some(pane_dead),
             Some(pane_current_command),
-            Some(pane_start_command),
+            Some(rest),
         ) = (
             parts.next(),
             parts.next(),
@@ -1030,6 +1031,12 @@ fn parse_pane_metadata(output: &str) -> HashMap<String, PaneMetadata> {
         )
         else {
             continue;
+        };
+        // The start command may itself contain the separator, so the pid is
+        // split off the tail rather than the command off the head.
+        let (pane_start_command, pane_pid) = match rest.rsplit_once(FIELD_SEP) {
+            Some((command, pid)) => (command, pid.trim().parse().ok()),
+            None => (rest, None),
         };
         if !session_name.starts_with(SESSION_PREFIX) {
             continue;
@@ -1050,6 +1057,7 @@ fn parse_pane_metadata(output: &str) -> HashMap<String, PaneMetadata> {
             session_name.to_string(),
             PaneMetadata {
                 pane_dead: pane_dead == "1",
+                pane_pid,
                 pane_current_command: if pane_current_command.is_empty() {
                     None
                 } else {
@@ -1820,6 +1828,7 @@ mod tests {
                             pane_dead: false,
                             pane_current_command: None,
                             pane_start_command_is_protected: false,
+                            pane_pid: None,
                         },
                     )
                 })
@@ -1887,6 +1896,7 @@ mod tests {
             pane_dead: dead,
             pane_current_command: None,
             pane_start_command_is_protected: false,
+            pane_pid: None,
         }
     }
 
@@ -2080,13 +2090,14 @@ mod tests {
 
     #[test]
     fn test_parse_pane_metadata_basic() {
-        let output = format!("{P}my_proj_abc12345|0|0|claude|claude\n");
+        let output = format!("{P}my_proj_abc12345|0|0|claude|claude|4242\n");
         let map = parse_pane_metadata(&output);
         assert_eq!(map.len(), 1);
         let meta = map.get(&format!("{P}my_proj_abc12345")).unwrap();
         assert!(!meta.pane_dead);
         assert_eq!(meta.pane_current_command.as_deref(), Some("claude"));
         assert!(!meta.pane_start_command_is_protected);
+        assert_eq!(meta.pane_pid, Some(4242));
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -396,11 +396,11 @@ enum GridReconcile {
 /// Geometry wins: a resize reseeds anyway, so there is no point ruling on a
 /// cursor that the reflow is about to move.
 ///
-/// The cursor check exists because nothing else resyncs the grid. `pipe-pane`
-/// is a one-way byte stream with no acknowledgement, so any byte the grid
-/// misses (or applies twice) is a permanent divergence, and before this the
-/// only reseed was on a size change: a pane that never resized stayed wrong
-/// indefinitely.
+/// The cursor check is the grid's resync for a pane that is being watched but
+/// never resizes. `pipe-pane` is a one-way byte stream with no
+/// acknowledgement, so any byte the grid misses (or applies twice) is a
+/// permanent divergence, and before this the only reseed was on a size change:
+/// a pane that never resized stayed wrong indefinitely.
 ///
 /// Confirming across two passes is what keeps it from firing on a race. The
 /// probe is a fork, so a pane that emits output between the grid's last applied
@@ -570,16 +570,19 @@ fn seed_parser(
     app_cursor: &AtomicBool,
     cols: u16,
     rows: u16,
-) {
+) -> bool {
     let Some((body, state)) = capture_seed_snapshot(target) else {
-        return;
+        return false;
     };
     let stream = assemble_seed_stream(&body, &state, rows);
-    if let Ok(mut p) = parser.lock() {
-        *p = vt100::Parser::new(rows, cols, SCROLLBACK_LINES);
-        p.process(&stream);
-        app_cursor.store(p.screen().application_cursor(), Ordering::Relaxed);
-    }
+    parser
+        .lock()
+        .map(|mut p| {
+            *p = vt100::Parser::new(rows, cols, SCROLLBACK_LINES);
+            p.process(&stream);
+            app_cursor.store(p.screen().application_cursor(), Ordering::Relaxed);
+        })
+        .is_ok()
 }
 
 /// How many times [`capture_seed_snapshot`] re-runs the probe/capture/probe
@@ -1553,11 +1556,13 @@ impl VtChannel {
     ///
     /// - **geometry changed**, the original trigger.
     /// - **the cursor drifted** and stayed drifted across a pass with no output
-    ///   in between, which means the grid genuinely diverged from tmux. This is
-    ///   the only resync the grid has: `pipe-pane` is an unacknowledged one-way
-    ///   stream, so a missed or doubled byte is permanent, and a pane that never
-    ///   resizes used to carry that divergence forever. `reconcile_step` owns the
-    ///   race-vs-drift call.
+    ///   in between, which means the grid genuinely diverged from tmux:
+    ///   `pipe-pane` is an unacknowledged one-way stream, so a missed or doubled
+    ///   byte is permanent, and a pane that never resizes used to carry that
+    ///   divergence forever. `reconcile_step` owns the race-vs-drift call, and
+    ///   deliberately does not reseed while output is flowing. A cursor-clean
+    ///   divergence is caught instead by the capture worker's periodic
+    ///   [`VtChannel::resync_from_pane`].
     fn reconcile_grid(&self) {
         let mut guard = self.last_size_check.lock().unwrap();
         if guard.elapsed() < Duration::from_secs(1) {
@@ -1625,20 +1630,22 @@ impl VtChannel {
     /// Rebuild the grid from `capture-pane` and clear any armed drift, so the
     /// freshly seeded cursor is not immediately re-judged against a stale
     /// generation.
-    fn reseed(&self, cols: u16, rows: u16) {
-        seed_parser(&self.target, &self.parser, &self.app_cursor, cols, rows);
+    fn reseed(&self, cols: u16, rows: u16) -> bool {
+        let seeded = seed_parser(&self.target, &self.parser, &self.app_cursor, cols, rows);
         self.grid_gen.fetch_add(1, Ordering::Relaxed);
         self.clear_drift();
+        seeded
     }
 
     /// Rebuild the grid from a fresh `capture-pane` at its current size, the
     /// seed `acquire` starts from, so a grid that has stably diverged from
-    /// tmux cannot stand indefinitely.
-    pub(crate) fn resync_from_pane(&self) {
+    /// tmux cannot stand indefinitely. False when the pane could not be
+    /// captured, so the caller can retry sooner than its normal interval.
+    pub(crate) fn resync_from_pane(&self) -> bool {
         self.reseed(
             self.cols.load(Ordering::Relaxed),
             self.rows.load(Ordering::Relaxed),
-        );
+        )
     }
 
     /// Serialise up to `max_lines` of (scrollback + screen) to per-row ANSI,

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -1631,6 +1631,16 @@ impl VtChannel {
         self.clear_drift();
     }
 
+    /// Rebuild the grid from a fresh `capture-pane` at its current size, the
+    /// seed `acquire` starts from, so a grid that has stably diverged from
+    /// tmux cannot stand indefinitely.
+    pub(crate) fn resync_from_pane(&self) {
+        self.reseed(
+            self.cols.load(Ordering::Relaxed),
+            self.rows.load(Ordering::Relaxed),
+        );
+    }
+
     /// Serialise up to `max_lines` of (scrollback + screen) to per-row ANSI,
     /// plus the authoritative cursor (with `history_size` set to the full
     /// scrollback depth). `max_lines` mirrors the capture path's window: both

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -717,10 +717,12 @@ const LIVE_CAPTURE_INTERVAL_IDLE_MS: u64 = 250;
 /// one cheap failed attempt per interval rather than one per 25ms tick.
 const VT_REARM_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
-/// How long the VT grid stands as the sole source of truth before the worker
-/// re-seeds it from `capture-pane`. Bounds a grid that has stably diverged
-/// from tmux (a dropped byte, a reflow the stream did not carry) at one fork
-/// per interval, off the render thread.
+/// How long the VT grid stands as the sole source of truth, and how long the
+/// pane must have been quiet, before the worker re-seeds it from
+/// `capture-pane`. Bounds a grid that has stably diverged from tmux (a dropped
+/// byte, a reflow the stream did not carry) at one seed per interval, off the
+/// render thread. A streaming pane is skipped: its own output heals the grid,
+/// and a seed taken mid-burst races the reader.
 const VT_RESYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Cloneable handle that nudges a [`LiveCaptureWorker`] out of its
@@ -808,6 +810,9 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// down an armed channel (disabling its `pipe-pane`) and falls back to
     /// the capture path in place, no restart needed.
     vt_enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Whether the last cycle sampled a live VT grid rather than forking
+    /// `capture-pane`; see [`Self::vt_active`].
+    vt_active: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Whether the raw OSC 52 observer may run when terminal rendering uses
     /// capture-pane. Mirrors the Clipboard Pass-through setting, so disabled
     /// mode does not keep a second pipe-pane connection open.
@@ -1015,6 +1020,8 @@ impl LiveCaptureWorker {
         let clipboard_capture_enabled = Arc::new(AtomicBool::new(false));
         let cycles = Arc::new(AtomicU64::new(0));
         let cycles_cell = cycles.clone();
+        let vt_active = Arc::new(AtomicBool::new(false));
+        let vt_active_cell = vt_active.clone();
         let lines_cell = capture_lines.clone();
         let target_cell = target.clone();
         let slot = latest.clone();
@@ -1067,7 +1074,7 @@ impl LiveCaptureWorker {
             #[cfg(unix)]
             let mut last_vt_arm: Option<std::time::Instant> = None;
             #[cfg(unix)]
-            let mut last_vt_resync: Option<std::time::Instant> = None;
+            let mut next_vt_resync: Option<std::time::Instant> = None;
             #[cfg(unix)]
             let mut last_osc52_arm: Option<std::time::Instant> = None;
             // Panes in the target window, refreshed on the lazy
@@ -1119,7 +1126,7 @@ impl LiveCaptureWorker {
                     {
                         vt_source = None;
                         last_vt_arm = None;
-                        last_vt_resync = None;
+                        next_vt_resync = None;
                         osc52_source = None;
                         osc52_seen = 0;
                         last_osc52_arm = None;
@@ -1232,7 +1239,7 @@ impl LiveCaptureWorker {
                             // the remainder of a poll interval.
                             if let Some(v) = vt_source.as_ref() {
                                 v.set_change_wakeup(nudge_thread.clone());
-                                last_vt_resync = last_vt_arm;
+                                next_vt_resync = last_vt_arm.map(|t| t + VT_RESYNC_INTERVAL);
                             }
                         }
                         // A channel whose forwarder has disconnected stops
@@ -1246,10 +1253,17 @@ impl LiveCaptureWorker {
                         }
                         match vt_source.as_ref() {
                             Some(v) => {
-                                if last_vt_resync.is_none_or(|t| t.elapsed() >= VT_RESYNC_INTERVAL)
-                                {
-                                    last_vt_resync = Some(std::time::Instant::now());
-                                    v.resync_from_pane();
+                                let now = std::time::Instant::now();
+                                let quiet = last_published_at
+                                    .is_none_or(|t| t.elapsed() >= VT_RESYNC_INTERVAL);
+                                if quiet && next_vt_resync.is_none_or(|at| at <= now) {
+                                    // A failed seed retries on the arm cadence
+                                    // rather than standing for a full interval.
+                                    next_vt_resync = Some(if v.resync_from_pane() {
+                                        now + VT_RESYNC_INTERVAL
+                                    } else {
+                                        now + VT_REARM_INTERVAL
+                                    });
                                 }
                                 clipboard_now = v.take_clipboard();
                                 if composite {
@@ -1402,6 +1416,7 @@ impl LiveCaptureWorker {
                 let vt_active = vt_source.as_ref().is_some_and(|v| v.is_alive());
                 #[cfg(not(unix))]
                 let vt_active = false;
+                vt_active_cell.store(vt_active, Ordering::Relaxed);
                 let ms = if vt_active {
                     LIVE_CAPTURE_INTERVAL_FAST_MS
                 } else {
@@ -1431,6 +1446,7 @@ impl LiveCaptureWorker {
             cursor,
             clipboard,
             vt_enabled,
+            vt_active,
             clipboard_capture_enabled,
             cycles,
         }
@@ -1571,6 +1587,14 @@ impl LiveCaptureWorker {
     /// "nothing changed".
     pub(in crate::tui) fn cycles(&self) -> u64 {
         self.cycles.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Whether the worker is sampling a live VT grid. A VT worker re-seeds its
+    /// own grid, so the render thread can leave its fallback fork off for as
+    /// long as the worker pulses; a `capture-pane` worker publishes nothing for
+    /// a pane that is gone, so that fallback has to stay bounded.
+    pub(in crate::tui) fn vt_active(&self) -> bool {
+        self.vt_active.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// The newest cursor for the worker's CURRENT target pane, or `None`

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -717,6 +717,12 @@ const LIVE_CAPTURE_INTERVAL_IDLE_MS: u64 = 250;
 /// one cheap failed attempt per interval rather than one per 25ms tick.
 const VT_REARM_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
+/// How long the VT grid stands as the sole source of truth before the worker
+/// re-seeds it from `capture-pane`. Bounds a grid that has stably diverged
+/// from tmux (a dropped byte, a reflow the stream did not carry) at one fork
+/// per interval, off the render thread.
+const VT_RESYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Cloneable handle that nudges a [`LiveCaptureWorker`] out of its
 /// inter-capture wait. Handed to [`LiveSendWorker`] so a dispatched
 /// keystroke batch triggers an immediate capture of the typed echo rather
@@ -1061,6 +1067,8 @@ impl LiveCaptureWorker {
             #[cfg(unix)]
             let mut last_vt_arm: Option<std::time::Instant> = None;
             #[cfg(unix)]
+            let mut last_vt_resync: Option<std::time::Instant> = None;
+            #[cfg(unix)]
             let mut last_osc52_arm: Option<std::time::Instant> = None;
             // Panes in the target window, refreshed on the lazy
             // `PANE_COUNT_PROBE_MS` cadence. The seed only covers the window
@@ -1111,6 +1119,7 @@ impl LiveCaptureWorker {
                     {
                         vt_source = None;
                         last_vt_arm = None;
+                        last_vt_resync = None;
                         osc52_source = None;
                         osc52_seen = 0;
                         last_osc52_arm = None;
@@ -1223,6 +1232,7 @@ impl LiveCaptureWorker {
                             // the remainder of a poll interval.
                             if let Some(v) = vt_source.as_ref() {
                                 v.set_change_wakeup(nudge_thread.clone());
+                                last_vt_resync = last_vt_arm;
                             }
                         }
                         // A channel whose forwarder has disconnected stops
@@ -1236,6 +1246,11 @@ impl LiveCaptureWorker {
                         }
                         match vt_source.as_ref() {
                             Some(v) => {
+                                if last_vt_resync.is_none_or(|t| t.elapsed() >= VT_RESYNC_INTERVAL)
+                                {
+                                    last_vt_resync = Some(std::time::Instant::now());
+                                    v.resync_from_pane();
+                                }
                                 clipboard_now = v.take_clipboard();
                                 if composite {
                                     capture_composited_over_grid(

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -190,35 +190,14 @@ fn preview_frozen(scroll_offset: u16, has_selection: bool) -> bool {
 /// `capture-pane` fallback fires no more often than this.
 const PREVIEW_REFRESH_MS: u128 = 250;
 
-/// Ceiling on how long the capture worker may be the sole source of truth.
-///
-/// The 250ms poll was incidentally a self-healing authoritative refresh: it
-/// overwrote the cache with real `capture-pane` output four times a second, so
-/// any divergence between the worker's picture of the pane and tmux's was
-/// repaired before anyone saw it. Suppressing it removes that net for the one
-/// failure a cycle counter cannot see, a worker that cycles at full rate while
-/// being confidently wrong (its VT grid stably diverged, so `last_captured`
-/// matches every cycle and nothing publishes). This restores the self-heal at
-/// one fortieth of the old fork rate, which keeps essentially all of the win.
-const WORKER_TRUST_CEILING_MS: u128 = 10_000;
-
-/// Whether the idle poll should pay for a synchronous `capture-pane`.
-///
-/// Three ways it does not:
-/// - inside the cadence, which is the pre-existing throttle;
-/// - while frozen (reading scrollback or holding a selection), because a fresh
-///   bottom-anchored snapshot would shift the held content out from under the
-///   reader or the drag. Session change, resize, and the reading grow refresh
-///   through their own clauses regardless;
-/// - while the capture worker is pulsing, because it publishes every change,
-///   so a fork here could only re-read identical bytes at 10-50ms on the
-///   render thread. That suppression expires at [`WORKER_TRUST_CEILING_MS`],
-///   so a worker that is wrong rather than wedged still gets corrected.
+/// Whether the idle poll should pay for a synchronous `capture-pane`: only
+/// past the cadence, never while frozen (a fresh bottom-anchored snapshot
+/// would shift held content out from under a reader or a drag), and never
+/// while the capture worker is pulsing, since it publishes every change and
+/// re-seeds its own grid on `VT_RESYNC_INTERVAL`. Session change, resize, and
+/// the reading grow refresh through their own clauses regardless.
 fn idle_poll_due(frozen: bool, idle_elapsed_ms: u128, worker_covers_idle: bool) -> bool {
-    if frozen || idle_elapsed_ms <= PREVIEW_REFRESH_MS {
-        return false;
-    }
-    !worker_covers_idle || idle_elapsed_ms > WORKER_TRUST_CEILING_MS
+    !frozen && idle_elapsed_ms > PREVIEW_REFRESH_MS && !worker_covers_idle
 }
 
 /// How an observed capture-worker cycle counter folds into a liveness verdict,
@@ -2291,8 +2270,8 @@ impl HomeView {
         // content flowing on its own thread; `apply_worker_capture` below
         // just applies the newest it has produced. The synchronous fork via
         // `refresh_preview_cache_core` remains as the cold-start fallback,
-        // plus the wedged-worker and trust-ceiling paths in `idle_poll_due`;
-        // a worker that is merely idle no longer trips it. This
+        // plus the wedged-worker path in `idle_poll_due`; a worker that is
+        // merely idle no longer trips it. This
         // moves the per-frame capture cost (~8.5ms on macOS, ~90% of a
         // frame; the `tui.render` `capture_us` trace measures it) off the
         // render thread for every view, not just agent live-send.
@@ -4213,13 +4192,12 @@ mod tests {
     // `home/tests.rs`, which renders a real frame and asserts
     // `preview_visible_rows == preview_pane_area.height`.
 
-    /// The idle-poll gate itself. A pulsing worker suppresses the fork, but
-    /// only up to the trust ceiling, so a worker that is confidently wrong
-    /// rather than wedged still gets corrected (njbrake on #3559).
+    /// The idle-poll gate itself: a pulsing worker suppresses the fork for as
+    /// long as it pulses, since the worker owns the grid resync (#3559).
     #[test]
-    fn idle_poll_due_suppresses_a_pulsing_worker_only_until_the_trust_ceiling() {
+    fn idle_poll_due_suppresses_a_pulsing_worker() {
         let past_cadence = PREVIEW_REFRESH_MS + 1;
-        let past_ceiling = WORKER_TRUST_CEILING_MS + 1;
+        let long_idle = PREVIEW_REFRESH_MS * 1_000;
         // (frozen, elapsed_ms, worker_covers_idle, expected)
         let cases = [
             // Inside the cadence: the pre-existing throttle, worker or not.
@@ -4227,13 +4205,12 @@ mod tests {
             (false, PREVIEW_REFRESH_MS, true, false),
             // Past the cadence with no trustworthy worker: fork, as before.
             (false, past_cadence, false, true),
-            // Past the cadence with a pulsing worker: this is the whole fix.
+            // Past the cadence with a pulsing worker: never fork here.
             (false, past_cadence, true, false),
-            // Past the ceiling: the self-heal fires even while pulsing.
-            (false, past_ceiling, true, true),
+            (false, long_idle, true, false),
             // Frozen wins over everything; the reader's content must not move.
             (true, past_cadence, false, false),
-            (true, past_ceiling, false, false),
+            (true, long_idle, false, false),
         ];
         for (frozen, elapsed, covered, expected) in cases {
             assert_eq!(

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -190,14 +190,31 @@ fn preview_frozen(scroll_offset: u16, has_selection: bool) -> bool {
 /// `capture-pane` fallback fires no more often than this.
 const PREVIEW_REFRESH_MS: u128 = 250;
 
+/// Ceiling on how long a pulsing `capture-pane` worker suppresses the
+/// fallback fork. That worker publishes nothing for a pane that is gone, so
+/// without a ceiling a stale preview would stand forever. A VT worker re-seeds
+/// its own grid on `VT_RESYNC_INTERVAL` and needs none.
+const WORKER_TRUST_CEILING_MS: u128 = 10_000;
+
 /// Whether the idle poll should pay for a synchronous `capture-pane`: only
-/// past the cadence, never while frozen (a fresh bottom-anchored snapshot
-/// would shift held content out from under a reader or a drag), and never
-/// while the capture worker is pulsing, since it publishes every change and
-/// re-seeds its own grid on `VT_RESYNC_INTERVAL`. Session change, resize, and
-/// the reading grow refresh through their own clauses regardless.
-fn idle_poll_due(frozen: bool, idle_elapsed_ms: u128, worker_covers_idle: bool) -> bool {
-    !frozen && idle_elapsed_ms > PREVIEW_REFRESH_MS && !worker_covers_idle
+/// past the cadence; never while frozen (a fresh bottom-anchored snapshot
+/// would shift held content out from under a reader or a drag); never while
+/// the worker pulses on a VT grid; and only past [`WORKER_TRUST_CEILING_MS`]
+/// while a `capture-pane` worker pulses. Session change, resize, and the
+/// reading grow refresh through their own clauses regardless.
+fn idle_poll_due(
+    frozen: bool,
+    idle_elapsed_ms: u128,
+    worker_covers_idle: bool,
+    worker_is_vt: bool,
+) -> bool {
+    if frozen || idle_elapsed_ms <= PREVIEW_REFRESH_MS {
+        return false;
+    }
+    if !worker_covers_idle {
+        return true;
+    }
+    !worker_is_vt && idle_elapsed_ms > WORKER_TRUST_CEILING_MS
 }
 
 /// How an observed capture-worker cycle counter folds into a liveness verdict,
@@ -2035,6 +2052,10 @@ impl HomeView {
         // `apply_worker_capture` almost always has a fresh frame to hand over
         // and returns before this.
         let worker_covers_idle = self.observe_worker_pulse();
+        let worker_is_vt = self
+            .preview_capture_worker
+            .as_ref()
+            .is_some_and(|worker| worker.vt_active());
 
         let cache = select(self);
         let idle_elapsed = cache.last_refresh.elapsed().as_millis();
@@ -2047,7 +2068,7 @@ impl HomeView {
                 visible_rows,
                 scroll_offset,
             )
-            || idle_poll_due(frozen, idle_elapsed, worker_covers_idle);
+            || idle_poll_due(frozen, idle_elapsed, worker_covers_idle, worker_is_vt);
         if !needs_refresh {
             return;
         }
@@ -2270,8 +2291,8 @@ impl HomeView {
         // content flowing on its own thread; `apply_worker_capture` below
         // just applies the newest it has produced. The synchronous fork via
         // `refresh_preview_cache_core` remains as the cold-start fallback,
-        // plus the wedged-worker path in `idle_poll_due`; a worker that is
-        // merely idle no longer trips it. This
+        // plus the wedged-worker and capture-pane-ceiling paths in
+        // `idle_poll_due`; a worker that is merely idle no longer trips it. This
         // moves the per-frame capture cost (~8.5ms on macOS, ~90% of a
         // frame; the `tui.render` `capture_us` trace measures it) off the
         // render thread for every view, not just agent live-send.
@@ -4192,31 +4213,36 @@ mod tests {
     // `home/tests.rs`, which renders a real frame and asserts
     // `preview_visible_rows == preview_pane_area.height`.
 
-    /// The idle-poll gate itself: a pulsing worker suppresses the fork for as
-    /// long as it pulses, since the worker owns the grid resync (#3559).
+    /// The idle-poll gate itself: a pulsing VT worker suppresses the fork for
+    /// as long as it pulses (it owns the grid resync, #3559), while a pulsing
+    /// `capture-pane` worker is trusted only up to the ceiling.
     #[test]
-    fn idle_poll_due_suppresses_a_pulsing_worker() {
+    fn idle_poll_due_trusts_a_vt_worker_and_bounds_a_capture_worker() {
         let past_cadence = PREVIEW_REFRESH_MS + 1;
-        let long_idle = PREVIEW_REFRESH_MS * 1_000;
-        // (frozen, elapsed_ms, worker_covers_idle, expected)
+        let past_ceiling = WORKER_TRUST_CEILING_MS + 1;
+        // (frozen, elapsed_ms, worker_covers_idle, worker_is_vt, expected)
         let cases = [
             // Inside the cadence: the pre-existing throttle, worker or not.
-            (false, PREVIEW_REFRESH_MS, false, false),
-            (false, PREVIEW_REFRESH_MS, true, false),
+            (false, PREVIEW_REFRESH_MS, false, false, false),
+            (false, PREVIEW_REFRESH_MS, true, true, false),
             // Past the cadence with no trustworthy worker: fork, as before.
-            (false, past_cadence, false, true),
-            // Past the cadence with a pulsing worker: never fork here.
-            (false, past_cadence, true, false),
-            (false, long_idle, true, false),
+            (false, past_cadence, false, false, true),
+            (false, past_cadence, false, true, true),
+            // A pulsing VT worker: never fork, however long it has been.
+            (false, past_cadence, true, true, false),
+            (false, past_ceiling, true, true, false),
+            // A pulsing capture-pane worker: trusted only until the ceiling.
+            (false, past_cadence, true, false, false),
+            (false, past_ceiling, true, false, true),
             // Frozen wins over everything; the reader's content must not move.
-            (true, past_cadence, false, false),
-            (true, long_idle, false, false),
+            (true, past_cadence, false, false, false),
+            (true, past_ceiling, true, false, false),
         ];
-        for (frozen, elapsed, covered, expected) in cases {
+        for (frozen, elapsed, covered, vt, expected) in cases {
             assert_eq!(
-                idle_poll_due(frozen, elapsed, covered),
+                idle_poll_due(frozen, elapsed, covered, vt),
                 expected,
-                "frozen={frozen} elapsed={elapsed} covered={covered}"
+                "frozen={frozen} elapsed={elapsed} covered={covered} vt={vt}"
             );
         }
     }

--- a/tests/integration/hidden_env_batch.rs
+++ b/tests/integration/hidden_env_batch.rs
@@ -1,0 +1,75 @@
+//! `get_hidden_env_batch` against a real tmux server.
+//!
+//! tmux aborts a `;`-separated command list at the first command that fails,
+//! so a session whose key is unset truncates every later segment. The batch
+//! must not report those sessions as unset.
+
+use agent_of_empires::tmux::test_support as env;
+use serial_test::serial;
+use std::process::Command;
+
+struct Cleanup(Vec<String>);
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        for name in &self.0 {
+            let _ = Command::new("tmux")
+                .arg("-S")
+                .arg(crate::common::tmux_socket())
+                .args(["kill-session", "-t", name])
+                .output();
+        }
+    }
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+#[serial]
+fn batch_reads_sessions_after_one_without_the_key() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not on PATH");
+        return;
+    }
+    let socket = crate::common::tmux_socket();
+    let names = ["aoe_hb_a", "aoe_hb_b", "aoe_hb_c"];
+    let mut cleanup = Cleanup(Vec::new());
+    for name in names {
+        let out = Command::new("tmux")
+            .arg("-S")
+            .arg(&socket)
+            .args(["new-session", "-d", "-s", name, "sh"])
+            .output()
+            .expect("tmux new-session");
+        assert!(
+            out.status.success(),
+            "new-session {name}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        cleanup.0.push(name.to_string());
+    }
+    // The middle session deliberately has no AOE_INSTANCE_ID, like a paired
+    // terminal session.
+    env::set_hidden_env(names[0], env::AOE_INSTANCE_ID_KEY, "aaa").unwrap();
+    env::set_hidden_env(names[2], env::AOE_INSTANCE_ID_KEY, "ccc").unwrap();
+
+    let got = env::get_hidden_env_batch(&names, env::AOE_INSTANCE_ID_KEY);
+    let got: Vec<(&str, Option<&str>)> = got
+        .iter()
+        .map(|(n, v)| (n.as_str(), v.as_deref()))
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            ("aoe_hb_a", Some("aaa")),
+            ("aoe_hb_b", None),
+            ("aoe_hb_c", Some("ccc")),
+        ]
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -14,6 +14,7 @@ mod config_merge;
 mod config_wiring;
 mod diff_integration;
 mod group_persistence;
+mod hidden_env_batch;
 mod hooks_config;
 mod migration_pipeline;
 mod parallel_capture;


### PR DESCRIPTION
## Description

Profiling the TUI on a host with 13 live sessions showed its CPU almost entirely in fork/spawn/read of child processes. Four sources removed or reduced:

- Batched `tmux show-environment` failed on every cycle (a paired terminal lacks `AOE_INSTANCE_ID`, tmux exits 1) and degraded to one fork per session per session-id poll. Segments now print a marker and stdout is parsed by marker.
- Health-strip sampler ran `ps -A -E` plus one `display-message` per session every second; now one `list-panes -a` (`PaneMetadata.pane_pid`).
- `docker stats` TTL 5s to 15s (the 2s command was in flight ~40% of the time).
- The 10s VT self-heal `capture-pane` moves from the render thread into the capture worker.

Measured, same state: 0 batch fallbacks (was ~1 per 1.6s), CPU ~5% (was ~13%), 1 over-budget frame per 30s idle (was ~1 per 3s).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Lib suite 6472 passed. `acp_runner_control::runner_accepts_next_relay_after_outbound_half_close` (#3578) fails on this macOS host before and after; not touched here.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the behavior is subprocess cadence, covered by unit tests on the batch parser, pane metadata parser, and idle-poll gate; an e2e harness cannot observe fork counts.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5 via Claude Code

**Any Additional AI Details you'd like to share:** Profiling (macOS `sample` on a symbolized dev-release build, child-process census, trace-log frame timings), the diagnosis, and the patch were done by the model; scope and decisions were @njbrake's.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR was drafted by Claude Fable 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LA6mGvA7MZccn8oMAspUyr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR reduces idle CPU use and render-thread work in the TUI.

- Parses batched tmux environment data reliably and repairs incomplete results.
- Collects pane process IDs with one tmux call and validates reused panes.
- Increases Docker stats refresh intervals from 5 to 15 seconds.
- Moves VT resynchronization to the capture worker and retries failed attempts sooner.
- Limits synchronous `capture-pane` calls while workers are active.
- Adds parser, process-identity, idle-poll, and real-tmux integration tests.

These changes reduce unnecessary subprocess activity and improve idle frame timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->