### PR TITLE
feat(sandbox): add container run-policy settings (#3581)

### DIFF
--- a/aoe-settings-derive/src/lib.rs
+++ b/aoe-settings-derive/src/lib.rs
@@ -28,7 +28,8 @@
 //! `repo` ("allow" | "deny": repo-config override policy; defaults to the
 //!   section's `repo_default`),
 //! `validate` ("none" | "range:min[:max]" | "nonempty" | "memory_limit" |
-//!   "volume_list" | "env_list" | "port_mapping_list" | "network"),
+//!   "volume_list" | "env_list" | "port_mapping_list" | "capability_list" |
+//!   "security_opt_list" | "network"),
 //! `global_only` (flag: field is shown but not profile-overridable),
 //! `skip` (flag: exclude the field from the schema entirely).
 //! When `desc` is omitted, the field's doc comment is used.
@@ -362,6 +363,8 @@ fn build_validation(
         "volume_list" => quote!(ValidationKind::VolumeList),
         "env_list" => quote!(ValidationKind::EnvList),
         "port_mapping_list" => quote!(ValidationKind::PortMappingList),
+        "capability_list" => quote!(ValidationKind::CapabilityList),
+        "security_opt_list" => quote!(ValidationKind::SecurityOptList),
         "network" => quote!(ValidationKind::Network),
         range if range.starts_with("range:") => {
             let parts: Vec<&str> = range.trim_start_matches("range:").split(':').collect();

--- a/docs/development/adding-settings.md
+++ b/docs/development/adding-settings.md
@@ -63,7 +63,7 @@ Pick a `widget` for the field's type:
 
 - `validate`: server-authoritative value check (`range:MIN[:MAX]`, `nonempty`,
   `memory_limit`, `volume_list`, `env_list`, `port_mapping_list`,
-  `capability_list`, `security_opt_list`). Add a new
+  `capability_list`, `security_opt_list`, `network`). Add a new
   `ValidationKind` variant (`src/session/config/settings_schema/`) and a `validate=`
   keyword (`aoe-settings-derive`) if none fits; that is what drives both the
   client UX validator and the server gate from one rule.

--- a/docs/development/adding-settings.md
+++ b/docs/development/adding-settings.md
@@ -62,7 +62,8 @@ Pick a `widget` for the field's type:
 `select`), `min` / `max` / `step`, `multiline` / `mono`, plus:
 
 - `validate`: server-authoritative value check (`range:MIN[:MAX]`, `nonempty`,
-  `memory_limit`, `volume_list`, `env_list`, `port_mapping_list`). Add a new
+  `memory_limit`, `volume_list`, `env_list`, `port_mapping_list`,
+  `capability_list`, `security_opt_list`). Add a new
   `ValidationKind` variant (`src/session/config/settings_schema/`) and a `validate=`
   keyword (`aoe-settings-derive`) if none fits; that is what drives both the
   client UX validator and the server gate from one rule.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -408,7 +408,7 @@ default_image = "ghcr.io/agent-of-empires/aoe-sandbox:latest" # container image
 environment = ["GH_TOKEN=$AOE_GH_TOKEN"]                      # env vars forwarded into the container
 ```
 
-See [Docker Sandbox](sandbox.md) for the full key reference (`cpu_limit`, `memory_limit`, `port_mappings`, `extra_volumes`, `volume_ignores`, `volume_ignores_strategy`, `auto_cleanup`, `default_terminal_mode`), the `environment` grammar, and credential handling. For env vars on host (non-sandboxed) sessions, use [Host Environment](#host-environment) instead; the two lists are disjoint.
+See [Docker Sandbox](sandbox.md) for the full key reference (`cpu_limit`, `memory_limit`, `port_mappings`, `extra_volumes`, `volume_ignores`, `volume_ignores_strategy`, `auto_cleanup`, `default_terminal_mode`, and the run-policy keys `privileged`, `cap_add`, `cap_drop`, `security_opt`, `extra_run_args`), the `environment` grammar, and credential handling. For env vars on host (non-sandboxed) sessions, use [Host Environment](#host-environment) instead; the two lists are disjoint.
 
 ## Host Hooks
 

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -94,7 +94,7 @@ auto_cleanup = true
 default_terminal_mode = "host"   # "host" or "container"
 ```
 
-Security-sensitive sandbox settings are ignored from repo config (with a warning naming the keys): `enabled_by_default`, `default_image`, `container_runtime`, `extra_volumes`, `mount_ssh`, and `selinux_relabel`. Set them in global or profile config instead, or pass `--sandbox` / `--sandbox-image` per session; `container_runtime` is global-only, so set it in the global config.
+Security-sensitive sandbox settings are ignored from repo config (with a warning naming the keys): `enabled_by_default`, `default_image`, `container_runtime`, `extra_volumes`, `mount_ssh`, `selinux_relabel`, `privileged`, `cap_add`, `cap_drop`, `security_opt`, and `extra_run_args`. Set them in global or profile config instead, or pass `--sandbox` / `--sandbox-image` per session; `container_runtime` is global-only, so set it in the global config.
 
 List fields (`environment`, `volume_ignores`, `port_mappings`) accept either an array or a single string:
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -78,6 +78,33 @@ environment = ["ANTHROPIC_API_KEY"]
 | `extra_volumes` | `[]` | Additional volume mounts |
 | `mount_ssh` | `false` | Mount `~/.ssh/` read-only into containers |
 | `default_terminal_mode` | `"host"` | Paired terminal location: `"host"` (on host machine) or `"container"` (inside Docker) |
+| `privileged` | `false` | Run the container in privileged mode (`--privileged`) |
+| `cap_add` | `[]` | Capabilities granted on top of the runtime default (`--cap-add`) |
+| `cap_drop` | `[]` | Capabilities removed from the runtime default (`--cap-drop`) |
+| `security_opt` | `[]` | Security options (`--security-opt`, e.g. `seccomp=unconfined`) |
+| `extra_run_args` | `[]` | Extra arguments passed to container run, before the image |
+
+### Run Policy
+
+Configure container privileges, capabilities, and security options:
+
+```toml
+[sandbox]
+# Privileged mode
+privileged = true
+
+# Capabilities
+cap_add = ["SYS_ADMIN"]
+cap_drop = ["NET_RAW"]
+
+# Security options
+security_opt = ["seccomp=unconfined"]
+
+# Additional arguments passed to container run
+extra_run_args = ["--device", "/dev/fuse"]
+```
+
+Docker and Podman support all run-policy options. Apple Container supports `cap_add` and `cap_drop`; `privileged` and `security_opt` are ignored with a warning. `extra_run_args` is passed through on all runtimes.
 
 ## Volume Mounts
 

--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -83,6 +83,25 @@ pub fn docker_env_args(entries: &[EnvEntry]) -> (Vec<String>, Vec<(String, Strin
     (argv, inherit)
 }
 
+/// A Docker-style `run` flag supported by a container runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunFlag {
+    Privileged,
+    CapAdd,
+    CapDrop,
+    SecurityOpt,
+}
+
+/// Container run-policy flags mapped from `[sandbox]` settings.
+#[derive(Debug, Default, Clone)]
+pub struct RunPolicy {
+    pub privileged: bool,
+    pub cap_add: Vec<String>,
+    pub cap_drop: Vec<String>,
+    pub security_opt: Vec<String>,
+    pub extra_run_args: Vec<String>,
+}
+
 #[derive(Default)]
 pub struct ContainerConfig {
     pub working_dir: String,
@@ -104,6 +123,7 @@ pub struct ContainerConfig {
     pub selinux_relabel: bool,
     /// Runtime-only evidence that this config installed an identity publisher.
     pub identity_publisher_installed: bool,
+    pub run_policy: RunPolicy,
 }
 
 impl ContainerConfig {

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -9,7 +9,9 @@ use std::collections::HashMap;
 
 use crate::cli::truncate_id;
 use crate::session::{Config, ContainerRuntimeName};
-pub use container_interface::{ContainerConfig, EnvEntry, NamedVolumeMount, VolumeMount};
+pub use container_interface::{
+    ContainerConfig, EnvEntry, NamedVolumeMount, RunPolicy, VolumeMount,
+};
 use error::Result;
 pub use runtime::ContainerRuntime;
 

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -1,4 +1,4 @@
-use super::container_interface::{docker_env_args, ContainerConfig};
+use super::container_interface::{docker_env_args, ContainerConfig, RunFlag};
 use super::error::{sanitize_stderr, DockerError, Result};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -59,6 +59,8 @@ pub(crate) struct RuntimeBase {
     pub supports_network_mode: bool,
     /// Whether `run --label key=value` and label inspection are supported.
     pub supports_labels: bool,
+    /// Which Docker-style `run` flags this runtime accepts (see [`RunFlag`]).
+    pub supported_run_flags: &'static [RunFlag],
     /// Case-insensitive stderr substrings that identify a "container does not
     /// exist" error for this runtime. Each runtime words it differently (Docker
     /// "No such container", Apple Container "notFound … not found"), so the
@@ -87,6 +89,14 @@ pub(crate) struct RuntimeBase {
     pub permission_denied_markers: &'static [&'static str],
 }
 
+/// Docker-style run flags supported by Docker and Podman.
+const ALL_RUN_FLAGS: &[RunFlag] = &[
+    RunFlag::Privileged,
+    RunFlag::CapAdd,
+    RunFlag::CapDrop,
+    RunFlag::SecurityOpt,
+];
+
 impl RuntimeBase {
     pub const DOCKER: Self = Self {
         binary: "docker",
@@ -100,6 +110,7 @@ impl RuntimeBase {
         supports_selinux_relabel: true,
         supports_network_mode: true,
         supports_labels: true,
+        supported_run_flags: ALL_RUN_FLAGS,
         not_found_markers: &["no such container"],
         // moby/moby client/errors.go connectionFailed() is the single source
         // of this message across every Docker OS variant (macOS Desktop, Linux
@@ -128,6 +139,9 @@ impl RuntimeBase {
         supports_selinux_relabel: false,
         supports_network_mode: false,
         supports_labels: true,
+        // `--cap-add`/`--cap-drop` exist since container 0.12; there is no
+        // `--privileged` or `--security-opt`.
+        supported_run_flags: &[RunFlag::CapAdd, RunFlag::CapDrop],
         // Apple Container surfaces a missing container with two distinct
         // wordings depending on the subcommand:
         // - `container delete`/`container logs`: `notFound: "container with
@@ -173,6 +187,7 @@ impl RuntimeBase {
         supports_selinux_relabel: true,
         supports_network_mode: true,
         supports_labels: true,
+        supported_run_flags: ALL_RUN_FLAGS,
         not_found_markers: &["no such container"],
         // Two distinct daemon-down wordings observed in real Podman output:
         // - "connect to Podman socket" fires on Linux socket mode
@@ -552,6 +567,51 @@ impl RuntimeBase {
             args.push(mem.clone());
         }
 
+        let policy = &config.run_policy;
+        let pairs = |flag: &str, values: &[String]| -> Vec<String> {
+            values
+                .iter()
+                .flat_map(|v| [flag.to_string(), v.clone()])
+                .collect()
+        };
+        for (flag, config_key, argv) in [
+            (
+                RunFlag::Privileged,
+                "privileged",
+                Vec::from_iter(policy.privileged.then(|| "--privileged".to_string())),
+            ),
+            (
+                RunFlag::CapAdd,
+                "cap_add",
+                pairs("--cap-add", &policy.cap_add),
+            ),
+            (
+                RunFlag::CapDrop,
+                "cap_drop",
+                pairs("--cap-drop", &policy.cap_drop),
+            ),
+            (
+                RunFlag::SecurityOpt,
+                "security_opt",
+                pairs("--security-opt", &policy.security_opt),
+            ),
+        ] {
+            if argv.is_empty() {
+                continue;
+            }
+            if self.supported_run_flags.contains(&flag) {
+                args.extend(argv);
+            } else {
+                tracing::warn!(
+                    target: "containers.runtime",
+                    "ignoring sandbox.{config_key}: {} does not support it",
+                    self.name
+                );
+            }
+        }
+
+        args.extend(policy.extra_run_args.iter().cloned());
+
         args.push(image.to_string());
         args.push("sleep".to_string());
         args.push("infinity".to_string());
@@ -750,7 +810,7 @@ impl RuntimeBase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::containers::container_interface::{EnvEntry, VolumeMount};
+    use crate::containers::container_interface::{EnvEntry, RunPolicy, VolumeMount};
 
     // Real stderr captured from `<runtime> rm/delete <missing>` on 2026-07-01.
     // These pin the per-runtime not-found classification that `remove()` and
@@ -1352,6 +1412,76 @@ mod tests {
         // Apple Container doesn't support :z; the mount stays plain.
         assert!(args.contains(&"/host/path:/container/path".to_string()));
         assert!(!args.iter().any(|a| a.contains(":z")));
+    }
+
+    #[test]
+    fn test_build_create_args_run_policy_flags() {
+        let base = RuntimeBase::DOCKER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            run_policy: RunPolicy {
+                privileged: true,
+                cap_add: vec!["SYS_ADMIN".to_string()],
+                cap_drop: vec!["NET_RAW".to_string()],
+                security_opt: vec!["seccomp=unconfined".to_string()],
+                extra_run_args: vec!["--isolation".to_string(), "chroot".to_string()],
+            },
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        assert!(args.contains(&"--privileged".to_string()));
+        assert_eq!(arg_after(&args, "--cap-add"), Some("SYS_ADMIN"));
+        assert_eq!(arg_after(&args, "--cap-drop"), Some("NET_RAW"));
+        assert_eq!(
+            arg_after(&args, "--security-opt"),
+            Some("seccomp=unconfined")
+        );
+        let isolation = args.iter().position(|a| a == "--isolation").unwrap();
+        let image = args.iter().position(|a| a == "alpine:latest").unwrap();
+        assert_eq!(args[isolation + 1], "chroot");
+        assert_eq!(isolation + 2, image);
+    }
+
+    #[test]
+    fn test_build_create_args_run_policy_skipped_on_unsupported_runtime() {
+        let base = RuntimeBase::APPLE_CONTAINER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            run_policy: RunPolicy {
+                privileged: true,
+                cap_add: vec!["SYS_ADMIN".to_string()],
+                cap_drop: vec!["ALL".to_string()],
+                security_opt: vec!["seccomp=unconfined".to_string()],
+                extra_run_args: vec!["--virtiofs".to_string()],
+            },
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        for flag in ["--privileged", "--security-opt"] {
+            assert!(!args.contains(&flag.to_string()), "unexpected {flag}");
+        }
+        assert_eq!(arg_after(&args, "--cap-add"), Some("SYS_ADMIN"));
+        assert_eq!(arg_after(&args, "--cap-drop"), Some("ALL"));
+        assert!(args.contains(&"--virtiofs".to_string()));
+    }
+
+    #[test]
+    fn test_build_create_args_no_run_policy_by_default() {
+        let base = RuntimeBase::DOCKER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        for flag in ["--privileged", "--cap-add", "--cap-drop", "--security-opt"] {
+            assert!(!args.contains(&flag.to_string()), "unexpected {flag}");
+        }
     }
 
     #[test]

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
-use crate::containers::{ContainerConfig, EnvEntry, NamedVolumeMount, VolumeMount};
+use crate::containers::{ContainerConfig, EnvEntry, NamedVolumeMount, RunPolicy, VolumeMount};
 use crate::git::GitWorktree;
 use crate::session::config::VolumeIgnoresStrategy;
 
@@ -2286,6 +2286,13 @@ pub(crate) fn build_container_config(
         network: sanitize_network(sandbox_config.network.as_deref()),
         selinux_relabel: sandbox_config.selinux_relabel,
         identity_publisher_installed,
+        run_policy: RunPolicy {
+            privileged: sandbox_config.privileged,
+            cap_add: sandbox_config.cap_add.clone(),
+            cap_drop: sandbox_config.cap_drop.clone(),
+            security_opt: sandbox_config.security_opt.clone(),
+            extra_run_args: sandbox_config.extra_run_args.clone(),
+        },
     })
 }
 
@@ -4041,6 +4048,87 @@ mount_ssh = true
             crate::session::artifacts::CONTAINER_ARTIFACT_DIR,
             volume_pairs
         );
+    }
+
+    /// The `[sandbox]` run-policy fields flow from user config into the
+    /// ContainerConfig, and a repo config cannot set any of them (#3218, #2704).
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_run_policy() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        // Global config carries run policy; repo config overrides are ignored.
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let app_dir = temp_home
+            .path()
+            .join(".config")
+            .join(crate::session::APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
+        fs::create_dir_all(&app_dir).unwrap();
+        fs::write(
+            app_dir.join("config.toml"),
+            r#"
+[sandbox]
+cap_add = ["SYS_ADMIN"]
+cap_drop = ["ALL"]
+security_opt = ["seccomp=unconfined"]
+"#,
+        )
+        .unwrap();
+
+        let project_dir = TempDir::new().unwrap();
+        let config_dir = project_dir.path().join(".agent-of-empires");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            r#"
+[sandbox]
+privileged = true
+cap_add = ["NET_ADMIN"]
+cap_drop = []
+extra_run_args = ["--privileged"]
+"#,
+        )
+        .unwrap();
+
+        git2::Repository::init(project_dir.path()).unwrap();
+
+        let sandbox_info = crate::session::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        };
+
+        let project_path_str = project_dir.path().to_str().unwrap();
+        let config = build_container_config(
+            project_path_str,
+            &sandbox_info,
+            ContainerAgentSelection::new("claude", None),
+            false,
+            "test-instance-id",
+            None,
+            "",
+        )
+        .unwrap();
+
+        assert_eq!(config.run_policy.cap_add, vec!["SYS_ADMIN"]);
+        assert_eq!(config.run_policy.cap_drop, vec!["ALL"]);
+        assert_eq!(config.run_policy.security_opt, vec!["seccomp=unconfined"]);
+        assert!(
+            !config.run_policy.privileged,
+            "repo must not grant --privileged"
+        );
+        assert!(config.run_policy.extra_run_args.is_empty());
     }
 
     /// `sandbox.network` stays repo-overridable, but namespace-sharing forms

--- a/src/session/config/mod.rs
+++ b/src/session/config/mod.rs
@@ -2459,6 +2459,86 @@ pub struct SandboxConfig {
     )]
     pub selinux_relabel: bool,
 
+    /// Run the container with `--privileged`: full device access and all
+    /// capabilities. Needed to run a container engine (rootless podman,
+    /// dockerd) inside the sandbox.
+    #[serde(default)]
+    #[setting(
+        label = "Privileged",
+        widget = "toggle",
+        web = "local_only:grants the container full host privileges",
+        repo = "deny",
+        advanced
+    )]
+    pub privileged: bool,
+
+    /// Capabilities to add to the container (`--cap-add`), e.g. "SYS_ADMIN".
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "super::serde_helpers::string_or_vec"
+    )]
+    #[setting(
+        label = "Add Capabilities",
+        widget = "list",
+        validate = "capability_list",
+        web = "local_only:grants the container extra Linux capabilities",
+        repo = "deny",
+        advanced
+    )]
+    pub cap_add: Vec<String>,
+
+    /// Capabilities to drop from the container (`--cap-drop`), e.g. "ALL".
+    /// A write replaces rather than adds, so clearing it undoes hardening.
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "super::serde_helpers::string_or_vec"
+    )]
+    #[setting(
+        label = "Drop Capabilities",
+        widget = "list",
+        validate = "capability_list",
+        web = "local_only:a write replaces the list, so it can undo hardening",
+        repo = "deny",
+        advanced
+    )]
+    pub cap_drop: Vec<String>,
+
+    /// Security options for the container (`--security-opt`), e.g.
+    /// "seccomp=unconfined" or "no-new-privileges:true".
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "super::serde_helpers::string_or_vec"
+    )]
+    #[setting(
+        label = "Security Options",
+        widget = "list",
+        validate = "security_opt_list",
+        web = "local_only:relaxes the container security profile",
+        repo = "deny",
+        advanced
+    )]
+    pub security_opt: Vec<String>,
+
+    /// Extra arguments appended verbatim to the container `run` invocation,
+    /// before the image. Unvalidated, so entries bypass `sandbox.network`'s
+    /// refusal of `host`.
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "super::serde_helpers::string_or_vec"
+    )]
+    #[setting(
+        label = "Extra Run Args",
+        widget = "list",
+        web = "local_only:arbitrary container runtime argv, a host execution surface",
+        repo = "deny",
+        advanced
+    )]
+    pub extra_run_args: Vec<String>,
+
     /// Custom instruction text appended to the agent's system prompt in
     /// sandboxed sessions (Claude, Codex only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2524,6 +2604,11 @@ impl Default for SandboxConfig {
             volume_ignores_strategy: VolumeIgnoresStrategy::default(),
             mount_ssh: false,
             selinux_relabel: false,
+            privileged: false,
+            cap_add: Vec::new(),
+            cap_drop: Vec::new(),
+            security_opt: Vec::new(),
+            extra_run_args: Vec::new(),
             custom_instruction: None,
             container_runtime: ContainerRuntimeName::default(),
         }

--- a/src/session/config/profile_config.rs
+++ b/src/session/config/profile_config.rs
@@ -251,6 +251,27 @@ pub fn validate_port_mapping_format(mapping: &str) -> Result<(), String> {
     }
 }
 
+/// Validate a Linux capability name (`sandbox.cap_add` / `sandbox.cap_drop`).
+pub fn validate_capability_format(cap: &str) -> Result<(), String> {
+    let re = regex::Regex::new(r"^[A-Z][A-Z_]+$").unwrap();
+    if re.is_match(cap) {
+        Ok(())
+    } else {
+        Err("Must be a capability name, e.g. ALL, SYS_ADMIN, CAP_NET_RAW".to_string())
+    }
+}
+
+/// Validate a `--security-opt` entry (`sandbox.security_opt`).
+pub fn validate_security_opt_format(opt: &str) -> Result<(), String> {
+    if opt.is_empty() || opt.chars().any(char::is_whitespace) || opt.starts_with('-') {
+        return Err(
+            "Must be a security option, e.g. seccomp=unconfined or no-new-privileges:true"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Validate a container network mode (`sandbox.network`). Empty (unset),
 /// `none`, `bridge`, or a named network matching Docker's network-name grammar
 /// are accepted. `host` is rejected outright because sharing the host network

--- a/src/session/config/repo_config.rs
+++ b/src/session/config/repo_config.rs
@@ -2168,6 +2168,11 @@ mod tests {
             ("sandbox", "default_image", false),
             ("sandbox", "container_runtime", false),
             ("sandbox", "selinux_relabel", false),
+            ("sandbox", "privileged", false),
+            ("sandbox", "cap_add", false),
+            ("sandbox", "cap_drop", false),
+            ("sandbox", "security_opt", false),
+            ("sandbox", "extra_run_args", false),
             ("updates", "auto_update_plugins", false),
             ("acp", "auto_approve", false),
             ("tmux", "status_bar", false),
@@ -2243,6 +2248,11 @@ mod tests {
             extra_volumes = ["/:/host:rw"]
             mount_ssh = true
             selinux_relabel = true
+            privileged = true
+            cap_add = ["SYS_ADMIN"]
+            cap_drop = []
+            security_opt = ["seccomp=unconfined"]
+            extra_run_args = ["--privileged"]
             memory_limit = "16g"
             volume_ignores = ["node_modules"]
         "#,
@@ -2258,6 +2268,10 @@ mod tests {
         assert!(merged.sandbox.extra_volumes.is_empty());
         assert!(!merged.sandbox.mount_ssh);
         assert!(!merged.sandbox.selinux_relabel);
+        assert!(!merged.sandbox.privileged);
+        assert!(merged.sandbox.cap_add.is_empty());
+        assert!(merged.sandbox.security_opt.is_empty());
+        assert!(merged.sandbox.extra_run_args.is_empty());
         assert_eq!(merged.sandbox.memory_limit.as_deref(), Some("16g"));
         assert_eq!(merged.sandbox.volume_ignores, vec!["node_modules"]);
 
@@ -2265,10 +2279,15 @@ mod tests {
         assert_eq!(
             rejected,
             vec![
+                "sandbox.cap_add",
+                "sandbox.cap_drop",
                 "sandbox.default_image",
                 "sandbox.enabled_by_default",
+                "sandbox.extra_run_args",
                 "sandbox.extra_volumes",
                 "sandbox.mount_ssh",
+                "sandbox.privileged",
+                "sandbox.security_opt",
                 "sandbox.selinux_relabel",
             ]
         );

--- a/src/session/config/settings_schema/mod.rs
+++ b/src/session/config/settings_schema/mod.rs
@@ -267,6 +267,10 @@ pub enum ValidationKind {
     EnvList,
     /// Each list entry must be a `host:container` port mapping (digits only).
     PortMappingList,
+    /// Each list entry must be a Linux capability name.
+    CapabilityList,
+    /// Each list entry must be a `--security-opt` value.
+    SecurityOptList,
     /// A container network mode: empty, `none`, `bridge`, or a named network
     /// (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`). `host` and other namespace-sharing
     /// forms are rejected because they defeat sandbox isolation.

--- a/src/session/config/settings_schema/registry.rs
+++ b/src/session/config/settings_schema/registry.rs
@@ -193,12 +193,6 @@ mod tests {
                 d.web_write
             );
         }
-
-        assert!(
-            !descriptor("sandbox", "container_runtime")
-                .unwrap()
-                .profile_overridable
-        );
     }
 
     /// Every descriptor carries a resolved repo policy: its own

--- a/src/session/config/settings_schema/registry.rs
+++ b/src/session/config/settings_schema/registry.rs
@@ -174,6 +174,33 @@ mod tests {
         assert!(!d.advanced);
     }
 
+    #[test]
+    fn field_declared_repo_and_write_policies() {
+        use super::super::{RepoPolicy, ValidationKind, WebWritePolicy};
+        for (field, validation) in [
+            ("privileged", ValidationKind::None),
+            ("cap_add", ValidationKind::CapabilityList),
+            ("cap_drop", ValidationKind::CapabilityList),
+            ("security_opt", ValidationKind::SecurityOptList),
+            ("extra_run_args", ValidationKind::None),
+        ] {
+            let d = descriptor("sandbox", field).unwrap_or_else(|| panic!("sandbox.{field}"));
+            assert_eq!(d.repo_policy, RepoPolicy::Deny, "sandbox.{field}");
+            assert_eq!(d.validation, validation, "sandbox.{field}");
+            assert!(
+                matches!(d.web_write, WebWritePolicy::LocalOnly { .. }),
+                "sandbox.{field} must be local_only, got {:?}",
+                d.web_write
+            );
+        }
+
+        assert!(
+            !descriptor("sandbox", "container_runtime")
+                .unwrap()
+                .profile_overridable
+        );
+    }
+
     /// Every descriptor carries a resolved repo policy: its own
     /// `#[setting(repo = ...)]` where it declares one, otherwise the
     /// `repo_default` of its `#[setting_section(...)]`.

--- a/src/session/config/settings_schema/validate.rs
+++ b/src/session/config/settings_schema/validate.rs
@@ -109,6 +109,12 @@ pub fn validate_value(kind: &ValidationKind, value: &Value) -> Result<(), Valida
         ValidationKind::PortMappingList => {
             validate_string_list(value, crate::session::validate_port_mapping_format)
         }
+        ValidationKind::CapabilityList => {
+            validate_string_list(value, crate::session::validate_capability_format)
+        }
+        ValidationKind::SecurityOptList => {
+            validate_string_list(value, crate::session::validate_security_opt_format)
+        }
         ValidationKind::Network => {
             let s = value
                 .as_str()

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -128,8 +128,9 @@ pub fn set_favorites_first(on: bool) {
 
 pub use config::profile_config::{
     load_profile_config, merge_configs, resolve_config, resolve_config_or_warn,
-    save_profile_config, validate_check_interval, validate_env_format, validate_memory_limit,
-    validate_network_format, validate_port_mapping_format, validate_volume_format, ProfileConfig,
+    save_profile_config, validate_capability_format, validate_check_interval, validate_env_format,
+    validate_memory_limit, validate_network_format, validate_port_mapping_format,
+    validate_security_opt_format, validate_volume_format, ProfileConfig,
 };
 pub use config::repo_config::{
     check_repo_trust, execute_hooks, execute_hooks_in_container, load_repo_config,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -686,6 +686,8 @@ export type SettingsValidation =
   | { rule: "volume_list" }
   | { rule: "env_list" }
   | { rule: "port_mapping_list" }
+  | { rule: "capability_list" }
+  | { rule: "security_opt_list" }
   | { rule: "network" }
   | { rule: "cron" }
   | {


### PR DESCRIPTION
## Description

Implements #3581: `[sandbox]` gains a run policy: `privileged`, `cap_add`, `cap_drop`, `security_opt`, and `extra_run_args` to override some runtime options.

FTR, my personal interest is in `extra_run_args`, I'm looking to wire gVisor.
During implementation, I noticed that I would be adding quite a few settings that repo shouldn't be able to override, so I added a schema descriptor, `#[setting(repo = "allow" | "deny")]` to replace `REPO_DENIED_SANDBOX_FIELDS` / `REPO_ALLOWED_SESSION_FIELDS` lists.
As a drive-by fix: `sandbox.container_runtime` becomes `global_only`: it is resolved through `Config::load` and snapshotted per session at creation, so a profile or repo value could never take effect, and it picks which host binary executes, the same trust surface as `default_image`.

## Deviations from #3581

- **No `user` key.** Container `$HOME` is hardcoded to `/root` and the agent's state is bind-mounted under it, so a non-root uid cannot read its own configuration: the key would ship a setting that cannot work. Arbitrary uids are #2268, which #3581 holds separate. `extra_run_args = ["--user", "1000:1000"]` remains, for an image built to match.
- **No `no_new_privileges` key.** `security_opt` already writes `--security-opt`, so a dedicated key is a second spelling of one flag, with Docker taking the last as an undocumented precedence between two settings. #2704's profile is one `security_opt` entry.

## PR Type

- [X] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [X] New and existing tests pass
- [X] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (not a UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [X] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [X] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [X] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
Kimi CLI+Kimi K3, claude CLI+Claude Opus 5

**Any Additional AI Details you'd like to share:**
Wrote bulk of impl with K3 in 2-3 iteration, switched to Claude for an automated review session then went back to Kimi for additional human review fixes.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds sandbox run-policy settings for privileged mode, capabilities, security options, and extra runtime arguments.
- Supports runtime-specific behavior for Docker, Podman, and Apple Container.
- Replaces repository field allowlists with per-field `repo = "allow"` or `repo = "deny"` policies.
- Makes `container_runtime` global-only and snapshots it when a session starts.
- Adds validation for capability and security option lists.
- Improves network setting checks and repository override warnings.
- Updates configuration and sandbox documentation.

## Benefits

- Enables runtime integrations such as gVisor.
- Prevents repository configuration from changing sensitive sandbox options.
- Provides clearer schema-based control for repository overrides.
- Adds stronger validation for container security settings.

## Follow-up

- Dashboard, TUI, CLI, and session-lifecycle test coverage remain outside this change.
- Related pre-existing security concerns are tracked separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->