### PR TITLE
fix(tmux): frame batched hidden env reads so continuations cannot spoof a key

### DIFF
--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -307,8 +307,14 @@ fn parse_batch_output<'a>(
         let (line, after_line) = split_line(rest);
         let marked = line.trim().strip_prefix(BATCH_MARKER);
         if let Some(name) = marked.and_then(|n| session_names.iter().copied().find(|s| *s == n)) {
+            // tmux collapses each non-ASCII character of the name to `_` for a
+            // client whose locale is not UTF-8, so two sessions can print the
+            // same marker. A repeat is ambiguous: drop it and let the caller
+            // re-read that session exactly.
+            if values.insert(name, None).is_some() {
+                unparsed.insert(name);
+            }
             current = Some(name);
-            values.entry(name).or_insert(None);
             rest = after_line;
             continue;
         }
@@ -454,6 +460,13 @@ mod tests {
             // so it drops out and the caller re-reads the session.
             (
                 format!("{m}s1\nnot an entry\n{id}"),
+                &["s1"][..],
+                vec![None],
+            ),
+            // Two sessions whose names differ only outside ASCII print one
+            // marker to a non-UTF-8 client; neither reading is trustworthy.
+            (
+                format!("{m}s1\n{id}{m}s1\n{}", entry(key, "second")),
                 &["s1"][..],
                 vec![None],
             ),

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -5,7 +5,7 @@
 //! child processes, making them ideal for storing session metadata.
 
 use anyhow::bail;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub const AOE_INSTANCE_ID_KEY: &str = "AOE_INSTANCE_ID";
 pub const AOE_CAPTURED_SESSION_ID_KEY: &str = "AOE_CAPTURED_SESSION_ID";
@@ -201,40 +201,27 @@ fn sequential_set_fallback(entries: &[(&str, &str, &str)]) {
 /// First character of the marker line each batched segment prints ahead of
 /// its `show-environment` output, so a block that is empty (the session has
 /// no hidden vars) cannot shift every later line onto the wrong session.
-const BATCH_MARKER: char = '\u{1f}';
+///
+/// Printable ASCII on purpose: tmux rewrites every byte outside `0x20..=0x7e`
+/// to `_` for a client whose locale is not UTF-8, so a control character here
+/// would erase every marker and leave the whole batch to the fallback.
+const BATCH_MARKER: char = '@';
 
 /// Get a hidden environment variable from multiple sessions in one tmux
 /// command, returning `(session_name, value)` in input order.
 ///
 /// tmux ABORTS a `;`-separated command list at the first command that fails,
 /// so no segment may fail: each one queries the session's whole hidden
-/// environment (`show-environment -h` with no variable exits 0 even when the
-/// variable, or every variable, is unset) rather than the single key, and the
-/// key is picked out of the marked block. A session that disappears mid-batch
-/// still truncates the run, so any session whose marker never came back is
-/// re-read sequentially instead of being reported as unset.
+/// environment (`show-environment -h -s` with no variable exits 0 even when
+/// the variable, or every variable, is unset) rather than the single key, and
+/// the key is picked out of the marked block. A session that disappears
+/// mid-batch still truncates the run, so any session whose marker never came
+/// back is re-read sequentially instead of being reported as unset.
 pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, Option<String>)> {
     if session_names.is_empty() {
         return Vec::new();
     }
-    let mut args: Vec<String> = Vec::new();
-    for (i, session_name) in session_names.iter().enumerate() {
-        if i > 0 {
-            args.push(";".to_string());
-        }
-        args.extend([
-            "display-message".to_string(),
-            "-p".to_string(),
-            "-t".to_string(),
-            session_name.to_string(),
-            format!("{BATCH_MARKER}{}", session_name.replace('#', "##")),
-            ";".to_string(),
-            "show-environment".to_string(),
-            "-h".to_string(),
-            "-t".to_string(),
-            session_name.to_string(),
-        ]);
-    }
+    let args = batch_args(session_names);
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let output = crate::tmux::tmux_command().args(&str_args).output();
     let mut covered = match output {
@@ -275,40 +262,129 @@ pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, O
     results
 }
 
+/// tmux argument list for one batched read: a marker line then the whole
+/// hidden environment, per session.
+fn batch_args(session_names: &[&str]) -> Vec<String> {
+    let mut args: Vec<String> = Vec::new();
+    for (i, session_name) in session_names.iter().enumerate() {
+        if i > 0 {
+            args.push(";".to_string());
+        }
+        args.extend([
+            "display-message".to_string(),
+            "-p".to_string(),
+            "-t".to_string(),
+            session_name.to_string(),
+            format!("{BATCH_MARKER}{}", session_name.replace('#', "##")),
+            ";".to_string(),
+            "show-environment".to_string(),
+            "-h".to_string(),
+            "-s".to_string(),
+            "-t".to_string(),
+            session_name.to_string(),
+        ]);
+    }
+    args
+}
+
 /// Parse marker-delimited batch output into `key`'s value per session.
 ///
 /// Only sessions whose marker line came back are present in the map: an entry
 /// is the authoritative reading for that session (`None` = the key is unset),
-/// while an ABSENT session is one the run never reached and the caller must
-/// read separately. `-KEY` (explicitly removed) reads as unset.
+/// while an ABSENT session is one the run never reached, or one whose block
+/// did not parse, and the caller must read separately. `unset KEY;`
+/// (explicitly removed) reads as unset.
 fn parse_batch_output<'a>(
     output: &str,
     session_names: &[&'a str],
     key: &str,
 ) -> HashMap<&'a str, Option<String>> {
-    let prefix = format!("{key}=");
     let mut values: HashMap<&str, Option<String>> = HashMap::new();
+    let mut unparsed: HashSet<&str> = HashSet::new();
     let mut current: Option<&str> = None;
-    for line in output.lines() {
-        let line = line.trim();
-        if let Some(name) = line.strip_prefix(BATCH_MARKER) {
-            current = session_names.iter().copied().find(|n| *n == name);
-            if let Some(name) = current {
-                values.entry(name).or_insert(None);
-            }
+    let mut rest = output;
+    while !rest.is_empty() {
+        let (line, after_line) = split_line(rest);
+        let marked = line.trim().strip_prefix(BATCH_MARKER);
+        if let Some(name) = marked.and_then(|n| session_names.iter().copied().find(|s| *s == n)) {
+            current = Some(name);
+            values.entry(name).or_insert(None);
+            rest = after_line;
             continue;
         }
-        let Some(name) = current else { continue };
-        if let Some(value) = line.strip_prefix(&prefix) {
-            values.insert(name, Some(value.to_string()));
+        if let Some((name, value, after_entry)) = parse_env_entry(rest) {
+            if name == key {
+                if let Some(session) = current {
+                    values.insert(session, value);
+                }
+            }
+            rest = after_entry;
+            continue;
         }
+        // A marker for a session nobody asked about ends the current block;
+        // anything else means the block did not parse as tmux wrote it, so
+        // drop it rather than guess which entry a stray line belonged to.
+        if marked.is_some() {
+            current = None;
+        } else if let Some(session) = current {
+            unparsed.insert(session);
+        }
+        rest = after_line;
+    }
+    for name in unparsed {
+        values.remove(name);
     }
     values
+}
+
+/// Consume one `show-environment -s` record from the head of `input`,
+/// returning `(name, value, remainder)`; `None` when the head is not a record.
+///
+/// `-s` wraps every value in double quotes and backslash-escapes any quote or
+/// backslash inside it, so a value holding a newline cannot end a record: the
+/// scan runs to the first unescaped quote, not to the next line break. That is
+/// what stops a continuation line reading `KEY=...` from impersonating an
+/// entry for `KEY` (#3616).
+fn parse_env_entry(input: &str) -> Option<(&str, Option<String>, &str)> {
+    if let Some(rest) = input.strip_prefix("unset ") {
+        let (line, after) = split_line(rest);
+        let name = line.strip_suffix(';')?;
+        return (!name.is_empty()).then_some((name, None, after));
+    }
+    let (head, _) = split_line(input);
+    let name = &input[..head.find("=\"")?];
+    if name.is_empty() {
+        return None;
+    }
+    let mut value = String::new();
+    let body = &input[name.len() + 2..];
+    let mut chars = body.char_indices();
+    while let Some((i, c)) = chars.next() {
+        match c {
+            '\\' => value.push(chars.next()?.1),
+            '"' => return Some((name, Some(value), split_line(&body[i + 1..]).1)),
+            _ => value.push(c),
+        }
+    }
+    None
+}
+
+/// Split off the first line, dropping its terminator.
+fn split_line(input: &str) -> (&str, &str) {
+    match input.split_once('\n') {
+        Some((line, rest)) => (line.strip_suffix('\r').unwrap_or(line), rest),
+        None => (input, ""),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// One `show-environment -s` record. `value` is already tmux-escaped.
+    fn entry(name: &str, value: &str) -> String {
+        format!("{name}=\"{value}\"; export {name};\n")
+    }
 
     fn marked(name: &str, body: &str) -> String {
         format!("{BATCH_MARKER}{name}\n{body}")
@@ -318,57 +394,68 @@ mod tests {
     fn test_parse_batch_output_attributes_by_marker() {
         let m = BATCH_MARKER;
         let key = "AOE_INSTANCE_ID";
+        let id = entry(key, "abc123");
         // (output, sessions, expected per session: None = not covered by the
         // run at all, Some(None) = covered and unset)
         let cases = vec![
-            (
-                marked("s1", "AOE_INSTANCE_ID=abc123\n"),
-                &["s1"][..],
-                vec![Some(Some("abc123"))],
-            ),
+            (marked("s1", &id), &["s1"][..], vec![Some(Some("abc123"))]),
             // Covered but unset: the block is empty, or holds other keys only.
             (marked("s1", ""), &["s1"][..], vec![Some(None)]),
             (
-                marked("s1", "AOE_CAPTURED_SESSION_ID=other\n"),
+                marked("s1", &entry(AOE_CAPTURED_SESSION_ID_KEY, "other")),
                 &["s1"][..],
                 vec![Some(None)],
             ),
             (
-                marked("s1", "-AOE_INSTANCE_ID\n"),
+                marked("s1", "unset AOE_INSTANCE_ID;\n"),
                 &["s1"][..],
                 vec![Some(None)],
             ),
             (
-                marked("s1", "AOE_INSTANCE_ID=value=with=equals\n"),
+                marked("s1", &entry(key, "value=with=equals")),
                 &["s1"][..],
                 vec![Some(Some("value=with=equals"))],
             ),
+            // tmux escapes quotes and backslashes inside the value; the
+            // reading must undo that rather than stop at the first quote.
+            (
+                marked("s1", &entry(key, r#"a\"b\\c"#)),
+                &["s1"][..],
+                vec![Some(Some(r#"a"b\c"#))],
+            ),
             // A session lacking the variable must not shift the rest.
             (
-                format!("{m}s1\nAOE_INSTANCE_ID=abc123\n{m}s2\n{m}s3\nAOE_INSTANCE_ID=xyz789\n"),
+                format!("{m}s1\n{id}{m}s2\n{m}s3\n{}", entry(key, "xyz789")),
                 &["s1", "s2", "s3"][..],
                 vec![Some(Some("abc123")), Some(None), Some(Some("xyz789"))],
             ),
-            // The regression: tmux aborts the list at a failing segment, so
-            // sessions past it produce no marker and must read as uncovered
-            // (the caller re-reads them) rather than as unset.
+            // tmux aborts the list at a failing segment, so sessions past it
+            // produce no marker and must read as uncovered (the caller
+            // re-reads them) rather than as unset.
             (
-                format!("{m}s1\nAOE_INSTANCE_ID=abc123\n"),
+                format!("{m}s1\n{id}"),
                 &["s1", "s2"][..],
                 vec![Some(Some("abc123")), None],
             ),
             (String::new(), &["s1", "s2"][..], vec![None, None]),
-            ("AOE_INSTANCE_ID=abc\n".to_string(), &["s1"][..], vec![None]),
+            (id.clone(), &["s1"][..], vec![None]),
             // A block for a session that was not asked about is ignored.
             (
-                format!("{m}other\nAOE_INSTANCE_ID=nope\n{m}s1\nAOE_INSTANCE_ID=abc\n"),
+                format!("{m}other\n{}{m}s1\n{id}", entry(key, "nope")),
                 &["s1"][..],
-                vec![Some(Some("abc"))],
+                vec![Some(Some("abc123"))],
             ),
             (
-                format!("  {m}s1  \n  AOE_INSTANCE_ID=value123  \n"),
+                format!("  {m}s1  \n{id}"),
                 &["s1"][..],
-                vec![Some(Some("value123"))],
+                vec![Some(Some("abc123"))],
+            ),
+            // A line tmux could not have written leaves the block ambiguous,
+            // so it drops out and the caller re-reads the session.
+            (
+                format!("{m}s1\nnot an entry\n{id}"),
+                &["s1"][..],
+                vec![None],
             ),
         ];
         for (output, sessions, expected) in cases {
@@ -379,6 +466,109 @@ mod tests {
                 .collect();
             assert_eq!(got, expected, "values for {output:?}");
         }
+    }
+
+    /// #3616: an unrelated multiline value emits continuation lines that can
+    /// read as `KEY=...` or as a marker. They belong to the variable that
+    /// opened the quote and must not be read as entries of their own.
+    #[test]
+    fn test_parse_batch_output_ignores_multiline_continuations() {
+        let m = BATCH_MARKER;
+        let key = "AOE_INSTANCE_ID";
+        let cases = vec![
+            // The key is set and a later variable's continuation claims it.
+            (
+                format!(
+                    "{m}s1\n{}{}",
+                    entry(key, "real-id"),
+                    entry("ZZZ", "unrelated\nAOE_INSTANCE_ID=spoofed-id"),
+                ),
+                &["s1"][..],
+                vec![Some(Some("real-id"))],
+            ),
+            // The key is unset and an earlier variable's continuation invents
+            // it. Sorted output puts that continuation where the real entry
+            // would have been.
+            (
+                format!("{m}s1\n{}", entry("AAA", "x\nAOE_INSTANCE_ID=spoofed-id")),
+                &["s1"][..],
+                vec![Some(None)],
+            ),
+            // A continuation that imitates the next session's marker must not
+            // reattribute the rest of the run.
+            (
+                format!(
+                    "{m}s1\n{}{m}s2\n{}",
+                    entry("ZZZ", "x\n@s2\nAOE_INSTANCE_ID=spoofed-id"),
+                    entry(key, "s2-id"),
+                ),
+                &["s1", "s2"][..],
+                vec![Some(None), Some(Some("s2-id"))],
+            ),
+            // Escaped quotes cannot close the value early to fake an entry.
+            (
+                format!(
+                    "{m}s1\n{}",
+                    entry(
+                        "NASTY",
+                        "a\\\"; export ZZZ;\nAOE_INSTANCE_ID=\\\"spoofed-id\\\""
+                    ),
+                ),
+                &["s1"][..],
+                vec![Some(None)],
+            ),
+        ];
+        for (output, sessions, expected) in cases {
+            let parsed = parse_batch_output(&output, sessions, key);
+            let got: Vec<Option<Option<&str>>> = sessions
+                .iter()
+                .map(|name| parsed.get(name).map(|v| v.as_deref()))
+                .collect();
+            assert_eq!(got, expected, "values for {output:?}");
+        }
+    }
+
+    /// The batch is worthless if its own markers do not survive tmux. tmux
+    /// rewrites bytes outside printable ASCII to `_` for a client whose
+    /// locale is not UTF-8, so pin that client and require full coverage:
+    /// without it every session silently falls through to a sequential read.
+    #[test]
+    fn test_batch_output_covers_sessions_for_a_non_utf8_client() {
+        struct KillSession(&'static str);
+        impl Drop for KillSession {
+            fn drop(&mut self) {
+                let _ = crate::tmux::tmux_command()
+                    .args(["kill-session", "-t", self.0])
+                    .output();
+            }
+        }
+
+        let name = "aoe_env_batch_marker_probe";
+        let created = crate::tmux::tmux_command()
+            .args(["new-session", "-d", "-s", name, "sh"])
+            .output();
+        if !created.is_ok_and(|out| out.status.success()) {
+            eprintln!("skipping: tmux unavailable");
+            return;
+        }
+        let _cleanup = KillSession(name);
+
+        set_hidden_env(name, AOE_INSTANCE_ID_KEY, "real-id").unwrap();
+        set_hidden_env(name, "ZZZ", "unrelated\nAOE_INSTANCE_ID=spoofed-id").unwrap();
+
+        let output = crate::tmux::tmux_command()
+            .env("LC_ALL", "C")
+            .args(batch_args(&[name]))
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed = parse_batch_output(&stdout, &[name], AOE_INSTANCE_ID_KEY);
+        assert_eq!(
+            parsed.get(name).map(|v| v.as_deref()),
+            Some(Some("real-id")),
+            "batch output: {stdout:?}"
+        );
     }
 
     #[test]

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -499,7 +499,7 @@ mod tests {
             (
                 format!(
                     "{m}s1\n{}{m}s2\n{}",
-                    entry("ZZZ", "x\n@s2\nAOE_INSTANCE_ID=spoofed-id"),
+                    entry("ZZZ", &format!("x\n{m}s2\nAOE_INSTANCE_ID=spoofed-id")),
                     entry(key, "s2-id"),
                 ),
                 &["s1", "s2"][..],
@@ -528,22 +528,20 @@ mod tests {
         }
     }
 
-    /// The batch is worthless if its own markers do not survive tmux. tmux
-    /// rewrites bytes outside printable ASCII to `_` for a client whose
-    /// locale is not UTF-8, so pin that client and require full coverage:
-    /// without it every session silently falls through to a sequential read.
+    /// Both halves of the framing, against a real tmux, with the client
+    /// locale pinned because each half only exists under one of them.
+    ///
+    /// Under `C` tmux rewrites every byte outside printable ASCII to `_`, so
+    /// the marker has to be printable or the batch covers nothing and every
+    /// session silently falls through to a sequential read. That same rewrite
+    /// flattens a value's newline, so the #3616 spoof can only be reproduced
+    /// under a UTF-8 client; the raw output is asserted to carry the
+    /// continuation before the parse is trusted to have rejected it.
     #[test]
-    fn test_batch_output_covers_sessions_for_a_non_utf8_client() {
-        struct KillSession(&'static str);
-        impl Drop for KillSession {
-            fn drop(&mut self) {
-                let _ = crate::tmux::tmux_command()
-                    .args(["kill-session", "-t", self.0])
-                    .output();
-            }
-        }
-
-        let name = "aoe_env_batch_marker_probe";
+    #[serial_test::serial]
+    fn test_batch_output_frames_records_against_a_real_tmux() {
+        let session = crate::tmux::test_helpers::TmuxTestSession::new("aoe_env_batch_probe");
+        let name = session.name();
         let created = crate::tmux::tmux_command()
             .args(["new-session", "-d", "-s", name, "sh"])
             .output();
@@ -551,24 +549,31 @@ mod tests {
             eprintln!("skipping: tmux unavailable");
             return;
         }
-        let _cleanup = KillSession(name);
 
         set_hidden_env(name, AOE_INSTANCE_ID_KEY, "real-id").unwrap();
         set_hidden_env(name, "ZZZ", "unrelated\nAOE_INSTANCE_ID=spoofed-id").unwrap();
 
-        let output = crate::tmux::tmux_command()
-            .env("LC_ALL", "C")
-            .args(batch_args(&[name]))
-            .output()
-            .unwrap();
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let parsed = parse_batch_output(&stdout, &[name], AOE_INSTANCE_ID_KEY);
-        assert_eq!(
-            parsed.get(name).map(|v| v.as_deref()),
-            Some(Some("real-id")),
-            "batch output: {stdout:?}"
-        );
+        // (locale, must the raw output carry the spoofing continuation)
+        for (locale, expect_continuation) in [("C", false), ("C.UTF-8", true)] {
+            let output = crate::tmux::tmux_command()
+                .env("LC_ALL", locale)
+                .args(batch_args(&[name]))
+                .output()
+                .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let spoofed = stdout.contains("\nAOE_INSTANCE_ID=spoofed-id");
+            if expect_continuation && !spoofed {
+                eprintln!("skipping {locale} leg: locale unavailable, tmux flattened the value");
+                continue;
+            }
+            assert_eq!(spoofed, expect_continuation, "{locale}: {stdout:?}");
+            let parsed = parse_batch_output(&stdout, &[name], AOE_INSTANCE_ID_KEY);
+            assert_eq!(
+                parsed.get(name).map(|v| v.as_deref()),
+                Some(Some("real-id")),
+                "{locale}: {stdout:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -202,9 +202,11 @@ fn sequential_set_fallback(entries: &[(&str, &str, &str)]) {
 /// its `show-environment` output, so a block that is empty (the session has
 /// no hidden vars) cannot shift every later line onto the wrong session.
 ///
-/// Printable ASCII on purpose: tmux rewrites every byte outside `0x20..=0x7e`
-/// to `_` for a client whose locale is not UTF-8, so a control character here
-/// would erase every marker and leave the whole batch to the fallback.
+/// It carries the session's batch index, not its name, because tmux rewrites
+/// every byte outside `0x20..=0x7e` to `_` for a client whose locale is not
+/// UTF-8: a control character would erase every marker, and a name would let
+/// `aoe_café` print the marker of a live `aoe_caf_`. Decimal digits are
+/// injective under that rewrite, so a marker names exactly one session.
 const BATCH_MARKER: char = '@';
 
 /// Get a hidden environment variable from multiple sessions in one tmux
@@ -275,7 +277,7 @@ fn batch_args(session_names: &[&str]) -> Vec<String> {
             "-p".to_string(),
             "-t".to_string(),
             session_name.to_string(),
-            format!("{BATCH_MARKER}{}", session_name.replace('#', "##")),
+            format!("{BATCH_MARKER}{i}"),
             ";".to_string(),
             "show-environment".to_string(),
             "-h".to_string(),
@@ -301,16 +303,17 @@ fn parse_batch_output<'a>(
 ) -> HashMap<&'a str, Option<String>> {
     let mut values: HashMap<&str, Option<String>> = HashMap::new();
     let mut unparsed: HashSet<&str> = HashSet::new();
+    let mut read_key: HashSet<&str> = HashSet::new();
     let mut current: Option<&str> = None;
     let mut rest = output;
     while !rest.is_empty() {
         let (line, after_line) = split_line(rest);
         let marked = line.trim().strip_prefix(BATCH_MARKER);
-        if let Some(name) = marked.and_then(|n| session_names.iter().copied().find(|s| *s == n)) {
-            // tmux collapses each non-ASCII character of the name to `_` for a
-            // client whose locale is not UTF-8, so two sessions can print the
-            // same marker. A repeat is ambiguous: drop it and let the caller
-            // re-read that session exactly.
+        if let Some(name) = marked
+            .and_then(|i| i.parse::<usize>().ok())
+            .and_then(|i| session_names.get(i).copied())
+        {
+            // Each index is printed once, so a repeat did not come from tmux.
             if values.insert(name, None).is_some() {
                 unparsed.insert(name);
             }
@@ -321,6 +324,11 @@ fn parse_batch_output<'a>(
         if let Some((name, value, after_entry)) = parse_env_entry(rest) {
             if name == key {
                 if let Some(session) = current {
+                    // tmux walks a keyed tree once, so a second record for the
+                    // requested key is not a shape tmux can emit.
+                    if !read_key.insert(session) {
+                        unparsed.insert(session);
+                    }
                     values.insert(session, value);
                 }
             }
@@ -350,7 +358,9 @@ fn parse_batch_output<'a>(
 /// backslash inside it, so a value holding a newline cannot end a record: the
 /// scan runs to the first unescaped quote, not to the next line break. That is
 /// what stops a continuation line reading `KEY=...` from impersonating an
-/// entry for `KEY` (#3616).
+/// entry for `KEY` (#3616). The `; export <name>;` tail is required rather
+/// than skipped, so a record tmux did not write is rejected outright instead
+/// of being read up to its quote.
 fn parse_env_entry(input: &str) -> Option<(&str, Option<String>, &str)> {
     if let Some(rest) = input.strip_prefix("unset ") {
         let (line, after) = split_line(rest);
@@ -368,7 +378,11 @@ fn parse_env_entry(input: &str) -> Option<(&str, Option<String>, &str)> {
     while let Some((i, c)) = chars.next() {
         match c {
             '\\' => value.push(chars.next()?.1),
-            '"' => return Some((name, Some(value), split_line(&body[i + 1..]).1)),
+            '"' => {
+                let (tail, after) = split_line(&body[i + 1..]);
+                let exported = tail.strip_prefix("; export ")?.strip_suffix(';')?;
+                return (exported == name).then_some((name, Some(value), after));
+            }
             _ => value.push(c),
         }
     }
@@ -392,8 +406,9 @@ mod tests {
         format!("{name}=\"{value}\"; export {name};\n")
     }
 
-    fn marked(name: &str, body: &str) -> String {
-        format!("{BATCH_MARKER}{name}\n{body}")
+    /// One session's segment: its batch-index marker, then its records.
+    fn marked(index: usize, body: &str) -> String {
+        format!("{BATCH_MARKER}{index}\n{body}")
     }
 
     #[test]
@@ -404,34 +419,34 @@ mod tests {
         // (output, sessions, expected per session: None = not covered by the
         // run at all, Some(None) = covered and unset)
         let cases = vec![
-            (marked("s1", &id), &["s1"][..], vec![Some(Some("abc123"))]),
+            (marked(0, &id), &["s1"][..], vec![Some(Some("abc123"))]),
             // Covered but unset: the block is empty, or holds other keys only.
-            (marked("s1", ""), &["s1"][..], vec![Some(None)]),
+            (marked(0, ""), &["s1"][..], vec![Some(None)]),
             (
-                marked("s1", &entry(AOE_CAPTURED_SESSION_ID_KEY, "other")),
+                marked(0, &entry(AOE_CAPTURED_SESSION_ID_KEY, "other")),
                 &["s1"][..],
                 vec![Some(None)],
             ),
             (
-                marked("s1", "unset AOE_INSTANCE_ID;\n"),
+                marked(0, "unset AOE_INSTANCE_ID;\n"),
                 &["s1"][..],
                 vec![Some(None)],
             ),
             (
-                marked("s1", &entry(key, "value=with=equals")),
+                marked(0, &entry(key, "value=with=equals")),
                 &["s1"][..],
                 vec![Some(Some("value=with=equals"))],
             ),
             // tmux escapes quotes and backslashes inside the value; the
             // reading must undo that rather than stop at the first quote.
             (
-                marked("s1", &entry(key, r#"a\"b\\c"#)),
+                marked(0, &entry(key, r#"a\"b\\c"#)),
                 &["s1"][..],
                 vec![Some(Some(r#"a"b\c"#))],
             ),
             // A session lacking the variable must not shift the rest.
             (
-                format!("{m}s1\n{id}{m}s2\n{m}s3\n{}", entry(key, "xyz789")),
+                format!("{m}0\n{id}{m}1\n{m}2\n{}", entry(key, "xyz789")),
                 &["s1", "s2", "s3"][..],
                 vec![Some(Some("abc123")), Some(None), Some(Some("xyz789"))],
             ),
@@ -439,7 +454,7 @@ mod tests {
             // produce no marker and must read as uncovered (the caller
             // re-reads them) rather than as unset.
             (
-                format!("{m}s1\n{id}"),
+                format!("{m}0\n{id}"),
                 &["s1", "s2"][..],
                 vec![Some(Some("abc123")), None],
             ),
@@ -447,28 +462,48 @@ mod tests {
             (id.clone(), &["s1"][..], vec![None]),
             // A block for a session that was not asked about is ignored.
             (
-                format!("{m}other\n{}{m}s1\n{id}", entry(key, "nope")),
+                format!("{m}9\n{}{m}0\n{id}", entry(key, "nope")),
                 &["s1"][..],
                 vec![Some(Some("abc123"))],
             ),
             (
-                format!("  {m}s1  \n{id}"),
+                format!("  {m}0  \n{id}"),
                 &["s1"][..],
                 vec![Some(Some("abc123"))],
             ),
             // A line tmux could not have written leaves the block ambiguous,
             // so it drops out and the caller re-reads the session.
+            (format!("{m}0\nnot an entry\n{id}"), &["s1"][..], vec![None]),
+            // A repeated marker did not come from tmux; neither reading of
+            // that block is trustworthy.
             (
-                format!("{m}s1\nnot an entry\n{id}"),
+                format!("{m}0\n{id}{m}0\n{}", entry(key, "second")),
                 &["s1"][..],
                 vec![None],
             ),
-            // Two sessions whose names differ only outside ASCII print one
-            // marker to a non-UTF-8 client; neither reading is trustworthy.
+            // Jerome #3628: a second record for the requested key is a shape
+            // tmux cannot emit, so the block loses its exact-read fallback
+            // unless it drops out here.
             (
-                format!("{m}s1\n{id}{m}s1\n{}", entry(key, "second")),
+                format!("{m}0\n{id}{}", entry(key, "second")),
                 &["s1"][..],
                 vec![None],
+            ),
+            // Trailing text after the closing quote means the record is not
+            // what tmux wrote.
+            (
+                format!("{m}0\nAOE_INSTANCE_ID=\"real\"; export AOE_INSTANCE_ID; junk\n"),
+                &["s1"][..],
+                vec![None],
+            ),
+            // A sanitized name can no longer claim a colliding session: the
+            // marker is the batch index, so the truncated run leaves the ASCII
+            // session uncovered instead of handing it the Unicode session's
+            // block.
+            (
+                format!("{m}0\n{}", entry(key, "cafe-id")),
+                &["aoe_caf\u{e9}", "aoe_caf_"][..],
+                vec![Some(Some("cafe-id")), None],
             ),
         ];
         for (output, sessions, expected) in cases {
@@ -492,7 +527,7 @@ mod tests {
             // The key is set and a later variable's continuation claims it.
             (
                 format!(
-                    "{m}s1\n{}{}",
+                    "{m}0\n{}{}",
                     entry(key, "real-id"),
                     entry("ZZZ", "unrelated\nAOE_INSTANCE_ID=spoofed-id"),
                 ),
@@ -503,7 +538,7 @@ mod tests {
             // it. Sorted output puts that continuation where the real entry
             // would have been.
             (
-                format!("{m}s1\n{}", entry("AAA", "x\nAOE_INSTANCE_ID=spoofed-id")),
+                format!("{m}0\n{}", entry("AAA", "x\nAOE_INSTANCE_ID=spoofed-id")),
                 &["s1"][..],
                 vec![Some(None)],
             ),
@@ -511,8 +546,8 @@ mod tests {
             // reattribute the rest of the run.
             (
                 format!(
-                    "{m}s1\n{}{m}s2\n{}",
-                    entry("ZZZ", &format!("x\n{m}s2\nAOE_INSTANCE_ID=spoofed-id")),
+                    "{m}0\n{}{m}1\n{}",
+                    entry("ZZZ", &format!("x\n{m}1\nAOE_INSTANCE_ID=spoofed-id")),
                     entry(key, "s2-id"),
                 ),
                 &["s1", "s2"][..],
@@ -521,7 +556,7 @@ mod tests {
             // Escaped quotes cannot close the value early to fake an entry.
             (
                 format!(
-                    "{m}s1\n{}",
+                    "{m}0\n{}",
                     entry(
                         "NASTY",
                         "a\\\"; export ZZZ;\nAOE_INSTANCE_ID=\\\"spoofed-id\\\""
@@ -587,6 +622,70 @@ mod tests {
                 "{locale}: {stdout:?}"
             );
         }
+    }
+
+    /// #3628 review: under a non-UTF-8 client tmux prints `aoe_..caf\u{e9}` as
+    /// `aoe_..caf_`, so a name-based marker let the Unicode session's block be
+    /// attributed to the live ASCII session whose name it now matched. A
+    /// repeated marker catches that only when the twin marker arrives; tmux
+    /// aborts the list at a failing segment, so here it never does. Batch
+    /// indices are injective under that rewrite, so the block stays with the
+    /// session that produced it and the unreached one falls back.
+    #[test]
+    #[serial_test::serial]
+    fn test_batch_marker_survives_a_sanitized_name_collision() {
+        let base = format!("aoe_env_collide_{}", std::process::id());
+        // `sanitize_session_name` keeps any Unicode alphanumeric, and tmux
+        // rewrites the last character of this one to `_`, producing `ascii`.
+        let unicode =
+            crate::tmux::test_helpers::TmuxTestSession::from_name(format!("{base}\u{e9}"));
+        let ascii = crate::tmux::test_helpers::TmuxTestSession::from_name(format!("{base}_"));
+        for (session, id) in [(&unicode, "unicode-id"), (&ascii, "ascii-id")] {
+            let created = crate::tmux::tmux_command()
+                .args(["new-session", "-d", "-s", session.name(), "sh"])
+                .output();
+            if !created.is_ok_and(|out| out.status.success()) {
+                eprintln!("skipping: tmux unavailable");
+                return;
+            }
+            set_hidden_env(session.name(), AOE_INSTANCE_ID_KEY, id).unwrap();
+        }
+
+        let sanitized = crate::tmux::tmux_command()
+            .env("LC_ALL", "C")
+            .args([
+                "display-message",
+                "-p",
+                "-t",
+                unicode.name(),
+                "#{session_name}",
+            ])
+            .output()
+            .unwrap();
+        if String::from_utf8_lossy(&sanitized.stdout).trim() != ascii.name() {
+            eprintln!("skipping: this tmux client does not sanitize the name");
+            return;
+        }
+
+        // The middle session does not exist, so tmux aborts the list there and
+        // the ASCII session's own marker is never printed.
+        let missing = format!("{base}_gone");
+        let names = [unicode.name(), missing.as_str(), ascii.name()];
+        let output = crate::tmux::tmux_command()
+            .env("LC_ALL", "C")
+            .args(batch_args(&names))
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed = parse_batch_output(&stdout, &names, AOE_INSTANCE_ID_KEY);
+        assert_eq!(
+            names.map(|n| parsed.get(n).map(|v| v.as_deref())),
+            // The unreached ASCII session is what a name-based marker used to
+            // fill in with the Unicode session's value. The middle name never
+            // existed, so reporting it unset matches what re-reading it gives.
+            [Some(Some("unicode-id")), Some(None), None],
+            "{stdout:?}"
+        );
     }
 
     #[test]

--- a/tests/integration/hidden_env_batch.rs
+++ b/tests/integration/hidden_env_batch.rs
@@ -73,3 +73,40 @@ fn batch_reads_sessions_after_one_without_the_key() {
         ]
     );
 }
+
+/// #3616: `show-environment` emits a multiline value as continuation lines, so
+/// an unrelated variable can print a line reading `AOE_INSTANCE_ID=...`. The
+/// batch must still report the variable's real value.
+#[test]
+#[serial]
+fn batch_ignores_a_multiline_value_that_imitates_the_key() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not on PATH");
+        return;
+    }
+    let socket = crate::common::tmux_socket();
+    let name = "aoe_hb_multiline";
+    let out = Command::new("tmux")
+        .arg("-S")
+        .arg(&socket)
+        .args(["new-session", "-d", "-s", name, "sh"])
+        .output()
+        .expect("tmux new-session");
+    assert!(
+        out.status.success(),
+        "new-session {name}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _cleanup = Cleanup(vec![name.to_string()]);
+
+    env::set_hidden_env(name, env::AOE_INSTANCE_ID_KEY, "real-id").unwrap();
+    env::set_hidden_env(
+        name,
+        "ZZZ",
+        &format!("unrelated\n{}=spoofed-id", env::AOE_INSTANCE_ID_KEY),
+    )
+    .unwrap();
+
+    let got = env::get_hidden_env_batch(&[name], env::AOE_INSTANCE_ID_KEY);
+    assert_eq!(got, vec![(name.to_string(), Some("real-id".to_string()))]);
+}


### PR DESCRIPTION
## Description

When AoE needs to know which of its own instances owns each running tmux session, it asks tmux for that information for every session at once, in a single call. tmux answers by printing the session's stored variables, one per line. The problem is that a variable's value is allowed to contain a line break, and when it does, tmux just prints it across several lines with no indication that the extra lines belong to the variable above. So a completely unrelated variable whose value happens to contain a line reading `AOE_INSTANCE_ID=something` produced output that looked exactly like the real answer, and AoE believed the fake one over the real one. The consequence would be AoE thinking a session belongs to a different copy of itself than it really does, which can make it re-adopt a session another instance is already running, or skip one it should have picked up.

This changes the request so tmux wraps each value in quotes and escapes any quote inside it. Now a value's line breaks stay safely inside its own quotes and cannot be mistaken for the start of a new variable. If the output ever looks like something tmux would not have produced, AoE stops guessing and asks tmux for that one session directly instead.

While confirming the fix, a second problem turned up in the same code. Each session's answer is introduced by a short marker line, and that marker was an invisible control character. tmux replaces characters like that with an underscore whenever the program asking is not running under a UTF-8 locale. On those machines no marker was ever recognised, so the grouped lookup found nothing and every session was looked up one at a time anyway, on top of the grouped call that had just been wasted. The marker is now an ordinary printable character, which tmux passes through untouched. Both problems are fixed here because both come from the same decision about how the answer is framed.

### Detail

- `get_hidden_env_batch` read `show-environment -h` and scanned physical lines for `KEY=`, keeping the last match. tmux emits a multiline value as continuation lines, so an unrelated variable holding `"...\nAOE_INSTANCE_ID=other"` produced a line indistinguishable from the real entry, and it won. Verified against tmux 3.6: the batch returned `spoofed-id` where the exact single-key read returned `real-id`.
- It now reads `show-environment -h -s`, whose records are `NAME="value"; export NAME;` with `"` and `\` escaped inside the value. A record ends at its closing quote, not at the next line break, so continuations stay attached to the variable that opened the quote. A block containing a line tmux could not have written is dropped from the result, and the caller re-reads that session with the exact single-key query.
- `BATCH_MARKER` moves from `\u{1f}` to `@`, and carries the session's batch index rather than its name. tmux's `utf8_sanitize` rewrites every byte outside `0x20..=0x7e` to `_` for a client without a UTF-8 locale, which erased the old marker, left every session uncovered, and turned #3612's batch into one extra tmux call on top of the per-session reads it replaced.

- Making the marker printable also made marker collisions possible: `sanitize_session_name` keeps any Unicode alphanumeric, so `aoe_café` printed the marker of a live `aoe_caf_`. Decimal indices are injective under that rewrite, which closes it outright; rejecting a repeated marker only caught it once the twin arrived, and tmux aborts the list at a failing segment, so a truncated run never printed one.
- A second record for the requested key, and a quoted record not closed by its exact `; export <name>;` tail, both now drop the block. Neither is reachable from tmux today, but the design rests on refusing to guess at output tmux did not write, and every rejection costs only the exact per-session re-read.

Reading the key through a format (`#{AOE_INSTANCE_ID}`) was considered and rejected: a format resolves a hidden session variable, but falls back to the tmux server's global environment when the session has none, so a stray global would make every session report the same owner. It also cannot tell an unset variable from an empty one.

Fixes #3616

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Each test fails without its half of the fix, checked by reverting rather than by assumption. Reverting the marker to `\u{1f}` fails the real-tmux test's `C` leg with the actual sanitized output, `"_aoe_env_batch_probe..."`. Ending a record at a newline fails its `C.UTF-8` leg and the parser cases.

- `tests/integration/hidden_env_batch.rs`: real-tmux regression with an unrelated multiline variable whose continuation matches the requested key, as the issue asks for.
- `src/tmux/env.rs`: parser cases for continuations that imitate an entry (key set and key unset), a continuation that imitates the next session's marker, and escaped quotes that try to close the value early.
- `src/tmux/env.rs`: a real-tmux test run under both client locales, because each half of the fix only exists under one of them. Under `C` tmux erases a non-printable marker, so that leg covers the marker. That same rewrite flattens the value's newline, so the #3616 continuation only exists under `C.UTF-8`; that leg asserts the raw output really carries the continuation before trusting the parse, so it cannot pass vacuously.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: the behavior is a tmux output parser, fully covered by unit and integration tests against a real tmux server. An e2e test would need a hostile hidden variable planted on a live session to observe anything.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

The tmux behaviors this depends on were verified live against tmux 3.6 rather than assumed: that `-s` escapes quotes and backslashes inside values, that `utf8_sanitize` rewrites the old marker on a non-UTF-8 client, and that `show-environment` output is sorted, so a continuation can land where a real entry would have been.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Hardened batched tmux environment reads against multiline values that imitate requested keys.
- Added validation for malformed, incomplete, duplicate, or ambiguous records.
- Added exact-key fallback reads when batch output is unsafe.
- Improved marker handling across locales and session-name collisions.
- Added parser and real-tmux regression tests for spoofed values, escaped data, malformed output, and locale differences.

## Benefits

- Prevents incorrect session ownership and captured-session correlation.
- Improves reliability across locale settings.
- Preserves efficient batch reads when the output is valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


