### PR TITLE
fix(web): render every theme's code pane in its own Shiki palette

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -87,7 +87,7 @@ aoe theme list                      # show all available themes
 aoe theme dir                       # print the custom themes directory
 ```
 
-The schema is flat and every field is optional. Missing color fields fall back to the Empire baseline; an omitted `appearance` or `[syntax].shiki_theme` is derived from the theme's background luminance rather than copied from Empire. Color fields cover background, borders, text, status semantics, diff colors, branch/sandbox chips, and accent. `appearance = "dark" | "light"` and `[syntax].shiki_theme` control the web dashboard's surface ramp and code-block syntax theme.
+The schema is flat and every field is optional. Missing color fields fall back to the Empire baseline; an omitted `appearance` or `[syntax].shiki_theme` is derived from the theme's background luminance rather than copied from Empire. Color fields cover background, borders, text, status semantics, diff colors, branch/sandbox chips, and accent. `appearance = "dark" | "light"` and `[syntax].shiki_theme` control the web dashboard's surface ramp and code-block syntax theme. `shiki_theme` accepts any theme id [Shiki bundles](https://shiki.style/themes); a name it does not ship falls back to `github-dark` or `github-light` by appearance.
 
 ## Session
 

--- a/web/src/components/diff/pierre/DiffWorkerPoolProvider.tsx
+++ b/web/src/components/diff/pierre/DiffWorkerPoolProvider.tsx
@@ -6,6 +6,9 @@ import { useShikiTheme } from "../../../hooks/useShikiTheme";
  * Provides a shared off-main-thread highlighter worker pool for the diff
  * renderer, so syntax highlighting of large diffs doesn't block the UI.
  *
+ * The non-diff panes highlight through `lib/highlighter` on the main thread
+ * instead, so two engines run side by side. See #3913.
+ *
  * Keyed by the active Shiki theme so a theme switch re-initializes the pool
  * with the new theme. When `Worker` is unavailable (SSR / jsdom tests) it
  * renders children directly; the diff components then highlight on the main

--- a/web/src/hooks/useHighlightedLines.ts
+++ b/web/src/hooks/useHighlightedLines.ts
@@ -3,6 +3,9 @@ import { ensureThemeLoaded, getHighlighter, langImportForPath, type ThemedToken 
 import type { RichDiffHunk } from "../lib/types";
 import { useShikiTheme } from "./useShikiTheme";
 
+// Highlights on the main thread via `lib/highlighter`, not the diff pane's
+// worker pool. See #3913.
+
 /** A single token with content and an optional foreground color. */
 export interface SyntaxToken {
   content: string;

--- a/web/src/lib/highlighter.test.ts
+++ b/web/src/lib/highlighter.test.ts
@@ -1,4 +1,6 @@
+import { readFileSync, readdirSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bundledThemes } from "shiki/themes";
 
 // Stub the shiki core/engine so no real wasm or grammar loads happen.
 // `createHighlighterCore` returns a fake HighlighterCore whose loaded-theme
@@ -33,20 +35,27 @@ vi.mock("shiki/engine/oniguruma", () => ({
 // into the stubbed engine, so we don't need to resolve it to a real module.
 vi.mock("shiki/wasm", () => ({ default: {} }));
 
-// Every theme module the source can import. Each resolves to a `default`
-// carrying a `name`, except the two below that exercise fallback branches.
+// `getHighlighter` imports github-dark directly for its construction theme.
 vi.mock("shiki/themes/github-dark.mjs", () => ({ default: { name: "github-dark" } }));
-vi.mock("shiki/themes/github-light.mjs", () => ({ default: { name: "github-light" } }));
-vi.mock("shiki/themes/github-dark-dimmed.mjs", () => ({ default: { name: "github-dark-dimmed" } }));
-vi.mock("shiki/themes/catppuccin-latte.mjs", () => ({ default: { name: "catppuccin-latte" } }));
-vi.mock("shiki/themes/dracula.mjs", () => ({ default: { name: "dracula" } }));
-vi.mock("shiki/themes/material-theme-ocean.mjs", () => ({ default: { name: "material-theme-ocean" } }));
-// Resolves with no usable default -> exercises the `if (theme)` falsy branch.
-vi.mock("shiki/themes/tokyo-night.mjs", () => ({ default: undefined }));
-// Import rejects -> exercises the catch branch.
-vi.mock("shiki/themes/rose-pine.mjs", () => {
-  throw new Error("boom");
-});
+
+// `ensureThemeLoaded` reads shiki's real `bundledThemes` registry, so these
+// tests run against the ids shiki actually ships rather than a restatement of
+// them. Shiki's registry entries are dynamic imports inside its own dist
+// bundle, which `vi.mock` cannot reach, so the two failure branches swap one
+// registry entry for the duration of a single test instead.
+async function withThemeImport(
+  id: keyof typeof bundledThemes,
+  stub: () => Promise<unknown>,
+  body: () => Promise<void>,
+): Promise<void> {
+  const real = bundledThemes[id];
+  (bundledThemes as Record<string, () => Promise<unknown>>)[id] = stub;
+  try {
+    await body();
+  } finally {
+    (bundledThemes as Record<string, () => Promise<unknown>>)[id] = real;
+  }
+}
 
 // Every language module the source can import. The exact `name` value is
 // irrelevant; loadLanguage only needs a truthy `default`.
@@ -285,21 +294,36 @@ describe("ensureThemeLoaded", () => {
     expect(loadThemeMock).not.toHaveBeenCalled();
   });
 
-  it("returns the appearance-appropriate fallback for an unknown theme", async () => {
+  it("returns the appearance-appropriate fallback for an unknown theme, warning once", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(await ensureThemeLoaded("not-a-real-theme", "light")).toBe(DEFAULT_SHIKI_THEME_LIGHT);
     expect(await ensureThemeLoaded("not-a-real-theme", "dark")).toBe(DEFAULT_SHIKI_THEME);
     expect(await ensureThemeLoaded("not-a-real-theme")).toBe(DEFAULT_SHIKI_THEME);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
   });
 
   it("falls back when the module resolves without a usable default", async () => {
-    const name = await ensureThemeLoaded("tokyo-night", "light");
-    expect(name).toBe(DEFAULT_SHIKI_THEME_LIGHT);
-    expect(loadThemeMock).not.toHaveBeenCalled();
+    await withThemeImport(
+      "tokyo-night",
+      async () => ({ default: undefined }),
+      async () => {
+        expect(await ensureThemeLoaded("tokyo-night", "light")).toBe(DEFAULT_SHIKI_THEME_LIGHT);
+        expect(loadThemeMock).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("falls back when the importer rejects", async () => {
-    const name = await ensureThemeLoaded("rose-pine", "dark");
-    expect(name).toBe(DEFAULT_SHIKI_THEME);
+    await withThemeImport(
+      "rose-pine",
+      async () => {
+        throw new Error("boom");
+      },
+      async () => {
+        expect(await ensureThemeLoaded("rose-pine", "dark")).toBe(DEFAULT_SHIKI_THEME);
+      },
+    );
   });
 
   it("loads every other registered theme cleanly", async () => {
@@ -309,9 +333,36 @@ describe("ensureThemeLoaded", () => {
       "github-dark-dimmed",
       "catppuccin-latte",
       "material-theme-ocean",
+      // Shipped by shiki but outside the old hand-picked allowlist.
+      "dark-plus",
+      "light-plus",
+      "monokai",
+      "solarized-dark",
+      "solarized-light",
+      "red",
+      "min-light",
+      "gruvbox-dark-medium",
+      "github-dark-high-contrast",
+      "github-light-high-contrast",
     ]) {
       expect(await ensureThemeLoaded(theme, "dark")).toBe(theme);
       expect(loadedThemes).toContain(theme);
+    }
+  });
+});
+
+// The Rust side asserts every builtin theme *has* a `shiki_theme`; this asserts
+// the id it names is one shiki can actually load, which the wholesale registry
+// read no longer checks for us.
+describe("builtin theme syntax palettes", () => {
+  it("each name a palette shiki bundles", () => {
+    const dir = new URL("../../../themes/builtin/", import.meta.url);
+    const files = readdirSync(dir).filter((f) => f.endsWith(".toml"));
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      const id = /^\s*shiki_theme\s*=\s*"([^"]+)"/m.exec(readFileSync(new URL(file, dir), "utf8"))?.[1];
+      expect(id, `${file} declares no shiki_theme`).toBeTruthy();
+      expect(Object.hasOwn(bundledThemes, id!), `${file} names "${id}"`).toBe(true);
     }
   });
 });

--- a/web/src/lib/highlighter.ts
+++ b/web/src/lib/highlighter.ts
@@ -1,30 +1,19 @@
 import type { HighlighterCore, ThemedToken } from "shiki";
 import { createHighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
+// Shiki's own registry of the themes it bundles, keyed by theme id, each entry
+// a lazy import that code-splits on demand. Reading it means any AoE theme,
+// builtin or user-authored, can name any theme shiki ships. The import costs
+// the id table, not the theme modules behind it.
+import { bundledThemes, type BundledTheme } from "shiki/themes";
 
 let instance: HighlighterCore | null = null;
 let loading: Promise<HighlighterCore> | null = null;
 
-/** Shiki theme module imports for every theme an AoE-resolved theme
- *  can name. Unknown values fall back to `DEFAULT_SHIKI_THEME`. Lazy
- *  imports so users on Empire don't pay for the Dracula/Tokyo Night
- *  modules they never see. */
-const SHIKI_THEME_IMPORTS: Record<string, () => Promise<unknown>> = {
-  "github-dark": () => import("shiki/themes/github-dark.mjs"),
-  "github-light": () => import("shiki/themes/github-light.mjs"),
-  "github-dark-dimmed": () => import("shiki/themes/github-dark-dimmed.mjs"),
-  "tokyo-night": () => import("shiki/themes/tokyo-night.mjs"),
-  "catppuccin-latte": () => import("shiki/themes/catppuccin-latte.mjs"),
-  dracula: () => import("shiki/themes/dracula.mjs"),
-  "rose-pine": () => import("shiki/themes/rose-pine.mjs"),
-  "material-theme-ocean": () => import("shiki/themes/material-theme-ocean.mjs"),
-};
-
-/** Fallback Shiki themes when the resolver names a theme this bundle
- *  doesn't carry (user-defined themes with arbitrary shiki_theme
- *  entries). Picked by appearance so a light AoE theme falling back
- *  doesn't end up rendering code on a light surface with a dark
- *  syntax theme. */
+/** Fallback Shiki themes for a `shiki_theme` value shiki doesn't ship
+ *  (a user-defined theme naming something arbitrary, or a typo). Picked
+ *  by appearance so a light AoE theme falling back doesn't end up
+ *  rendering code on a light surface with a dark syntax theme. */
 export const DEFAULT_SHIKI_THEME = "github-dark";
 export const DEFAULT_SHIKI_THEME_LIGHT = "github-light";
 
@@ -37,6 +26,10 @@ export function fallbackShikiTheme(appearance: "dark" | "light" | undefined): st
  * via `loadLanguage()` so the initial bundle stays small. The default
  * theme is bundled at construction time; switch to another bundled
  * theme via `ensureThemeLoaded`.
+ *
+ * This is the second highlighter in the dashboard: the diff pane runs
+ * `@pierre/diffs`' own shared instance in a worker. See #3913 for
+ * collapsing the two.
  */
 export async function getHighlighter(): Promise<HighlighterCore> {
   if (instance) return instance;
@@ -52,6 +45,22 @@ export async function getHighlighter(): Promise<HighlighterCore> {
   return loading;
 }
 
+/** `Object.hasOwn` rather than a truthy lookup so an arbitrary
+ *  `shiki_theme` string cannot reach an inherited property. */
+function isBundledTheme(name: string): name is BundledTheme {
+  return Object.hasOwn(bundledThemes, name);
+}
+
+const warnedUnknownThemes = new Set<string>();
+
+/** A theme naming a palette shiki doesn't ship is almost always a typo, and
+ *  the fallback is otherwise silent. Warn once per id, not per render. */
+function warnUnknownTheme(name: string): void {
+  if (warnedUnknownThemes.has(name)) return;
+  warnedUnknownThemes.add(name);
+  console.warn(`shiki_theme "${name}" is not a theme Shiki bundles; falling back.`);
+}
+
 /** Lazy-load a Shiki theme module and register it on the singleton
  *  highlighter. Returns the name the caller should pass to
  *  `codeToHtml` / `codeToTokens`: the requested name if it loaded
@@ -59,8 +68,11 @@ export async function getHighlighter(): Promise<HighlighterCore> {
  *  (`github-dark` / `github-light`) so a light AoE theme isn't
  *  rendered with a dark syntax palette. Idempotent. */
 export async function ensureThemeLoaded(name: string, appearance?: "dark" | "light"): Promise<string> {
-  const importer = SHIKI_THEME_IMPORTS[name];
-  if (!importer) return fallbackShikiTheme(appearance);
+  if (!isBundledTheme(name)) {
+    warnUnknownTheme(name);
+    return fallbackShikiTheme(appearance);
+  }
+  const importer = bundledThemes[name];
   const hl = await getHighlighter();
   if (hl.getLoadedThemes().includes(name)) return name;
   try {


### PR DESCRIPTION
## Description

The dashboard has two code renderers and they disagreed with each other:

* The file viewer honored the built-in 8 default themes, but fell back to GitHub Dark or GitHub Light for everything else.
* The diff pane honored all syntax palettes requested by themes-- even custom themes (like those in my [VS Code themes plugin](https://github.com/matthewpwatkins/aoe-vscode-themes)).

So if you opened one file in both panes, you saw it painted two different ways, with a potentially jarring experience on the file viewer pane.

The file viewer now resolves palettes the way the diff pane already did, by reading Shiki's own registry of the themes it bundles instead of a hand-maintained subset of it. Any of the 65 palettes Shiki ships can be named by any theme-- built-in or not-- and the two panes now agree. 

Palettes still load only when a theme asks for one, so the initial download is unchanged; actually the entry chunk comes out 6 KB smaller. A nonexistent Shiki them keeps the appearance-matched GitHub Light/Dark fallback and now logs a one-time warning instead of substituting silently.

The screenshots below show the same file open in the files pane and the diff pane at once, under the `vscode-red` theme, which asks for Shiki's Red palette, making the old discrepancy especially clear:

### Before (files pane uses GitHub Dark, diff pane uses custom theme)

<img width="1353" height="625" alt="image" src="https://github.com/user-attachments/assets/6dc726e9-754d-46bb-a625-213e788d7e2b" />

### After (files pane and diff pane both respect the custom theme)

<img width="1351" height="630" alt="image" src="https://github.com/user-attachments/assets/fe45484b-23b5-4fc7-8ae4-84f1323e602f" />

TODO (#3913): The two panes now agree on which palettes exist, but I noticed they still load them by different routes. Collapsing them is a bigger change than this fix and reviews better on its own, so this PR only drops a pointer to #3913 in the comments of both entry points.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Covered by Vitest unit tests because this is palette resolution in `web/src/lib/`, not a browser behavior (focus, keyboard, drag/drop, touch). The coverage matrix tracks `web/src/components/**`, so it needs no entry and `node tests/validate-coverage-matrix.mjs` agrees.

**TUI / CLI (e2e test)**

- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code

**Any Additional AI Details you'd like to share:** Claude found the allowlist, wrote the fix and tests, and prepared this PR; a second model reviewed it and its findings are folded in. I reviewed the diff and ran both sides in local debug builds against my own plugin themes to take the screenshots above.

- [ ] I am an AI Agent filling out this form (check box if true)

## How I tested

- The theme tests now run against Shiki's real registry instead of a mock of it, so an id Shiki drops upstream fails the suite rather than passing against a stand-in. The two failure paths (module resolves without a usable theme, import rejects) swap one registry entry for the duration of their own test.
- Added a case asserting every builtin theme's declared palette is one Shiki can actually load. The Rust-side check only asserted the field was present.
- Built debug binaries from `main` and from this branch, ran each against an isolated home seeded with the nineteen VS Code plugin themes, and compared the files and diff panes side by side under `vscode-red` (see screenshots). Sampled the rendered token colors rather than eyeballing them: `export` comes back as GitHub Dark's `#f97583` before and Red's `#f12727` after.
- `npm run test:unit`, `npm run format:check`, `npm run lint`, `npx tsc -b`, and `node tests/validate-coverage-matrix.mjs` all clean.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Shiki now provides the theme registry for syntax highlighting.
- All bundled Shiki themes and custom theme selections now work in the file viewer and diff pane.
- Unknown themes use the existing GitHub Light/Dark fallback and log one warning.
- Theme loading remains lazy, with a smaller entry bundle.
- Tests now use Shiki’s real theme registry and validate configured builtin themes.
- Documentation and comments explain the separate highlighting paths.

## Benefits

Users see consistent syntax highlighting across file and diff views. Theme support is broader and easier to maintain.

## Further enhancement

The file viewer and diff pane still use separate highlighting engines. Consolidating them could reduce duplicated work in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->