### PR TITLE
test(session): re-force the tmux cache before each probe in the resolved-name status test

### DIFF
--- a/src/session/instance/status_update.rs
+++ b/src/session/instance/status_update.rs
@@ -530,10 +530,16 @@ mod tests {
         let resolved = format!("{}live_elsewhere_00000000", crate::tmux::SESSION_PREFIX);
 
         let guard = crate::tmux::SessionCacheGuard::capture();
-        guard.force_present(&[resolved.as_str()]);
 
+        // Force the snapshot immediately before each probe. `#[serial]` only
+        // excludes other serial tests, and the resolved-name pass below spawns
+        // tmux for pane metadata and capture; a parallel test refreshing the
+        // process-global cache during that window (routine on a suite whose
+        // tmux server comes and goes) leaves a `data: None` snapshot, and the
+        // second probe then reads Unknown instead of Absent.
         let mut inst = Instance::new("resolve-r2", "/tmp/resolve-r2");
         inst.status = Status::Running;
+        guard.force_present(&[resolved.as_str()]);
         inst.update_status_with_metadata_inner(None, Some(&resolved));
         assert!(
             inst.ever_confirmed_present,
@@ -543,6 +549,7 @@ mod tests {
 
         let mut untold = Instance::new("resolve-r2", "/tmp/resolve-r2");
         untold.status = Status::Running;
+        guard.force_present(&[resolved.as_str()]);
         untold.update_status_with_metadata_inner(None, None);
         assert_eq!(
             untold.status,


### PR DESCRIPTION
## Description

`Cargo Test (macos)` failed on 6 of its last 20 real runs (it is skipped on PRs, so 20 of the last 100 `tests.yml` runs actually ran it). 5 of those 6 were the same assertion, always `left: Running, right: Error`:

```
session::instance::status_update::tests::update_status_probes_the_resolved_name_not_the_title
assertion `left == right` failed: without the resolved name the title-derived name is absent from the cache
```

The test forces the process-global `SESSION_CACHE` once, then runs two probes with a full detection pass between them. That pass spawns tmux four times (pane-dead, `pane_current_command`, `capture_pane`, shell check). `#[serial_test::serial]` only excludes other *serial* tests, so any parallel test calling `refresh_session_cache()` in that window lands on "no server running" (the suite's tmux server comes and goes) and stores a fresh `data: None` snapshot. The second probe then reads `SessionExistence::Unknown` rather than `Absent`, and the grace window at `status_update.rs:200` correctly retains `Running`.

Evidence the clobber came from another thread: the failing test's captured stdout carries no `tmux.cache: session cache refreshed` line, and `unknown_since.elapsed()` is sub-microsecond, so `Unknown` was the first answer the second probe got.

macOS is where this bites because tmux commands measure ~177ms there against ~10ms on Linux, widening the window by an order of magnitude.

The production path is correct as written. `Unknown` -> hold status -> escalate after a bounded window is deliberate, and `UNKNOWN_ERROR_WINDOW_CONFIRMED_PRESENT` is sized against a measured ~11s real blip. Collapsing the cache's `data: None` into `Absent` for the recognized no-server case (the way `resolved_agent_existence` does for rekeying) would also make this test pass, but `error connecting to <socket> (No such file or directory)` classifies as no-server and is exactly the transient blip the window exists to absorb, so that would reopen the false-Error-latch bug.

Fix: force the snapshot immediately before each probe, shrinking the exposed window from ~30ms of tmux work to the gap between `force_present` and the cache read. Mirrors `test_confirmed_absent_session_still_latches_error`, which has never flaked.

Not addressed here: `tmux::session::tests::wait_until_ready_blocks_until_the_marker_appears` failed once in the same 20 runs. Same family, opposite direction (a serial test's forced snapshot leaking into a parallel test that needs the real one), lower frequency, different fix.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Verification: injecting a single `refresh_session_cache()` between the two phases reproduces the CI failure verbatim (`left: Running, right: Error`); with this change the same injected clobber passes. `cargo test --lib` green (4766 passed), `cargo fmt --check` clean, no new clippy warnings.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This is a test-only change to an existing regression guard; both assertions it makes are preserved.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Diagnosis and patch drafted by the model from the CI logs and a local reproduction; reviewed and directed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kw8Jc9AUqC7pBBT6yS9S1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the flaky macOS session status test to refresh the tmux cache immediately before each probe.
- Added comments that explain the protection against concurrent cache refreshes.
- Kept production status-handling logic unchanged.

## Benefits

- Reduces race conditions during the test.
- Ensures the test reports `Absent` instead of `Unknown` when the session is missing.
- The change passes the full library test suite, formatting checks, and clippy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->