### PR TITLE
refactor(server): make the daemon core, gate only the web bundle behind `web`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,28 @@ jobs:
         with:
           cache-bin: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # `--all-features` so the `serve`-gated tree gets linted too. A plain
-      # `cargo clippy` resolves `default = ["default-plugins"]`, which leaves
-      # src/acp/ and src/serve/ (the structured view, the dashboard backend,
-      # roughly 42k lines) out of every lint run; only the cargo-test legs
-      # ever compiled them. The web-dist placeholder stands in for the npm
-      # bundle that build.rs would otherwise build, so this job still needs
-      # no Node setup; same trick as the rustdoc step in the docs job.
+      # `--all-features` so the `web`-gated dashboard tree gets linted too.
+      # The web-dist placeholder stands in for the npm bundle that build.rs
+      # would otherwise build, so this job still needs no Node setup; same
+      # trick as the rustdoc step in the docs job.
       - name: Clippy (all features)
         run: |
           mkdir -p target/ci-web-dist
           printf '<!doctype html><title>aoe clippy placeholder</title>\n' > target/ci-web-dist/index.html
           AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo clippy --all-features -- -D warnings
+      # `serve` is a deprecated alias that only turns on `web` (#3619). A
+      # `cfg(feature = "serve")` would therefore compile out under
+      # `--features web` while still working under the alias: a silent split.
+      # Gate on the source so the alias stays inert until it is removed.
+      - name: Deprecated `serve` feature-gate guard
+        run: |
+          set -euo pipefail
+          hits="$(grep -rn 'feature *= *"serve"' --include='*.rs' src/ tests/ build.rs || true)"
+          if [ -n "$hits" ]; then
+            echo "::error::cfg(feature = serve) found; the serve feature is an alias for web. Use feature = web:"
+            printf '%s\n' "$hits"
+            exit 1
+          fi
       - name: file_watch consolidation guard
         run: |
           set -euo pipefail
@@ -124,7 +134,7 @@ jobs:
         run: |
           mkdir -p target/ci-web-dist
           printf '<!doctype html><title>aoe docs placeholder</title>\n' > target/ci-web-dist/index.html
-          AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo doc --no-deps --features serve
+          AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo doc --no-deps --features web
 
   skill:
     name: Skill Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check CLI docs are up-to-date
         run: |
-          mkdir -p target/ci-web-dist
-          printf '<!doctype html><title>aoe docs placeholder</title>\n' > target/ci-web-dist/index.html
-          AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo xtask gen-docs
+          cargo xtask gen-docs
           git diff --exit-code docs/cli/reference.md \
             || (echo "::error::CLI docs are out of date. Run 'cargo xtask gen-docs' and commit." && exit 1)
       - name: Check rustdoc is warning-clean

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,10 +38,7 @@ jobs:
           node-version: '22'
 
       - name: Generate CLI documentation
-        run: |
-          mkdir -p target/ci-web-dist
-          printf '<!doctype html><title>aoe docs placeholder</title>\n' > target/ci-web-dist/index.html
-          AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo xtask gen-docs
+        run: cargo xtask gen-docs
 
       - name: Build site
         run: ./scripts/build-site.sh

--- a/.github/workflows/e2e-recording.yml
+++ b/.github/workflows/e2e-recording.yml
@@ -20,8 +20,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      # Default features include `serve`, so building the e2e crate runs
-      # the web frontend build in build.rs.
+      # The e2e suite drives Node helpers (the fake ACP agent), so Node is
+      # needed at run time even though the default build invokes no npm.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --features serve --target ${{ matrix.target }}
+        run: cargo build --release --features web --target ${{ matrix.target }}
 
       - name: Verify Linux binary glibc floor
         if: matrix.container != ''

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        leg: [serve-e2e, serve-rest, bare-core]
+        leg: [web-e2e, core-rest, bare-core]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -55,16 +55,17 @@ jobs:
       # tests/integration/acp_smoke.rs spawns the Node ACP shim under
       # acp-worker/test-shim/. The shim depends on @agentclientprotocol/sdk,
       # so its deps must be installed before the integration crate runs. Only
-      # the serve-rest leg runs the integration binary; the serve-e2e leg uses
+      # the core-rest leg runs the integration binary; the web-e2e leg uses
       # the fake ACP agent under web/tests/helpers/ instead, and bare-core does
-      # not exercise the shim.
+      # not exercise the shim. Node here is a test-runtime dependency, not a
+      # build one: core-rest's `cargo build` never invokes npm.
       - name: Install ACP shim deps
-        if: matrix.leg == 'serve-rest'
+        if: matrix.leg == 'core-rest'
         working-directory: acp-worker/test-shim
         run: npm ci
-      # serve-e2e: just the e2e binary. The e2e target is gated behind the
-      # `e2e-tests` feature so the serve-rest leg below can skip it; this leg
-      # opts in.
+      # web-e2e: just the e2e binary, and the only leg that builds the
+      # dashboard bundle. The e2e target is gated behind the `e2e-tests`
+      # feature so the core-rest leg below can skip it; this leg opts in.
       #
       # `--test-threads=3` on a 4-vCPU runner: the suite used to be entirely
       # `#[serial]` and took ~4 min of pure wall. Only the handful of tests that
@@ -75,32 +76,29 @@ jobs:
       # measured 336s -> 114s pinned to 4 cores, with identical results.
       # Raise this only with evidence; 4+ starts trading wall for flake risk on
       # the tests that wait on an ACP handshake.
-      - name: Cargo test (serve, e2e only)
-        if: matrix.leg == 'serve-e2e'
-        run: cargo test --features serve,e2e-tests --test e2e -- --test-threads=3
-      # serve-rest: the full serve suite minus e2e (lib + bins + integration +
-      # the standalone test bins). `--features serve` leaves the e2e target
-      # gated off, so it is skipped here while every non-e2e test binary stays
-      # auto-discovered. `--features serve` is a strict superset of the default
-      # suite and pulls in the aoe.web plugin (serve-gated) the e2e tests assert
-      # on, so the two feature gates are both covered across this leg + serve-e2e.
-      - name: Cargo test (serve, everything except e2e)
-        if: matrix.leg == 'serve-rest'
-        run: cargo test --features serve
-      # bare-core: the three no-default-features feature corners.
+      - name: Cargo test (web, e2e only)
+        if: matrix.leg == 'web-e2e'
+        run: cargo test --features web,e2e-tests --test e2e -- --test-threads=3
+      # core-rest: the full default-feature suite minus e2e (lib + bins +
+      # integration + the standalone test bins). The daemon is core, so this
+      # leg covers it end to end with no dashboard bundle and no npm in the
+      # build. Without `e2e-tests` the e2e target is gated off, so it is
+      # skipped here while every non-e2e test binary stays auto-discovered.
+      - name: Cargo test (default features, everything except e2e)
+        if: matrix.leg == 'core-rest'
+        run: cargo test
+      # bare-core: the three no-default-features feature corners. `web` is not
+      # a default feature, so these runs are also the dashboard-off compile
+      # gate that keeps the `cfg(feature = "web")` sites from rotting.
       #  - lib/bins: with every bundled plugin compiled out, core must still
-      #    build and pass its unit tests. `--no-default-features` also drops
-      #    `serve`, so this doubles as the TUI-only compile gate, keeping the
-      #    ~27 cfg(feature = "serve") sites from rotting.
+      #    build and pass its unit tests.
       #  - e2e: acceptance criterion 1 of #268 (issue #2097): with all default
       #    plugins disabled, aoe still creates, attaches to, and destroys a
-      #    tmux + worktree session from CLI and TUI. The serve-gated e2e modules
-      #    self-gate to empty here. `e2e-tests` opts the gated target back in.
-      #    Filtered to the modules that carry that criterion instead of the
-      #    whole 134-test suite: the rest re-asserts serve-off behavior the
-      #    serve-e2e leg already covers with plugins on, for ~90s of duplicate
-      #    wall on a concurrency-bound workflow.
-      #  - check --all-targets: default-plugins on, serve off compile gate;
+      #    tmux + worktree session from CLI and TUI. Filtered to the modules
+      #    that carry that criterion instead of the whole 134-test suite: the
+      #    rest re-asserts behavior the web-e2e leg already covers with plugins
+      #    on, for ~90s of duplicate wall on a concurrency-bound workflow.
+      #  - check --all-targets: default-plugins on, dashboard off compile gate;
       #    `e2e-tests` keeps the e2e target inside the --all-targets sweep, which
       #    the gate would otherwise silently drop.
       - name: Cargo test (bare core, no default features)
@@ -110,23 +108,36 @@ jobs:
           cargo test --no-default-features --features e2e-tests --test e2e -- \
             --test-threads=3 cli:: tui_launch:: new_session::
           cargo check --no-default-features --features default-plugins,e2e-tests --all-targets
+      # A default `cargo build` must ship the daemon without invoking Node
+      # (#3619). Shadow node and npm with failing stubs so a `web`-gate
+      # regression in build.rs fails here rather than silently reintroducing
+      # the toolchain requirement for every source build.
+      - name: Cargo build without a Node toolchain
+        if: matrix.leg == 'bare-core'
+        run: |
+          mkdir -p "$RUNNER_TEMP/no-node"
+          for stub in node npm npx; do
+            printf '#!/bin/sh\necho "$0 must not be invoked by a default cargo build" >&2\nexit 1\n' \
+              > "$RUNNER_TEMP/no-node/$stub"
+            chmod +x "$RUNNER_TEMP/no-node/$stub"
+          done
+          PATH="$RUNNER_TEMP/no-node:$PATH" cargo build
       # Folded in from a former standalone `hook-privdrop` job. That job existed
       # only to build a lib test binary it could re-run under sudo, which meant a
       # third full compile of the crate at a third feature set (~1.7 min) plus
       # its own 451MB rust-cache slot. This leg has already built the lib test
-      # binary, and `--features serve` is a superset of the default feature set,
-      # so the privdrop tests are present in it. Reusing that binary makes the
-      # privileged run nearly free.
+      # binary, and the privdrop tests are core, so they are present in it.
+      # Reusing that binary makes the privileged run nearly free.
       #
       # The privileged step is safe only on a disposable GitHub-hosted runner.
       # Do not move this leg to a persistent or self-hosted machine.
       - name: Exercise alien uid guards (privdrop)
-        if: matrix.leg == 'serve-rest'
+        if: matrix.leg == 'core-rest'
         shell: bash
         run: |
           set -euo pipefail
           test_binary="$(
-            cargo test --features serve --no-run --lib --message-format=json \
+            cargo test --no-run --lib --message-format=json \
               | jq -r '
                   select(
                     .reason == "compiler-artifact"
@@ -196,7 +207,7 @@ jobs:
     # `e2e-tests` is an empty feature whose only consumer is `required-features`
     # on the `[[test]] name = "e2e"` target, so adding it to the --lib --bins
     # run changes the cargo fingerprint and not one line of compiled behavior.
-    # `--features serve` is a strict superset of the default suite, so one run
+    # `--features web` is a strict superset of the default suite, so one run
     # covers both feature gates.
     #
     # The two halves of the macOS surface:
@@ -244,10 +255,10 @@ jobs:
           node-version: '22'
       - name: Cargo test (macOS, lib + bins)
         if: github.event_name != 'pull_request'
-        run: cargo test --features serve,e2e-tests --lib --bins
+        run: cargo test --features web,e2e-tests --lib --bins
       - name: Cargo test (macOS, acp live-daemon e2e)
         if: github.event_name != 'pull_request'
-        run: cargo test --features serve,e2e-tests --test e2e -- acp_ --test-threads=1 --nocapture
+        run: cargo test --features web,e2e-tests --test e2e -- acp_ --test-threads=1 --nocapture
       - name: Skipped on pull requests
         if: github.event_name == 'pull_request'
         run: echo "macOS runs post-merge on main; see the comment on this job."
@@ -484,7 +495,7 @@ jobs:
           # keeps INLINE sourcemaps. The mocked job uses external maps (much
           # smaller `.js`, far faster navigation); see web/vite.config.ts.
           AOE_COVERAGE_INLINE_SOURCEMAP: '1'
-        run: cargo build --features serve
+        run: cargo build --features web
       - name: Install web deps
         working-directory: web
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,15 @@ jobs:
       - name: Cargo test (web, e2e only)
         if: matrix.leg == 'web-e2e'
         run: cargo test --features web,e2e-tests --test e2e -- --test-threads=3
+      # `cargo test --features web` is otherwise never run: core-rest builds at
+      # default features and this leg names only the e2e target, so the two
+      # `cfg(feature = "web")` test blocks (the dashboard-route half of
+      # daemon_core_web_optional and the aoe.web builtin assertion in
+      # plugin_install) would compile nowhere in CI. This leg already has the
+      # lib built with `web`, so naming those two binaries is nearly free.
+      - name: Cargo test (web-gated test blocks)
+        if: matrix.leg == 'web-e2e'
+        run: cargo test --features web --test daemon_core_web_optional --test plugin_install
       # core-rest: the full default-feature suite minus e2e (lib + bins +
       # integration + the standalone test bins). The daemon is core, so this
       # leg covers it end to end with no dashboard bundle and no npm in the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,15 +79,23 @@ jobs:
       - name: Cargo test (web, e2e only)
         if: matrix.leg == 'web-e2e'
         run: cargo test --features web,e2e-tests --test e2e -- --test-threads=3
-      # `cargo test --features web` is otherwise never run: core-rest builds at
-      # default features and this leg names only the e2e target, so the two
-      # `cfg(feature = "web")` test blocks (the dashboard-route half of
-      # daemon_core_web_optional and the aoe.web builtin assertion in
-      # plugin_install) would compile nowhere in CI. This leg already has the
-      # lib built with `web`, so naming those two binaries is nearly free.
+      # The `web`-gated test code runs nowhere else: core-rest builds at
+      # default features and the step above names only the e2e target. Both
+      # halves need naming. The integration blocks are the dashboard-route half
+      # of daemon_core_web_optional and the aoe.web builtin assertion in
+      # plugin_install; the lib-level ones are src/server/assets.rs (the whole
+      # module is `web`-gated) and the QR seam in src/tui/dialogs/serve.rs,
+      # which would otherwise be neither compiled nor run on a PR. Keep
+      # `e2e-tests` on so the feature set matches the step above and cargo
+      # reuses its artifacts instead of rebuilding the crate; filter the lib run
+      # so it does not re-run the whole suite core-rest already covers.
       - name: Cargo test (web-gated test blocks)
         if: matrix.leg == 'web-e2e'
-        run: cargo test --features web --test daemon_core_web_optional --test plugin_install
+        run: |
+          cargo test --features web,e2e-tests \
+            --test daemon_core_web_optional --test plugin_install
+          cargo test --features web,e2e-tests --lib -- \
+            server::assets:: tui::dialogs::serve::qr_seam
       # core-rest: the full default-feature suite minus e2e (lib + bins +
       # integration + the standalone test bins). The daemon is core, so this
       # leg covers it end to end with no dashboard bundle and no npm in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,9 @@ duplicating cases across test functions.
 
 ### E2E tests
 
-Run `cargo test --features e2e-tests --test e2e`; add `serve` for dashboard or
-structured-view coverage. New e2e tests use `#[parallel]`. Reserve `#[serial]`
-for tests that mutate process-global state. The harness already isolates HOME,
+Run `cargo test --features e2e-tests --test e2e`; add `web` for dashboard
+coverage. New e2e tests use `#[parallel]`. Reserve `#[serial]` for tests
+that mutate process-global state. The harness already isolates HOME,
 tmux sockets, and session names. Tests auto-skip unavailable external tools.
 
 Use `RECORD_E2E=1` to record local review artifacts. See `tests/e2e/harness.rs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@
 ## Commands
 
 ```sh
-cargo build                         # TUI only
-cargo build --features serve        # web dashboard, requires Node and npm
+cargo build                         # TUI + daemon, no Node needed
+cargo build --features web          # web dashboard, requires Node and npm
 cargo build --profile dev-release   # optimized local build without LTO
 cargo test
 cargo fmt
@@ -82,7 +82,7 @@ for the harness API.
 - Follow `.github/pull_request_template.md`; include what changed, why, tests,
   and screenshots or recordings for UI changes.
 - Before review, run `cargo fmt`, `cargo clippy`, and `cargo test`, adding
-  `--features serve` when relevant.
+  `--features web` when relevant.
 - For `web/` changes also run its format, lint, type, and applicable test checks
   from `web/AGENTS.md`, including the coverage matrix requirement.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,67 +140,65 @@ which = "8.0"
 # via opencode's bun:ffi OpenTUI extract path (see anomalyco/opencode#6523).
 rusqlite = { version = "0.40", features = ["bundled"] }
 
-# Web server (optional, behind "serve" feature)
-axum = { version = "0.8", features = ["ws"], optional = true }
-# Cross-platform browser launcher for `aoe serve --open`.
-webbrowser = { version = "1", optional = true }
-tower-http = { version = "0.7", features = ["fs"], optional = true }
+# Daemon HTTP/WS server. Core: the daemon is the product, the dashboard is one
+# surface on it (see the `web` feature).
+axum = { version = "0.8", features = ["ws"] }
+# Cross-platform browser launcher: `aoe serve --open`, the plugin host's
+# `ui.open_url`, and structured-view link activation.
+webbrowser = "1"
+tower-http = { version = "0.7", features = ["fs"] }
+# Embedded dashboard bundle, behind `web`.
 rust-embed = { version = "8", features = ["debug-embed"], optional = true }
-mime_guess = { version = "2.0", optional = true }
+# Content type for the session file-read endpoint.
+mime_guess = "2.0"
+# QR of the dashboard URL (TUI serve dialog, tunnel startup). Behind `web`:
+# scanning it is only useful when there is a dashboard to open.
 qrcode = { version = "0.14", optional = true }
-argon2 = { version = "0.5", optional = true }
-subtle = { version = "2", optional = true }
+argon2 = "0.5"
+subtle = "2"
 
-# Always-on: used by the TUI for OSC 52 clipboard writes (preview
-# drag-select in live mode) and re-exported via the `serve` feature
-# for Web Push payload encoding.
+# TUI OSC 52 clipboard writes and Web Push payload encoding.
 base64 = "0.23"
 
-# Web Push (VAPID + payload encryption), optional behind "serve".
-p256 = { version = "0.13", features = ["pem", "pkcs8", "ecdsa", "ecdh"], optional = true }
-hkdf = { version = "0.13", optional = true }
-aes-gcm = { version = "0.11", optional = true }
-jsonwebtoken = { version = "11.0", features = ["aws_lc_rs"], optional = true }
-getrandom = { version = "0.4", optional = true }
+# Web Push (VAPID + payload encryption).
+p256 = { version = "0.13", features = ["pem", "pkcs8", "ecdsa", "ecdh"] }
+hkdf = "0.13"
+aes-gcm = "0.11"
+jsonwebtoken = { version = "11.0", features = ["aws_lc_rs"] }
+getrandom = "0.4"
 
-# Agent Client Protocol — drives the structured view surface bundled with `serve`.
-agent-client-protocol = { version = "2.0", optional = true, features = ["unstable_end_turn_token_usage", "unstable_elicitation", "unstable_session_fork"] }
+# Agent Client Protocol — drives the structured view surface.
+agent-client-protocol = { version = "2.0", features = ["unstable_end_turn_token_usage", "unstable_elicitation", "unstable_session_fork"] }
 
 # Semver parsing for ACP adapter compatibility checks (see src/acp/agent_compat.rs).
-semver = { version = "1", optional = true }
+semver = "1"
 
-# Tar stream handling. Used by the structured view's bundled-Node fallback
-# (with xz2 for tar.xz) and by external plugin install (with flate2 for
-# tar.gz). The `tar` and `flate2` crates are pure Rust and unconditional so
-# plugin install works in a TUI-only build; xz2 needs system liblzma and stays
-# gated to the structured view (serve).
+# Tar stream handling: the structured view's bundled-Node fallback (with xz2
+# for tar.xz) and external plugin install (with flate2 for tar.gz). xz2 needs
+# system liblzma.
 tar = "0.4"
 flate2 = "1"
-xz2 = { version = "0.1", optional = true }
+xz2 = "0.1"
 
 # WebSocket client for the structured view-in-TUI view: subscribes to the daemon's
-# `/sessions/{id}/acp/ws` stream and pumps frames into the local reducer.
-# Folded into the `serve` feature alongside the rest of the structured view surface;
-# the daemon itself uses axum's built-in WS support and never pulls this in.
-tokio-tungstenite = { version = "0.30", default-features = false, features = ["rustls-tls-webpki-roots", "connect"], optional = true }
+# `/sessions/{id}/acp/ws` stream and pumps frames into the local reducer. The
+# daemon itself uses axum's built-in WS support and never pulls this in.
+tokio-tungstenite = { version = "0.30", default-features = false, features = ["rustls-tls-webpki-roots", "connect"] }
 
 # Capability-safe file opens for the session file-read endpoint (#3088): open
 # beneath a Dir so a component swapped after the containment check cannot
 # escape the intended root.
-cap-std = { version = "4.0.2", optional = true }
+cap-std = "4.0.2"
 
 # Unix-only: O_NOFOLLOW for race-free plugin-tree reads/copies (no std constant).
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [features]
-# Lean by default: a plain `cargo build` needs no Node/npm. `serve` (the web
-# dashboard) stays opt-in (`cargo build --features serve`); the aoe.web builtin
-# rides along with it. Released binaries are built `--features serve`, so every
-# distributed binary ships the dashboard. `default-plugins` stays on by default
-# so the bundled-plugin set is the norm for source builds; it currently gates
-# nothing on its own (aoe.web needs `serve`), but reserves the on-by-default
-# slot for first-party plugins that do not require the dashboard.
+# The daemon (REST/WS API, auth, Web Push, ACP, structured view) is core: a
+# plain `cargo build` ships it and needs no Node. `web` adds the embedded
+# dashboard bundle, which is what invokes npm; released binaries are built
+# `--features web`, so every distributed binary ships the dashboard.
 default = ["default-plugins"]
 # Re-exports private tmux env helpers via `crate::tmux::test_support` so that
 # integration tests in `tests/` can poke them. Not enabled by default — only
@@ -210,44 +208,17 @@ test-support = []
 # criterion 1 of #268) by opting out with `--no-default-features`.
 default-plugins = []
 # Gates the `e2e` test target (tests/e2e/main.rs). Off by default so CI can run
-# the serve suite as two parallel shards without enumerating every non-e2e test
-# binary: `cargo test --features serve` runs everything except e2e (the target
-# is skipped when the feature is off), and `cargo test --features serve,e2e-tests
-# --test e2e` runs e2e only. Run the full serve suite locally with
-# `cargo test --features serve,e2e-tests`. Naming the target explicitly
-# (`cargo test --test e2e`) without the feature errors loudly rather than
-# skipping silently.
+# the suite as two parallel shards without enumerating every non-e2e test
+# binary: `cargo test` runs everything except e2e (the target is skipped when
+# the feature is off), and `cargo test --features e2e-tests --test e2e` runs
+# e2e only. Naming the target explicitly (`cargo test --test e2e`) without the
+# feature errors loudly rather than skipping silently.
 e2e-tests = []
-serve = [
-    "axum",
-    "tower-http",
-    "rust-embed",
-    "mime_guess",
-    "qrcode",
-    "argon2",
-    "subtle",
-    "p256",
-    "hkdf",
-    "aes-gcm",
-    "jsonwebtoken",
-    "getrandom",
-    "webbrowser",
-    # Structured view (ACP-based structured rendering of agent state) ships
-    # alongside the web dashboard — the two share state, REST routes,
-    # and the WebSocket fanout. Folded into `serve` so building the
-    # dashboard always includes the structured view surface; pulling them
-    # apart later is straightforward (structured view code lives entirely
-    # under src/acp/).
-    "agent-client-protocol",
-    "semver",
-    "xz2",
-    "tokio-tungstenite",
-    # Sandboxed, race-safe file reads for the session file endpoint (#3088):
-    # open beneath a capability Dir so a symlink or component swapped between
-    # the confinement check and the open cannot escape the intended root.
-    "cap-std",
-]
-cap-std = ["dep:cap-std"]
+# Embedded web dashboard. Builds `web/dist` in build.rs (needs Node and npm),
+# serves it from `src/server/assets.rs`, and registers the `aoe.web` builtin.
+# Without it the daemon still runs and answers `/api/*`; only the dashboard
+# routes are absent.
+web = ["rust-embed", "qrcode"]
 
 [dev-dependencies]
 serial_test = "4.0"
@@ -264,9 +235,6 @@ serde_json = "1.0"
 # dependency; the build-cache guard test parses .cargo/config.toml.
 toml = "1.1"
 cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt"] }
-# Test-only axum dep, used by the update e2e fixture server that serves
-# a fake release tarball. The runtime code uses reqwest, not axum.
-axum = { version = "0.8", features = ["ws"] }
 # Test-only tower dep for `ServiceExt::oneshot`, so the DNS-rebinding gate
 # (#2735) can be driven through the real router without binding a socket.
 tower = { version = "0.5", features = ["util"] }
@@ -274,8 +242,8 @@ tower = { version = "0.5", features = ["util"] }
 # integration tests so they can reach `crate::tmux::test_support`. This is
 # the standard Cargo pattern for opt-in test-only re-exports; the lib build
 # (and release binaries) never see the feature. `default-features = false`
-# matters: without it this entry re-enables the default `serve` feature
-# under `cargo test --no-default-features`, making that CI job meaningless.
+# matters: without it this entry re-enables the default features under
+# `cargo test --no-default-features`, making that CI job meaningless.
 agent-of-empires = { path = ".", default-features = false, features = ["test-support"] }
 
 [profile.release]
@@ -294,15 +262,9 @@ codegen-units = 16
 debug-assertions = false
 
 [[test]]
-# ACP runner is part of the serve / structured-view surface.
-name = "acp_runner_orphan"
-path = "tests/acp_runner_orphan.rs"
-required-features = ["serve"]
-
-[[test]]
 # Explicit target so the `e2e-tests` feature gate applies. Without this entry
 # Cargo auto-discovers tests/e2e/main.rs unconditionally; the gate lets CI split
-# the serve suite into "everything except e2e" and "e2e only" shards. The other
+# the suite into "everything except e2e" and "e2e only" shards. The other
 # standalone test binaries stay auto-discovered.
 name = "e2e"
 path = "tests/e2e/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,11 @@ e2e-tests = []
 # Without it the daemon still runs and answers `/api/*`; only the dashboard
 # routes are absent.
 web = ["rust-embed", "qrcode"]
+# Deprecated alias for `web`, kept for one release so existing
+# `--features serve` invocations keep building. build.rs warns when it is
+# set, and a CI guard rejects any `cfg(feature = "serve")` so the alias
+# cannot diverge from `web`.
+serve = ["web"]
 
 [dev-dependencies]
 serial_test = "4.0"

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ cargo build
 cargo test
 cargo fmt
 cargo clippy
-cargo build --features serve
+cargo build --features web
 ```
 
 See [Development](docs/development.md) for the full reference.

--- a/aoe-plugin-api/Cargo.toml
+++ b/aoe-plugin-api/Cargo.toml
@@ -18,6 +18,5 @@ toml = "1.1"
 thiserror = "2.0"
 sha2 = "0.11"
 # Parses and matches the manifest's `aoe_version` host-compatibility range.
-# Direct dep here (not via the host) because plugin install/load runs in
-# TUI-only builds, where the main crate's `serve`-gated semver is absent.
+# Direct dep here (not via the host) so this crate stays standalone.
 semver = "1"

--- a/build.rs
+++ b/build.rs
@@ -6,9 +6,22 @@ include!("build_git_watch.rs");
 fn main() {
     check_stale_build_cache();
     emit_build_version();
+    warn_on_deprecated_serve_feature();
 
     #[cfg(feature = "web")]
     build_frontend();
+}
+
+/// `serve` is an alias for `web` and is removed after one release. Cargo sets
+/// `CARGO_FEATURE_SERVE` only when the alias itself was selected, so this
+/// stays quiet for a plain `--features web` build.
+fn warn_on_deprecated_serve_feature() {
+    if std::env::var_os("CARGO_FEATURE_SERVE").is_some() {
+        println!(
+            "cargo:warning=the `serve` feature is deprecated and will be removed after the next \
+             release; use `--features web` instead"
+        );
+    }
 }
 
 /// Emit `AOE_BUILD_VERSION`, the build identity stamped on each structured view

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
     check_stale_build_cache();
     emit_build_version();
 
-    #[cfg(feature = "serve")]
+    #[cfg(feature = "web")]
     build_frontend();
 }
 
@@ -157,7 +157,7 @@ fn check_stale_build_cache() {
     let _ = std::fs::write(&hash_file, &current_hash);
 }
 
-#[cfg(feature = "serve")]
+#[cfg(feature = "web")]
 fn build_frontend() {
     use std::path::Path;
     use std::process::Command;
@@ -204,7 +204,7 @@ fn build_frontend() {
 
     assert!(
         Command::new("npm").arg("--version").output().is_ok(),
-        "npm is required to build with --features serve. Install Node.js: https://nodejs.org/"
+        "npm is required to build with --features web. Install Node.js: https://nodejs.org/"
     );
 
     maybe_install_web_deps();
@@ -229,7 +229,7 @@ fn build_frontend() {
 /// TypeScript errors like "Cannot find module 'cmdk'" because the old
 /// node_modules was considered "good enough." This now compares mtimes so any
 /// lockfile change triggers a reinstall.
-#[cfg(feature = "serve")]
+#[cfg(feature = "web")]
 fn maybe_install_web_deps() {
     use std::path::Path;
     use std::process::Command;
@@ -280,7 +280,7 @@ fn maybe_install_web_deps() {
     }
 }
 
-#[cfg(feature = "serve")]
+#[cfg(feature = "web")]
 fn copy_dir(src: &std::path::Path, dst: &std::path::Path) {
     std::fs::create_dir_all(dst).expect("Failed to create directory");
     for entry in std::fs::read_dir(src).expect("Failed to read directory") {
@@ -294,7 +294,7 @@ fn copy_dir(src: &std::path::Path, dst: &std::path::Path) {
     }
 }
 
-#[cfg(feature = "serve")]
+#[cfg(feature = "web")]
 fn is_newer_than(path: &std::path::Path, reference: std::time::SystemTime) -> bool {
     match path.metadata().and_then(|m| m.modified()) {
         Ok(mtime) => mtime > reference,

--- a/clippy.toml
+++ b/clippy.toml
@@ -6,6 +6,5 @@
 # that is measuring an idiom, not a problem. 192 clears `Response` with
 # headroom while still flagging an error type that is genuinely large.
 #
-# This surfaced only once CI started linting the `serve` feature set; the
-# affected helpers live in src/server/api/ and were never in a clippy run.
+# The affected helpers live in src/server/api/.
 large-error-threshold = 192

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -157,8 +157,8 @@ Run without arguments to launch the TUI dashboard.
 * `telemetry` — Manage anonymous opt-in usage telemetry
 * `mcp` — Inspect the effective MCP server set (provenance, conflicts, drift)
 * `skill` — Query and manage agent skills
-* `serve` — Start a web dashboard for remote session access
-* `url` — Print the current dashboard URL of a running `aoe serve` daemon
+* `serve` — Start the aoe daemon: REST/WebSocket API, plus the web dashboard in builds that embed it
+* `url` — Print the URL of a running `aoe serve` daemon
 * `acp` — Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...)
 * `uninstall` — Uninstall Agent of Empires
 * `update` — Update aoe to the latest release
@@ -1526,7 +1526,7 @@ Copy AoE-managed skills into the agents' own skills directories
 
 ## `aoe serve`
 
-Start a web dashboard for remote session access
+Start the aoe daemon: REST/WebSocket API, plus the web dashboard in builds that embed it
 
 **Usage:** `aoe serve [OPTIONS]`
 
@@ -1546,7 +1546,7 @@ Start a web dashboard for remote session access
 * `--allowed-origin <ORIGIN>` — Extra browser `Origin` to accept (repeatable, full origin `scheme://host[:port]`, e.g. `https://aoe.example.com:8443`). Needed only for a reverse proxy on a nonstandard port; standard 80/443 origins for `--allowed-host` entries are derived automatically
 * `--read-only` — Read-only mode: view terminals but cannot send keystrokes
 * `--cityhall` — CityHall client mode: a locked-down, composer-first dashboard for non-technical users (structured view only; no terminal/diff/project management). Equivalent to `AOE_CITYHALL_MODE=1`; the flag is what the daemon replays to its restart child so the mode survives `aoe update` and `aoe serve --restart`. See #7
-* `--remote` — Expose the dashboard over a public HTTPS tunnel. Prefers Tailscale Funnel when `tailscale` is installed and logged in (stable `.ts.net` URL, installable PWAs survive restarts). Falls back to a Cloudflare quick tunnel otherwise (fresh URL on every restart)
+* `--remote` — Expose the daemon over a public HTTPS tunnel. Prefers Tailscale Funnel when `tailscale` is installed and logged in (stable `.ts.net` URL, installable PWAs survive restarts). Falls back to a Cloudflare quick tunnel otherwise (fresh URL on every restart)
 * `--tunnel-name <TUNNEL_NAME>` — Use a named Cloudflare Tunnel (requires prior `cloudflared tunnel create`). Takes precedence over Tailscale auto-detection
 * `--no-tailscale` — Skip Tailscale Funnel auto-detection and go straight to Cloudflare. Useful if you have Tailscale installed for unrelated reasons
 * `--tunnel-url <TUNNEL_URL>` — Hostname for a named tunnel (e.g., aoe.example.com)
@@ -1556,14 +1556,14 @@ Start a web dashboard for remote session access
 
    `--status` is read-only and incompatible with every flag that would change daemon state (`--stop`, `--daemon`, `--remote`) or the bind config of a fresh daemon (`--no-auth`, `--auth`, `--behind-proxy`, `--read-only`, `--passphrase`, `--port`, `--tunnel-name`, `--no-tailscale`, `--tunnel-url`, `--open`, `--allowed-host`, `--allowed-origin`). Clap reports the misuse instead of silently ignoring the extras.
 * `--passphrase <PASSPHRASE>` — Require a passphrase for login (second-factor auth). Can also be set via AOE_SERVE_PASSPHRASE environment variable
-* `--open` — Open the dashboard URL in the default browser once the server is ready. Ignored under --daemon, --remote, SSH (SSH_CONNECTION/SSH_TTY), or when no display server is reachable on Linux/BSD
+* `--open` — Open the dashboard URL in the default browser once the server is ready. Ignored in a build with no dashboard bundle, and under --daemon, --remote, SSH (SSH_CONNECTION/SSH_TTY), or when no display server is reachable on Linux/BSD
 * `--restart` — Restart a running `aoe serve` daemon, replaying the host, port, mode, and auth it was launched with (read from `serve.launch`). The passphrase is recalled from `serve.passphrase` or `AOE_SERVE_PASSPHRASE` before the old daemon is stopped, so a passphrase-protected daemon is never left down. Incompatible with the flags that would change the daemon's bind config: that config comes from the persisted launch state
 
 
 
 ## `aoe url`
 
-Print the current dashboard URL of a running `aoe serve` daemon
+Print the URL of a running `aoe serve` daemon
 
 **Usage:** `aoe url [OPTIONS]`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,7 +28,7 @@ AOE_TERMINAL_TRACE=1 cargo run
 aoe logs
 ```
 
-For the dashboard, `cargo xtask dev` runs a serve-enabled debug backend on 8081
+For the dashboard, `cargo xtask dev` runs a dashboard-enabled debug backend on 8081
 and Vite with HMR on 5173. Add `--watch` to rebuild and restart the backend when
 Rust inputs change. A failed rebuild leaves the previous backend running.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,10 +5,10 @@ Install Rust and tmux. Node.js and npm are required only for the web dashboard.
 ## Build and test
 
 ```sh
-cargo build                         # debug TUI build
+cargo build                         # debug build: TUI + daemon, no Node
 cargo build --release               # shipping build with LTO
 cargo build --profile dev-release   # optimized build without LTO
-cargo build --features serve        # include the web dashboard
+cargo build --features web          # include the web dashboard
 cargo test
 cargo fmt
 cargo clippy

--- a/docs/development/adding-settings.md
+++ b/docs/development/adding-settings.md
@@ -33,7 +33,7 @@ crate) turns the annotated field into a `FieldDescriptor` in
   extend.
 - **`config.toml`** round-trips via `serde`.
 
-Run `cargo test` and `cargo build --features serve`; the field is live on all
+Run `cargo test` and `cargo build --features web`; the field is live on all
 surfaces.
 
 ## Choosing the section and widget

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -19,7 +19,7 @@ should use [Writing plugins](../writing-plugins.md) and the
 
 `src/plugin/mod.rs` owns a lazily loaded process-wide registry. Reloading it
 after a config change updates CLI, TUI, and web views from the same
-`PluginView`. The `aoe.web` builtin is present only with the `serve` feature.
+`PluginView`. The `aoe.web` builtin is present only with the `web` feature.
 
 The standalone `aoe-plugin-api` crate is the source of truth for
 `aoe-plugin.toml`. Parsing is strict and rejects unknown fields, unsupported API

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -19,7 +19,7 @@ Mobile and touch behavior is documented inline on each page.
 
 The dashboard ships in all release binaries: [GitHub Releases](https://github.com/agent-of-empires/agent-of-empires/releases), the [quick install script](../installation.md#quick-install-recommended), and Homebrew (`brew install aoe`). Just run `aoe serve`.
 
-Building from source requires the `serve` Cargo feature and Node.js to compile the embedded frontend.
+Building from source requires the `web` Cargo feature and Node.js to compile the embedded frontend. A plain `cargo build` still ships the daemon, so `aoe serve` runs and answers the API; there is just no dashboard to open.
 
 ## Starting the server
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,11 @@
 - [Docker](https://www.docker.com/) (optional, for sandboxing agents in containers)
 - [Node.js](https://nodejs.org/) (optional, only needed when building the web dashboard from source with `--features web`)
 
+Building from source also needs a C toolchain for the bundled native
+dependencies (SQLite, libgit2, OpenSSL, liblzma, and AWS-LC). Most platforms
+are covered by a stock `cc`; targets without pre-generated AWS-LC bindings
+also need CMake.
+
 ## Install Agent of Empires
 
 ### Quick Install (Recommended)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 - [tmux](https://github.com/tmux/tmux/wiki) (required)
 - [Docker](https://www.docker.com/) (optional, for sandboxing agents in containers)
-- [Node.js](https://nodejs.org/) (optional, only needed when building the web dashboard from source with `--features serve`)
+- [Node.js](https://nodejs.org/) (optional, only needed when building the web dashboard from source with `--features web`)
 
 ## Install Agent of Empires
 
@@ -37,7 +37,7 @@ The binary will be at `target/release/aoe`.
 To include the web dashboard (browser access):
 
 ```bash
-cargo build --release --features serve
+cargo build --release --features web
 ```
 
 This requires Node.js and npm. The web frontend is built automatically during compilation.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -37,13 +37,14 @@ survives every config save.
 
 | Plugin | What it does | Disabled behavior |
 |---|---|---|
-| `aoe.web` | The web dashboard management marker. Present whenever the dashboard is compiled in (`--features serve`), so every released binary ships it, enabled by default. | When disabled, `aoe serve` is an unrecognized subcommand (hidden from `aoe --help`); re-enable with `aoe plugin enable aoe.web`. `--stop` / `--status` / `--restart` still reach a running daemon. |
+| `aoe.web` | The web dashboard management marker. Present whenever the dashboard is compiled in (`--features web`), so every released binary ships it, enabled by default. | When disabled, `aoe serve` is an unrecognized subcommand (hidden from `aoe --help`); re-enable with `aoe plugin enable aoe.web`. `--stop` / `--status` / `--restart` still reach a running daemon. |
 
 `aoe.web` is the only bundled plugin today, and it rides along with the web
-dashboard. So a release binary (or any `cargo build --features serve`) shows it
-in `aoe plugin list`, while a TUI-only build (`cargo build`, no `serve`) has an
+dashboard. So a release binary (or any `cargo build --features web`) shows it
+in `aoe plugin list`, while a build without the dashboard (`cargo build`) has an
 empty registry and `aoe plugin list` reports no plugins. That is expected, not a
-bug.
+bug. The daemon itself is always compiled in, so `aoe serve` still runs there;
+it just serves the API with no dashboard behind it.
 
 The bundled set is deliberately minimal while the system is proven out. More
 first-party plugins land as each piece is verified.

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -85,7 +85,6 @@ aoe add . --agent codex --model gpt-5       # pick an ACP agent + model (implies
 `--agent` for an uninstalled adapter errors with an install hint; `--structured-view` (no `--agent`) falls back to the terminal view with a warning so the command still succeeds.
 ## Requirements
 
-- aoe built with `--features serve`.
 - Node.js 22+ on `PATH` (the structured view spawns an ACP agent subprocess; `aoe-agent` declares `engines.node: >=22.0.0`).
 - For Claude Code, a `claude login` session.
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,10 +109,10 @@
           # build.rs respects AOE_WEB_DIST to use the pre-built frontend.
           # buildDepsOnly uses a dummy crate source so AOE_WEB_DIST is irrelevant there.
           commonArgsWithWeb = commonArgs // {
-            cargoExtraArgs = "--package agent-of-empires --features serve";
+            cargoExtraArgs = "--package agent-of-empires --features web";
           };
 
-          # Rust dep cache compiled with --features serve (no npm involved).
+          # Rust dep cache compiled with --features web (no npm involved).
           cargoArtifactsWithWeb = craneLib.buildDepsOnly commonArgsWithWeb;
 
           aoeWithWeb = craneLib.buildPackage (commonArgsWithWeb // {
@@ -175,7 +175,7 @@
             packages = with pkgs; [
               rust-analyzer
               tmux
-              nodejs # for web frontend development (--features serve)
+              nodejs # for web frontend development (--features web)
             ];
           };
         };

--- a/plugins/aoe-web/aoe-plugin.toml
+++ b/plugins/aoe-web/aoe-plugin.toml
@@ -1,7 +1,7 @@
 # First-party web dashboard plugin marker (P8 of #268).
 #
 # The dashboard itself is Tier 2 trusted-native code compiled behind the
-# `serve` cargo feature; this manifest puts it under plugin management so it
+# `web` cargo feature; this manifest puts it under plugin management so it
 # can be disabled at runtime (`aoe plugin disable aoe.web`) independently of
 # the compile-time feature. `aoe serve` refuses to start while disabled.
 # Full extraction of the web crate is the last phase of the proving sequence.
@@ -10,4 +10,4 @@ id = "aoe.web"
 name = "Web Dashboard"
 version = "1.0.0"
 api_version = 1
-description = "The aoe serve web dashboard and REST/WebSocket API. Disable to keep aoe TUI-only at runtime; the serve command refuses to start while disabled."
+description = "The aoe serve web dashboard. Disable to keep aoe TUI-only at runtime; the serve command refuses to start while disabled."

--- a/scripts/dev/capture-web-screenshots.sh
+++ b/scripts/dev/capture-web-screenshots.sh
@@ -10,13 +10,14 @@
 #   scripts/dev/capture-web-screenshots.sh
 #
 # Honors AOE_E2E_BINARY if set; otherwise prefers an existing
-# target/release/aoe, then builds one with default features (includes serve).
+# target/release/aoe, then builds one with `--features web`. A default build
+# ships the daemon but no dashboard bundle, so every page would capture as a 404.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
-# Resolve a serve-enabled binary.
+# Resolve a binary with the dashboard bundle embedded.
 if [[ -n "${AOE_E2E_BINARY:-}" && -x "${AOE_E2E_BINARY}" ]]; then
   BIN="${AOE_E2E_BINARY}"
 elif [[ -x "target/release/aoe" ]]; then
@@ -24,8 +25,8 @@ elif [[ -x "target/release/aoe" ]]; then
 elif [[ -x "target/debug/aoe" ]]; then
   BIN="target/debug/aoe"
 else
-  echo "No aoe binary found; building release with default features (this is slow on a cold cache)."
-  cargo build --release
+  echo "No aoe binary found; building release with --features web (this is slow on a cold cache)."
+  cargo build --release --features web
   BIN="target/release/aoe"
 fi
 export AOE_E2E_BINARY="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"

--- a/scripts/verify-shared-target.sh
+++ b/scripts/verify-shared-target.sh
@@ -27,8 +27,8 @@ set -euo pipefail
 #                 store, then reads kache's restore counters and asserts the
 #                 second (warm) build restored its dependency artifacts as
 #                 reflinks/hardlinks (shared blocks) rather than copies. Also
-#                 builds --no-default-features into a third dir to prove serve and
-#                 non-serve builds coexist against one store. Needs kache
+#                 builds --no-default-features into a third dir to prove both
+#                 feature sets coexist against one store. Needs kache
 #                 installed and a single filesystem under $TMPDIR; skips cleanly
 #                 otherwise.
 #
@@ -168,10 +168,10 @@ full_run() {
     fail "kache copied dependency artifacts instead of sharing them; no disk dedup across worktrees"
   fi
 
-  info "building --no-default-features into a third dir (serve + non-serve coexist)..."
+  info "building --no-default-features into a third dir (feature sets coexist)..."
   cargo build --manifest-path "$ROOT_DIR/Cargo.toml" --no-default-features --target-dir "$target_serve" >/dev/null ||
     fail "--no-default-features build failed against the shared store"
-  ok "--no-default-features builds against the same store as the default (serve) builds"
+  ok "--no-default-features builds against the same store as the default builds"
 
   trap - EXIT
   rm -rf "$base"

--- a/src/acp/acp_client/resolve_command.rs
+++ b/src/acp/acp_client/resolve_command.rs
@@ -108,7 +108,6 @@ pub(super) fn bundled_resolution(
 /// True when `path` reports a version below the adapter's startup floor.
 /// Conservative: any probe failure or unparseable output returns false, so
 /// an unknown version keeps the user's own copy rather than overriding it.
-#[cfg(feature = "serve")]
 pub(super) fn path_copy_below_floor(command: &str, path: &std::path::Path) -> bool {
     let Some(gate) = crate::acp::agent_compat::version_gate_for(
         crate::acp::agent_compat::ExpectedAgent::from_command(command),
@@ -132,7 +131,6 @@ pub(super) fn path_copy_below_floor(command: &str, path: &std::path::Path) -> bo
 /// otherwise block session spawn forever. It mirrors `version_probe`'s 2s
 /// budget; any failure or timeout yields `None` so the caller keeps the
 /// user's own copy.
-#[cfg(feature = "serve")]
 pub(super) fn probe_version_bounded(path: &std::path::Path) -> Option<String> {
     const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
     const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
@@ -172,11 +170,6 @@ pub(super) fn probe_version_bounded(path: &std::path::Path) -> Option<String> {
             Err(_) => return None,
         }
     }
-}
-
-#[cfg(not(feature = "serve"))]
-pub(super) fn path_copy_below_floor(_command: &str, _path: &std::path::Path) -> bool {
-    false
 }
 
 pub(super) fn find_in_path_env(binary: &str) -> Option<std::path::PathBuf> {
@@ -285,7 +278,7 @@ mod tests {
     /// A hanging adapter must not block session spawn: the probe has to give
     /// up on its deadline and report nothing, so the caller keeps the user's
     /// copy rather than waiting forever.
-    #[cfg(all(unix, feature = "serve"))]
+    #[cfg(unix)]
     #[test]
     fn probe_version_bounded_gives_up_on_a_hanging_binary() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -303,7 +296,7 @@ mod tests {
         );
     }
 
-    #[cfg(all(unix, feature = "serve"))]
+    #[cfg(unix)]
     #[test]
     fn probe_version_bounded_reads_version_output() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/src/acp/adapters.rs
+++ b/src/acp/adapters.rs
@@ -483,7 +483,6 @@ mod tests {
     /// The pin is only meaningful if it satisfies the floor the startup gate
     /// enforces; otherwise `doctor --fix` would install an adapter that
     /// `initialize` then rejects. Mirrors `dockerfile_pin_matches_floor`.
-    #[cfg(feature = "serve")]
     #[test]
     fn claude_pin_satisfies_startup_floor() {
         let manifest: serde_json::Value =

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -612,8 +612,7 @@ impl HttpClient {
     /// the daemon already resolves the active profile's value for the web
     /// dashboard. See #3253.
     pub async fn compaction_reminder(&self) -> Result<Option<u8>, HttpError> {
-        /// The two `/api/about` fields the view needs. `ServerAbout` lives
-        /// behind the `serve` feature, so a TUI-only build cannot name it.
+        /// The two `/api/about` fields the view needs.
         #[derive(serde::Deserialize)]
         struct ReminderAbout {
             acp_compaction_reminder: bool,

--- a/src/acp/mcp_config.rs
+++ b/src/acp/mcp_config.rs
@@ -2,8 +2,8 @@
 //!
 //! Parsing, layering, provenance, and the precedence merge all live in the
 //! always-compiled `session::mcp_model` resolver, which the unified management
-//! surface (#1996), the CLI, and the TUI also read. This serve-gated module is
-//! the thin edge that converts the resolver's winning set into ACP `McpServer`
+//! surface (#1996), the CLI, and the TUI also read. This module is the thin
+//! edge that converts the resolver's winning set into ACP `McpServer`
 //! wire values and drops any transport the agent did not advertise. Sharing one
 //! resolver across forwarding and display guarantees what the user sees equals
 //! what the agent receives.

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -14,7 +14,6 @@
 
 pub mod acp_client;
 pub mod adapters;
-#[cfg(feature = "serve")]
 pub mod agent_compat;
 pub mod agent_policy;
 pub mod agent_profiles;
@@ -33,13 +32,11 @@ pub mod fs_handler;
 pub mod install_hints;
 pub mod mcp_config;
 pub mod node;
-/// Recall cache of per-agent ACP config options; consumed only by the web
-/// dashboard defaults page, so it is compiled with the serve feature.
-#[cfg(feature = "serve")]
+/// Recall cache of per-agent ACP config options, consumed by the dashboard's
+/// defaults page.
 pub mod option_catalog;
 pub mod permissions;
 pub mod protocol;
-#[cfg(feature = "serve")]
 pub mod sandbox;
 pub mod session_paths;
 pub mod session_tee;
@@ -47,7 +44,6 @@ pub mod state;
 pub mod supervisor;
 pub mod terminal_handler;
 pub mod transcript;
-#[cfg(feature = "serve")]
 pub mod version_probe;
 
 pub use agent_registry::{inherited_acp_base, AgentRegistry, AgentSpec};

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1554,8 +1554,7 @@ pub fn get_agent(name: &str) -> Option<&'static AgentDef> {
 /// Registry lifecycle state for an ACP-registry key. Falls back to Active
 /// for registry entries with no `AGENTS` counterpart (bundled or alias-only
 /// keys). Shared by the doctor, `/api/acp/agents`, and `aoe acp agents`
-/// surfaces; every consumer is serve-gated, so the helper is too.
-#[cfg(feature = "serve")]
+/// surfaces.
 pub(crate) fn registry_lifecycle(name: &str) -> AgentLifecycle {
     get_agent(name)
         .map(|def| def.lifecycle)

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -250,7 +250,6 @@ struct AgentVersionIssue {
     install_command: String,
 }
 
-#[cfg(feature = "serve")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum DoctorFixAction {
     PrintHint { reason: String },
@@ -261,7 +260,6 @@ enum DoctorFixAction {
 /// npm-distributed adapters are installed by `adapters::install`, not
 /// here). Missing or stale gated adapters get a manual install hint; a
 /// current or ungated adapter is left alone.
-#[cfg(feature = "serve")]
 fn doctor_fix_action(
     gate: Option<crate::acp::agent_compat::VersionGate>,
     probe: &crate::acp::version_probe::ProbeStatus,
@@ -308,7 +306,6 @@ fn doctor_fix_action(
 /// the bundled install above. A bundled adapter that IS on `PATH` still
 /// gets checked, because that copy shadows the pinned one (PATH-first
 /// resolution) and a stale one would break the session anyway.
-#[cfg(feature = "serve")]
 fn skip_gate_check(binary: &str, on_path: bool) -> bool {
     !on_path && crate::acp::adapters::is_bundled(binary)
 }
@@ -324,7 +321,6 @@ fn skip_gate_check(binary: &str, on_path: bool) -> bool {
 /// or failed probe keeps the PATH copy at spawn, so it stays flagged
 /// here. Absence with nothing installed stays the presence check's
 /// report; probing cannot sharpen it.
-#[cfg(feature = "serve")]
 fn doctor_version_issue(
     gate: &crate::acp::agent_compat::VersionGate,
     probe: &crate::acp::version_probe::ProbeStatus,
@@ -371,7 +367,6 @@ fn doctor_version_issue(
 /// in the app data dir, not merely bundleable. Shared by the `--fix`
 /// reporter and the plain listing so the #1017 fallback semantics have
 /// one definition.
-#[cfg(feature = "serve")]
 fn bundled_copy_installed(binary: &str) -> bool {
     crate::session::get_app_dir()
         .is_ok_and(|app_dir| crate::acp::adapters::bundled_adapter_bin(&app_dir, binary).is_some())
@@ -382,7 +377,6 @@ fn bundled_copy_installed(binary: &str) -> bool {
 /// and credit the pinned bundle only when its own copy provably meets
 /// the floor. Skips the probe subprocess entirely when nothing usable
 /// is installed; the presence branch already reports that.
-#[cfg(feature = "serve")]
 async fn run_doctor_version_issue(
     gate: &crate::acp::agent_compat::VersionGate,
 ) -> Option<AgentVersionIssue> {
@@ -429,7 +423,6 @@ async fn run_doctor_version_issue(
 
 /// Strict stdout semver of the installed pinned copy, probed at its
 /// resolved data-dir path (`which::which` cannot see it there).
-#[cfg(feature = "serve")]
 async fn bundled_copy_strict_version(binary: &str) -> Option<semver::Version> {
     let app_dir = crate::session::get_app_dir().ok()?;
     let path = crate::acp::adapters::bundled_adapter_bin(&app_dir, binary)?;
@@ -446,13 +439,11 @@ async fn bundled_copy_strict_version(binary: &str) -> Option<semver::Version> {
 /// an older pin in the data dir; crediting it would reproduce #3267
 /// behind a green doctor, since spawn prefers it whenever the PATH copy
 /// looks stale and validate() then rejects the handshake.
-#[cfg(feature = "serve")]
 async fn bundled_copy_meets_floor(gate: &crate::acp::agent_compat::VersionGate) -> bool {
     let found = bundled_copy_strict_version(gate.binary).await;
     semver::Version::parse(gate.min_version).is_ok_and(|min| found.is_some_and(|v| v >= min))
 }
 
-#[cfg(feature = "serve")]
 async fn run_doctor_fix_action(binary: &str) {
     let gate = crate::acp::agent_compat::version_gate_for(
         crate::acp::agent_compat::ExpectedAgent::from_command(binary),
@@ -579,7 +570,6 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
         // any bundled adapter whose PATH copy shadows the pinned one. A
         // stale global would otherwise win at spawn with `--fix` reporting
         // success. See #1017.
-        #[cfg(feature = "serve")]
         for gate in crate::acp::agent_compat::version_gates() {
             if skip_gate_check(gate.binary, find_in_path(gate.binary).is_some()) {
                 continue;
@@ -590,12 +580,10 @@ async fn doctor(json: bool, fix: bool, adapter: Vec<String>, all_adapters: bool)
     let registry = AgentRegistry::with_defaults();
 
     let node_status = check_node();
-    #[cfg(feature = "serve")]
     let mut gate_issues: Vec<(&'static str, Option<AgentVersionIssue>)> = Vec::new();
     let mut agent_entries: Vec<AgentDoctorEntry> = Vec::new();
     for (name, spec) in registry.list() {
         let command_present = command_present(&spec.command);
-        #[cfg(feature = "serve")]
         let version_issue = if command_present {
             let expected = crate::acp::agent_compat::ExpectedAgent::from_command(&spec.command);
             match crate::acp::agent_compat::version_gate_for(expected) {
@@ -1288,7 +1276,6 @@ mod tests {
         assert_eq!(value["lifecycle"]["since"], "2026-06-18", "{value}");
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn doctor_fix_hints_missing_and_stale_gated_agents() {
         let claude = crate::acp::agent_compat::version_gate_for(
@@ -1311,7 +1298,6 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn doctor_fix_skips_current_and_ungated_agents() {
         let claude = crate::acp::agent_compat::version_gate_for(
@@ -1369,7 +1355,6 @@ mod tests {
         assert!(!skip_gate_check("opencode", true));
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn doctor_fix_hints_non_npm_stale_agents() {
         let opencode = crate::acp::agent_compat::version_gate_for(
@@ -1389,7 +1374,6 @@ mod tests {
     }
 
     /// Gate fixture for the doctor version-issue tests.
-    #[cfg(feature = "serve")]
     fn claude_gate() -> crate::acp::agent_compat::VersionGate {
         crate::acp::agent_compat::version_gate_for(
             crate::acp::agent_compat::ExpectedAgent::ClaudeAgentAcp,
@@ -1401,7 +1385,6 @@ mod tests {
     /// gate, not mere binary presence. The exact repro from the issue:
     /// global adapter at 0.37.0 against the 0.55.0 floor, on PATH,
     /// nothing bundled, sessions dying at initialize.
-    #[cfg(feature = "serve")]
     #[test]
     fn doctor_flags_stale_gated_adapter_with_remediation() {
         let gate = claude_gate();
@@ -1427,7 +1410,6 @@ mod tests {
     /// stale, and absence stays the presence check's report instead of a
     /// second complaint. Bundle-only installs never reach this function:
     /// the runner judges them from the pinned copy itself.
-    #[cfg(feature = "serve")]
     #[test]
     fn doctor_version_issue_verdicts() {
         use crate::acp::version_probe::ProbeStatus;

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -137,19 +137,16 @@ pub struct AddArgs {
     /// to the terminal (raw tmux/PTY) so the CLI matches the TUI; pass this
     /// (or `--agent`) to opt into the structured rendering. Ignored for
     /// tools with no ACP adapter.
-    #[cfg(feature = "serve")]
     #[arg(long = "structured-view")]
     structured_view: bool,
 
     /// Pick a specific ACP agent for the structured view (e.g., claude-code,
     /// codex).
-    #[cfg(feature = "serve")]
     #[arg(long = "agent")]
     agent: Option<String>,
 
     /// Override the model used by the ACP agent (e.g., claude-opus-4-7,
     /// gpt-5, gemini-2.5-pro). Forwarded to the agent at session start.
-    #[cfg(feature = "serve")]
     #[arg(long = "model")]
     model: Option<String>,
 
@@ -284,12 +281,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // incoherent: structured fork is its own flow (ACP `session/fork`) and is
     // offered from the web dashboard, not here. Reject it here, before any
     // worktree or scratch directory is created, so the refusal leaks nothing.
-    // The structured-view flags are serve-gated, so `wants_structured` is
-    // always false on bare-core.
-    #[cfg(feature = "serve")]
     let wants_structured = args.structured_view || args.agent.is_some();
-    #[cfg(not(feature = "serve"))]
-    let wants_structured = false;
     if args.fork_from.is_some() && wants_structured {
         bail!(
             "`--fork-from` performs a terminal fork and cannot be combined with \
@@ -730,38 +722,36 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // structured. `--structured-view` (or `--agent`, which names a specific
     // ACP agent) opts into the structured rendering; a non-ACP tool always
     // runs in the terminal view.
-    #[cfg(feature = "serve")]
-    {
-        // `--agent` is an explicit structured-view choice: the user named a
-        // specific ACP agent, so a missing adapter is a hard error rather
-        // than a silent downgrade.
-        let user_picked_agent = args.agent.is_some();
-        let user_wants_structured = args.structured_view || user_picked_agent;
-        // The `--fork-from` + structured-view refusal is hoisted above
-        // worktree/scratch creation (see the early fork-validation block) so it
-        // leaks no resources; nothing to re-check here.
-        instance.agent_name = args.agent.clone();
-        instance.agent_model = args.model.clone();
+    // `--agent` is an explicit structured-view choice: the user named a
+    // specific ACP agent, so a missing adapter is a hard error rather
+    // than a silent downgrade.
+    let user_picked_agent = args.agent.is_some();
+    let user_wants_structured = args.structured_view || user_picked_agent;
+    // The `--fork-from` + structured-view refusal is hoisted above
+    // worktree/scratch creation (see the early fork-validation block) so it
+    // leaks no resources; nothing to re-check here.
+    instance.agent_name = args.agent.clone();
+    instance.agent_model = args.model.clone();
 
-        let registry = crate::acp::agent_registry::AgentRegistry::with_defaults();
-        let agent_name = pick_acp_agent_name(
-            &registry,
-            &config.session,
-            &config.acp,
-            &instance.tool,
-            instance.agent_name.as_deref(),
-        );
-        // Capability is judged against the explicit `--agent` (or, with none,
-        // the tool itself), NOT `pick_acp_agent_name`'s default-agent fallback:
-        // otherwise every tool would look ACP-capable via that default and
-        // `--structured-view` could never be rejected for a non-ACP tool (it
-        // would silently substitute the default). Mirrors the server create
-        // path in `src/server/api/sessions.rs`.
-        let capability_key = instance
-            .agent_name
-            .as_deref()
-            .unwrap_or(instance.tool.as_str());
-        let acp_capable = registry.get(capability_key).is_some()
+    let registry = crate::acp::agent_registry::AgentRegistry::with_defaults();
+    let agent_name = pick_acp_agent_name(
+        &registry,
+        &config.session,
+        &config.acp,
+        &instance.tool,
+        instance.agent_name.as_deref(),
+    );
+    // Capability is judged against the explicit `--agent` (or, with none,
+    // the tool itself), NOT `pick_acp_agent_name`'s default-agent fallback:
+    // otherwise every tool would look ACP-capable via that default and
+    // `--structured-view` could never be rejected for a non-ACP tool (it
+    // would silently substitute the default). Mirrors the server create
+    // path in `src/server/api/sessions.rs`.
+    let capability_key = instance
+        .agent_name
+        .as_deref()
+        .unwrap_or(instance.tool.as_str());
+    let acp_capable = registry.get(capability_key).is_some()
             || config.session.agent_acp_cmd.contains_key(capability_key)
             || config.session.agent_acp_cmd.contains_key(&instance.tool)
             // A custom agent inheriting a registry-backed base via
@@ -772,132 +762,131 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             || crate::acp::inherited_acp_base(&instance.tool, &config.session.agent_detect_as)
                 .is_some();
 
-        if user_picked_agent && !acp_capable {
-            bail!(
-                "agent `{agent_name}` is not ACP-capable: it has no registry entry and no \
+    if user_picked_agent && !acp_capable {
+        bail!(
+            "agent `{agent_name}` is not ACP-capable: it has no registry entry and no \
                  `[session.agent_acp_cmd]` command.\n\
                  Run `aoe acp doctor` to see configured agents, or omit --agent for a \
                  terminal-view session."
-            );
-        }
+        );
+    }
 
-        if args.structured_view && !acp_capable {
-            bail!(
-                "tool `{}` is not ACP-capable, so --structured-view has no effect.\n\
+    if args.structured_view && !acp_capable {
+        bail!(
+            "tool `{}` is not ACP-capable, so --structured-view has no effect.\n\
                  Run `aoe acp doctor` to see configured agents, or drop --structured-view \
                  for a terminal-view session.",
-                instance.tool
-            );
-        }
+            instance.tool
+        );
+    }
 
-        instance.view = if user_wants_structured && acp_capable {
-            crate::session::View::Structured
-        } else {
-            crate::session::View::Terminal
-        };
+    instance.view = if user_wants_structured && acp_capable {
+        crate::session::View::Structured
+    } else {
+        crate::session::View::Terminal
+    };
 
-        // Precondition: the structured view needs the resolved ACP adapter
-        // binary on PATH. A missing adapter would otherwise surface as a
-        // silent 404 on the first prompt. When the user explicitly named
-        // an agent (--agent) we bail; otherwise (the default path) we fall
-        // back to the terminal view with a warning so `aoe add` still
-        // succeeds on a machine without the adapter installed.
-        if instance.is_structured() {
-            let (mut spec, spec_from_registry) = match registry.get(&agent_name) {
-                Some(spec) => (spec.clone(), true),
-                None => match config.session.agent_acp_cmd.get(&agent_name) {
+    // Precondition: the structured view needs the resolved ACP adapter
+    // binary on PATH. A missing adapter would otherwise surface as a
+    // silent 404 on the first prompt. When the user explicitly named
+    // an agent (--agent) we bail; otherwise (the default path) we fall
+    // back to the terminal view with a warning so `aoe add` still
+    // succeeds on a machine without the adapter installed.
+    if instance.is_structured() {
+        let (mut spec, spec_from_registry) = match registry.get(&agent_name) {
+            Some(spec) => (spec.clone(), true),
+            None => match config.session.agent_acp_cmd.get(&agent_name) {
+                Some(cmd) => (
+                    crate::acp::AgentSpec::from_acp_cmd(&agent_name, cmd)
+                        .map_err(|e| anyhow::anyhow!(e))?,
+                    false,
+                ),
+                None => match config.session.agent_acp_cmd.get(&instance.tool) {
                     Some(cmd) => (
-                        crate::acp::AgentSpec::from_acp_cmd(&agent_name, cmd)
+                        crate::acp::AgentSpec::from_acp_cmd(&instance.tool, cmd)
                             .map_err(|e| anyhow::anyhow!(e))?,
                         false,
                     ),
-                    None => match config.session.agent_acp_cmd.get(&instance.tool) {
-                        Some(cmd) => (
-                            crate::acp::AgentSpec::from_acp_cmd(&instance.tool, cmd)
-                                .map_err(|e| anyhow::anyhow!(e))?,
-                            false,
-                        ),
-                        // A custom agent inheriting a registry-backed base runs
-                        // that base's adapter; check that binary is on PATH.
-                        // Resolve inheritance from the same keys the capability
-                        // check accepted (`capability_key` for an explicit
-                        // --agent wrapper, else the tool), so `--tool X --agent
-                        // <wrapper>` where only the wrapper inherits does not
-                        // fall through to `unreachable!`.
-                        None => match crate::acp::inherited_acp_base(
-                            capability_key,
+                    // A custom agent inheriting a registry-backed base runs
+                    // that base's adapter; check that binary is on PATH.
+                    // Resolve inheritance from the same keys the capability
+                    // check accepted (`capability_key` for an explicit
+                    // --agent wrapper, else the tool), so `--tool X --agent
+                    // <wrapper>` where only the wrapper inherits does not
+                    // fall through to `unreachable!`.
+                    None => match crate::acp::inherited_acp_base(
+                        capability_key,
+                        &config.session.agent_detect_as,
+                    )
+                    .or_else(|| {
+                        crate::acp::inherited_acp_base(
+                            &instance.tool,
                             &config.session.agent_detect_as,
                         )
-                        .or_else(|| {
-                            crate::acp::inherited_acp_base(
-                                &instance.tool,
-                                &config.session.agent_detect_as,
-                            )
-                        })
-                        .and_then(|base| registry.get(&base).cloned())
-                        {
-                            Some(spec) => (spec, true),
-                            None => unreachable!("acp_capable implies a resolvable spec"),
-                        },
+                    })
+                    .and_then(|base| registry.get(&base).cloned())
+                    {
+                        Some(spec) => (spec, true),
+                        None => unreachable!("acp_capable implies a resolvable spec"),
                     },
                 },
-            };
-            // Overlay session.agent_command_override the same way the agent
-            // spawn path does, so the precondition checks the binary that
-            // will actually launch (e.g. opencode-plannotator), not the
-            // bare registry binary. See #1910.
-            if let Some(ovr) = crate::server::acp_reconciler::command_override_for_spawn(
-                &instance.tool,
-                &instance.command,
-            ) {
-                crate::acp::supervisor::apply_agent_command_override(
-                    &agent_name,
-                    spec_from_registry,
-                    &ovr,
-                    &mut spec,
-                )?;
-            }
-            if !crate::cli::acp::command_present(&spec.command) {
-                let hint = crate::acp::install_hints::install_hint_for(&spec.command)
-                    .unwrap_or("install via your package manager and re-run");
-                if user_picked_agent {
-                    bail!(
-                        "ACP adapter `{}` is not installed or not on $PATH.\n\
+            },
+        };
+        // Overlay session.agent_command_override the same way the agent
+        // spawn path does, so the precondition checks the binary that
+        // will actually launch (e.g. opencode-plannotator), not the
+        // bare registry binary. See #1910.
+        if let Some(ovr) = crate::server::acp_reconciler::command_override_for_spawn(
+            &instance.tool,
+            &instance.command,
+        ) {
+            crate::acp::supervisor::apply_agent_command_override(
+                &agent_name,
+                spec_from_registry,
+                &ovr,
+                &mut spec,
+            )?;
+        }
+        if !crate::cli::acp::command_present(&spec.command) {
+            let hint = crate::acp::install_hints::install_hint_for(&spec.command)
+                .unwrap_or("install via your package manager and re-run");
+            if user_picked_agent {
+                bail!(
+                    "ACP adapter `{}` is not installed or not on $PATH.\n\
                          Install: {}\n\
                          Or run: aoe acp doctor --fix\n\
                          Or use the terminal view: drop --agent / --structured-view.",
-                        spec.command,
-                        hint
-                    );
-                }
-                eprintln!(
-                    "warning: ACP adapter `{}` is not installed; this session will use the \
+                    spec.command,
+                    hint
+                );
+            }
+            eprintln!(
+                "warning: ACP adapter `{}` is not installed; this session will use the \
                      terminal view. Install it ({}) or run `aoe acp doctor --fix`, then \
                      switch the session to the structured view.",
-                    spec.command, hint
-                );
-                instance.view = crate::session::View::Terminal;
-            }
+                spec.command, hint
+            );
+            instance.view = crate::session::View::Terminal;
         }
+    }
 
-        // Pin the structured-view model AFTER the adapter check above, which may
-        // have downgraded the session to terminal. Only a session that stays
-        // structured persists the per-agent default: agent_model is ACP-only, so
-        // a terminal fallback must not retain an ACP-derived default. Routed
-        // through the shared resolver so an explicit --model wins and is trimmed
-        // identically to the web create path; an explicit --model on a
-        // downgraded session is left untouched. `agent_name` is the same key the
-        // spawn resolves defaults against (see pick_agent_for_tool). Effort has
-        // no Instance field, so the spawn path resolves the default effort.
-        if instance.is_structured() {
-            let defaults = config.acp.acp_defaults_for(&agent_name);
-            instance.agent_model = crate::session::config::resolve_spawn_model_effort(
-                defaults,
-                instance.agent_model.take(),
-                None,
-            )
-            .0;
-        }
+    // Pin the structured-view model AFTER the adapter check above, which may
+    // have downgraded the session to terminal. Only a session that stays
+    // structured persists the per-agent default: agent_model is ACP-only, so
+    // a terminal fallback must not retain an ACP-derived default. Routed
+    // through the shared resolver so an explicit --model wins and is trimmed
+    // identically to the web create path; an explicit --model on a
+    // downgraded session is left untouched. `agent_name` is the same key the
+    // spawn resolves defaults against (see pick_agent_for_tool). Effort has
+    // no Instance field, so the spawn path resolves the default effort.
+    if instance.is_structured() {
+        let defaults = config.acp.acp_defaults_for(&agent_name);
+        instance.agent_model = crate::session::config::resolve_spawn_model_effort(
+            defaults,
+            instance.agent_model.take(),
+            None,
+        )
+        .0;
     }
 
     // Apply the fork seed validated earlier (before worktree/scratch creation):
@@ -1220,10 +1209,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         }
     }
 
-    #[cfg(feature = "serve")]
     let is_acp = instance.is_structured();
-    #[cfg(not(feature = "serve"))]
-    let is_acp = false;
 
     if is_acp {
         // Acp sessions aren't backed by tmux: their ACP worker is
@@ -1450,7 +1436,6 @@ fn cleanup_partial_session(
 /// registry entry → custom agent with `agent_acp_cmd` → custom agent
 /// inheriting a registry-backed base via `agent_detect_as` (resolves to
 /// the base key) → `claude` for the claude tool, else `acp.default_agent`.
-#[cfg(feature = "serve")]
 fn pick_acp_agent_name(
     registry: &crate::acp::agent_registry::AgentRegistry,
     session: &crate::session::config::SessionConfig,

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -202,10 +202,11 @@ pub enum Commands {
         command: SkillCommands,
     },
 
-    /// Start a web dashboard for remote session access
+    /// Start the aoe daemon: REST/WebSocket API, plus the web dashboard in
+    /// builds that embed it
     Serve(ServeArgs),
 
-    /// Print the current dashboard URL of a running `aoe serve` daemon
+    /// Print the URL of a running `aoe serve` daemon
     Url(UrlArgs),
 
     /// Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...).

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -6,7 +6,6 @@
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
-#[cfg(feature = "serve")]
 use super::acp::AcpCommands;
 use super::add::AddArgs;
 use super::cityhall::CityHallCommands;
@@ -15,7 +14,6 @@ use super::group::GroupCommands;
 use super::init::InitArgs;
 use super::killall::KillallArgs;
 use super::list::ListArgs;
-#[cfg(feature = "serve")]
 use super::log_level::LogLevelArgs;
 use super::logs::LogsArgs;
 use super::mcp::McpCommands;
@@ -25,7 +23,6 @@ use super::project::ProjectCommands;
 use super::ps::PsArgs;
 use super::remove::RemoveArgs;
 use super::send::SendArgs;
-#[cfg(feature = "serve")]
 use super::serve::ServeArgs;
 use super::session::SessionCommands;
 use super::settings::SettingsCommands;
@@ -37,7 +34,6 @@ use super::theme::ThemeCommands;
 use super::tmux::TmuxCommands;
 use super::uninstall::UninstallArgs;
 use super::update::UpdateArgs;
-#[cfg(feature = "serve")]
 use super::url::UrlArgs;
 use super::worktree::WorktreeCommands;
 
@@ -95,7 +91,6 @@ pub enum Commands {
     /// Pass a bare level (debug/info/...) for the safe expansion, or
     /// `--filter <expr>` for raw EnvFilter syntax. `--get` prints the
     /// current filter. Changes are ephemeral and lost on daemon restart.
-    #[cfg(feature = "serve")]
     LogLevel(LogLevelArgs),
 
     /// Remove a session
@@ -208,15 +203,12 @@ pub enum Commands {
     },
 
     /// Start a web dashboard for remote session access
-    #[cfg(feature = "serve")]
     Serve(ServeArgs),
 
     /// Print the current dashboard URL of a running `aoe serve` daemon
-    #[cfg(feature = "serve")]
     Url(UrlArgs),
 
     /// Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...).
-    #[cfg(feature = "serve")]
     Acp {
         #[command(subcommand)]
         command: AcpCommands,
@@ -225,7 +217,6 @@ pub enum Commands {
     /// Internal: per-acp-worker shim spawned by `aoe serve`. Owns the
     /// agent subprocess and outlives the daemon so workers survive
     /// `aoe serve --stop`. Hidden from help.
-    #[cfg(feature = "serve")]
     #[command(name = "__acp-runner", hide = true)]
     AcpRunner(Box<crate::process::runner::AcpRunnerArgs>),
 
@@ -252,12 +243,9 @@ pub enum Commands {
 /// Every command name [`command_name`] can return, used as the closed
 /// allowlist when building the `cli_usage` telemetry event: any key loaded from
 /// a hand-edited or corrupt `telemetry.json` that is not in this set is dropped
-/// before sending, so the wire payload can only ever carry these tokens. The
-/// `serve` / `url` / `acp` / `log_level` names are listed unconditionally
-/// even though their variants are `serve`-feature-gated; in a TUI-only build
-/// those commands cannot run, so the extra allowlist entries are simply never
-/// matched. Keep in sync with [`command_name`]; the unit test asserts every
-/// `command_name` output is a member.
+/// before sending, so the wire payload can only ever carry these tokens. Keep
+/// in sync with [`command_name`]; the unit test asserts every `command_name`
+/// output is a member.
 pub const CLI_COMMAND_NAMES: &[&str] = &[
     "add",
     "agents",
@@ -310,7 +298,6 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::List(_) => "list",
         Commands::Ps(_) => "ps",
         Commands::Logs(_) => "logs",
-        #[cfg(feature = "serve")]
         Commands::LogLevel(_) => "log_level",
         Commands::Remove(_) => "remove",
         Commands::Send(_) => "send",
@@ -332,14 +319,10 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Telemetry { .. } => "telemetry",
         Commands::Mcp { .. } => "mcp",
         Commands::Skill { .. } => "skill",
-        #[cfg(feature = "serve")]
         Commands::Serve(_) => "serve",
-        #[cfg(feature = "serve")]
         Commands::Url(_) => "url",
-        #[cfg(feature = "serve")]
         Commands::Acp { .. } => "acp",
         // Internal, machine-spawned commands: never a user action, never counted.
-        #[cfg(feature = "serve")]
         Commands::AcpRunner(_) => return None,
         Commands::ExtractSessionId(_) => return None,
         Commands::Uninstall(_) => "uninstall",
@@ -397,9 +380,9 @@ mod tests {
     /// nothing forces a matching `CLI_COMMAND_NAMES` entry. Without this guard a
     /// contributor could add a counted command and silently drop it from the
     /// `cli_usage` payload (`build_cli_usage` filters unknown keys). Assert every
-    /// visible clap subcommand is in the allowlist (subset direction: the
-    /// allowlist may carry extra `serve`-only names in a TUI-only build, which is
-    /// a harmless never-matched filter key). `log-level` maps to `log_level`.
+    /// visible clap subcommand is in the allowlist (subset direction: an
+    /// extra allowlist entry is a harmless never-matched filter key).
+    /// `log-level` maps to `log_level`.
     #[test]
     fn allowlist_covers_every_visible_subcommand() {
         use clap::CommandFactory;

--- a/src/cli/graft.rs
+++ b/src/cli/graft.rs
@@ -47,13 +47,11 @@ pub fn plugin_commands() -> Vec<PluginCommand> {
 /// so no extra cost is added to the fast parse path.
 pub fn augmented_command() -> Command {
     let cmd = graft_onto(Cli::command(), plugin_commands());
-    #[cfg(feature = "serve")]
-    let cmd = hide_disabled_serve(cmd, web_disabled());
-    cmd
+
+    hide_disabled_serve(cmd, web_disabled())
 }
 
 /// True when the builtin `aoe.web` plugin is present and disabled.
-#[cfg(feature = "serve")]
 pub fn web_disabled() -> bool {
     crate::plugin::registry()
         .get("aoe.web")
@@ -63,7 +61,6 @@ pub fn web_disabled() -> bool {
 /// Hide `serve` from `--help` when the dashboard plugin is off. It stays
 /// parseable, since the lifecycle verbs must keep working; a fresh start is
 /// rejected as unrecognized in `main` (see `serve_start_blocked`).
-#[cfg(feature = "serve")]
 fn hide_disabled_serve(cmd: Command, web_disabled: bool) -> Command {
     if web_disabled {
         cmd.mut_subcommand("serve", |c| c.hide(true))
@@ -76,7 +73,6 @@ fn hide_disabled_serve(cmd: Command, web_disabled: bool) -> Command {
 /// subcommand: the command is `serve`, it is not a daemon lifecycle verb
 /// (`--stop` / `--status` / `--restart`, which must always reach a running
 /// daemon), and the `aoe.web` plugin is disabled.
-#[cfg(feature = "serve")]
 pub fn serve_start_blocked(cli: &Cli, web_disabled: bool) -> bool {
     let Some(super::definition::Commands::Serve(args)) = &cli.command else {
         return false;
@@ -182,7 +178,6 @@ mod tests {
         assert!(dispatch_plugin_command(&matches).is_err());
     }
 
-    #[cfg(feature = "serve")]
     fn parse(args: &[&str]) -> Cli {
         use clap::FromArgMatches;
         Cli::from_arg_matches(
@@ -193,7 +188,6 @@ mod tests {
         .expect("into Cli")
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn serve_start_blocked_only_when_web_off_and_not_lifecycle() {
         let start = parse(&["aoe", "serve"]);
@@ -207,11 +201,10 @@ mod tests {
                 "{verb} must bypass the gate"
             );
         }
-        // A non-serve command is never blocked.
+        // A command other than `serve` is never blocked.
         assert!(!serve_start_blocked(&parse(&["aoe", "agents"]), true));
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn hide_disabled_serve_hides_only_when_disabled() {
         let shown = hide_disabled_serve(Cli::command(), false);

--- a/src/cli/killall.rs
+++ b/src/cli/killall.rs
@@ -11,30 +11,24 @@ use clap::Args;
 pub struct KillallArgs {
     /// Grace period in seconds before force-killing agent workers. tmux
     /// sessions and the daemon use their own built-in grace.
-    #[cfg(feature = "serve")]
     #[arg(long, default_value_t = 5)]
     pub timeout_secs: u64,
 
     /// Leave the `aoe serve` daemon running; stop only workers and tmux
     /// sessions.
-    #[cfg(feature = "serve")]
     #[arg(long)]
     pub keep_daemon: bool,
 }
 
 pub async fn run(args: KillallArgs) -> Result<()> {
     // Every surface is best-effort: each is attempted independently and its
-    // failure is collected here rather than aborting the rest. In a TUI-only
-    // build only the tmux sweep runs, so `args` carries no fields.
-    #[cfg(not(feature = "serve"))]
-    let _ = args;
+    // failure is collected here rather than aborting the rest.
 
     let mut errors: Vec<String> = Vec::new();
 
     // Daemon first. Removing the orchestrator means the worker sweep below
     // cannot race a daemon-driven respawn; any orphaned workers still die via
     // their recorded process group in that sweep.
-    #[cfg(feature = "serve")]
     if !args.keep_daemon {
         if crate::cli::serve::daemon_pid().is_some() {
             match crate::cli::serve::stop_daemon().await {
@@ -46,7 +40,6 @@ pub async fn run(args: KillallArgs) -> Result<()> {
         }
     }
 
-    #[cfg(feature = "serve")]
     match crate::cli::acp::stop_all_workers(args.timeout_secs).await {
         Ok(n) => println!("Stopped {n} agent worker(s)."),
         Err(e) => errors.push(format!("workers: {e}")),

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,9 +1,9 @@
 //! `aoe mcp` CLI: inspect the effective MCP server set (#1996).
 //!
 //! Mirrors the read model the web and TUI surfaces render, so a user can debug
-//! "which MCP servers will my agent reach, and where did each come from" without
-//! a serve build. Top-level (not under the serve-gated `aoe acp` group) and
-//! always compiled, because inspecting config is useful before any session runs.
+//! "which MCP servers will my agent reach, and where did each come from".
+//! Top-level rather than under the `aoe acp` group, because inspecting config
+//! is useful before any session runs.
 //! Every value is redacted: command/args/url identify a server, env and header
 //! VALUES are reduced to names.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,5 @@
 //! CLI command implementations
 
-#[cfg(feature = "serve")]
 pub mod acp;
 pub mod add;
 pub mod agents;
@@ -12,7 +11,6 @@ pub mod group;
 pub mod init;
 pub mod killall;
 pub mod list;
-#[cfg(feature = "serve")]
 pub mod log_level;
 pub mod logs;
 pub mod mcp;
@@ -23,7 +21,6 @@ pub mod project;
 pub mod ps;
 pub mod remove;
 pub mod send;
-#[cfg(feature = "serve")]
 pub mod serve;
 pub mod session;
 pub mod settings;
@@ -35,7 +32,6 @@ pub mod theme;
 pub mod tmux;
 pub mod uninstall;
 pub mod update;
-#[cfg(feature = "serve")]
 pub mod url;
 pub mod worktree;
 
@@ -117,12 +113,9 @@ pub fn resolve_session<'a>(identifier: &str, instances: &'a [Instance]) -> Resul
 /// not exist; a failure to open or write it returns `Err` so callers keep the
 /// session row rather than orphan its transcript. See #2489, #2524.
 ///
-/// The delete is idempotent and feature-independent: `rusqlite` is a
-/// non-optional dependency, so a default (non-`serve`) build can reach the
-/// store too. It deliberately does NOT gate on `Instance::is_structured()`,
-/// which always returns `false` in a non-`serve` build (the `view` field is
-/// serve-gated), so the old guard left the non-serve bail unreachable and
-/// orphaned transcripts. Deleting zero rows for a terminal session is harmless.
+/// The delete is idempotent and deliberately does NOT gate on
+/// `Instance::is_structured()`: deleting zero rows for a terminal session is
+/// harmless, and the old guard orphaned transcripts (#2524).
 pub(crate) fn purge_acp_transcript(inst: &Instance) -> Result<()> {
     let app_dir = crate::session::get_app_dir()
         .map_err(|e| anyhow::anyhow!("acp transcript purge: resolve app dir: {e}"))?;
@@ -136,8 +129,7 @@ pub(crate) fn purge_acp_transcript(inst: &Instance) -> Result<()> {
 /// Delete a session's rows from the ACP event store at `db_path`, removing both
 /// the event rows and their attachment blobs (mirrors
 /// `crate::events::delete_topic`'s cascade so no orphaned bytes are left).
-/// A missing table means the store predates it: nothing to purge. Kept
-/// feature-independent so non-`serve` CLI builds can clean transcripts too.
+/// A missing table means the store predates it: nothing to purge.
 fn purge_acp_transcript_rows(db_path: &std::path::Path, session_id: &str) -> Result<()> {
     let mut conn = rusqlite::Connection::open(db_path)
         .map_err(|e| anyhow::anyhow!("acp transcript purge: open event store: {e}"))?;
@@ -151,11 +143,12 @@ fn purge_acp_transcript_rows(db_path: &std::path::Path, session_id: &str) -> Res
     let tx = conn
         .transaction()
         .map_err(|e| anyhow::anyhow!("acp transcript purge: begin transaction: {e}"))?;
-    // The source of truth for these names is `crate::events::Schema` (prefix
-    // "acp"), which is serve-gated and so cannot be referenced from here. They
-    // are fixed literals, not user input, and `session_id` is bound, so the
-    // `format!` only interpolates a constant.
-    for table in ["acp_events", "acp_attachments"] {
+    // Table names come from the same `crate::events::Schema` the store is
+    // opened with, so they cannot drift; `session_id` is bound, so the
+    // `format!` only interpolates a validated constant.
+    let schema = crate::events::Schema::new("acp")
+        .map_err(|e| anyhow::anyhow!("acp transcript purge: schema: {e}"))?;
+    for table in [schema.events_table(), schema.attachments_table()] {
         match tx.execute(
             &format!("DELETE FROM {table} WHERE session_id = ?1"),
             rusqlite::params![session_id],
@@ -313,9 +306,9 @@ mod tests {
         assert!(!purge_restored_row_must_be_kept(false, true));
     }
 
-    // #2524: the non-serve purge path used to be unreachable, orphaning
-    // transcripts. The feature-independent row delete must drop both the
-    // event rows and their attachment blobs for the target session only.
+    // #2524: the purge path used to be unreachable, orphaning transcripts.
+    // The row delete must drop both the event rows and their attachment blobs
+    // for the target session only.
     #[test]
     fn purge_acp_transcript_rows_deletes_only_target_session() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -33,11 +33,8 @@ const TITLE_BUDGET: usize = 20;
 // version paired with a 12-char sha is 20 chars ("1.14.0+g46c8908c1cd2") and
 // " (stale)" is 8 more. The 24 that `aoe acp ps` used truncated the marker off
 // the realistic case, which defeated the column's purpose (#1754).
-#[cfg(feature = "serve")]
 const COL_BUILD: usize = 28;
-#[cfg(feature = "serve")]
 const COL_MODEL: usize = 20;
-#[cfg(feature = "serve")]
 const COL_CWD: usize = 30;
 
 #[derive(Args)]
@@ -120,7 +117,6 @@ struct TmuxState {
 /// ACP-only columns, present only on acp-substrate rows. tmux rows carry
 /// `None`, so the default core view never renders them. These come straight
 /// off the worker registry record, so an acp orphan still carries them.
-#[cfg(feature = "serve")]
 struct AcpExtra {
     build_version: String,
     build_stale: bool,
@@ -133,8 +129,8 @@ struct AcpExtra {
 }
 
 /// An acp substrate probe. `state` is pre-normalized by
-/// [`crate::process::worker_registry::worker_state_label`] (serve-gated) so this
-/// struct carries no serve-only types and the merge stays feature-independent.
+/// [`crate::process::worker_registry::worker_state_label`], so this struct
+/// carries no ACP types and the merge stays generic.
 /// `session_id` is the full id (`== Instance.id`). `started_at` is only the AGE
 /// fallback for orphans (see `TmuxState`). `acp_extra` carries the ACP-only
 /// columns unlocked by `aoe ps --acp`.
@@ -144,7 +140,6 @@ struct AcpState {
     agent: String,
     state: &'static str,
     started_at: u64,
-    #[cfg(feature = "serve")]
     acp_extra: Option<AcpExtra>,
 }
 
@@ -163,12 +158,10 @@ struct Row {
     // Substrate-specific extras. Only `acp_extra` exists today (populated for
     // acp rows, `None` for tmux). A future `--tmux` column unlock would add a
     // parallel `tmux_extra` here and a matching `render_table_tmux`.
-    #[cfg(feature = "serve")]
     acp_extra: Option<AcpExtra>,
     // The worker's boot epoch, carried onto the row so the `--acp --json`
     // superset can serialize it without a second copy on `AcpExtra`. Read only
     // by `acp_rows_json` (acp rows), which is why tmux rows leave it 0.
-    #[cfg(feature = "serve")]
     started_at: u64,
 }
 
@@ -242,9 +235,7 @@ fn merge_rows(
             age_secs,
             agent: st.agent.clone(),
             is_orphan,
-            #[cfg(feature = "serve")]
             acp_extra: None,
-            #[cfg(feature = "serve")]
             started_at: 0,
         });
     }
@@ -274,9 +265,7 @@ fn merge_rows(
             age_secs: Some(age_secs),
             agent: st.agent,
             is_orphan,
-            #[cfg(feature = "serve")]
             acp_extra: st.acp_extra,
-            #[cfg(feature = "serve")]
             started_at: st.started_at,
         });
     }
@@ -396,7 +385,6 @@ fn render_table(rows: &[Row]) -> String {
 /// before the field existed) shows `<legacy>`; any worker whose build differs
 /// from the running daemon's is tagged `(stale)` so a not-yet-respawned worker
 /// is visible rather than silent. See #1754.
-#[cfg(feature = "serve")]
 fn render_build_cell(build_version: &str, stale: bool) -> String {
     let base = if build_version.is_empty() {
         "<legacy>"
@@ -414,7 +402,6 @@ fn render_build_cell(build_version: &str, stale: bool) -> String {
 /// mental model transfers from the default view), then the ACP-only columns
 /// BUILD, MODEL, CWD, and SOCKET appended. A future `--tmux` unlock would add a
 /// parallel `render_table_tmux` appending tmux-only columns to the same prefix.
-#[cfg(feature = "serve")]
 fn render_table_acp(rows: &[Row]) -> String {
     use std::fmt::Write;
     let mut out = String::new();
@@ -503,7 +490,6 @@ fn render_table_acp(rows: &[Row]) -> String {
 /// emitted (identical names, types, semantics) plus `substrate`, `state`,
 /// `age_secs`, and `model`. Keeping the old names means a migrating script only
 /// changes its argv and its sort, not its field access.
-#[cfg(feature = "serve")]
 #[derive(Serialize)]
 struct AcpRowJson {
     session_id: String,
@@ -527,7 +513,6 @@ struct AcpRowJson {
     model: Option<String>,
 }
 
-#[cfg(feature = "serve")]
 fn acp_rows_json(rows: &[Row]) -> Vec<AcpRowJson> {
     rows.iter()
         .filter_map(|r| {
@@ -663,7 +648,6 @@ fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
     states
 }
 
-#[cfg(feature = "serve")]
 fn acp_state_from_record(rec: crate::process::worker_registry::WorkerRecord) -> AcpState {
     use crate::process::worker_registry;
     let live = worker_registry::is_record_live(&rec);
@@ -688,7 +672,6 @@ fn acp_state_from_record(rec: crate::process::worker_registry::WorkerRecord) -> 
     }
 }
 
-#[cfg(feature = "serve")]
 fn collect_acp_states() -> Vec<AcpState> {
     crate::process::worker_registry::list()
         .unwrap_or_default()
@@ -697,18 +680,8 @@ fn collect_acp_states() -> Vec<AcpState> {
         .collect()
 }
 
-#[cfg(not(feature = "serve"))]
-fn collect_acp_states() -> Vec<AcpState> {
-    Vec::new()
-}
-
 #[tracing::instrument(target = "cli.ps", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<()> {
-    #[cfg(not(feature = "serve"))]
-    if args.acp {
-        anyhow::bail!("--acp requires a build with the serve feature");
-    }
-
     let filter = if args.tmux {
         SubstrateFilter::Tmux
     } else if args.acp {
@@ -758,7 +731,6 @@ pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<
     );
 
     if args.json {
-        #[cfg(feature = "serve")]
         if args.acp {
             super::output::print_json(&acp_rows_json(&rows))?;
             return Ok(());
@@ -767,7 +739,6 @@ pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<
     } else if rows.is_empty() {
         println!("No running sessions.");
     } else {
-        #[cfg(feature = "serve")]
         if args.acp {
             print!("{}", render_table_acp(&rows));
             return Ok(());
@@ -813,7 +784,6 @@ mod tests {
             agent: "claude-agent-acp".to_string(),
             state,
             started_at,
-            #[cfg(feature = "serve")]
             acp_extra: Some(AcpExtra {
                 build_version: "1.9.5+gabc123".to_string(),
                 build_stale: false,
@@ -1075,9 +1045,7 @@ mod tests {
             age_secs: None,
             agent: String::new(),
             is_orphan: false,
-            #[cfg(feature = "serve")]
             acp_extra: None,
-            #[cfg(feature = "serve")]
             started_at: 0,
         };
         let cell = session_cell(&row);
@@ -1103,15 +1071,12 @@ mod tests {
             age_secs: None,
             agent: String::new(),
             is_orphan: true,
-            #[cfg(feature = "serve")]
             acp_extra: None,
-            #[cfg(feature = "serve")]
             started_at: 0,
         };
         assert_eq!(session_cell(&row), "99999999");
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn acp_table_appends_acp_columns_and_core_table_omits_them() {
         let instances = vec![inst("acp-id-1", "Structured")];
@@ -1149,7 +1114,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn acp_table_renders_orphan_row_with_absent_model_as_dash() {
         // An orphan (no matching instance) with model=None and a legacy
@@ -1182,7 +1146,6 @@ mod tests {
     /// worker registry, so its key set is the migration contract for scripts
     /// that used `aoe acp ps --json` (#3023). Driven from a real `WorkerRecord`
     /// so the record-derived values, not just the key names, are pinned.
-    #[cfg(feature = "serve")]
     #[test]
     fn acp_json_schema_carries_every_old_key_plus_the_additions() {
         use crate::process::worker_registry::WorkerRecord;
@@ -1255,7 +1218,6 @@ mod tests {
     /// Story 3: the BUILD column surfaces the worker build version, tags a
     /// build-stale worker, and renders an empty (legacy) version as
     /// `<legacy>`. See #1754.
-    #[cfg(feature = "serve")]
     #[test]
     fn render_build_cell_cases() {
         let cases = [

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -95,7 +95,7 @@ pub struct ServeArgs {
     #[arg(long)]
     pub cityhall: bool,
 
-    /// Expose the dashboard over a public HTTPS tunnel. Prefers Tailscale
+    /// Expose the daemon over a public HTTPS tunnel. Prefers Tailscale
     /// Funnel when `tailscale` is installed and logged in (stable
     /// `.ts.net` URL, installable PWAs survive restarts). Falls back to a
     /// Cloudflare quick tunnel otherwise (fresh URL on every restart).
@@ -153,8 +153,9 @@ pub struct ServeArgs {
     pub passphrase: Option<String>,
 
     /// Open the dashboard URL in the default browser once the server is ready.
-    /// Ignored under --daemon, --remote, SSH (SSH_CONNECTION/SSH_TTY), or when
-    /// no display server is reachable on Linux/BSD.
+    /// Ignored in a build with no dashboard bundle, and under --daemon,
+    /// --remote, SSH (SSH_CONNECTION/SSH_TTY), or when no display server is
+    /// reachable on Linux/BSD.
     #[arg(long)]
     pub open: bool,
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -123,7 +123,6 @@ pub struct ImportArgs {
     /// Import as structured-view sessions (rendered in the web dashboard and
     /// the structured TUI view) instead of terminal/tmux sessions. Structured
     /// sessions replay their transcript under `aoe serve`.
-    #[cfg(feature = "serve")]
     #[arg(long)]
     pub structured: bool,
 
@@ -879,11 +878,6 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 /// of the session appearing on disk). Calling `start`/`stop`/`restart`
 /// from the CLI silently no-ops, which previously misled users into
 /// thinking the session was up. Bail loudly with the actual remediation.
-///
-/// `structured_view` is gated behind the `serve` feature; without it the
-/// field doesn't exist on `Instance` and no session can be in structured view
-/// mode, so this is a no-op shim.
-#[cfg(feature = "serve")]
 fn bail_if_acp(inst: &crate::session::Instance, verb: &str) -> Result<()> {
     if inst.is_structured() {
         bail!(
@@ -894,11 +888,6 @@ fn bail_if_acp(inst: &crate::session::Instance, verb: &str) -> Result<()> {
              To control an structured-view session, use the web dashboard or the REST API."
         );
     }
-    Ok(())
-}
-
-#[cfg(not(feature = "serve"))]
-fn bail_if_acp(_inst: &crate::session::Instance, _verb: &str) -> Result<()> {
     Ok(())
 }
 
@@ -920,7 +909,7 @@ fn resolve_import_roots(paths: &[String]) -> Result<Vec<std::path::PathBuf>> {
 
 /// True when `id` is already imported by some instance, so a re-run does not
 /// create duplicates. Checks the terminal resume target, the poller-observed
-/// id, and (serve builds) the structured-view id.
+/// id, and the structured-view id.
 fn already_imported(instances: &[Instance], id: &str) -> bool {
     instances.iter().any(|inst| {
         if inst.agent_session_id.as_deref() == Some(id) {
@@ -929,7 +918,6 @@ fn already_imported(instances: &[Instance], id: &str) -> bool {
         if matches!(&inst.resume_intent, ResumeIntent::Use(s) if s == id) {
             return true;
         }
-        #[cfg(feature = "serve")]
         if inst.acp_session_id.as_deref() == Some(id) {
             return true;
         }
@@ -959,7 +947,6 @@ fn build_import_instance(
     inst
 }
 
-#[cfg(feature = "serve")]
 fn apply_import_mode(
     inst: &mut Instance,
     s: &crate::session::claude_import::ClaudeSessionSummary,
@@ -974,22 +961,10 @@ fn apply_import_mode(
     }
 }
 
-#[cfg(not(feature = "serve"))]
-fn apply_import_mode(
-    inst: &mut Instance,
-    s: &crate::session::claude_import::ClaudeSessionSummary,
-    _structured: bool,
-) {
-    inst.resume_intent = ResumeIntent::Use(s.session_id.clone());
-}
-
 async fn import_sessions(profile: &str, args: ImportArgs) -> Result<()> {
     use crate::session::claude_import::{scan_sessions, sessions_under_paths, MAX_SESSIONS};
 
-    #[cfg(feature = "serve")]
     let structured = args.structured;
-    #[cfg(not(feature = "serve"))]
-    let structured = false;
 
     // Discover, then narrow to the requested paths unless --all.
     let mut discovered = scan_sessions();
@@ -1398,16 +1373,7 @@ fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<S
     instances
         .iter()
         .filter(|i| !matches!(i.status, Status::Deleting | Status::Creating))
-        .filter(|_i| {
-            #[cfg(feature = "serve")]
-            {
-                !_i.is_structured()
-            }
-            #[cfg(not(feature = "serve"))]
-            {
-                true
-            }
-        })
+        .filter(|i| !i.is_structured())
         .map(|i| i.id.clone())
         .collect()
 }
@@ -2385,7 +2351,6 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
         .context("failed to acquire instance resume-target lock")?;
     let (title, tool) = storage.update(|instances, _groups| {
         super::patch_instance(instances, &target_id, |inst| {
-            #[cfg(feature = "serve")]
             if inst.is_structured() {
                 anyhow::bail!(
                     "cannot set resume target on structured view-mode session '{}'; structured view manages its own conversation lifecycle via ACP",
@@ -3048,7 +3013,7 @@ mod set_color_tests {
     }
 }
 
-#[cfg(all(test, feature = "serve"))]
+#[cfg(test)]
 mod acp_reject_tests {
     use super::{set_session_id, SetSessionIdArgs};
     use crate::session::{Instance, Storage};
@@ -3145,7 +3110,6 @@ mod import_tests {
         assert_eq!(inst.group_path, "team/imports");
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn structured_import_seeds_replay_fields() {
         let s = summary("sid-1", "/home/me/proj", Some("x"));

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -3,7 +3,6 @@
 use anyhow::{bail, Context, Result};
 use clap::Args;
 use std::io::{self, IsTerminal, Write};
-#[cfg(feature = "serve")]
 use std::path::Path;
 
 use crate::update::check_for_update;
@@ -110,20 +109,13 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
             "✓ Updated to v{}. Restart `aoe` to use the new version.",
             info.latest_version
         );
-        #[cfg(feature = "serve")]
         handle_daemon_restart_after_update(binary_path, args.yes)?;
-        #[cfg(not(feature = "serve"))]
-        {
-            let _ = binary_path;
-            println!("{}", daemon_restart_hint());
-        }
         println!("{}", completion_refresh_hint());
     } else if matches!(&method, InstallMethod::Homebrew) {
         println!("✓ brew upgrade complete.");
         // Homebrew swaps a Cellar/bin binary whose path we cannot reliably
         // resolve from this process, so we never auto-restart; point the
         // user at the manual step when a daemon is up.
-        #[cfg(feature = "serve")]
         if !matches!(
             crate::cli::serve::daemon_status(),
             crate::cli::serve::DaemonStatus::Absent
@@ -135,7 +127,6 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
 }
 
 /// What to do with a running daemon after a successful in-place update.
-#[cfg(feature = "serve")]
 #[derive(Debug, PartialEq, Eq)]
 enum RestartDecision {
     /// No daemon process or persisted PID state was found.
@@ -153,7 +144,6 @@ enum RestartDecision {
     Auto,
 }
 
-#[cfg(feature = "serve")]
 #[derive(Clone, Copy, Debug)]
 enum UpdateDaemonState {
     Absent,
@@ -167,7 +157,6 @@ enum UpdateDaemonState {
 /// `serve.launch` record that authorizes this PID; every other state prints a
 /// hint naming the owner that has to do the restart. Pure so the matrix is
 /// unit testable.
-#[cfg(feature = "serve")]
 fn restart_decision(daemon: UpdateDaemonState, is_tty: bool, yes: bool) -> RestartDecision {
     match daemon {
         UpdateDaemonState::Absent => RestartDecision::NotApplicable,
@@ -184,7 +173,6 @@ fn restart_decision(daemon: UpdateDaemonState, is_tty: bool, yes: bool) -> Resta
 /// freshly installed binary as `aoe serve --restart` so the new code, not
 /// this old in-memory image (whose `current_exe()` may now point at the
 /// replaced/unlinked inode), spawns the replacement daemon.
-#[cfg(feature = "serve")]
 fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<()> {
     use crate::cli::serve;
     let daemon = match serve::daemon_status() {
@@ -220,7 +208,6 @@ fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<(
 /// Hint for a running daemon that aoe did not start itself (foreground,
 /// or under systemd/launchd): `aoe serve --restart` would refuse it, so
 /// point the user at the supervisor that owns the process instead.
-#[cfg(feature = "serve")]
 fn external_restart_hint() -> &'static str {
     "  WARNING: an `aoe serve` daemon is running but was not started by\n  \
      `aoe serve --daemon`; restart it through whatever launched it (your\n  \
@@ -233,7 +220,6 @@ fn external_restart_hint() -> &'static str {
 /// by another user, so the hint names ownership rather than `aoe serve
 /// --restart`: that command runs the same verification and refuses an
 /// unverified daemon, which would leave the user chasing a contradiction.
-#[cfg(feature = "serve")]
 fn unverified_restart_hint() -> &'static str {
     "  WARNING: aoe found daemon state but could not verify the running process.\n  \
      Existing `aoe serve` processes keep running the old build until restarted.\n  \
@@ -242,7 +228,6 @@ fn unverified_restart_hint() -> &'static str {
      verify: restart it as its owner, or through its terminal or service manager."
 }
 
-#[cfg(feature = "serve")]
 fn manual_update_restart_hint() -> &'static str {
     "  WARNING: existing `aoe serve` processes keep running the old build until\n  \
      restarted. If started with `aoe serve --daemon`, run `aoe serve --restart`;\n  \
@@ -252,7 +237,6 @@ fn manual_update_restart_hint() -> &'static str {
 /// Spawn the freshly installed binary as `aoe serve --restart`. Best
 /// effort: on any failure we fall back to the manual hint rather than
 /// failing the whole update, which already succeeded.
-#[cfg(feature = "serve")]
 fn restart_via_new_binary(binary_path: &Path) {
     println!("Restarting daemon…");
     match std::process::Command::new(binary_path)
@@ -321,31 +305,27 @@ mod tests {
 
         // Every hint has to name a recovery path the reader can actually take,
         // since each one is printed in place of the restart aoe declined to do.
-        #[cfg(feature = "serve")]
-        {
-            // The unverified case is usually another user's daemon, so the hint
-            // must name ownership instead of promising a restart that refuses.
-            let fallback = super::unverified_restart_hint();
-            assert!(fallback.contains("belongs to another user"));
-            assert!(fallback.contains("terminal or service manager"));
+        // The unverified case is usually another user's daemon, so the hint
+        // must name ownership instead of promising a restart that refuses.
+        let fallback = super::unverified_restart_hint();
+        assert!(fallback.contains("belongs to another user"));
+        assert!(fallback.contains("terminal or service manager"));
 
-            // An externally launched daemon must be sent to its launcher, not
-            // to `aoe serve --restart`, which refuses a daemon it did not start.
-            let external = super::external_restart_hint();
-            assert!(external.contains("WARNING:"));
-            assert!(!external.contains("aoe serve --restart"));
-            assert!(external.contains("service manager"));
+        // An externally launched daemon must be sent to its launcher, not
+        // to `aoe serve --restart`, which refuses a daemon it did not start.
+        let external = super::external_restart_hint();
+        assert!(external.contains("WARNING:"));
+        assert!(!external.contains("aoe serve --restart"));
+        assert!(external.contains("service manager"));
 
-            // The manual-install path cannot know how the daemon was launched,
-            // so it has to cover both recoveries.
-            let manual = super::manual_update_restart_hint();
-            assert!(manual.contains("WARNING:"));
-            assert!(manual.contains("aoe serve --restart"));
-            assert!(manual.contains("terminal or service manager"));
-        }
+        // The manual-install path cannot know how the daemon was launched,
+        // so it has to cover both recoveries.
+        let manual = super::manual_update_restart_hint();
+        assert!(manual.contains("WARNING:"));
+        assert!(manual.contains("aoe serve --restart"));
+        assert!(manual.contains("terminal or service manager"));
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn restart_decision_matrix() {
         use super::{restart_decision, RestartDecision, UpdateDaemonState};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![deny(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-#[cfg(feature = "serve")]
 pub mod acp;
 pub mod agents;
 pub mod build_info;
@@ -11,9 +10,7 @@ pub mod claude_settings;
 pub mod cli;
 pub mod containers;
 /// Protocol-agnostic durable event log, the storage substrate behind the
-/// ACP transcript store and (later) the plugin host's event bus. Serve-gated
-/// because its only consumer today is the serve-gated acp module.
-#[cfg(feature = "serve")]
+/// ACP transcript store and (later) the plugin host's event bus.
 pub mod events;
 pub mod file_watch;
 pub mod git;
@@ -23,7 +20,6 @@ pub mod logging;
 pub mod migrations;
 pub mod plugin;
 pub mod process;
-#[cfg(feature = "serve")]
 pub mod server;
 pub mod session;
 pub mod sound;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -492,15 +492,10 @@ impl std::fmt::Display for LogFilterError {
 
 impl std::error::Error for LogFilterError {}
 
-/// Optional top-of-stack layer injected at subscriber init. Only the
-/// serve daemon supplies a real one (the per-session tee, see
-/// `crate::acp::session_tee`); the acp module is `serve`-gated, so without
-/// that feature the slot is the no-op `Identity` layer and callers always
-/// pass `None`.
-#[cfg(feature = "serve")]
+/// Optional top-of-stack layer injected at subscriber init. Only the daemon
+/// supplies a real one (the per-session tee, see `crate::acp::session_tee`);
+/// every other caller passes `None`.
 pub type TeeLayer = crate::acp::session_tee::SessionTeeLayer;
-#[cfg(not(feature = "serve"))]
-pub type TeeLayer = tracing_subscriber::layer::Identity;
 
 pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
     init_subscriber_with_options(target, filter, false, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,23 +8,14 @@ use anyhow::Result;
 use clap::{CommandFactory, FromArgMatches, Parser};
 use clap_complete::generate;
 
-/// Did the user invoke `aoe serve`? Feature-gated because `Commands::Serve`
-/// only exists when the `serve` feature is on; in TUI-only builds we
-/// always return false so the tracing-init branch below compiles.
-#[cfg(feature = "serve")]
+/// Did the user invoke `aoe serve`?
 fn is_serve_command(cli: &Cli) -> bool {
     matches!(cli.command, Some(Commands::Serve(_)))
-}
-
-#[cfg(not(feature = "serve"))]
-fn is_serve_command(_cli: &Cli) -> bool {
-    false
 }
 
 /// Bridge the serve `--cityhall` flag into the `AOE_CITYHALL_MODE` env var at
 /// the early, single-threaded point in `main` (before the tokio worker pool),
 /// so downstream readers stay env-driven without an in-runtime `set_var`. #7.
-#[cfg(feature = "serve")]
 fn seed_cityhall_env(cli: &Cli) {
     if let Some(Commands::Serve(args)) = &cli.command {
         if args.cityhall {
@@ -37,9 +28,6 @@ fn seed_cityhall_env(cli: &Cli) {
     }
 }
 
-#[cfg(not(feature = "serve"))]
-fn seed_cityhall_env(_cli: &Cli) {}
-
 /// Did the parent `aoe serve --daemon` spawn this process as the detached
 /// child? Set by `start_daemon()` via the hidden `--daemon-child` flag.
 /// Drives sink resolution: child's stdout/stderr are redirected to the
@@ -47,14 +35,8 @@ fn seed_cityhall_env(_cli: &Cli) {}
 /// would land bytes in the same file via the OS redirect, but mixing two
 /// writers on the same fd hurts ordering, and the configured-sink path
 /// is what the TUI dialog and `aoe logs` tail).
-#[cfg(feature = "serve")]
 fn is_serve_daemon_child(cli: &Cli) -> bool {
     matches!(cli.command, Some(Commands::Serve(ref args)) if args.daemon_child)
-}
-
-#[cfg(not(feature = "serve"))]
-fn is_serve_daemon_child(_cli: &Cli) -> bool {
-    false
 }
 
 /// When the `aoe.web` plugin is disabled, a fresh `aoe serve` start behaves as
@@ -64,7 +46,6 @@ fn is_serve_daemon_child(_cli: &Cli) -> bool {
 /// so a running daemon can always be inspected and brought down. Returns the
 /// clap error to raise, or `None` when the invocation is allowed. Only the
 /// caller calls `.exit()`, so the decision stays unit-testable.
-#[cfg(feature = "serve")]
 fn serve_unavailable_error(cli: &Cli) -> Option<clap::Error> {
     cli::graft::serve_start_blocked(cli, cli::graft::web_disabled()).then(|| {
         Cli::command().error(
@@ -138,7 +119,6 @@ async fn main() -> Result<()> {
     // With the `aoe.web` plugin disabled, a fresh `aoe serve` start is treated
     // as an unrecognized subcommand. Done here, before any logging/app-dir side
     // effects, so a rejected start creates no serve log or ProcessContext.
-    #[cfg(feature = "serve")]
     if let Some(err) = serve_unavailable_error(&cli) {
         err.exit();
     }
@@ -228,9 +208,7 @@ async fn main() -> Result<()> {
                 };
                 // Only the serve daemon multiplexes many sessions, so it is
                 // the one process that tees session-scoped tracing into each
-                // session's acp-workers/<id>.log (#1864). The acp module is
-                // serve-gated, so the tee only exists in serve builds.
-                #[cfg(feature = "serve")]
+                // session's acp-workers/<id>.log (#1864).
                 let session_tee = if matches!(
                     ctx,
                     ProcessContext::ServeForeground | ProcessContext::ServeDaemonChild
@@ -239,8 +217,6 @@ async fn main() -> Result<()> {
                 } else {
                     None
                 };
-                #[cfg(not(feature = "serve"))]
-                let session_tee: Option<logging::TeeLayer> = None;
                 let res = logging::init_subscriber_with_options(
                     resolution.target,
                     filter,
@@ -383,7 +359,6 @@ async fn run(
         }
         Some(Commands::Agents) => return cli::agents::run(),
         Some(Commands::Logs(args)) => return cli::logs::run(args).await,
-        #[cfg(feature = "serve")]
         Some(Commands::LogLevel(args)) => return cli::log_level::run(args).await,
         Some(Commands::Sounds { command }) => return cli::sounds::run(command).await,
         Some(Commands::Theme { command }) => {
@@ -468,13 +443,9 @@ async fn run(
         // `apply` merges settings and writes the project registry, so it has to
         // run after migrations have brought that data to the current shape.
         Some(Commands::Cityhall { command }) => cli::cityhall::run(command),
-        #[cfg(feature = "serve")]
         Some(Commands::Serve(args)) => cli::serve::run(&profile, args).await,
-        #[cfg(feature = "serve")]
         Some(Commands::Url(args)) => cli::url::run(args),
-        #[cfg(feature = "serve")]
         Some(Commands::Acp { command }) => cli::acp::run(command).await,
-        #[cfg(feature = "serve")]
         Some(Commands::AcpRunner(args)) => agent_of_empires::process::runner::run(*args).await,
         None => {
             // Fold the drift notice into the existing startup-warning channel

--- a/src/plugin/auto_update.rs
+++ b/src/plugin/auto_update.rs
@@ -18,14 +18,13 @@ use crate::session::Config;
 
 use super::{install, update_check};
 
-/// Surfaces a consent-needed auto-update skip in-product. Kept abstract so this
-/// module (which compiles in TUI-only builds) never references the serve-gated
-/// plugin host. The `aoe serve` daemon implements it on `PluginHost`.
+/// Surfaces a consent-needed auto-update skip in-product. Kept abstract so the
+/// sweep never reaches into the plugin host; the `aoe serve` daemon implements
+/// it on `PluginHost`.
 pub trait UpdateNotifier: Send + Sync {
     fn needs_approval(&self, plugin_id: &str, reason: &str);
 }
 
-#[cfg(feature = "serve")]
 impl UpdateNotifier for super::host::PluginHost {
     fn needs_approval(&self, plugin_id: &str, reason: &str) {
         self.notify_host(
@@ -126,7 +125,7 @@ fn already_dismissed(id: &str, fingerprint: &str) -> bool {
 /// startup is never delayed by network or git; the registry is reloaded inside
 /// `install::update_clean` as each update lands. `notifier` is the running
 /// plugin host (`aoe serve`), used to surface consent-needed skips as
-/// notifications; `None` in TUI-only contexts, where there is no ring.
+/// notifications; `None` where there is no ring.
 pub fn spawn_if_enabled(config: &Config, notifier: Option<Arc<dyn UpdateNotifier>>) {
     if !config.updates.auto_update_plugins {
         return;

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -106,41 +106,31 @@ pub async fn set_enabled_live(plugin_id: &str, enabled: bool) -> Result<LiveTogg
     if super::registry().get(plugin_id).is_none() {
         bail!("unknown plugin {plugin_id:?}; see `aoe plugin list`");
     }
-    // The daemon client lives in the serve-gated `acp` module; a TUI-only
-    // build ships no daemon, so it always writes locally.
-    #[cfg(feature = "serve")]
-    {
-        let endpoint = match crate::acp::client::discovery::discover_local() {
-            Ok(endpoint) => endpoint,
-            Err(_) => {
-                set_enabled(plugin_id, enabled)?;
-                return Ok(LiveToggle::Local);
-            }
-        };
-        let daemon_result = async {
-            let client = crate::acp::client::HttpClient::new(endpoint)?;
-            client.set_plugin_enabled(plugin_id, enabled).await
+    let endpoint = match crate::acp::client::discovery::discover_local() {
+        Ok(endpoint) => endpoint,
+        Err(_) => {
+            set_enabled(plugin_id, enabled)?;
+            return Ok(LiveToggle::Local);
         }
-        .await;
-        match daemon_result {
-            Ok(()) => {
-                // The daemon wrote config to disk; refresh this process's
-                // registry from it rather than writing again.
-                super::reload_registry();
-                Ok(LiveToggle::Daemon)
-            }
-            Err(e) => {
-                set_enabled(plugin_id, enabled)?;
-                Ok(LiveToggle::LocalDaemonStale {
-                    reason: format!("{e}"),
-                })
-            }
-        }
+    };
+    let daemon_result = async {
+        let client = crate::acp::client::HttpClient::new(endpoint)?;
+        client.set_plugin_enabled(plugin_id, enabled).await
     }
-    #[cfg(not(feature = "serve"))]
-    {
-        set_enabled(plugin_id, enabled)?;
-        Ok(LiveToggle::Local)
+    .await;
+    match daemon_result {
+        Ok(()) => {
+            // The daemon wrote config to disk; refresh this process's
+            // registry from it rather than writing again.
+            super::reload_registry();
+            Ok(LiveToggle::Daemon)
+        }
+        Err(e) => {
+            set_enabled(plugin_id, enabled)?;
+            Ok(LiveToggle::LocalDaemonStale {
+                reason: format!("{e}"),
+            })
+        }
     }
 }
 
@@ -1071,51 +1061,43 @@ pub fn approve_installed(id: &str, expected_manifest_hash: &str) -> Result<()> {
 /// order) supersedes older batches, and a global lock serializes the actual
 /// requests, so the newest save's values always land last.
 pub fn nudge_daemon_enabled(changes: Vec<(String, bool)>) {
-    // No daemon client in a TUI-only build (see `set_enabled_live`).
-    #[cfg(not(feature = "serve"))]
-    {
-        let _ = changes;
-    }
-    #[cfg(feature = "serve")]
-    {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static GENERATION: AtomicU64 = AtomicU64::new(0);
-        static IN_FLIGHT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static GENERATION: AtomicU64 = AtomicU64::new(0);
+    static IN_FLIGHT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-        if changes.is_empty() {
+    if changes.is_empty() {
+        return;
+    }
+    let generation = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+    tokio::spawn(async move {
+        let _serialize = IN_FLIGHT.lock().await;
+        // A newer save superseded this batch while it waited its turn;
+        // its values are already stale against disk, so drop it.
+        if GENERATION.load(Ordering::SeqCst) != generation {
             return;
         }
-        let generation = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
-        tokio::spawn(async move {
-            let _serialize = IN_FLIGHT.lock().await;
-            // A newer save superseded this batch while it waited its turn;
-            // its values are already stale against disk, so drop it.
+        let Ok(endpoint) = crate::acp::client::discovery::discover_local() else {
+            return;
+        };
+        let client = match crate::acp::client::HttpClient::new(endpoint) {
+            Ok(client) => client,
+            Err(e) => {
+                tracing::warn!("plugin toggle: daemon client build failed: {e}");
+                return;
+            }
+        };
+        for (id, enabled) in changes {
             if GENERATION.load(Ordering::SeqCst) != generation {
                 return;
             }
-            let Ok(endpoint) = crate::acp::client::discovery::discover_local() else {
-                return;
-            };
-            let client = match crate::acp::client::HttpClient::new(endpoint) {
-                Ok(client) => client,
-                Err(e) => {
-                    tracing::warn!("plugin toggle: daemon client build failed: {e}");
-                    return;
-                }
-            };
-            for (id, enabled) in changes {
-                if GENERATION.load(Ordering::SeqCst) != generation {
-                    return;
-                }
-                if let Err(e) = client.set_plugin_enabled(&id, enabled).await {
-                    tracing::warn!(
-                        "plugin toggle: daemon did not reconcile {id} (enabled={enabled}): {e}; \
+            if let Err(e) = client.set_plugin_enabled(&id, enabled).await {
+                tracing::warn!(
+                    "plugin toggle: daemon did not reconcile {id} (enabled={enabled}): {e}; \
                          restart the daemon or toggle from the dashboard"
-                    );
-                }
+                );
             }
-        });
-    }
+        }
+    });
 }
 
 /// Record that the user declined an available update by its fingerprint, so the
@@ -1752,8 +1734,7 @@ mod tests {
     fn reject_incompatible_host_blocks_out_of_range_and_allows_in_range() {
         // The host is this crate's CARGO_PKG_VERSION (a 1.x release); a range
         // bracketing 1.x installs, a future-major-only range is refused with an
-        // id-prefixed message. Keep the literals semver-free so this compiles in
-        // a TUI-only build, where the host crate's semver dep is serve-gated.
+        // id-prefixed message.
         let in_range = manifest_with_aoe_version(Some(">=1.0.0, <2.0.0"));
         assert!(reject_incompatible_host(&in_range).is_ok());
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -15,22 +15,14 @@ pub mod update_check;
 pub mod view;
 
 // Worker modules need the event and session stores owned by `aoe serve`.
-#[cfg(feature = "serve")]
 pub(crate) mod automation_policy;
-#[cfg(feature = "serve")]
 pub mod host;
-#[cfg(feature = "serve")]
 pub mod host_api;
-#[cfg(feature = "serve")]
 pub mod protocol;
-#[cfg(feature = "serve")]
 pub mod sandbox;
-#[cfg(feature = "serve")]
 pub mod session_api;
-#[cfg(feature = "serve")]
 pub mod ui_state;
 
-// Launch resolution is also used by the installer, so it is not serve-gated.
 pub mod launch;
 
 use std::path::PathBuf;

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -57,13 +57,13 @@ pub struct BuiltinPlugin {
 }
 
 /// First-party plugins bundled with the binary. Deliberately minimal while the
-/// system is proven out: just the `aoe.web` dashboard marker (under `serve`).
+/// system is proven out: just the `aoe.web` dashboard marker (under `web`).
 /// More land as each piece is verified.
 pub static BUILTINS: &[BuiltinPlugin] = &[
-    // The web dashboard's management marker is present whenever the dashboard
-    // is compiled in (`feature = "serve"`), so serve and release builds always
-    // surface aoe.web; a TUI-only build has an empty builtin set.
-    #[cfg(feature = "serve")]
+    // The dashboard's management marker is present whenever the bundle is
+    // compiled in, so release builds always surface aoe.web; a build without
+    // `web` has an empty builtin set.
+    #[cfg(feature = "web")]
     BuiltinPlugin {
         manifest_toml: include_str!("../../plugins/aoe-web/aoe-plugin.toml"),
     },

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-#[cfg(feature = "serve")]
 use std::process::{Child, ChildStdin, Command, Stdio};
 
 pub(super) use super::unix::{
@@ -315,13 +314,11 @@ fn parse_stat_field(content: &str, field_idx: usize) -> Option<i64> {
 
 /// Prevents user-idle system sleep by holding a `systemd-inhibit` block lock.
 /// `--what=idle:sleep` blocks idle sleep only (the display still sleeps).
-#[cfg(feature = "serve")]
 pub(super) struct SystemdInhibitor {
     child: Option<Child>,
     stdin: Option<ChildStdin>,
 }
 
-#[cfg(feature = "serve")]
 impl SystemdInhibitor {
     pub(super) fn new() -> Self {
         Self {
@@ -331,7 +328,6 @@ impl SystemdInhibitor {
     }
 }
 
-#[cfg(feature = "serve")]
 impl super::SleepInhibit for SystemdInhibitor {
     fn acquire(&mut self) -> anyhow::Result<()> {
         if super::sleep_inhibit_unavailable() {

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -387,19 +387,16 @@ fn find_process_in_group(pgrp: u32) -> Option<u32> {
 
 /// Prevents user-idle system sleep by holding a `caffeinate` child. `-i`
 /// inhibits system idle sleep only, so the display still sleeps normally.
-#[cfg(feature = "serve")]
 pub(super) struct CaffeinateInhibitor {
     child: Option<std::process::Child>,
 }
 
-#[cfg(feature = "serve")]
 impl CaffeinateInhibitor {
     pub(super) fn new() -> Self {
         Self { child: None }
     }
 }
 
-#[cfg(feature = "serve")]
 impl super::SleepInhibit for CaffeinateInhibitor {
     fn acquire(&mut self) -> anyhow::Result<()> {
         if super::sleep_inhibit_unavailable() {

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -279,7 +279,6 @@ fn aggregate_agents(
         .filter(|i| eligible_instance(i))
         .cloned()
         .collect();
-    #[cfg(feature = "serve")]
     let worker_records: Vec<crate::process::worker_registry::WorkerRecord> =
         crate::process::worker_registry::list()
             .unwrap_or_default()
@@ -290,14 +289,11 @@ fn aggregate_agents(
     // Structured sessions are excluded from `eligible`, so their sandboxes
     // have to be counted here or a host whose only sandbox runs under a
     // structured worker would never fetch the map its row needs.
-    #[cfg(feature = "serve")]
     let sandboxed_worker = worker_records.iter().any(|rec| {
         instances
             .iter()
             .any(|i| i.id == rec.session_id && sandbox_container_name(i).is_some())
     });
-    #[cfg(not(feature = "serve"))]
-    let sandboxed_worker = false;
 
     // Skip the runtime's stats pass unless a sandbox session is loaded;
     // `cached_stats` then hands back the last completed map without blocking.
@@ -343,7 +339,6 @@ fn aggregate_agents(
         });
     }
 
-    #[cfg(feature = "serve")]
     for rec in worker_records {
         let Some(root) = by_pid.get(&rec.pid) else {
             continue;

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -37,25 +37,19 @@ mod platform {
 pub(crate) mod metrics;
 
 /// Protocol-agnostic plumbing for supervised worker subprocesses, lifted
-/// out of `src/acp/` so the future plugin host can reuse it. Serve-gated
-/// because its only consumer today is the serve-gated `acp` module.
-#[cfg(feature = "serve")]
+/// out of `src/acp/` so the future plugin host can reuse it.
 pub mod worker;
 
 /// On-disk registry of detached ACP worker subprocesses (pid, socket path,
 /// build version, `stored_acp_session_id`). Colocated here with the
 /// protocol-agnostic `worker` substrate it builds on, so the plugin host can
 /// reuse that substrate directly. Dependency direction is one-way: consumers
-/// point down to `process`, never to each other. Serve-gated to match its
-/// consumers.
-#[cfg(feature = "serve")]
+/// point down to `process`, never to each other.
 pub mod worker_registry;
 
 /// The `aoe __acp-runner` shim: owns a detached ACP agent subprocess and
 /// outlives `aoe serve`. Colocated with `worker_registry` and the
-/// protocol-agnostic `worker` substrate they build on; serve-gated to match
-/// its consumers.
-#[cfg(feature = "serve")]
+/// protocol-agnostic `worker` substrate they build on.
 pub mod runner;
 
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -365,7 +359,6 @@ pub fn get_foreground_pid(shell_pid: u32) -> Option<u32> {
 /// `caffeinate -w <daemon_pid>` watches the daemon PID; the Linux `cat` sees
 /// EOF on the stdin pipe the daemon held), and init then reaps it. The
 /// `server` status loop is the only consumer.
-#[cfg(feature = "serve")]
 pub trait SleepInhibit: Send {
     /// Acquire the assertion by spawning and retaining the backing child.
     fn acquire(&mut self) -> anyhow::Result<()>;
@@ -380,7 +373,6 @@ pub trait SleepInhibit: Send {
 /// Build the platform sleep inhibitor: `caffeinate -i -w <daemon_pid>` on
 /// macOS, `systemd-inhibit --what=idle:sleep ... cat` on Linux, and a no-op
 /// on every other platform.
-#[cfg(feature = "serve")]
 pub fn sleep_inhibitor() -> Box<dyn SleepInhibit> {
     #[cfg(target_os = "macos")]
     {
@@ -400,10 +392,10 @@ pub fn sleep_inhibitor() -> Box<dyn SleepInhibit> {
 
 /// Sleep inhibitor for platforms with no supported backend: acquire and release
 /// are no-ops, and `is_held_alive` reports held to avoid pointless respawns.
-#[cfg(all(feature = "serve", not(any(target_os = "linux", target_os = "macos"))))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 struct NoopInhibitor;
 
-#[cfg(all(feature = "serve", not(any(target_os = "linux", target_os = "macos"))))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 impl SleepInhibit for NoopInhibitor {
     fn acquire(&mut self) -> anyhow::Result<()> {
         Ok(())
@@ -425,11 +417,11 @@ impl SleepInhibit for NoopInhibitor {
 /// builds a fresh inhibitor on every reacquire, so a per-instance guard could
 /// not remember across rebuilds; the backends read it to report the dead
 /// backend as held, which stops the reconciler respawning a doomed child.
-#[cfg(all(feature = "serve", any(target_os = "linux", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 static SLEEP_INHIBIT_UNAVAILABLE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
-#[cfg(all(feature = "serve", any(target_os = "linux", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn sleep_inhibit_unavailable() -> bool {
     SLEEP_INHIBIT_UNAVAILABLE.load(std::sync::atomic::Ordering::Relaxed)
 }
@@ -443,7 +435,6 @@ fn sleep_inhibit_unavailable() -> bool {
 /// no logind), and false on platforms with only `NoopInhibitor`. The latch is
 /// monotonic and never resets for the daemon's lifetime, so this stays false
 /// until restart even if the missing tool is later installed.
-#[cfg(feature = "serve")]
 pub(crate) fn sleep_inhibit_backend_available() -> bool {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
@@ -458,7 +449,7 @@ pub(crate) fn sleep_inhibit_backend_available() -> bool {
 /// Latch the sleep-inhibit backend unavailable and warn exactly once. Shared
 /// by the platform backends so the warn-once policy lives in one place while
 /// each backend keeps only its own spawn and liveness mechanics.
-#[cfg(all(feature = "serve", any(target_os = "linux", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn latch_sleep_inhibit_unavailable(reason: &str) {
     if !SLEEP_INHIBIT_UNAVAILABLE.swap(true, std::sync::atomic::Ordering::Relaxed) {
         tracing::warn!(target: "process.sleep_inhibit", "{reason}");
@@ -469,7 +460,7 @@ fn latch_sleep_inhibit_unavailable(reason: &str) {
 /// still holding the assertion. Shared by both platform backends because the
 /// exit-code discrimination is policy (like the warn-once latch), not per-OS
 /// mechanics, so the two copies cannot drift; only `exit_reason` differs.
-#[cfg(all(feature = "serve", any(target_os = "linux", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn sleep_inhibit_child_held_alive(child: &mut Option<Child>, exit_reason: &str) -> bool {
     if sleep_inhibit_unavailable() {
         return true;

--- a/src/server/access.rs
+++ b/src/server/access.rs
@@ -324,7 +324,6 @@ pub(super) async fn access_policy(
 /// the handlers keep their `cityhall_block*` calls as defense in depth. Reads
 /// (GET/HEAD) pass the gate; the few sensitive ones keep their per-handler
 /// guard. See #7.
-#[cfg(feature = "serve")]
 pub(super) const CITYHALL_MUTATION_ALLOW: &[(&str, &str)] = &[
     // Session creation (server-derived) + lifecycle / metadata on the structured
     // sessions this mode owns; each handler re-checks the target is structured.
@@ -463,7 +462,6 @@ pub(super) const CITYHALL_MUTATION_DENY: &[(&str, &str)] = &[
 /// for: it covers every module prefix and method uniformly (an unmatched or
 /// unlisted mutating route fails closed), so a handler can no longer silently
 /// reopen a hole by omission. See #7.
-#[cfg(feature = "serve")]
 pub(super) async fn cityhall_gate(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
     request: axum::extract::Request,

--- a/src/server/acp_events.rs
+++ b/src/server/acp_events.rs
@@ -13,7 +13,6 @@ use crate::server::{acp_ws, api};
 /// One task instead of two halves the broadcast clone count and locks
 /// `state.instances` once per event instead of twice for the events
 /// (e.g. `AcpSessionAssigned`) that both consumers care about.
-#[cfg(feature = "serve")]
 pub(super) async fn acp_event_listener(state: Arc<AppState>) {
     let mut rx = state.acp_events_tx.subscribe();
     loop {
@@ -450,7 +449,6 @@ pub(super) async fn acp_event_listener(state: Arc<AppState>) {
 /// Acts via the same `apply_status_intent` path as the live listener
 /// so push subscribers and the broadcast channel see the seeded
 /// transitions as ordinary StatusChange events. See #1103 (B).
-#[cfg(feature = "serve")]
 pub(crate) async fn seed_acp_statuses(state: Arc<AppState>) {
     let acp_ids: Vec<String> = state
         .instances
@@ -493,7 +491,6 @@ pub(crate) async fn seed_acp_statuses(state: Arc<AppState>) {
 /// callers hold the write lock. Sends a `StatusChange` on
 /// `status_tx` so push notifications and the dashboard see the
 /// transition like any tmux-driven one.
-#[cfg(feature = "serve")]
 pub(crate) fn apply_status_intent(
     inst: &mut Instance,
     intent: Option<StatusIntent>,
@@ -574,7 +571,6 @@ pub(crate) fn apply_status_intent(
 /// user, who is by construction present for it. Every `Stopped` reason maps to
 /// `Idle`, so a rate-limit park marks unread too; that is the same policy
 /// terminal sessions get, and a parked session does want attention.
-#[cfg(feature = "serve")]
 pub(super) fn should_mark_acp_unread(
     inst: &Instance,
     old_status: Status,
@@ -611,7 +607,6 @@ pub(super) fn should_mark_acp_unread(
 /// A stale-profile write is not retried. The row is left read rather than
 /// half-marked, the turn's mark is simply lost, and the move is rare enough that
 /// a re-resolve loop is not worth the added failure surface here.
-#[cfg(feature = "serve")]
 pub(super) async fn persist_and_mirror_unread(
     instances: &RwLock<Vec<Instance>>,
     instance_lock: &tokio::sync::Mutex<()>,
@@ -682,7 +677,6 @@ pub(super) async fn persist_and_mirror_unread(
 ///   daemon that died mid-turn would otherwise trap the dot grey. Mid-run a
 ///   `Stopped` in memory is a deliberate stop, so `apply_status_intent`'s guard
 ///   should keep it.
-#[cfg(feature = "serve")]
 pub(super) async fn recover_structured_unread_after_lag(
     instances: &RwLock<Vec<Instance>>,
     event_store: &crate::acp::event_store::EventStore,
@@ -735,7 +729,6 @@ pub(super) async fn recover_structured_unread_after_lag(
 /// owning profile when sessions.json needs to be re-saved (so the new
 /// `acp_session_id` survives daemon restart), or `None` if the
 /// change was a no-op or no change was emitted.
-#[cfg(feature = "serve")]
 pub(super) fn apply_acp_session_change(
     inst: &mut Instance,
     session_id: &str,
@@ -850,7 +843,6 @@ pub(super) fn apply_acp_session_change(
 /// What an event tells the ACP-session-id listener to do. `None` means
 /// the event is irrelevant. Extracted so the JSON-shape parsing has a
 /// pure-function test surface.
-#[cfg(feature = "serve")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(super) enum AcpSessionChange {
     Assigned(String),
@@ -861,7 +853,6 @@ pub(super) enum AcpSessionChange {
     Cleared,
 }
 
-#[cfg(feature = "serve")]
 pub(super) fn derive_acp_session_change(event: &crate::acp::Event) -> Option<AcpSessionChange> {
     use crate::acp::Event;
     match event {
@@ -879,14 +870,12 @@ pub(super) fn derive_acp_session_change(event: &crate::acp::Event) -> Option<Acp
 /// current status is `Error` (used to recover the sidebar from a
 /// sticky `AgentStartupError` banner after a successful respawn
 /// without clobbering an in-progress Running/Waiting turn).
-#[cfg(feature = "serve")]
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum StatusIntent {
     Set(Status),
     HealError,
 }
 
-#[cfg(feature = "serve")]
 pub(crate) fn derive_acp_status(event: &crate::acp::Event) -> Option<StatusIntent> {
     use crate::acp::Event;
     match event {
@@ -938,7 +927,6 @@ mod tests {
     /// #3181: the automatic mark's predicate for a structured row, driven off
     /// the live ACP turn-end event. One table rather than a test per case, per
     /// the repo's compile-cost rule.
-    #[cfg(feature = "serve")]
     #[test]
     fn should_mark_acp_unread_only_on_a_structured_running_to_idle_turn_end() {
         // (name, structured, old_status, new_status, unread_enabled, already_unread, expected)
@@ -1043,7 +1031,6 @@ mod tests {
     /// Seed `profile`'s store with `rows`, so a persist closure has a matching
     /// id to mark. Mirrors the shape used by the `flush_passive_transition_*`
     /// tests in `status_poll.rs`.
-    #[cfg(feature = "serve")]
     fn seed_profile_store(profile: &str, rows: Vec<Instance>) {
         crate::session::Storage::new_unwatched(profile)
             .expect("storage")
@@ -1054,7 +1041,6 @@ mod tests {
             .expect("seed write");
     }
 
-    #[cfg(feature = "serve")]
     fn load_profile_row(profile: &str, id: &str) -> Option<Instance> {
         crate::session::Storage::new_unwatched(profile)
             .expect("storage")
@@ -1072,7 +1058,6 @@ mod tests {
     /// nothing, so mirroring on `is_ok()` alone would mark memory off a
     /// successful no-op against a profile the row no longer lives in, and the
     /// next disk reload would silently drop the notification.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn persist_and_mirror_unread_mirrors_only_a_committed_mutation() {
@@ -1140,7 +1125,6 @@ mod tests {
     /// `flush_passive_transition_defers_unread_until_persist_ok` (in
     /// `status_poll.rs`) locks for the tmux poller. Separate test rather than a
     /// row in the one above because it needs the store deliberately broken.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn persist_and_mirror_unread_skips_the_mirror_on_a_failed_write() {
@@ -1190,7 +1174,6 @@ mod tests {
     /// lifecycle event, so the discriminator is the row rather than the event:
     /// only the structured row still sitting at `Running` represents a turn that
     /// ended unobserved.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn recover_structured_unread_after_lag_marks_only_a_missed_turn_end() {
@@ -1291,7 +1274,6 @@ mod tests {
     /// is dropped, or the mirror is reordered, because none of them run the
     /// listener. This one drives a real `Event::Stopped` frame through the
     /// broadcast and asserts both halves of the write.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn acp_event_listener_marks_a_finished_turn_unread_on_disk_and_in_memory() {
@@ -1382,7 +1364,6 @@ mod tests {
     // session/load reattach reuses it). Without this, a stale marker left by a
     // non-user respawn keeps the reconciler's resume filter skipping the
     // session forever once the worker dies, deadlocking a queued prompt.
-    #[cfg(feature = "serve")]
     #[test]
     fn acp_session_assigned_clears_stale_dormant_marker_on_same_id() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1411,7 +1392,6 @@ mod tests {
     // new-assignment path. That path must consume the one-shot fork_pending seed
     // and persist, so a restart resumes the child via session/load rather than
     // re-forking the parent.
-    #[cfg(feature = "serve")]
     #[test]
     fn assigning_forked_id_clears_fork_pending_and_persists() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1445,7 +1425,6 @@ mod tests {
     // None) must leave import_pending alone: that marker belongs to the import
     // flow, which lands on the same-id path, and clearing it here would block a
     // legitimate import retry from re-seeding the transcript.
-    #[cfg(feature = "serve")]
     #[test]
     fn non_fork_assignment_preserves_import_pending() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1476,7 +1455,6 @@ mod tests {
     // reconciler nor the supervisor re-issues the same failing session/fork on
     // the next reattach. This is the reducer side of the fork-failure retry-loop
     // fix; the reset carries no new id, so acp_session_id is cleared too.
-    #[cfg(feature = "serve")]
     #[test]
     fn reset_clears_fork_pending_and_import_pending() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1507,7 +1485,6 @@ mod tests {
     // must clear the dead id but leave import_pending untouched: that marker
     // belongs to the import flow, and clearing it here would block a legitimate
     // import retry. Mirrors the non-fork assignment guard.
-    #[cfg(feature = "serve")]
     #[test]
     fn reset_without_fork_pending_preserves_import_pending() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1530,7 +1507,6 @@ mod tests {
         assert!(profile.is_some(), "the reset must persist");
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn acp_session_assigned_same_id_no_marker_is_noop() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1552,7 +1528,6 @@ mod tests {
     // derived no session change, so the stale ACP id survived on disk and the
     // next worker restart replayed the pre-clear conversation via session/load.
     // It must now derive a Cleared change so the stored id is dropped.
-    #[cfg(feature = "serve")]
     #[test]
     fn session_cleared_derives_cleared_change() {
         assert_eq!(
@@ -1566,7 +1541,6 @@ mod tests {
     // dropping the paired fork/import markers too: a /clear issued before a
     // pending fork/import resolves must still restart as session/new, not
     // re-session/fork the parent. See #3080.
-    #[cfg(feature = "serve")]
     #[test]
     fn cleared_nulls_stored_id_and_pending_markers() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1592,7 +1566,6 @@ mod tests {
 
     // Regression for the event-ordering the listener sees: an id assigned at
     // connect followed by a later /clear must end with no stored id. See #3080.
-    #[cfg(feature = "serve")]
     #[test]
     fn assign_then_clear_leaves_no_stored_id() {
         let mut inst = Instance::new("seed", "/tmp/seed");
@@ -1612,7 +1585,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn derive_acp_status_maps_terminal_events() {
         use crate::acp::approvals::{ApprovalDecision, Nonce};
@@ -1714,7 +1686,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn derive_acp_session_change_extracts_assigned_id() {
         use crate::acp::Event;
@@ -1727,7 +1698,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn derive_acp_session_change_extracts_reset_reason() {
         use crate::acp::Event;
@@ -1742,7 +1712,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn derive_acp_session_change_ignores_unrelated_events() {
         use crate::acp::Event;
@@ -1759,7 +1728,6 @@ mod tests {
         assert_eq!(derive_acp_session_change(&Event::ThinkingStarted), None);
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn derive_acp_status_running_on_agent_activity() {
         use crate::acp::state::ToolCall;
@@ -1797,7 +1765,6 @@ mod tests {
 
     // --- #2248: a structured session must heal out of a stale Stopped ---
 
-    #[cfg(feature = "serve")]
     fn stopped_structured_instance() -> Instance {
         let mut inst = Instance::new("s", "/tmp/s");
         inst.view = crate::session::View::Structured;
@@ -1805,13 +1772,11 @@ mod tests {
         inst
     }
 
-    #[cfg(feature = "serve")]
     fn apply(inst: &mut Instance, intent: StatusIntent) {
         let tx = broadcast::channel(8).0;
         apply_status_intent(inst, Some(intent), &tx);
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn heal_error_wakes_a_stopped_session() {
         // AcpSessionAssigned / RateLimitAutoResumed -> HealError: a fresh
@@ -1826,7 +1791,6 @@ mod tests {
         assert_eq!(inst.status, Status::Running);
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn trailing_acp_event_cannot_change_a_trashed_session_status() {
         let mut inst = stopped_structured_instance();
@@ -1842,7 +1806,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn agent_activity_wakes_an_idle_session_after_a_fired_wakeup() {
         // A session that paused on ScheduleWakeup sits Idle. When the wake
@@ -1856,7 +1819,6 @@ mod tests {
         assert_eq!(inst.idle_entered_at, None);
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn heal_error_still_heals_a_sticky_error() {
         let mut inst = stopped_structured_instance();
@@ -1865,7 +1827,6 @@ mod tests {
         assert_eq!(inst.status, Status::Idle);
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn status_intent_transitions_preserve_last_accessed_at() {
         // #3465 residual: the intent applier used to restamp
@@ -1899,7 +1860,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn relayed_intent_stamp_wipes_concurrent_archive() {
         // Full #3465 residual chain on structured rows:
@@ -1932,7 +1892,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn trailing_set_intents_do_not_wake_a_stopped_session() {
         // A deliberate Stop, or a session mid-stop, keeps emitting acp
@@ -1950,7 +1909,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn deleting_and_creating_block_every_intent() {
         for terminal in [Status::Deleting, Status::Creating] {
@@ -1963,7 +1921,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn seed_unblocks_a_stopped_session_with_an_in_flight_turn() {
         use crate::acp::Event;
@@ -1989,7 +1946,6 @@ mod tests {
         assert_eq!(state.instances.read().await[0].status, Status::Running);
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn seed_preserves_a_deliberate_stop_across_restart() {
         use crate::acp::Event;

--- a/src/server/acp_ws.rs
+++ b/src/server/acp_ws.rs
@@ -888,7 +888,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "serve"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -10,11 +10,8 @@
 
 pub(super) use super::AppState;
 
-#[cfg(feature = "serve")]
 mod acp;
-#[cfg(feature = "serve")]
 mod client_log;
-#[cfg(feature = "serve")]
 mod file_provenance;
 mod git;
 mod log_level;
@@ -22,16 +19,13 @@ mod mcp;
 pub(crate) mod plugin_settings;
 pub mod plugins;
 mod projects;
-#[cfg(feature = "serve")]
 mod queue;
 pub(crate) mod sessions;
 mod skills;
 pub(crate) mod system;
 mod telemetry;
 
-#[cfg(feature = "serve")]
 pub(crate) use acp::structured_spawn_error_message;
-#[cfg(feature = "serve")]
 pub use acp::{
     acp_attachment, acp_cancel, acp_context_primer, acp_disable, acp_enable, acp_files,
     acp_force_end_turn, acp_prompt, acp_prompt_diff_comments, acp_replay, acp_set_config_option,
@@ -40,10 +34,8 @@ pub use acp::{
     switch_acp_agent,
 };
 
-#[cfg(feature = "serve")]
 pub use queue::{queue_clear, queue_edit, queue_enqueue, queue_list, queue_remove};
 
-#[cfg(feature = "serve")]
 pub use client_log::post_client_log;
 pub use git::{clone_repo, is_git_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
@@ -73,10 +65,8 @@ pub use skills::{
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;
 // Trash retention sweep, driven by the daemon's hourly loop; not a route handler.
-#[cfg(feature = "serve")]
 pub(crate) use sessions::purge_expired_trash;
 // Startup backfill that relocates trashed worktrees; not a route handler.
-#[cfg(feature = "serve")]
 pub(crate) use sessions::{reconcile_trashed_worktrees, reconcile_worktree_paths};
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -189,7 +189,7 @@ pub async fn plugin_commands() -> Json<serde_json::Value> {
 
 /// `GET /api/plugins/ui-state`: the plugin host's aggregated UI-state snapshot
 /// (the slots workers have pushed, plus the notification ring). Empty when no
-/// host is running (read-only mode, or a TUI-only build with no daemon). The
+/// host is running (read-only mode). The
 /// dashboard polls this alongside `/api/sessions` and renders each slot itself.
 pub async fn plugin_ui_state(
     State(state): State<std::sync::Arc<AppState>>,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -179,7 +179,6 @@ pub struct SessionResponse {
     /// How this session is rendered: `structured` (ACP native rendering) or
     /// `terminal` (tmux-backed PTY). The web dashboard branches on this to
     /// pick the structured panels vs the terminal view.
-    #[cfg(feature = "serve")]
     #[serde(default, skip_serializing_if = "crate::session::View::is_terminal")]
     pub view: crate::session::View,
     /// Live structured view worker lifecycle. `absent` for tmux sessions or
@@ -188,20 +187,17 @@ pub struct SessionResponse {
     /// `running` once the supervisor holds a live worker. Drives the
     /// sidebar `Resuming…` chip and the per-session banner in the
     /// structured view. See #1088.
-    #[cfg(feature = "serve")]
     pub acp_worker_state: crate::acp::supervisor::AcpWorkerState,
     /// True when this session's agent can run in structured view: a built-in
     /// with an ACP adapter, or a custom agent whose profile config
     /// declares a valid `agent_acp_cmd`. The web terminal view reads
     /// this to decide whether the "switch to structured view" affordance is
     /// available, replacing the hardcoded client-side tool list.
-    #[cfg(feature = "serve")]
     pub acp_capable: bool,
     /// The session's server-owned prompt queue (follow-ups the user lined up
     /// while a turn was busy), ordered by `seq`. The daemon owns it, so it is
     /// visible across the user's devices and survives a client reload; the
     /// structured view renders it and drains happen server-side.
-    #[cfg(feature = "serve")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub queued_prompts: Vec<crate::acp::state::QueuedPromptEntry>,
     /// The session's captured ACP session id, present only once the
@@ -209,7 +205,6 @@ pub struct SessionResponse {
     /// as `fork_from` on a structured fork create and gates the "Fork" action
     /// on it together with `acp_can_fork`. Omitted when absent (terminal
     /// sessions, or structured ones whose worker has not minted an id yet).
-    #[cfg(feature = "serve")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acp_session_id: Option<String>,
     /// The session's resolved ACP registry key (`agent_name` when set, else
@@ -219,7 +214,6 @@ pub struct SessionResponse {
     /// only event that populates the reduced `state.agent`), so it can gray
     /// out the running backend on a never-switched session. Omitted for
     /// sessions with no resolved agent. See #2803.
-    #[cfg(feature = "serve")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acp_agent: Option<String>,
     /// True when this session's agent can run a structured ACP `session/fork`,
@@ -228,7 +222,6 @@ pub struct SessionResponse {
     /// gates "Fork" on this AND `acp_session_id` rather than on a captured id
     /// alone. Omitted (read as not-forkable) for terminal sessions and
     /// non-forkable agents.
-    #[cfg(feature = "serve")]
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub acp_can_fork: bool,
     /// Whether switching this session between terminal and structured view
@@ -237,7 +230,6 @@ pub struct SessionResponse {
     /// `agents::acp_transcript_cli_resumable` so the dashboard and TUI stop
     /// each recomputing it from `tool` + `acp_agent`. Omitted for
     /// non-preserving pairings.
-    #[cfg(feature = "serve")]
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub keeps_context: bool,
     /// Slash-command aliases that reset the conversation for this session's
@@ -245,7 +237,6 @@ pub struct SessionResponse {
     /// `acp::agent_profiles::resolve(...).clear_aliases` so the composer's `/`
     /// palette and queued-prompt batching do not mirror the per-agent list.
     /// Omitted for agents with no clear alias.
-    #[cfg(feature = "serve")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub clear_aliases: Vec<String>,
     /// True when the session is a Claude Code session AND the user has
@@ -339,7 +330,6 @@ impl SessionResponse {
             inst,
             claude_fullscreen,
             None,
-            #[cfg(feature = "serve")]
             crate::acp::supervisor::AcpWorkerState::Absent,
             None,
             None,
@@ -354,7 +344,7 @@ impl SessionResponse {
         inst: &Instance,
         claude_fullscreen: bool,
         plan_summary: Option<PlanSummary>,
-        #[cfg(feature = "serve")] acp_worker_state: crate::acp::supervisor::AcpWorkerState,
+        acp_worker_state: crate::acp::supervisor::AcpWorkerState,
         next_wakeup_at: Option<String>,
         next_wakeup_reason: Option<String>,
         // `Some(description)` when the session has an armed `Monitor` (the
@@ -440,21 +430,17 @@ impl SessionResponse {
             notify_on_waiting: inst.notify_on_waiting,
             notify_on_idle: inst.notify_on_idle,
             notify_on_error: inst.notify_on_error,
-            #[cfg(feature = "serve")]
             view: inst.view,
-            #[cfg(feature = "serve")]
             queued_prompts: {
                 let mut q = inst.queued_prompts.clone();
                 q.sort_by_key(|e| e.seq);
                 q
             },
-            #[cfg(feature = "serve")]
             acp_worker_state,
             // Built-in ACP capability is resolved here from a process-wide
             // registry (cheap, no IO). Custom agents depend on profile
             // config; the list and create handlers overlay that without a
             // per-row config read.
-            #[cfg(feature = "serve")]
             acp_capable: {
                 let resolved = inst
                     .agent_name
@@ -463,13 +449,11 @@ impl SessionResponse {
                     .unwrap_or(inst.tool.as_str());
                 builtin_acp_registry().get(resolved).is_some()
             },
-            #[cfg(feature = "serve")]
             acp_session_id: inst.acp_session_id.clone(),
             // Resolved the same way as `acp_capable` above: `agent_name` when
             // set and non-empty, else `tool`. This is the ACP registry key,
             // so it matches `/api/acp/agents` names the switch-agent modal
             // filters against. See #2803.
-            #[cfg(feature = "serve")]
             acp_agent: {
                 let resolved = inst
                     .agent_name
@@ -481,11 +465,9 @@ impl SessionResponse {
             // Shares `agent_is_structured_fork_capable` with the create-time
             // guard so the web "Fork" affordance and server-side acceptance
             // cannot drift: forkable = built-in ACP adapter verified to fork.
-            #[cfg(feature = "serve")]
             acp_can_fork: agent_is_structured_fork_capable(&inst.tool, inst.agent_name.as_deref()),
             // Same agent resolution as `acp_agent` above; computed once here so
             // the web dashboard and native TUI stop mirroring the gate.
-            #[cfg(feature = "serve")]
             keeps_context: crate::agents::acp_transcript_cli_resumable(
                 &inst.tool,
                 inst.agent_name
@@ -496,7 +478,6 @@ impl SessionResponse {
             // Same agent resolution as `acp_agent` above; the composer palette
             // and queued-prompt clear-boundary hint read these instead of a
             // client-side per-agent mirror.
-            #[cfg(feature = "serve")]
             clear_aliases: crate::acp::agent_profiles::resolve(
                 inst.agent_name
                     .as_deref()
@@ -578,7 +559,6 @@ pub struct SessionsEnvelope {
 /// Process-wide built-in ACP registry, built once. Used to compute
 /// `SessionResponse.acp_capable` for built-in agents without allocating
 /// a registry per response row.
-#[cfg(feature = "serve")]
 fn builtin_acp_registry() -> &'static crate::acp::AgentRegistry {
     static REG: std::sync::OnceLock<crate::acp::AgentRegistry> = std::sync::OnceLock::new();
     REG.get_or_init(crate::acp::AgentRegistry::with_defaults)
@@ -588,7 +568,6 @@ fn builtin_acp_registry() -> &'static crate::acp::AgentRegistry {
 /// `agent_acp_cmd`, or it inherits a registry-backed base via
 /// `agent_detect_as`. Built-in capability is handled separately in the
 /// constructor, so this only covers the custom case.
-#[cfg(feature = "serve")]
 fn custom_agent_acp_capable(session: &crate::session::config::SessionConfig, tool: &str) -> bool {
     session
         .agent_acp_cmd
@@ -666,7 +645,6 @@ pub async fn list_sessions(
     let claude_fullscreen = crate::claude_settings::read_tui_fullscreen();
     // Snapshot the supervisor's worker lifecycle map once per request
     // rather than locking it per row. See #1088.
-    #[cfg(feature = "serve")]
     let worker_states = state.acp_supervisor.worker_states_snapshot().await;
     // Filtered once up front; every positional zip with `instances` below
     // (ACP capability overlay, smart-rename overlay) must walk this same
@@ -711,7 +689,6 @@ pub async fn list_sessions(
             } else {
                 None
             };
-            #[cfg(feature = "serve")]
             let acp_worker_state = worker_states
                 .get(&inst.id)
                 .copied()
@@ -720,7 +697,6 @@ pub async fn list_sessions(
                 inst,
                 claude_fullscreen,
                 plan_summary,
-                #[cfg(feature = "serve")]
                 acp_worker_state,
                 next_wakeup_at,
                 next_wakeup_reason,
@@ -739,19 +715,16 @@ pub async fn list_sessions(
     // Overlay custom-agent ACP capability (built-ins were resolved in the
     // constructor). Distinct `(profile, project_path)` pairs each resolve
     // once via the shared cache above.
-    #[cfg(feature = "serve")]
-    {
-        for (resp, inst) in sessions.iter_mut().zip(scoped_instances.iter().copied()) {
-            if resp.acp_capable {
-                continue;
-            }
-            let cfg = resolve_session_cfg(
-                &mut session_cfg_cache,
-                &inst.source_profile,
-                &inst.project_path,
-            );
-            resp.acp_capable = custom_agent_acp_capable(cfg, &inst.tool);
+    for (resp, inst) in sessions.iter_mut().zip(scoped_instances.iter().copied()) {
+        if resp.acp_capable {
+            continue;
         }
+        let cfg = resolve_session_cfg(
+            &mut session_cfg_cache,
+            &inst.source_profile,
+            &inst.project_path,
+        );
+        resp.acp_capable = custom_agent_acp_capable(cfg, &inst.tool);
     }
 
     // Resolve per-profile cleanup defaults with a TTL cache on AppState
@@ -2985,15 +2958,8 @@ pub async fn update_session_archive(
         }
         let response =
             SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
-        let structured_view;
-        #[cfg(feature = "serve")]
-        {
-            structured_view = inst.is_structured();
-        }
-        #[cfg(not(feature = "serve"))]
-        {
-            structured_view = false;
-        }
+
+        let structured_view = inst.is_structured();
         let inst_snap = inst.clone();
         drop(instances);
 
@@ -3011,7 +2977,6 @@ pub async fn update_session_archive(
         // Worker shutdown before ancillary kill so in-flight tool output
         // settles (mirrors acp.rs:1304-1310). shutdown() preserves the
         // transcript (#1710).
-        #[cfg(feature = "serve")]
         match state.acp_supervisor.shutdown(&id).await {
             Ok(()) | Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) => {}
             Err(e) => tracing::warn!(
@@ -3152,7 +3117,6 @@ pub async fn trash_session(
     }
 
     if was_structured_view {
-        #[cfg(feature = "serve")]
         match state.acp_supervisor.shutdown(&id).await {
             Ok(()) | Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) => {}
             Err(error) => tracing::warn!(
@@ -3700,15 +3664,8 @@ pub async fn stop_session(
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return super::session_not_found();
         };
-        let structured;
-        #[cfg(feature = "serve")]
-        {
-            structured = inst.is_structured();
-        }
-        #[cfg(not(feature = "serve"))]
-        {
-            structured = false;
-        }
+
+        let structured = inst.is_structured();
         // Mirror the TUI's `stop_selected` guard: a session that is already
         // stopped or mid-lifecycle has nothing to stop.
         let already = matches!(
@@ -3776,7 +3733,6 @@ pub async fn stop_session(
         // Structured view: shut down the worker so the reconciler does not
         // race to respawn it. `shutdown` preserves the transcript, so the
         // session resumes the conversation when reopened.
-        #[cfg(feature = "serve")]
         match state.acp_supervisor.shutdown(&id).await {
             Ok(()) | Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) => {}
             Err(e) => tracing::warn!(
@@ -3871,15 +3827,8 @@ pub async fn start_session(
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return super::session_not_found();
         };
-        let structured;
-        #[cfg(feature = "serve")]
-        {
-            structured = inst.is_structured();
-        }
-        #[cfg(not(feature = "serve"))]
-        {
-            structured = false;
-        }
+
+        let structured = inst.is_structured();
         (
             inst.source_profile.clone(),
             structured,
@@ -4087,15 +4036,8 @@ pub async fn update_session_snooze(
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return super::session_not_found();
         };
-        let structured_view;
-        #[cfg(feature = "serve")]
-        {
-            structured_view = inst.is_structured();
-        }
-        #[cfg(not(feature = "serve"))]
-        {
-            structured_view = false;
-        }
+
+        let structured_view = inst.is_structured();
         (structured_view, inst.source_profile.clone())
     };
 
@@ -4150,7 +4092,6 @@ pub async fn update_session_snooze(
     // `shutdown` preserves the agent transcript (no session/delete), so
     // that respawn resumes the conversation instead of resetting it
     // (#1710).
-    #[cfg(feature = "serve")]
     if was_structured_view && minutes.is_some() {
         match state.acp_supervisor.shutdown(&id).await {
             Ok(()) | Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) => {}
@@ -4161,8 +4102,6 @@ pub async fn update_session_snooze(
             ),
         }
     }
-    #[cfg(not(feature = "serve"))]
-    let _ = was_structured_view;
 
     let instances = state.instances.read().await;
     let response = match instances.iter().find(|i| i.id == id) {
@@ -4307,7 +4246,6 @@ async fn mark_delete_error(state: &AppState, id: &str, message: String) {
 /// removed, and `false` when a concurrent restore won the race and the row was
 /// deliberately kept (see the `kept_restored` branch). Callers must not report
 /// a kept row as deleted.
-#[cfg_attr(not(feature = "serve"), allow(unused_variables))]
 async fn purge_session_artifacts(
     state: &Arc<AppState>,
     id: &str,
@@ -4376,10 +4314,7 @@ async fn purge_session_artifacts(
         .await
         .map_err(|e| format!("Deletion hook task failed: {e}"))?;
 
-    #[cfg(feature = "serve")]
     let transcript_purged = instance.is_structured();
-    #[cfg(not(feature = "serve"))]
-    let transcript_purged = false;
 
     let deletion_result = if transcript_purged {
         // Commit the row removal before deleting the ACP transcript. A lost
@@ -4404,22 +4339,18 @@ async fn purge_session_artifacts(
 
                 // The worker may still use the worktree, so ACP teardown stays
                 // ahead of sidecar cleanup. The durable row is already gone.
-                #[cfg(feature = "serve")]
-                {
-                    match state.acp_supervisor.shutdown_and_delete(id).await {
-                        Ok(())
-                        | Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "shutdown during purge failed: {e}"
-                            );
-                        }
+                match state.acp_supervisor.shutdown_and_delete(id).await {
+                    Ok(()) | Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "acp.supervisor",
+                            session = %id,
+                            "shutdown during purge failed: {e}"
+                        );
                     }
-                    state.acp_supervisor.forget_session(id);
-                    state.acp_event_store.delete_session(id);
                 }
+                state.acp_supervisor.forget_session(id);
+                state.acp_event_store.delete_session(id);
 
                 tokio::task::spawn_blocking(move || committed.finish())
                     .await
@@ -4633,7 +4564,6 @@ pub(crate) async fn reconcile_trashed_worktrees(state: &Arc<AppState>) {
 /// per-instance locked and its trashed+expired state re-validated under the
 /// lock, so a concurrent restore wins the race and is never purged. See
 /// #2489.
-#[cfg(feature = "serve")]
 pub(crate) async fn purge_expired_trash(state: &Arc<AppState>) {
     use std::collections::HashMap;
 
@@ -5229,16 +5159,12 @@ pub struct CreateSessionBody {
     /// case it defaults to `terminal`. The value is re-validated against real
     /// ACP capability below before being persisted, so a tampered request
     /// can't force the structured view on a non-ACP tool.
-    #[cfg(feature = "serve")]
     #[serde(default)]
     pub view: crate::session::View,
-    #[cfg(feature = "serve")]
     #[serde(default)]
     pub agent_name: Option<String>,
-    #[cfg(feature = "serve")]
     #[serde(default)]
     pub agent_model: Option<String>,
-    #[cfg(feature = "serve")]
     #[serde(default)]
     pub agent_effort: Option<String>,
     /// Scratch session: server provisions a fresh directory under
@@ -5260,7 +5186,6 @@ pub struct CreateSessionBody {
     /// new session adopts this id as its `acp_session_id`, is forced to the
     /// structured view, and seeds its transcript from the agent's history
     /// replay. `path` must be the session's original cwd. See #2276.
-    #[cfg(feature = "serve")]
     #[serde(default)]
     pub import_acp_session_id: Option<String>,
     /// Fork an existing session: the source session's captured session id to
@@ -5272,7 +5197,6 @@ pub struct CreateSessionBody {
     /// resumes the parent `agent_session_id` with the agent's fork flag. A
     /// structured fork requested for a non-ACP agent is rejected rather than
     /// silently downgraded.
-    #[cfg(feature = "serve")]
     #[serde(default)]
     pub fork_from: Option<String>,
     /// External work-queue dispatcher completion callback: an HTTP POST
@@ -5322,7 +5246,6 @@ fn create_body_combines_scratch_and_worktree(body: &CreateSessionBody) -> bool {
 /// `Err` reports an unforkable terminal agent or missing parent id; a
 /// structured request is already rejected by the caller's
 /// `agent_is_structured_fork_capable` guard before it reaches here.
-#[cfg(feature = "serve")]
 fn resolve_create_fork_seed(
     tool: &str,
     parent_id: &str,
@@ -5344,7 +5267,6 @@ fn resolve_create_fork_seed(
 /// a parent. The two seed the new session from different sources, so allowing
 /// both would produce a contradictory half-imported, half-forked session.
 /// Trailing whitespace is treated as unset, matching the per-field guards.
-#[cfg(feature = "serve")]
 fn both_import_and_fork_set(body: &CreateSessionBody) -> bool {
     let set = |v: &Option<String>| v.as_deref().map(str::trim).is_some_and(|s| !s.is_empty());
     set(&body.import_acp_session_id) && set(&body.fork_from)
@@ -5354,7 +5276,6 @@ fn both_import_and_fork_set(body: &CreateSessionBody) -> bool {
 /// the single source of truth for "can this agent run the ACP `session/fork`
 /// handshake?". Shared by the `SessionResponse.acp_can_fork` projection (the web
 /// "Fork" affordance) and the create-time guard so they cannot drift.
-#[cfg(feature = "serve")]
 fn agent_is_structured_fork_capable(tool: &str, agent_name: Option<&str>) -> bool {
     crate::session::fork::structured_fork_capable(tool, agent_name)
 }
@@ -5364,7 +5285,6 @@ fn agent_is_structured_fork_capable(tool: &str, agent_name: Option<&str>) -> boo
 /// `agent_acp_cmd`. Mirrors the post-build capability check (below) so
 /// CityHall mode can reject a non-ACP agent up front instead of letting the
 /// session silently downgrade to the terminal view. See #7.
-#[cfg(feature = "serve")]
 /// The ACP registry key a create request resolves to: an explicit `agent_name`
 /// when present, else the tool name. Shared by the capability check and the
 /// allowlist check (#3241) so the two cannot judge different agents.
@@ -5683,7 +5603,6 @@ pub(crate) fn run_create_hooks(
 /// binary via `build_host_command`), destroy it, or edit it. Returns the
 /// canonical CityHall 403 (never a 404, so the mode does not leak which ids
 /// exist); `None` in normal mode or for a genuine structured target. See #7.
-#[cfg(feature = "serve")]
 async fn cityhall_block_non_structured(
     state: &AppState,
     id: &str,
@@ -5704,7 +5623,6 @@ async fn cityhall_block_non_structured(
 /// Plural [`cityhall_block_non_structured`]: refuse unless EVERY id resolves to
 /// a structured session this mode created. Used by multi-session teardown
 /// (`delete_workspace`), which acts on all ids, not just the owner. See #7.
-#[cfg(feature = "serve")]
 async fn cityhall_block_any_non_structured(
     state: &AppState,
     ids: &[String],
@@ -5854,32 +5772,29 @@ pub async fn create_session(
         let mut paths = projects.into_iter().map(|p| p.path);
         body.path = paths.next().unwrap();
         body.extra_repo_paths = paths.collect();
-        #[cfg(feature = "serve")]
-        {
-            body.view = crate::session::View::Structured;
-            // Fork / import resume an existing agent session and would bypass the
-            // server-derived path + ACP gate, so they are not honored in the mode.
-            body.fork_from = None;
-            body.import_acp_session_id = None;
-            let profile = body
-                .profile
-                .clone()
-                .unwrap_or_else(|| state.profile.clone());
-            if !agent_is_acp_capable(
-                &profile,
-                std::path::Path::new(&body.path),
-                &body.tool,
-                body.agent_name.as_deref(),
-            ) {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "error": "cityhall_agent_not_acp",
-                        "message": "CityHall mode requires an ACP-capable agent"
-                    })),
-                )
-                    .into_response();
-            }
+        body.view = crate::session::View::Structured;
+        // Fork / import resume an existing agent session and would bypass the
+        // server-derived path + ACP gate, so they are not honored in the mode.
+        body.fork_from = None;
+        body.import_acp_session_id = None;
+        let profile = body
+            .profile
+            .clone()
+            .unwrap_or_else(|| state.profile.clone());
+        if !agent_is_acp_capable(
+            &profile,
+            std::path::Path::new(&body.path),
+            &body.tool,
+            body.agent_name.as_deref(),
+        ) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "cityhall_agent_not_acp",
+                    "message": "CityHall mode requires an ACP-capable agent"
+                })),
+            )
+                .into_response();
         }
     }
 
@@ -6025,7 +5940,6 @@ pub async fn create_session(
     // non-ACP tool is downgraded to a terminal session further down, and terminal
     // sessions are deliberately out of scope (a pane can exec any binary), so
     // refusing here would reject a session the policy does not govern.
-    #[cfg(feature = "serve")]
     if body.view == crate::session::View::Structured {
         let agent_key = acp_agent_key(&body.tool, body.agent_name.as_deref());
         let profile = validation_profile.to_string();
@@ -6056,7 +5970,6 @@ pub async fn create_session(
     // different source (import adopts an on-disk session id; fork resumes a
     // parent's captured id), and honoring both would leave the session in a
     // contradictory half-imported, half-forked state. Reject up front.
-    #[cfg(feature = "serve")]
     if both_import_and_fork_set(&body) {
         return (
             StatusCode::BAD_REQUEST,
@@ -6077,7 +5990,6 @@ pub async fn create_session(
     // so a stale or hand-written request can't seed the transcript in the
     // wrong place. Runs after tool-identity validation so it sits ahead of
     // the build's spawn_blocking but behind the agent check.
-    #[cfg(feature = "serve")]
     if let Some(import_id) = body
         .import_acp_session_id
         .as_deref()
@@ -6127,7 +6039,6 @@ pub async fn create_session(
     // later. The builder applies the seed: a structured seed forces the
     // structured view and sets the one-shot `fork_pending`/`import_pending`
     // markers; a terminal seed pre-pins the child id and the Fork intent.
-    #[cfg(feature = "serve")]
     let fork_seed = match body
         .fork_from
         .as_deref()
@@ -6264,17 +6175,11 @@ pub async fn create_session(
         plugin_create_idempotency: None,
         pending_initial_turn: None,
         acp_mode_id: None,
-        #[cfg(feature = "serve")]
         view: body.view,
-        #[cfg(feature = "serve")]
         agent_name: body.agent_name,
-        #[cfg(feature = "serve")]
         agent_model: body.agent_model,
-        #[cfg(feature = "serve")]
         agent_effort: body.agent_effort,
-        #[cfg(feature = "serve")]
         import_acp_session_id: body.import_acp_session_id,
-        #[cfg(feature = "serve")]
         fork_seed,
     };
 
@@ -6293,24 +6198,20 @@ pub async fn create_session(
             // Carry the resolved tie value (#1927); list_sessions' overlay does
             // not run on this create response, so a managed worktree would
             // otherwise report untied until the next list refresh.
-            #[cfg(feature = "serve")]
-            {
-                if resp.has_managed_worktree {
-                    resp.tie_workdir_to_name =
-                        crate::session::profile_config::resolve_config_or_warn(
-                            &instance.source_profile,
-                        )
-                        .session
-                        .tie_workdir_to_name;
-                }
-                if !resp.acp_capable {
-                    let session = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                        &instance.source_profile,
-                        std::path::Path::new(&instance.project_path),
-                    )
-                    .session;
-                    resp.acp_capable = custom_agent_acp_capable(&session, &instance.tool);
-                }
+            if resp.has_managed_worktree {
+                resp.tie_workdir_to_name = crate::session::profile_config::resolve_config_or_warn(
+                    &instance.source_profile,
+                )
+                .session
+                .tie_workdir_to_name;
+            }
+            if !resp.acp_capable {
+                let session = crate::session::repo_config::resolve_config_with_repo_or_warn(
+                    &instance.source_profile,
+                    std::path::Path::new(&instance.project_path),
+                )
+                .session;
+                resp.acp_capable = custom_agent_acp_capable(&session, &instance.tool);
             }
 
             if query.wait.as_deref() == Some("ready") && instance.status == Status::Starting {
@@ -8224,7 +8125,6 @@ mod tests {
 
     // CityHall create-time capability gate (#7): create_session rejects a
     // non-ACP agent up front instead of downgrading to a hidden terminal view.
-    #[cfg(feature = "serve")]
     mod cityhall_capability {
         use super::*;
         use crate::session::test_support::isolate_app_dir;
@@ -8424,7 +8324,6 @@ mod tests {
     // Reverting to the profile-only resolver would miss the override and fall
     // through to the "no prompt yet" path (both are 409, so this asserts the
     // body message, not just the status).
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn force_smart_rename_preflight_sees_command_override_but_not_from_a_repo() {
@@ -8485,7 +8384,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn list_sessions_shares_config_resolution_across_overlays() {
@@ -8524,7 +8422,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn list_sessions_state_filter() {
@@ -8586,7 +8483,6 @@ mod tests {
         assert_eq!(ids(&explicit_all).len(), 3);
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn wait_until_left_starting_returns_immediately_if_already_left() {
         let mut inst = Instance::new("already-running", "/tmp/wait-a");
@@ -8608,7 +8504,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn wait_until_left_starting_resolves_on_broadcast() {
         let mut inst = Instance::new("starting", "/tmp/wait-b");
@@ -8647,7 +8542,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn wait_until_left_starting_times_out_with_current_status() {
         let mut inst = Instance::new("stuck", "/tmp/wait-c");
@@ -8668,7 +8562,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn wait_until_left_starting_returns_none_if_instance_vanished() {
         let state = crate::server::test_support::build_test_app_state(vec![]);
@@ -8878,7 +8771,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn acp_can_fork_tracks_acp_capable_and_fork_strategy() {
         // claude is ACP-capable AND declares a real fork strategy, so the web
@@ -12101,22 +11993,14 @@ mod workspace_ordering_tests {
             notify_on_waiting: None,
             notify_on_idle: None,
             notify_on_error: None,
-            #[cfg(feature = "serve")]
             view: crate::session::View::Terminal,
-            #[cfg(feature = "serve")]
             acp_worker_state: crate::acp::supervisor::AcpWorkerState::Absent,
             queued_prompts: Vec::new(),
-            #[cfg(feature = "serve")]
             acp_capable: false,
-            #[cfg(feature = "serve")]
             acp_session_id: None,
-            #[cfg(feature = "serve")]
             acp_agent: None,
-            #[cfg(feature = "serve")]
             acp_can_fork: false,
-            #[cfg(feature = "serve")]
             keeps_context: false,
-            #[cfg(feature = "serve")]
             clear_aliases: Vec::new(),
             claude_fullscreen: false,
             workspace_repos: Vec::new(),

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -10349,14 +10349,12 @@ mod tests {
     /// `purge_session_artifacts` refuses on its first line. The teardown that
     /// follows is what a delete must not start under an in-flight submission;
     /// these tests only need to observe that it waits for one.
-    #[cfg(feature = "serve")]
     fn delete_race_state(id: &str) -> std::sync::Arc<crate::server::AppState> {
         delete_race_state_for(&[id])
     }
 
     /// [`delete_race_state`] for a workspace: every id shares the shape, so a
     /// sibling teardown can be observed the same way the owner's is.
-    #[cfg(feature = "serve")]
     fn delete_race_state_for(ids: &[&str]) -> std::sync::Arc<crate::server::AppState> {
         let instances = ids
             .iter()
@@ -10380,7 +10378,6 @@ mod tests {
     /// Each permanent-delete path is checked the same way: hold the session's
     /// submission guard (standing in for that drain) and assert the delete
     /// parks before any teardown, then completes once the guard drops.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn permanent_deletion_waits_for_an_in_flight_submission() {
         use std::time::Duration;
@@ -10500,7 +10497,6 @@ mod tests {
     /// config, which reads the user's global config, before it reaches the
     /// guard, so the race above cannot cover it without reading user state.
     /// The lock order is asserted in the source instead.
-    #[cfg(feature = "serve")]
     #[test]
     fn the_retention_purge_takes_submission_before_the_instance_lock() {
         let source = std::fs::read_to_string(
@@ -10531,7 +10527,6 @@ mod tests {
     /// Before #3639 the drain held `instance_lock` across delivery and these
     /// four handlers were excluded by it. They take the submission guard now
     /// for the same reason `attach_project` and the tied renames do.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn worker_stopping_handlers_wait_for_an_in_flight_submission() {
         use std::time::Duration;
@@ -10600,7 +10595,6 @@ mod tests {
     /// id it is handed and nothing prunes it, so every externally reachable
     /// mutation that claims it must prove the session exists first. Otherwise
     /// an authenticated client grows daemon memory with random ids.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn session_mutations_allocate_no_prompt_lock_for_an_unknown_id() {
         let state = crate::server::test_support::build_test_app_state(Vec::new());

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -360,7 +360,6 @@ pub async fn update_settings(
             }
             // Tell each touched plugin's worker its settings changed (#2897),
             // after the durable write. Best-effort; config.get is the fallback.
-            #[cfg(feature = "serve")]
             if !plugin_changes.is_empty() {
                 if let Some(host) = &state.plugin_host {
                     host.emit_settings_changed(&plugin_changes).await;

--- a/src/server/idle_reap.rs
+++ b/src/server/idle_reap.rs
@@ -7,14 +7,12 @@ use super::state::AppState;
 /// How often the serve daemon evaluates plain tmux sessions for idle
 /// auto-stop. Mirrors the acp reaper's cadence so a 2s status tick does
 /// not drive a storage + tmux sweep on every iteration.
-#[cfg(feature = "serve")]
 pub(super) const SESSION_IDLE_REAP_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(60);
 
 /// Cap on concurrent `perform_stop` calls during one reap pass. `Instance::stop`
 /// can block ~10s on `docker stop`; without a bound, a fleet of sessions all
 /// crossing the threshold on the same tick would stampede the Docker daemon.
-#[cfg(feature = "serve")]
 pub(super) const SESSION_IDLE_REAP_MAX_CONCURRENT: usize = 4;
 
 /// Auto-stop plain (non-acp) tmux sessions that have been `Idle` past
@@ -23,7 +21,6 @@ pub(super) const SESSION_IDLE_REAP_MAX_CONCURRENT: usize = 4;
 /// under the per-profile storage lock (so a concurrently running TUI cannot
 /// double-stop it) and stopped on a detached task with bounded concurrency,
 /// keeping the status poll loop responsive.
-#[cfg(feature = "serve")]
 pub(super) async fn reap_idle_sessions(
     state: &Arc<AppState>,
     last_reap: &mut Option<std::time::Instant>,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,15 +1,13 @@
-//! Web dashboard for remote agent session access
-//!
-//! Provides an embedded axum web server that serves a responsive dashboard
-//! for monitoring and interacting with agent sessions from any browser.
+//! The daemon: an axum server exposing the REST/WS API that the dashboard,
+//! the TUI structured view, and ACP clients all speak. The embedded dashboard
+//! bundle it can also serve is optional (`web` feature, see [`assets`]).
 
 pub(crate) mod access;
 pub(crate) mod acp_events;
-#[cfg(feature = "serve")]
 pub mod acp_reconciler;
-#[cfg(feature = "serve")]
 pub mod acp_ws;
 pub mod api;
+#[cfg(feature = "web")]
 pub(crate) mod assets;
 pub(crate) mod attach_project;
 pub mod auth;
@@ -37,7 +35,7 @@ pub(crate) mod status_poll;
 pub(crate) mod structured_repair;
 #[cfg(test)]
 mod test_helpers;
-#[cfg(all(feature = "serve", any(test, feature = "test-support")))]
+#[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]
 pub mod test_support;
 pub(crate) mod token;
@@ -47,11 +45,17 @@ pub mod tunnel;
 /// kept under `crate::server::` so existing supervisor/WS call sites keep
 /// resolving without churn. The canonical definition lives in protocol.rs
 /// so the daemon and any client share a single source of truth.
-#[cfg(feature = "serve")]
 pub use crate::acp::protocol::AcpBroadcastFrame;
 pub(crate) use access::{is_untrusted_ip_literal, is_wildcard_bind, norm_host};
 pub(crate) use acp_events::{apply_status_intent, derive_acp_status};
+#[cfg(feature = "web")]
 pub use assets::web_build_id;
+
+/// No dashboard is embedded, so there is no bundle identity to report.
+#[cfg(not(feature = "web"))]
+pub fn web_build_id() -> Option<&'static str> {
+    None
+}
 pub(crate) use disk_watch::{
     add_profile_disk_watch, remove_profile_disk_watch, rename_profile_disk_watch,
 };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,7 @@
 //! The daemon: an axum server exposing the REST/WS API that the dashboard,
 //! the TUI structured view, and ACP clients all speak. The embedded dashboard
-//! bundle it can also serve is optional (`web` feature, see [`assets`]).
+//! bundle it can also serve is optional; the `web` feature gates it, and
+//! `assets` holds the serving code.
 
 pub(crate) mod access;
 pub(crate) mod acp_events;

--- a/src/server/reload.rs
+++ b/src/server/reload.rs
@@ -334,7 +334,7 @@ impl PriorById {
 pub(crate) async fn reload_state_instances_from_disk(
     state: &Arc<AppState>,
     fresh: Vec<Instance>,
-    #[cfg(feature = "serve")] live_worker_records: Vec<LiveStructuredWorkerRecord>,
+    live_worker_records: Vec<LiveStructuredWorkerRecord>,
     status_source: StatusSource,
     read_epoch: u64,
 ) {
@@ -416,16 +416,13 @@ pub(crate) async fn reload_state_instances_from_disk(
         merged.push(row);
     }
 
-    #[cfg(feature = "serve")]
     let repairs = repair_structured_rows_from_live_workers(&mut merged, live_worker_records);
 
-    #[cfg(feature = "serve")]
     apply_acp_overlay_inplace(&prior_by_id, &mut merged);
 
     *current = merged;
     drop(current);
 
-    #[cfg(feature = "serve")]
     persist_structured_row_repairs(state, repairs);
 }
 
@@ -449,7 +446,6 @@ pub(crate) async fn reload_state_instances_from_disk(
 /// event handlers are responsible for any post-restart re-emission that
 /// updates these fields for structured sessions; the passive-status
 /// writer at `status_poll_loop` deliberately does not.
-#[cfg(feature = "serve")]
 pub(super) fn apply_acp_overlay_inplace(prior_by_id: &PriorById, merged: &mut [Instance]) {
     for inst in merged.iter_mut() {
         if !inst.is_structured() {

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tracing::Instrument;
 
 use super::access::{access_policy, cityhall_gate, security_headers};
+#[cfg(feature = "web")]
 use super::assets::{serve_asset, serve_index, serve_public_file};
 use super::state::AppState;
 use crate::server::{acp_ws, api, auth, live_ws, login, push};
@@ -289,7 +290,6 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             get(live_ws::live_container_terminal_ws),
         );
 
-    #[cfg(feature = "serve")]
     let app = app
         .route("/sessions/{id}/acp/ws", get(acp_ws::acp_ws))
         .route("/api/sessions/{id}/acp/spawn", post(api::spawn_acp))
@@ -364,31 +364,33 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/acp/option-catalog", get(api::get_option_catalog))
         .route("/api/claude-sessions", get(api::list_claude_sessions));
 
-    app
-        // Static assets (Vite build output: assets/, manifest.json, sw.js, icons)
+    // Dashboard bundle (Vite build output) plus the SPA fallback. Without
+    // `web` the daemon still answers `/api/*`; browser paths 404.
+    #[cfg(feature = "web")]
+    let app = app
         .route("/assets/{*path}", get(serve_asset))
         .route("/manifest.json", get(serve_public_file))
         .route("/sw.js", get(serve_public_file))
         .route("/icon-192.png", get(serve_public_file))
         .route("/icon-512.png", get(serve_public_file))
-        // SPA fallback: all other GET routes serve index.html
-        .fallback(get(serve_index))
-        .layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            cityhall_gate,
-        ))
-        .layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            auth::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            access_policy,
-        ))
-        .layer(axum::middleware::from_fn(security_headers))
-        .layer(axum::middleware::from_fn(http_request_span))
-        .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
-        .with_state(state)
+        .fallback(get(serve_index));
+
+    app.layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        cityhall_gate,
+    ))
+    .layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        auth::auth_middleware,
+    ))
+    .layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        access_policy,
+    ))
+    .layer(axum::middleware::from_fn(security_headers))
+    .layer(axum::middleware::from_fn(http_request_span))
+    .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
+    .with_state(state)
 }
 
 /// Placeholder logged in place of a route template when axum matched no

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -193,7 +193,6 @@ pub struct SessionService {
     persist_locks: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     /// Per-session prompt-submission locks. See
     /// [`SessionService::prompt_submission`].
-    #[cfg(feature = "serve")]
     prompt_locks: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
@@ -1372,7 +1371,6 @@ impl SessionService {
     /// `send_turn`'s resume trigger, which answers `AlreadyResuming` or
     /// `AlreadyRunning` for a worker that is already there, so it costs a
     /// lookup rather than a wrong disposition.
-    #[cfg(feature = "serve")]
     pub(crate) async fn prompt_submission(&self, id: &str) -> tokio::sync::OwnedMutexGuard<()> {
         let lock = {
             let guard = self.prompt_locks.read().await;
@@ -1403,7 +1401,6 @@ impl SessionService {
     /// teardown and removes the session row before dropping its lock, so both
     /// a waiter parked on that lock and one that vivified a fresh entry after
     /// `forget_prompt_lock` observe the removal and decline.
-    #[cfg(feature = "serve")]
     pub(crate) async fn prompt_submission_for_session(
         &self,
         id: &str,
@@ -1424,7 +1421,6 @@ impl SessionService {
     /// disposition under it, so every turn-starting surface decides and
     /// dispatches as one step instead of dispatching unconditionally after
     /// the wait (#3649). `None` for a session that no longer exists.
-    #[cfg(feature = "serve")]
     pub(crate) async fn begin_prompt_submission(
         &self,
         id: &str,
@@ -1442,7 +1438,6 @@ impl SessionService {
         Some((guard, dispatch))
     }
 
-    #[cfg(feature = "serve")]
     async fn session_exists(&self, id: &str) -> bool {
         self.instances.read().await.iter().any(|i| i.id == id)
     }
@@ -1451,7 +1446,6 @@ impl SessionService {
     /// removal the same delete paths already do. The registry is keyed by
     /// session id and nothing prunes it otherwise, so without this a long-lived
     /// daemon retains one entry per session it has ever seen.
-    #[cfg(feature = "serve")]
     pub(crate) async fn forget_prompt_lock(&self, id: &str) {
         self.prompt_locks.write().await.remove(id);
     }
@@ -1459,7 +1453,7 @@ impl SessionService {
     /// Registry size for a test asserting `prompt_locks` stays bounded (e.g.
     /// does not grow for ids that were never admitted past an existence
     /// check).
-    #[cfg(all(test, feature = "serve"))]
+    #[cfg(test)]
     pub(crate) async fn prompt_locks_len(&self) -> usize {
         self.prompt_locks.read().await.len()
     }
@@ -2084,7 +2078,6 @@ mod tests {
     /// fixture `acp::wake_prompt_frees_instance_lock_and_publishes_nothing_without_a_worker`
     /// uses: it makes `wait_for_worker` park exactly as it does mid-respawn,
     /// with no process, sandbox, or agent involved.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn the_queue_drain_frees_instance_lock_while_it_waits_for_a_resuming_worker() {
         use crate::acp::supervisor::{ResumeKind, ResumeReservationOutcome};
@@ -2164,7 +2157,6 @@ mod tests {
     /// the new text with nothing to retry, and a clear empties the durable
     /// queue for a batch that goes out anyway. `remove_queued_prompt` was
     /// already serialized for this reason; `edit` and `clear` were not.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn queue_mutations_wait_for_an_in_flight_delivery() {
         use std::time::Duration;

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -78,7 +78,6 @@ enum IdempotentMatch {
 /// The `Instance` fields `mutate_instance_persisted` copies from memory to
 /// disk. Deliberately explicit: the disk write no longer re-runs the caller's
 /// closure, so a field that is not listed here is simply not persisted.
-#[cfg(feature = "serve")]
 struct MirroredFields {
     queued_prompts: Vec<crate::acp::state::QueuedPromptEntry>,
     queued_prompt_next_seq: u64,
@@ -103,7 +102,6 @@ struct MirroredFields {
 }
 
 /// Result of `SessionService::edit_queued_prompt`.
-#[cfg(feature = "serve")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EditQueuedOutcome {
     Updated,
@@ -122,7 +120,6 @@ pub(crate) enum EditQueuedOutcome {
 /// combines with blank-line separators (empty-text rows skipped). An agent with
 /// no clear aliases combines the whole queue. Pure, so the boundary logic is
 /// unit-tested without a live worker.
-#[cfg(feature = "serve")]
 fn queue_drain_batch<'a>(
     queue: &'a [crate::acp::state::QueuedPromptEntry],
     profile: &crate::acp::agent_profiles::AgentProfile,
@@ -169,18 +166,15 @@ pub struct SessionService {
     pub mutation_epoch: Arc<std::sync::atomic::AtomicU64>,
     /// Owns the per-session ACP agent subprocesses, shared with
     /// `AppState.acp_supervisor`.
-    #[cfg(feature = "serve")]
     pub acp_supervisor:
         Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
     /// Durable ACP event store, shared with `AppState.acp_event_store`. Used
     /// by the pending-turn drain to reload attachment blobs for a rate-limit
     /// resume continuation (#3028).
-    #[cfg(feature = "serve")]
     pub acp_event_store: Arc<crate::acp::event_store::EventStore>,
     /// Live control-state projection, shared with `AppState.acp_control_cache`.
     /// The queue drain reads turn liveness from it so it agrees with prompt
     /// dispatch; see [`SessionService::fold_control_state`].
-    #[cfg(feature = "serve")]
     pub acp_control_cache: Arc<crate::acp::control_cache::ControlStateCache>,
     /// In-flight plugin creates keyed by `(plugin_id, idempotency_key)`.
     /// Sync mutex: critical sections are tiny and never span an `await`.
@@ -207,7 +201,6 @@ pub struct SessionService {
 /// transport layer (HTTP handler, plugin RPC connection context, or the
 /// drain reconstructing the creator), never decoded from a request payload,
 /// so a caller cannot forge an identity (#2897).
-#[cfg(feature = "serve")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SessionCaller {
     /// A human-facing surface (HTTP dashboard, TUI).
@@ -221,7 +214,6 @@ pub(crate) enum SessionCaller {
 /// stream, so callers can map each stage faithfully (the HTTP handler keeps
 /// its exact pre-extraction status codes, and only fires the post-publish
 /// smart-rename hook when a publish actually happened).
-#[cfg(feature = "serve")]
 pub(crate) enum SendTurnError {
     /// Pre-publish: the session vanished (or was triaged) before the resume
     /// snapshot. Nothing was published; the honest answer is "not found",
@@ -247,7 +239,6 @@ pub(crate) enum SendTurnError {
     Send(crate::acp::supervisor::SupervisorError),
 }
 
-#[cfg(feature = "serve")]
 impl std::fmt::Display for SendTurnError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -264,7 +255,6 @@ impl std::fmt::Display for SendTurnError {
 /// The ACP collaborators `SessionService` shares with `AppState`. Grouped so
 /// the constructor keeps one parameter for "the ACP side" rather than one per
 /// handle.
-#[cfg(feature = "serve")]
 pub struct AcpDeps {
     pub supervisor: Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
     pub event_store: Arc<crate::acp::event_store::EventStore>,
@@ -272,7 +262,6 @@ pub struct AcpDeps {
 }
 
 impl SessionService {
-    #[cfg(feature = "serve")]
     pub fn new(
         instances: Arc<RwLock<Vec<Instance>>>,
         instance_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
@@ -294,26 +283,6 @@ impl SessionService {
             pending_drains: std::sync::Mutex::new(std::collections::HashSet::new()),
             persist_locks: RwLock::new(HashMap::new()),
             prompt_locks: RwLock::new(HashMap::new()),
-        }
-    }
-
-    #[cfg(not(feature = "serve"))]
-    pub fn new(
-        instances: Arc<RwLock<Vec<Instance>>>,
-        instance_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
-        file_watch: Arc<crate::file_watch::FileWatchService>,
-        telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
-        mutation_epoch: Arc<std::sync::atomic::AtomicU64>,
-    ) -> Self {
-        Self {
-            instances,
-            instance_locks,
-            file_watch,
-            telemetry_session_creates,
-            mutation_epoch,
-            create_in_flight: std::sync::Mutex::new(HashMap::new()),
-            pending_drains: std::sync::Mutex::new(std::collections::HashSet::new()),
-            persist_locks: RwLock::new(HashMap::new()),
         }
     }
 
@@ -485,7 +454,6 @@ impl SessionService {
     ///
     /// `woke_idle_dormant` forces the resume trigger even when the worker
     /// looks alive, mirroring the handler's idle-dormant wake (#1689).
-    #[cfg(feature = "serve")]
     pub(crate) async fn send_turn(
         self: &Arc<Self>,
         caller: &SessionCaller,
@@ -625,7 +593,6 @@ impl SessionService {
     /// then disk: a crash (or failed persist) between the forward and the
     /// disk clear re-delivers after restart, which is the documented
     /// at-least-once contract.
-    #[cfg(feature = "serve")]
     pub(crate) async fn drain_pending_initial_turn(self: &Arc<Self>, id: &str) {
         {
             let mut drains = self
@@ -750,7 +717,6 @@ impl SessionService {
     /// clobber a create/plugin turn) or the session is gone. Persists so a
     /// daemon restart mid-resume still re-delivers. Used to continue a
     /// rate-limit-interrupted turn on resume (#3028).
-    #[cfg(feature = "serve")]
     pub(crate) async fn set_pending_initial_turn(
         self: &Arc<Self>,
         id: &str,
@@ -803,7 +769,6 @@ impl SessionService {
     /// session, in memory and on disk. A newer user prompt supersedes a queued
     /// rate-limit resume continuation, so the stale continuation must not
     /// replay after the newer message (#3028). No-op when nothing is queued.
-    #[cfg(feature = "serve")]
     pub(crate) async fn clear_pending_initial_turn(self: &Arc<Self>, id: &str) {
         let profile = {
             let mut instances = self.instances.write().await;
@@ -875,7 +840,6 @@ impl SessionService {
     /// it on the next daemon restart. Copying a whole snapshot makes ordering
     /// load-bearing in a way that re-running the closure did not, so the lock
     /// comes with it.
-    #[cfg(feature = "serve")]
     async fn mutate_instance_persisted<T, F>(self: &Arc<Self>, id: &str, mutate: F) -> Option<T>
     where
         T: Send + 'static,
@@ -955,7 +919,6 @@ impl SessionService {
     /// the guard is not reentrant. The `queue_enqueue` handler claims it
     /// instead, so the row rewrite this does for an existing id still cannot
     /// land inside a drain's snapshot-to-send window.
-    #[cfg(feature = "serve")]
     pub(crate) async fn enqueue_prompt(
         self: &Arc<Self>,
         id: &str,
@@ -1002,7 +965,6 @@ impl SessionService {
     /// then sends, so an unserialized edit landing inside that window is
     /// written to a row the drain has already copied. It delivers the old
     /// text and retires the row, and the edit is lost with nothing to retry.
-    #[cfg(feature = "serve")]
     pub(crate) async fn edit_queued_prompt(
         self: &Arc<Self>,
         id: &str,
@@ -1039,7 +1001,6 @@ impl SessionService {
     /// agent would see the prompt twice. Serialized, the removal either beats
     /// the drain's snapshot (the drain never sees the row) or follows its
     /// retire (the removal reports `false`, and the caller sends nothing).
-    #[cfg(feature = "serve")]
     pub(crate) async fn remove_queued_prompt(
         self: &Arc<Self>,
         id: &str,
@@ -1071,7 +1032,6 @@ impl SessionService {
     /// inside the drain's snapshot-to-send window empties the durable rows
     /// while the batch the drain already copied still goes to the agent, so
     /// the user watches the queue empty and then sees it sent anyway.
-    #[cfg(feature = "serve")]
     pub(crate) async fn clear_queued_prompts(self: &Arc<Self>, id: &str) {
         let Some(_submission) = self.prompt_submission_for_session(id).await else {
             return;
@@ -1091,7 +1051,6 @@ impl SessionService {
     }
 
     /// Snapshot the session's queue, ordered by `seq`.
-    #[cfg(feature = "serve")]
     pub(crate) async fn queued_prompts_snapshot(
         &self,
         id: &str,
@@ -1119,7 +1078,6 @@ impl SessionService {
     /// The fold is cached because rebuilding it per call measured 68ms at 20k
     /// events and 342ms at 100k, holding the event store's connection mutex
     /// for the whole scan, which stalls event recording daemon-wide.
-    #[cfg(feature = "serve")]
     pub(crate) async fn fold_control_state(&self, id: &str) -> crate::acp::state::AcpState {
         use crate::acp::state::{AcpSessionId, AcpState, AgentName};
         let (agent, model) = {
@@ -1187,7 +1145,6 @@ impl SessionService {
     /// (`useAcpSession`): a clear-command row fires as its own turn; a leading
     /// run of non-clear rows combines into one with blank-line separators.
     /// A batch's buffered attachment bytes are reloaded and forwarded with it.
-    #[cfg(feature = "serve")]
     pub(crate) async fn drain_queued_prompts_once(self: &Arc<Self>, id: &str) {
         {
             let mut drains = self
@@ -1308,7 +1265,6 @@ impl SessionService {
     /// Drop a set of queue rows and the attachment bytes buffered for them.
     /// Shared by the delivered path and the undeliverable-husk path so both
     /// leave the queue and the pending-attachment store consistent.
-    #[cfg(feature = "serve")]
     async fn retire_drained_rows(self: &Arc<Self>, id: &str, ids: Vec<String>) {
         for pid in &ids {
             self.acp_event_store
@@ -1333,7 +1289,6 @@ impl SessionService {
     /// keeps the session awake and the write never blocks a spawn. Guards on
     /// `is_idle_dormant` so a session woken by another path between the
     /// reconciler snapshot and this call is left untouched.
-    #[cfg(feature = "serve")]
     pub(crate) async fn wake_dormant_for_queue_drain(self: &Arc<Self>, id: &str) {
         self.mutate_instance_persisted(id, |inst| {
             if inst.is_idle_dormant() {
@@ -1350,7 +1305,6 @@ impl SessionService {
     /// `mutate_instance_persisted`. Always acquired BEFORE `instances.write()`
     /// and never while holding it, and nothing acquires `instance_lock` while
     /// holding this, so it cannot form a cycle with either.
-    #[cfg(feature = "serve")]
     async fn persist_lock(&self, id: &str) -> Arc<tokio::sync::Mutex<()>> {
         {
             let guard = self.persist_locks.read().await;
@@ -1513,13 +1467,11 @@ impl SessionService {
 
 /// Releases a session's `pending_drains` claim on every exit path of
 /// [`SessionService::drain_pending_initial_turn`], including panics.
-#[cfg(feature = "serve")]
 struct PendingDrainGuard {
     service: Arc<SessionService>,
     id: String,
 }
 
-#[cfg(feature = "serve")]
 impl Drop for PendingDrainGuard {
     fn drop(&mut self) {
         self.service
@@ -1634,23 +1586,20 @@ fn spec_payload_hash(spec: &StructuredSessionSpec) -> String {
         "acp_mode_id",
         spec.acp_mode_id.as_deref().unwrap_or_default(),
     );
-    #[cfg(feature = "serve")]
-    {
-        field("view", &format!("{:?}", spec.view));
-        field("agent_name", spec.agent_name.as_deref().unwrap_or_default());
-        field(
-            "agent_model",
-            spec.agent_model.as_deref().unwrap_or_default(),
-        );
-        field(
-            "agent_effort",
-            spec.agent_effort.as_deref().unwrap_or_default(),
-        );
-        field(
-            "import_acp_session_id",
-            spec.import_acp_session_id.as_deref().unwrap_or_default(),
-        );
-    }
+    field("view", &format!("{:?}", spec.view));
+    field("agent_name", spec.agent_name.as_deref().unwrap_or_default());
+    field(
+        "agent_model",
+        spec.agent_model.as_deref().unwrap_or_default(),
+    );
+    field(
+        "agent_effort",
+        spec.agent_effort.as_deref().unwrap_or_default(),
+    );
+    field(
+        "import_acp_session_id",
+        spec.import_acp_session_id.as_deref().unwrap_or_default(),
+    );
     use std::fmt::Write;
     let digest = hasher.finalize();
     let mut out = String::with_capacity(digest.len() * 2);
@@ -1702,17 +1651,11 @@ mod tests {
             plugin_create_idempotency: None,
             pending_initial_turn: None,
             acp_mode_id: None,
-            #[cfg(feature = "serve")]
             view: crate::session::View::Structured,
-            #[cfg(feature = "serve")]
             agent_name: Some("claude".to_string()),
-            #[cfg(feature = "serve")]
             agent_model: None,
-            #[cfg(feature = "serve")]
             agent_effort: None,
-            #[cfg(feature = "serve")]
             import_acp_session_id: None,
-            #[cfg(feature = "serve")]
             fork_seed: None,
         }
     }
@@ -1797,7 +1740,6 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn in_flight_claim_waits_same_hash_and_conflicts_on_mismatch() {
         let service = crate::server::test_support::build_test_app_state(Vec::new())
@@ -1833,7 +1775,6 @@ mod tests {
         };
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn probe_resolves_replay_conflict_and_new() {
         // Seed a prior create whose stored hash matches `test_spec()`; the probe
@@ -1881,7 +1822,6 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn send_turn_enforces_plugin_ownership_before_any_side_effect() {
         let mut user_session = Instance::new("user-owned", "/tmp/aoe-2897-project");
@@ -1940,7 +1880,6 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn drain_is_a_noop_without_a_pending_turn_and_releases_its_claim() {
         let mut inst = Instance::new("no-pending", "/tmp/aoe-2897-project");
@@ -1975,7 +1914,6 @@ mod tests {
     /// drain retried the same head-of-queue batch every reconciler tick,
     /// nothing behind it drained, and `reap_idle_workers` skips a session
     /// holding a queue, so the agent subprocess was never reaped.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn an_undeliverable_queue_row_is_retired_instead_of_wedging_the_queue() {
         let mut inst = Instance::new("queue", "/tmp/aoe-queue-husk");
@@ -2058,7 +1996,6 @@ mod tests {
     /// bytes), because retiring a husk is the drain's only externally visible
     /// effect in a test with no live worker: the idle session's row is retired,
     /// the mid-turn session's row survives untouched.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn a_queued_prompt_is_not_drained_into_a_turn_status_has_not_caught_up_with() {
         use crate::acp::state::Event;
@@ -2309,7 +2246,6 @@ mod tests {
     /// The sink assertion is the other half: mirroring this field with
     /// `touch_last_accessed()` instead of a monotone max would pass the recency
     /// checks and reintroduce #3465's wipe.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
     async fn enqueueing_a_prompt_advances_recency_without_clearing_a_peer_sink() {
@@ -2389,7 +2325,6 @@ mod tests {
     /// would drop `b`), and the lock exists to make that ordering guaranteed
     /// rather than incidental, but 32-way concurrency here never reordered the
     /// two `Storage::update` calls, so the lock is defensive and unproven.
-    #[cfg(feature = "serve")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial_test::serial]
     async fn concurrent_enqueues_all_survive_to_disk() {
@@ -2459,7 +2394,6 @@ mod tests {
         assert_eq!(disk_seqs.len(), 32, "no two persisted rows share a seq");
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn queue_store_enqueue_edit_remove_clear() {
         let mut inst = Instance::new("queue", "/tmp/aoe-queue-project");
@@ -2574,7 +2508,6 @@ mod tests {
             .is_none());
     }
 
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn wake_dormant_for_queue_drain_clears_only_when_dormant() {
         // A session the idle reaper auto-stopped: dormant, so the resume pass
@@ -2612,7 +2545,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn queue_drain_batch_splits_on_clear_boundary() {
         use crate::acp::state::QueuedPromptEntry;

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -60,17 +60,11 @@ pub(crate) struct StructuredSessionSpec {
     /// supervisor applies it after every worker (re)spawn. Stamped by the
     /// plugin host create path after host-side classification.
     pub acp_mode_id: Option<String>,
-    #[cfg(feature = "serve")]
     pub view: crate::session::View,
-    #[cfg(feature = "serve")]
     pub agent_name: Option<String>,
-    #[cfg(feature = "serve")]
     pub agent_model: Option<String>,
-    #[cfg(feature = "serve")]
     pub agent_effort: Option<String>,
-    #[cfg(feature = "serve")]
     pub import_acp_session_id: Option<String>,
-    #[cfg(feature = "serve")]
     pub fork_seed: Option<crate::session::ForkSeed>,
 }
 
@@ -147,17 +141,11 @@ pub(crate) async fn spawn_structured_session(
             plugin_create_idempotency,
             pending_initial_turn,
             acp_mode_id,
-            #[cfg(feature = "serve")]
             view,
-            #[cfg(feature = "serve")]
             agent_name,
-            #[cfg(feature = "serve")]
             agent_model,
-            #[cfg(feature = "serve")]
             agent_effort,
-            #[cfg(feature = "serve")]
             import_acp_session_id,
-            #[cfg(feature = "serve")]
             fork_seed,
         } = spec;
 
@@ -228,10 +216,7 @@ pub(crate) async fn spawn_structured_session(
                 Vec::new()
             },
             scratch,
-            #[cfg(feature = "serve")]
             fork_seed,
-            #[cfg(not(feature = "serve"))]
-            fork_seed: None,
         };
 
         let build_result = builder::build_instance(params, &title_refs, &branch_refs, &profile)?;
@@ -257,7 +242,6 @@ pub(crate) async fn spawn_structured_session(
         // Apply structured-view fields from the request body. structured_view is
         // re-validated below against real ACP capability; non-ACP tools
         // fall back to terminal view rather than erroring at spawn time.
-        #[cfg(feature = "serve")]
         let agent_effort = {
             instance.view = view;
             // #2276: importing an existing Claude session forces the
@@ -418,10 +402,7 @@ pub(crate) async fn spawn_structured_session(
             // supervisor spawns the ACP agent on demand. Skip the tmux
             // `start()` to avoid creating an empty pane that no one will
             // attach to.
-            #[cfg(feature = "serve")]
             let skip_tmux_start = instance.is_structured();
-            #[cfg(not(feature = "serve"))]
-            let skip_tmux_start = false;
             if !skip_tmux_start {
                 instance.start()?;
             }
@@ -449,20 +430,15 @@ pub(crate) async fn spawn_structured_session(
             return Err(e);
         }
 
-        #[cfg(feature = "serve")]
-        return Ok::<(Instance, Vec<String>, Option<String>), anyhow::Error>((
+        Ok::<(Instance, Vec<String>, Option<String>), anyhow::Error>((
             instance,
             build_warnings,
             agent_effort,
-        ));
-
-        #[cfg(not(feature = "serve"))]
-        Ok::<(Instance, Vec<String>), anyhow::Error>((instance, build_warnings))
+        ))
     })
     .await;
 
     match result {
-        #[cfg(feature = "serve")]
         Ok(Ok((instance, warnings, agent_effort))) => {
             let response_instance = instance.clone();
             let acp_spawn_target = if instance.is_structured() {
@@ -631,17 +607,6 @@ pub(crate) async fn spawn_structured_session(
                 });
             }
 
-            Ok(SpawnOutcome {
-                instance: response_instance,
-                warnings,
-            })
-        }
-        #[cfg(not(feature = "serve"))]
-        Ok(Ok((instance, warnings))) => {
-            let response_instance = instance.clone();
-            let mut instances = service.instances.write().await;
-            instances.push(instance);
-            drop(instances);
             Ok(SpawnOutcome {
                 instance: response_instance,
                 warnings,

--- a/src/server/sleep_inhibit.rs
+++ b/src/server/sleep_inhibit.rs
@@ -12,17 +12,14 @@ use super::state::AppState;
 /// (caffeinate `-w <pid>` and the systemd-inhibit `cat` otherwise outlive every
 /// tick), and both acquire and release lag are dominated by the minutes-long
 /// grace window and the OS idle-sleep timer.
-#[cfg(feature = "serve")]
 pub(super) const SLEEP_INHIBIT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// `AppState::sleep_inhibit_snapshot` bit: `prevent_sleep_when_active` was on
 /// at the last reconcile.
-#[cfg(feature = "serve")]
 pub(crate) const SLEEP_INHIBIT_SNAPSHOT_ENABLED: u8 = 0b01;
 
 /// `AppState::sleep_inhibit_snapshot` bit: an inhibitor slot is retained. This
 /// is slot presence, not held: the endpoint gates it on `backend_available`.
-#[cfg(feature = "serve")]
 pub(crate) const SLEEP_INHIBIT_SNAPSHOT_SLOT_PRESENT: u8 = 0b10;
 
 /// Acquire or release the OS sleep-inhibit assertion. Throttled to
@@ -32,7 +29,6 @@ pub(crate) const SLEEP_INHIBIT_SNAPSHOT_SLOT_PRESENT: u8 = 0b10;
 /// then reconciles: hold the assertion while the toggle is on and any session
 /// has recent activity, release once every session has been idle past the
 /// grace window.
-#[cfg(feature = "serve")]
 pub(super) async fn update_sleep_inhibit(
     state: &Arc<AppState>,
     slot: &mut Option<Box<dyn crate::process::SleepInhibit>>,
@@ -77,7 +73,6 @@ pub(super) async fn update_sleep_inhibit(
 /// here is a subprocess spawn / `try_wait` / kill that returns in milliseconds,
 /// and the call is throttled to once per interval; only the config read in
 /// `update_sleep_inhibit`, which touches disk, is offloaded.
-#[cfg(feature = "serve")]
 pub(super) fn reconcile_sleep_inhibit(
     desired: bool,
     slot: &mut Option<Box<dyn crate::process::SleepInhibit>>,

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -534,10 +534,15 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             );
         }
 
-        // Nothing to show a browser without the dashboard bundle.
-        if cfg!(feature = "web") && open_browser && !is_daemon {
-            if let Some((_, primary)) = labeled_urls.first() {
-                maybe_open_browser(primary);
+        if open_browser && !is_daemon {
+            if cfg!(feature = "web") {
+                if let Some((_, primary)) = labeled_urls.first() {
+                    maybe_open_browser(primary);
+                }
+            } else {
+                // Opening a browser on an API-only daemon lands on a 404. Say
+                // so rather than dropping the flag on the floor.
+                eprintln!("--open ignored: this build has no dashboard bundle");
             }
         }
 

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -266,9 +266,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         None
     };
 
-    #[cfg(feature = "serve")]
     let acp_events_tx = broadcast::channel(ACP_CHANNEL_CAPACITY).0;
-    #[cfg(feature = "serve")]
     let acp_event_store = {
         let app_dir = crate::session::get_app_dir().context("acp event store: resolve app dir")?;
         let db_path = app_dir.join("acp_events.db");
@@ -277,9 +275,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 .context("acp event store: open")?,
         )
     };
-    #[cfg(feature = "serve")]
     let acp_control_cache = Arc::new(crate::acp::control_cache::ControlStateCache::new());
-    #[cfg(feature = "serve")]
     let acp_supervisor = {
         // Approval pushes are dispatched from `acp_event_listener`,
         // which subscribes to the broadcast that ChannelSink::publish
@@ -312,7 +308,6 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let idempotency_locks = Arc::new(RwLock::new(std::collections::HashMap::new()));
     let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
     let mutation_epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
-    #[cfg(feature = "serve")]
     let session_service = Arc::new(session_service::SessionService::new(
         Arc::clone(&instances),
         Arc::clone(&instance_locks),
@@ -325,19 +320,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             control_cache: acp_control_cache.clone(),
         },
     ));
-    #[cfg(not(feature = "serve"))]
-    let session_service = Arc::new(session_service::SessionService::new(
-        Arc::clone(&instances),
-        Arc::clone(&instance_locks),
-        Arc::clone(&file_watch),
-        Arc::clone(&telemetry_session_creates),
-        Arc::clone(&mutation_epoch),
-    ));
 
     // the daemon serves fine without plugin workers.
     // The host API includes mutating session.meta.set/cas, so a read-only
     // daemon must not run plugin workers at all: gate the host on !read_only.
-    #[cfg(feature = "serve")]
     let plugin_host = if read_only {
         tracing::info!(target: "plugin.host", "plugin host disabled in read-only serve mode");
         None
@@ -531,18 +517,25 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             vec![(IpKind::Loopback, make_url(host))]
         };
 
-        println!("aoe web dashboard running at:");
+        // A build without the dashboard bundle still serves the API, so the
+        // banner must not promise a page that is not there.
+        if cfg!(feature = "web") {
+            println!("aoe web dashboard running at:");
+        } else {
+            println!("aoe daemon running at (API only, no dashboard bundle):");
+        }
         for (_, u) in &labeled_urls {
             println!("  {}", u);
         }
-        if auth_token.is_some() {
+        if auth_token.is_some() && cfg!(feature = "web") {
             println!();
             println!(
                 "Open any URL above in a browser. Share it to access from other devices on your network."
             );
         }
 
-        if open_browser && !is_daemon {
+        // Nothing to show a browser without the dashboard bundle.
+        if cfg!(feature = "web") && open_browser && !is_daemon {
             if let Some((_, primary)) = labeled_urls.first() {
                 maybe_open_browser(primary);
             }
@@ -640,15 +633,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         remote_owner_cache: RwLock::new(std::collections::HashMap::new()),
         changed_files_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
         status_tx: broadcast::channel(STATUS_CHANNEL_CAPACITY).0,
-        #[cfg(feature = "serve")]
         acp_events_tx: acp_events_tx.clone(),
-        #[cfg(feature = "serve")]
         acp_event_store: acp_event_store.clone(),
-        #[cfg(feature = "serve")]
         acp_control_cache: acp_control_cache.clone(),
-        #[cfg(feature = "serve")]
         acp_supervisor: acp_supervisor.clone(),
-        #[cfg(feature = "serve")]
         plugin_host: plugin_host.clone(),
         plugin_jobs: Arc::new(api::plugins::PluginJobRegistry::new()),
         push: push_state,
@@ -879,7 +867,6 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // Launch plugin workers for every active plugin that declares a runtime.
     // Non-blocking: each worker runs in its own supervised task. A daemon with
     // no community plugin workers (the common case) does nothing here.
-    #[cfg(feature = "serve")]
     if let Some(host) = state.plugin_host.clone() {
         host.start(&crate::plugin::registry()).await;
     }
@@ -1050,7 +1037,6 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         shutdown_state.shutdown.cancel();
         // Reap plugin workers before the force-exit deadline so no worker tree
         // is left behind when the daemon stops.
-        #[cfg(feature = "serve")]
         if let Some(host) = shutdown_state.plugin_host.clone() {
             host.shutdown().await;
         }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -16,7 +16,6 @@ use super::serve_snapshot::{
 use super::token::TokenManager;
 use crate::server::{api, login, session_service};
 
-#[cfg(feature = "serve")]
 pub(super) const ACP_CHANNEL_CAPACITY: usize = 256;
 
 /// Per-profile cleanup defaults with a refresh timestamp. Re-resolved from
@@ -236,7 +235,6 @@ pub struct AppState {
     /// channel carries `(session_id, serialized event JSON)` frames so
     /// clients can filter by session. Empty when no clients are
     /// connected; senders never need to check before emitting.
-    #[cfg(feature = "serve")]
     pub acp_events_tx: broadcast::Sender<AcpBroadcastFrame>,
     /// Disk-backed acp event log. The single source of truth for
     /// replay: `ChannelSink::publish` writes here on every event, the
@@ -244,20 +242,16 @@ pub struct AppState {
     /// endpoint reads from here, and `Supervisor::next_seqs` is seeded
     /// from here at startup so a fresh publish gets `max_seq + 1`
     /// rather than 1.
-    #[cfg(feature = "serve")]
     pub acp_event_store: Arc<crate::acp::event_store::EventStore>,
     /// Live control-state projection per session, folded at the publish choke
     /// point and shared with `ChannelSink`. Prompt dispatch reads it instead
     /// of replaying the log on every POST; see `crate::acp::control_cache`.
-    #[cfg(feature = "serve")]
     pub acp_control_cache: Arc<crate::acp::control_cache::ControlStateCache>,
     /// Owns the per-session ACP agent subprocesses.
-    #[cfg(feature = "serve")]
     pub acp_supervisor:
         Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
     /// The Tier 1 plugin worker host. `None` in test harnesses that do not
     /// stand up a host; `Some` in a live daemon.
-    #[cfg(feature = "serve")]
     pub plugin_host: Option<Arc<crate::plugin::host::PluginHost>>,
     /// Tracks in-flight web plugin install / update / uninstall jobs so the
     /// dashboard can tail their host-side log. In-memory; see
@@ -463,7 +457,6 @@ mod tests {
     /// `idempotency_locks` must not grow for the daemon's lifetime: keys are
     /// caller-supplied and unbounded, so an entry nobody holds is pruned on
     /// the next miss. A key whose lock is still held must survive. See #3156.
-    #[cfg(feature = "serve")]
     #[tokio::test]
     async fn idempotency_lock_prunes_unreferenced_keys() {
         let state = test_support::build_test_app_state(vec![]);

--- a/src/server/status_poll.rs
+++ b/src/server/status_poll.rs
@@ -188,7 +188,6 @@ pub(super) async fn flush_passive_transition_writes(
 /// is guaranteed even on a tick whose scrape fails, and entries for a session
 /// that is merely paused (archived / snoozed / idle-dormant) are not needed to
 /// be re-derived here.
-#[cfg(feature = "serve")]
 pub(super) fn gc_reconciler_session_maps(
     live_ids: &std::collections::HashSet<&str>,
     attempted: &mut std::collections::HashSet<String>,
@@ -214,34 +213,26 @@ pub(super) async fn status_poll_loop(state: Arc<AppState>) {
     // queued ticks and collapse the 2s cooldown the per-tick work expects.
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    #[cfg(feature = "serve")]
     let mut attempted_acp_spawns: std::collections::HashSet<String> =
         std::collections::HashSet::new();
-    #[cfg(feature = "serve")]
     let mut acp_reap_cadence = acp_reconciler::ReapCadence::default();
-    #[cfg(feature = "serve")]
     let mut last_session_idle_reap: Option<std::time::Instant> = None;
     // Loop-local, single-owner sleep-inhibit assertion (single global toggle,
     // so one slot for the whole daemon). Kept off `AppState`, which is for
     // cross-task shared state; this is owned solely by the poll loop, like
     // `last_session_idle_reap`.
-    #[cfg(feature = "serve")]
     let mut sleep_inhibitor: Option<Box<dyn crate::process::SleepInhibit>> = None;
-    #[cfg(feature = "serve")]
     let mut last_sleep_inhibit_reconcile: Option<std::time::Instant> = None;
     // Per-session reconciler respawn budget + crash-loop park set (#1945).
     // Owned by the loop so they persist across ticks, swept against live
     // sessions inside the reconciler.
-    #[cfg(feature = "serve")]
     let mut acp_respawn_history: std::collections::HashMap<String, Vec<std::time::Instant>> =
         std::collections::HashMap::new();
-    #[cfg(feature = "serve")]
     let mut acp_parked: std::collections::HashSet<String> = std::collections::HashSet::new();
     // Per-session capacity-deferred marker (#1027). A structured session
     // refused by `CapacityFull` is re-armed for retry every tick; this set
     // gates the capacity banner to publish once per transition and is cleared
     // once the session's worker comes online or leaves the live set.
-    #[cfg(feature = "serve")]
     let mut acp_capacity_deferred: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     loop {
@@ -257,18 +248,14 @@ pub(super) async fn status_poll_loop(state: Arc<AppState>) {
         // long-uptime daemon's footprint stays bounded by live-session count,
         // not by lifetime-observed sessions (#2758). Above the scrape guard so
         // the sweep still runs on a tick whose tmux scrape fails.
-        #[cfg(feature = "serve")]
-        {
-            let live_ids: std::collections::HashSet<&str> =
-                prev.keys().map(String::as_str).collect();
-            gc_reconciler_session_maps(
-                &live_ids,
-                &mut attempted_acp_spawns,
-                &mut acp_respawn_history,
-                &mut acp_parked,
-                &mut acp_capacity_deferred,
-            );
-        }
+        let live_ids: std::collections::HashSet<&str> = prev.keys().map(String::as_str).collect();
+        gc_reconciler_session_maps(
+            &live_ids,
+            &mut attempted_acp_spawns,
+            &mut acp_respawn_history,
+            &mut acp_parked,
+            &mut acp_capacity_deferred,
+        );
         // Snapshot of the prior tick's status bookkeeping, taken from the same
         // in-memory `state.instances` this tick's `load_all_instances()` call
         // is about to reset to defaults. Fed to `seed_tick_tracking` below,
@@ -394,7 +381,6 @@ pub(super) async fn status_poll_loop(state: Arc<AppState>) {
 
             drain_session_id_updates_in_state(&state).await;
 
-            #[cfg(feature = "serve")]
             acp_reconciler::reconcile_acp_workers(
                 &state,
                 &mut attempted_acp_spawns,
@@ -405,10 +391,8 @@ pub(super) async fn status_poll_loop(state: Arc<AppState>) {
             )
             .await;
 
-            #[cfg(feature = "serve")]
             reap_idle_sessions(&state, &mut last_session_idle_reap).await;
 
-            #[cfg(feature = "serve")]
             update_sleep_inhibit(
                 &state,
                 &mut sleep_inhibitor,
@@ -427,7 +411,6 @@ mod tests {
     /// #2758: the reconciler's persistent per-session maps must be swept
     /// against the live instance set every tick, so a deleted session's id
     /// does not linger and grow the daemon's footprint over its uptime.
-    #[cfg(feature = "serve")]
     #[test]
     fn gc_reconciler_session_maps_drops_deleted_session_ids() {
         use std::collections::{HashMap, HashSet};

--- a/src/server/structured_repair.rs
+++ b/src/server/structured_repair.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use super::state::AppState;
 
-#[cfg(feature = "serve")]
 pub(super) struct StructuredRowRepair {
     session_id: String,
     source_profile: String,
@@ -15,11 +14,9 @@ pub(super) struct StructuredRowRepair {
     acp_session_id: String,
 }
 
-#[cfg(feature = "serve")]
 pub(super) type LiveStructuredWorkerRecord =
     (crate::process::worker_registry::WorkerRecord, String);
 
-#[cfg(feature = "serve")]
 pub(super) fn live_structured_worker_records() -> Vec<LiveStructuredWorkerRecord> {
     use crate::process::worker_registry::{self, is_record_live};
 
@@ -50,7 +47,6 @@ pub(super) fn live_structured_worker_records() -> Vec<LiveStructuredWorkerRecord
 
 /// Runs before the ACP overlay so freshly repaired rows pass the
 /// `is_structured()` gate and keep their live worker status.
-#[cfg(feature = "serve")]
 pub(super) fn repair_structured_rows_from_live_workers(
     merged: &mut [Instance],
     records: Vec<LiveStructuredWorkerRecord>,
@@ -104,7 +100,6 @@ pub(super) fn repair_structured_rows_from_live_workers(
     repairs
 }
 
-#[cfg(feature = "serve")]
 pub(super) fn persist_structured_row_repairs(
     state: &Arc<AppState>,
     repairs: Vec<StructuredRowRepair>,
@@ -181,7 +176,6 @@ pub(super) fn persist_structured_row_repairs(
     );
 }
 
-#[cfg(feature = "serve")]
 pub(super) async fn rollback_structured_row_repairs(state: &Arc<AppState>, failed_ids: &[String]) {
     let mut instances = state.instances.write().await;
     for inst in instances.iter_mut() {
@@ -196,7 +190,6 @@ pub(super) async fn rollback_structured_row_repairs(state: &Arc<AppState>, faile
 mod tests {
     use super::*;
 
-    #[cfg(feature = "serve")]
     #[test]
     #[serial_test::serial]
     fn repair_structured_rows_from_live_workers_restores_structured_session_rows() {

--- a/src/server/tunnel.rs
+++ b/src/server/tunnel.rs
@@ -836,7 +836,17 @@ fn extract_tunnel_url(line: &str) -> Option<String> {
     None
 }
 
+/// Render a QR code to stderr for easy phone scanning. Without the dashboard
+/// bundle there is nothing for a phone to open, so only the URL is printed.
+#[cfg(not(feature = "web"))]
+pub fn print_qr_code(url: &str) {
+    eprintln!();
+    eprintln!("  Open: {}", url);
+    eprintln!();
+}
+
 /// Render a QR code to stderr for easy phone scanning.
+#[cfg(feature = "web")]
 pub fn print_qr_code(url: &str) {
     use qrcode::QrCode;
 

--- a/src/session/attach_project.rs
+++ b/src/session/attach_project.rs
@@ -931,7 +931,6 @@ pub fn quiesce_for_conversion(storage: &Storage, instance: &super::Instance) -> 
 
     // The worker registry only exists in a build with the structured view, and
     // without it there is no ACP worker to stop.
-    #[cfg(feature = "serve")]
     if let Ok(Some(record)) = crate::process::worker_registry::load(&instance.id) {
         crate::process::worker_registry::delete(&instance.id).ok();
         crate::process::worker::terminate_process_group(record.pid);
@@ -1013,7 +1012,6 @@ pub fn resume_after_conversion(
         }
     }
 
-    #[cfg(feature = "serve")]
     if quiesced.worker_was_running {
         crate::process::worker_registry::mark_restart_pending(session_id);
     }

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -839,19 +839,10 @@ pub fn build_instance(
             } => {
                 // Structured fork: force the structured view, seed the parent
                 // for the ACP session/fork handshake, and replay history into
-                // the (empty) event store on first connect. The marker fields
-                // live behind the serve feature, so without it a structured
-                // fork is inapplicable and this arm is a no-op. Bind the field
-                // to `_` on bare-core so the destructure reads it without an
-                // `allow(unused_variables)` suppression (AGENTS.md).
-                #[cfg(feature = "serve")]
-                {
-                    instance.view = crate::session::View::Structured;
-                    instance.fork_pending = Some(parent_acp_session_id);
-                    instance.import_pending = Some(true);
-                }
-                #[cfg(not(feature = "serve"))]
-                let _ = parent_acp_session_id;
+                // the (empty) event store on first connect.
+                instance.view = crate::session::View::Structured;
+                instance.fork_pending = Some(parent_acp_session_id);
+                instance.import_pending = Some(true);
             }
         }
     }
@@ -1035,7 +1026,6 @@ pub fn cleanup_instance(
 /// handles explicit agent / model / import fields the TUI wizard doesn't
 /// expose), and the CLI in `src/cli/add.rs` with bail-vs-downgrade semantics
 /// keyed on how explicit the user's flag was. Keep the three in sync.
-#[cfg(feature = "serve")]
 pub mod structured {
     use super::Instance;
 
@@ -2385,7 +2375,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     #[serial_test::serial]
     fn build_instance_applies_structured_fork_seed() {
@@ -2440,7 +2429,6 @@ mod tests {
         const RULE_AGENT: &str = "fork-seed-registry-rule";
         let cases: &[(&str, fn())] = &[
             ("terminal", build_instance_applies_terminal_fork_seed),
-            #[cfg(feature = "serve")]
             ("structured", build_instance_applies_structured_fork_seed),
         ];
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1245,8 +1245,8 @@ pub struct SessionConfig {
     /// Hold an OS assertion preventing user-idle system sleep while any
     /// session is active. Released once every session has been idle past
     /// `prevent_sleep_idle_grace_minutes`. Global toggle, daemon only: the
-    /// `aoe serve` status loop owns the assertion, so a TUI-only user
-    /// without a running daemon gets no inhibition.
+    /// `aoe serve` status loop owns the assertion, so a user without a
+    /// running daemon gets no inhibition.
     ///
     /// `global_only`: the status loop reads only the global config to drive a
     /// single process-wide assertion, so a per-profile override would be

--- a/src/session/conversation_summary.rs
+++ b/src/session/conversation_summary.rs
@@ -240,10 +240,8 @@ pub fn delta_meets_threshold(delta_bytes: usize, new_turns: usize) -> bool {
     delta_bytes >= MIN_DELTA_BYTES || new_turns >= MIN_DELTA_TURNS
 }
 
-#[cfg(feature = "serve")]
 pub use serve::{should_trigger_summary, try_conversation_summary, SummaryTrigger};
 
-#[cfg(feature = "serve")]
 mod serve {
     use super::*;
     use crate::server::AppState;

--- a/src/session/fork.rs
+++ b/src/session/fork.rs
@@ -37,9 +37,7 @@ pub enum ForkDenied {
 /// Process-wide default ACP registry, used only to answer "does this built-in
 /// tool have an ACP adapter?" for capability checks that have no
 /// profile-resolved config handy. Cached so the check doesn't rebuild the
-/// registry per call. Structured fork is a serve-only concept (the `acp`
-/// module is serve-gated), so this and `structured_fork_capable` are too.
-#[cfg(feature = "serve")]
+/// registry per call.
 fn builtin_acp_registry() -> &'static crate::acp::AgentRegistry {
     static REG: std::sync::OnceLock<crate::acp::AgentRegistry> = std::sync::OnceLock::new();
     REG.get_or_init(crate::acp::AgentRegistry::with_defaults)
@@ -63,7 +61,6 @@ fn builtin_acp_registry() -> &'static crate::acp::AgentRegistry {
 /// `aoe-agent` is ACP-capable but reads false because it is registry-only: it
 /// has no `AGENTS` entry, so `get_agent` returns `None`, the same path custom
 /// agents take.
-#[cfg(feature = "serve")]
 pub fn structured_fork_capable(tool: &str, agent_name: Option<&str>) -> bool {
     let resolved = agent_name.filter(|s| !s.is_empty()).unwrap_or(tool);
     builtin_acp_registry().get(resolved).is_some()

--- a/src/session/instance/accessors.rs
+++ b/src/session/instance/accessors.rs
@@ -39,11 +39,8 @@ impl Instance {
             created_by_plugin: None,
             plugin_create_idempotency: None,
             pending_initial_turn: None,
-            #[cfg(feature = "serve")]
             pending_initial_turn_attachments: Vec::new(),
-            #[cfg(feature = "serve")]
             queued_prompts: Vec::new(),
-            #[cfg(feature = "serve")]
             queued_prompt_next_seq: 0,
             acp_mode_id: None,
             prior_tool_session_ids: HashMap::new(),
@@ -214,10 +211,9 @@ impl Instance {
         self.yolo_mode
     }
 
-    /// True when this session renders in the structured (ACP) view. The
-    /// persisted `view` field exists in every build so non-serve writers
-    /// round-trip it intact; rows damaged by pre-fix writers are healed on
-    /// reload by the server's structured row repair path.
+    /// True when this session renders in the structured (ACP) view. Rows
+    /// damaged by pre-fix writers are healed on reload by the server's
+    /// structured row repair path.
     pub fn is_structured(&self) -> bool {
         self.view == View::Structured
     }
@@ -233,10 +229,6 @@ impl Instance {
     /// CLI-resumable transcript (see `agents::acp_transcript_cli_resumable`).
     /// When `acp_session_id` is unset this only flips the view, leaving no
     /// resume target, which is why the caller also gates on it being present.
-    ///
-    /// Only the serve-gated `acp_disable` handler calls this, so it is
-    /// `cfg(serve)` to stay dead-code-free in a TUI-only build.
-    #[cfg(feature = "serve")]
     pub(crate) fn switch_to_terminal_keep_context(&mut self) {
         if let Some(sid) = self.acp_session_id.take() {
             self.agent_session_id = Some(sid.clone());
@@ -252,7 +244,6 @@ mod tests {
     use super::*;
     use crate::session::instance::test_helpers::*;
 
-    #[cfg(feature = "serve")]
     #[test]
     fn switch_to_terminal_keep_context_carries_acp_id_into_resume_target() {
         let mut inst = Instance::new("claude", "/tmp");

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -345,21 +345,17 @@ pub struct Instance {
     /// store and are reloaded at drain time. Empty for create-time initial
     /// turns (those are text-only). `#[serde(default)]` + skip-when-empty keeps
     /// pre-existing rows deserialising unchanged, so no migration is needed.
-    /// Serve-only: `PromptAttachmentRef` lives in the serve-gated `acp` module,
-    /// and only the structured-view resume path (serve) ever populates it.
-    #[cfg(feature = "serve")]
+    /// Only the structured-view resume path populates it.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pending_initial_turn_attachments: Vec<crate::acp::state::PromptAttachmentRef>,
 
     /// Server-owned follow-ups, ordered by `QueuedPromptEntry::seq`. Persisted
     /// here so the daemon can drain them without a connected client.
-    #[cfg(feature = "serve")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub queued_prompts: Vec<crate::acp::state::QueuedPromptEntry>,
 
     /// Monotonic counter for `QueuedPromptEntry::seq`, so ordering is stable
     /// even after rows drain or are removed. Never reused within a session.
-    #[cfg(feature = "serve")]
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub queued_prompt_next_seq: u64,
 

--- a/src/session/instance/reconcile.rs
+++ b/src/session/instance/reconcile.rs
@@ -40,7 +40,7 @@ impl Instance {
         // reconciliation path feeds a different consumer, and each consumer
         // rewrites the runtime field it observes before reading
         // (`pane_dead_observed` is rewritten by the TUI's status poller
-        // before its TUI-only consumers read).
+        // before its consumers read).
         let disk_has_newer_lifecycle = disk.lifecycle_generation > self.lifecycle_generation;
         if !disk_has_newer_lifecycle {
             disk.last_error_check = self.last_error_check;

--- a/src/session/instance/resume.rs
+++ b/src/session/instance/resume.rs
@@ -589,7 +589,6 @@ mod tests {
         std::fs::write(dir.join(format!("{sid}.jsonl")), "seed\n").expect("write transcript");
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn restart_outcome_for_acp_session_is_fresh() {

--- a/src/session/instance/types.rs
+++ b/src/session/instance/types.rs
@@ -251,7 +251,6 @@ mod tests {
     // A non-fork session omits fork_pending on the wire (skip_serializing_if),
     // so legacy sessions.json without the key deserializes to None and no
     // migration is needed. A seeded fork id round-trips.
-    #[cfg(feature = "serve")]
     #[test]
     fn test_fork_pending_serde_roundtrip_and_default() {
         let fresh = Instance::new("s", "/tmp/x");

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -2,8 +2,8 @@
 //!
 //! AoE assembles an effective MCP server set from up to four layers
 //! (`agent-native` -> `global` -> `per-profile` -> `project-local`, higher wins
-//! per server name). The serve-gated `acp::mcp_config` used to own both the
-//! parsing and the merge, but it returned ACP `McpServer` wire types and dropped
+//! per server name). `acp::mcp_config` used to own both the parsing and the
+//! merge, but it returned ACP `McpServer` wire types and dropped
 //! the layer label on merge, so the unified management surface had nowhere to
 //! read the merged set, its provenance, or its shadowing.
 //!

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -7,15 +7,13 @@ pub(crate) mod capture;
 pub mod cityhall_bundle;
 pub mod civilizations;
 pub(crate) mod claim;
-// Discovery of on-disk Claude Code sessions. Lives here (not under the
-// serve-gated `acp` module) because terminal/tmux import via the CLI works in
-// every build; only the structured-view import path needs `serve`.
+// Discovery of on-disk Claude Code sessions. Lives here rather than under
+// `acp` because terminal/tmux import via the CLI does not involve ACP.
 pub mod claude_import;
 pub mod config;
 pub(crate) mod container_config;
 // Depends on `crate::acp` (Event / event store) and is only driven from the
-// serve daemon, both of which are serve-gated. See #2808.
-#[cfg(feature = "serve")]
+// serve daemon. See #2808.
 pub mod conversation_summary;
 pub mod deletion;
 pub(crate) mod environment;

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -431,7 +431,7 @@ impl SessionPoller {
         }
     }
 
-    #[cfg(any(test, all(feature = "test-support", feature = "serve")))]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn inject_test_update(&self, instance_id: &str, session_id: &str) {
         self.result_tx
             .send((

--- a/src/session/project_mcp.rs
+++ b/src/session/project_mcp.rs
@@ -1,9 +1,8 @@
 //! Project-local `.mcp.json` parsing for the repo-trust gate (#1985).
 //!
-//! This lives outside the serve-gated `acp` module so the always-compiled trust
-//! system (`repo_config`) and the TUI trust dialog can read, fingerprint, and
-//! display a repo's project MCP servers without depending on the ACP schema
-//! types. The supervisor converts these into ACP `McpServer` values for
+//! This lives outside `acp` so the trust system (`repo_config`) and the TUI
+//! trust dialog can read, fingerprint, and display a repo's project MCP
+//! servers without depending on the ACP schema types. The supervisor converts these into ACP `McpServer` values for
 //! forwarding (see `acp::mcp_config::project_servers_to_acp`), parsing the file
 //! exactly once so the fingerprint that gates trust and the servers that are
 //! forwarded can never diverge.

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -49,10 +49,8 @@
 
 use std::cell::Cell;
 use std::path::{Path, PathBuf};
-#[cfg(feature = "serve")]
 use std::sync::Arc;
 use std::time::Duration;
-#[cfg(feature = "serve")]
 use std::time::Instant;
 
 use anyhow::Result;
@@ -213,10 +211,8 @@ pub fn orphaned_agents_alive(insts: &[Instance]) -> Vec<bool> {
 /// Callers on an async runtime must invoke this inside `spawn_blocking`: it
 /// walks the process table and would otherwise stall the executor.
 ///
-/// The TUI path scans in a batch via [`orphaned_agents_alive`], so this
-/// single-instance convenience is compiled only where it is actually used: the
-/// serve-gated daemon Phase B re-check and the unit tests.
-#[cfg(any(feature = "serve", test))]
+/// The TUI path scans in a batch via [`orphaned_agents_alive`]; this
+/// single-instance convenience serves the daemon's Phase B re-check.
 pub fn orphaned_agent_process_alive(inst: &Instance) -> bool {
     orphaned_agents_alive(std::slice::from_ref(inst))
         .first()
@@ -350,14 +346,12 @@ pub const STARTUP_RECOVERY_CONCURRENCY: usize = 3;
 /// confirmed-Dead pane, so the typical bound holds; if production telemetry
 /// shows the absolute case occurring, raise this to 11s rather than relying
 /// on early abort.
-#[cfg(feature = "serve")]
 pub const RECENTLY_RESTARTED_TTL: Duration = Duration::from_secs(8);
 
 /// Periodic GC interval for `recently_restarted`. Long-running daemons may
 /// accumulate thousands of entries over a session if they never GC; the TTL
 /// check on read filters but does not remove. Sweeping every 60s keeps the
 /// map bounded by `O(recoveries_in_last_60s)` rather than total uptime.
-#[cfg(feature = "serve")]
 pub const RECENTLY_RESTARTED_GC_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Shared `recently_restarted` map: instance id → time of last successful
@@ -365,11 +359,9 @@ pub const RECENTLY_RESTARTED_GC_INTERVAL: Duration = Duration::from_secs(60);
 /// `Status::Error` transition while a freshly-restarted agent is still
 /// settling. Entries older than `RECENTLY_RESTARTED_TTL` are ignored on read
 /// and removed by the GC task.
-#[cfg(feature = "serve")]
 pub type RecentlyRestarted = Arc<std::sync::RwLock<std::collections::HashMap<String, Instant>>>;
 
 /// Construct an empty `recently_restarted` map.
-#[cfg(feature = "serve")]
 pub fn new_recently_restarted() -> RecentlyRestarted {
     Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()))
 }
@@ -381,7 +373,6 @@ pub fn new_recently_restarted() -> RecentlyRestarted {
 /// (after the pane scrape, before the decision) cannot combine stale
 /// pane-missing metadata with a cleared mark and re-emit the phantom
 /// `Status::Error` the suppression is there to prevent.
-#[cfg(feature = "serve")]
 pub fn snapshot_recently_restarted(map: &RecentlyRestarted) -> std::collections::HashSet<String> {
     let guard = match map.read() {
         Ok(g) => g,
@@ -394,7 +385,6 @@ pub fn snapshot_recently_restarted(map: &RecentlyRestarted) -> std::collections:
         .collect()
 }
 
-#[cfg(feature = "serve")]
 pub fn mark_recently_restarted(map: &RecentlyRestarted, id: &str) {
     if let Ok(mut guard) = map.write() {
         guard.insert(id.to_string(), Instant::now());
@@ -404,7 +394,6 @@ pub fn mark_recently_restarted(map: &RecentlyRestarted, id: &str) {
 /// Inverse of `mark_recently_restarted`. Called when a pre-marked
 /// candidate turns out not to need recovery (post-lock re-check fails),
 /// to avoid suppressing the real status for the full TTL.
-#[cfg(feature = "serve")]
 pub fn unmark_recently_restarted(map: &RecentlyRestarted, id: &str) {
     if let Ok(mut guard) = map.write() {
         guard.remove(id);
@@ -415,7 +404,6 @@ pub fn unmark_recently_restarted(map: &RecentlyRestarted, id: &str) {
 /// avoids a tight read-vs-GC race where a reader observes an entry just
 /// before GC removes it; with 2x, a reader that saw the entry at age T has
 /// at least T more time before GC reaps it.
-#[cfg(feature = "serve")]
 pub fn gc_recently_restarted(map: &RecentlyRestarted) {
     let cutoff = RECENTLY_RESTARTED_TTL * 2;
     if let Ok(mut guard) = map.write() {
@@ -432,11 +420,9 @@ pub fn gc_recently_restarted(map: &RecentlyRestarted) {
 /// `STARTUP_RECOVERY_CONCURRENCY` semaphore queue past the TTL does not age
 /// out of suppression and trip a phantom `Status::Error` before its worker
 /// even begins.
-#[cfg(feature = "serve")]
 pub type RecoveryPending = Arc<std::sync::RwLock<std::collections::HashSet<String>>>;
 
 /// Construct an empty `recovery_pending` set.
-#[cfg(feature = "serve")]
 pub fn new_recovery_pending() -> RecoveryPending {
     Arc::new(std::sync::RwLock::new(std::collections::HashSet::new()))
 }
@@ -444,7 +430,6 @@ pub fn new_recovery_pending() -> RecoveryPending {
 /// Seed the pending set with every scheduled candidate id. Called by Phase A
 /// alongside the initial `mark_recently_restarted` so the refresher has the
 /// full work set before the cascade (and the refresher) start.
-#[cfg(feature = "serve")]
 pub fn seed_recovery_pending(pending: &RecoveryPending, ids: impl IntoIterator<Item = String>) {
     if let Ok(mut guard) = pending.write() {
         guard.extend(ids);
@@ -463,7 +448,6 @@ pub fn seed_recovery_pending(pending: &RecoveryPending, ids: impl IntoIterator<I
 /// never re-stamped) or it blocks until this read releases (its later unmark
 /// strictly succeeds this stamp). No mark-after-unmark resurrection is
 /// possible. See [`drain_recovery_pending`].
-#[cfg(feature = "serve")]
 pub fn refresh_recovery_pending(
     pending: &RecoveryPending,
     recently_restarted: &RecentlyRestarted,
@@ -485,7 +469,6 @@ pub fn refresh_recovery_pending(
 /// stops re-stamping it, *then* clear its suppression mark. The ordering
 /// (`W(pending)` before unmarking `recently_restarted`) is what makes the
 /// unmark stick against a racing refresher; see [`refresh_recovery_pending`].
-#[cfg(feature = "serve")]
 pub fn drain_recovery_pending(
     pending: &RecoveryPending,
     recently_restarted: &RecentlyRestarted,
@@ -609,7 +592,6 @@ impl Drop for HookTimeoutScope {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "serve")]
     #[test]
     fn snapshot_recently_restarted_includes_fresh_excludes_missing() {
         let map = new_recently_restarted();
@@ -619,7 +601,6 @@ mod tests {
         assert!(!snap.contains("other"));
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn snapshot_recently_restarted_excludes_expired() {
         let map = new_recently_restarted();
@@ -634,7 +615,6 @@ mod tests {
         assert!(snap.contains("fresh"));
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     fn recently_restarted_gc_removes_stale_entries() {
         let map = new_recently_restarted();
@@ -658,7 +638,6 @@ mod tests {
     /// pending set and leaves `recently_restarted` clear. Without the drain,
     /// the refresher would re-stamp the id forever and suppress its real
     /// status for the rest of the cascade.
-    #[cfg(feature = "serve")]
     #[test]
     fn refresher_does_not_resurrect_drained_worker_mark() {
         let recently = new_recently_restarted();
@@ -699,7 +678,6 @@ mod tests {
 
     /// The refresher keeps a still-queued candidate marked while a *different*
     /// candidate finishes. Draining one id must not stop refreshing the rest.
-    #[cfg(feature = "serve")]
     #[test]
     fn refresher_keeps_remaining_candidates_after_partial_drain() {
         let recently = new_recently_restarted();
@@ -735,7 +713,6 @@ mod tests {
     /// This fails if [`drain_recovery_pending`] is reordered to unmark before
     /// taking `W(pending)`: the premature unmark would race ahead of the
     /// stamp and the id would be resurrected.
-    #[cfg(feature = "serve")]
     #[test]
     fn refresher_mark_loses_to_concurrent_drain_under_lock_overlap() {
         use std::thread;

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -626,10 +626,9 @@ pub(crate) fn title_is_auto_overwritable(inst: &crate::session::instance::Instan
 // (native attach, web live-view, `aoe send`) and fires only once the pane
 // agent is idle, so the one-shot never races it for the provider API. The work
 // runs in a detached `aoe __smart-rename` child so it never blocks the poller.
-// Cross-process guards (a
-// per-session advisory lock, MAX_CONCURRENT global slot locks, and the
-// persisted `Instance.smart_rename_attempted` marker) coordinate the TUI, the
-// daemon, and sibling children, which are all separate processes.
+// Cross-process guards (a per-session advisory lock, MAX_CONCURRENT global slot
+// locks, and the persisted `Instance.smart_rename_attempted` marker) coordinate
+// the TUI, the daemon, and sibling children, which are all separate processes.
 // ---------------------------------------------------------------------------
 
 /// Head/tail byte budgets for the captured first-turn transcript handed to the

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -625,8 +625,8 @@ pub(crate) fn title_is_auto_overwritable(inst: &crate::session::instance::Instan
 // still-default-named session: that single edge covers every input path
 // (native attach, web live-view, `aoe send`) and fires only once the pane
 // agent is idle, so the one-shot never races it for the provider API. The work
-// runs in a detached `aoe __smart-rename` child so it never blocks the poller
-// and is identical in the TUI-only and serve builds. Cross-process guards (a
+// runs in a detached `aoe __smart-rename` child so it never blocks the poller.
+// Cross-process guards (a
 // per-session advisory lock, MAX_CONCURRENT global slot locks, and the
 // persisted `Instance.smart_rename_attempted` marker) coordinate the TUI, the
 // daemon, and sibling children, which are all separate processes.
@@ -992,20 +992,7 @@ pub async fn run_smart_rename_now(
         .map(|i| i.is_structured());
     drop(instances);
     match structured {
-        // Structured sessions rename through the daemon, whose client lives
-        // behind the `serve` feature. A non-serve (TUI-only) build has no
-        // structured view and no daemon client, so there is nothing to do.
-        Some(true) => {
-            #[cfg(feature = "serve")]
-            {
-                rename_structured_via_daemon(session_id).await
-            }
-            #[cfg(not(feature = "serve"))]
-            {
-                let _ = session_id;
-                Ok(())
-            }
-        }
+        Some(true) => rename_structured_via_daemon(session_id).await,
         Some(false) => run_terminal_rename(profile, session_id, force).await,
         None => Ok(()),
     }
@@ -1015,7 +1002,6 @@ pub async fn run_smart_rename_now(
 /// structured session via `POST /api/sessions/{id}/smart-rename`. The endpoint
 /// already forces past the disabled-setting gate. Best-effort: no daemon, or a
 /// non-2xx response, just leaves the generated name in place.
-#[cfg(feature = "serve")]
 async fn rename_structured_via_daemon(session_id: &str) -> anyhow::Result<()> {
     use crate::acp::client::{discovery, HttpClient};
     let endpoint = match discovery::discover() {
@@ -1173,10 +1159,8 @@ pub async fn run_terminal_rename(
     Ok(())
 }
 
-#[cfg(feature = "serve")]
 pub use serve::{should_trigger_smart_rename, try_smart_rename};
 
-#[cfg(feature = "serve")]
 mod serve {
     use super::*;
     use crate::server::AppState;

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -308,8 +308,7 @@ pub struct UsageSnapshot {
     /// Installed-plugin census: source bucket (`builtin` / `featured` /
     /// `community` / `local`) -> count. Counts the whole installed population
     /// per source, no identity, so it is safe for every source. Empty (and so
-    /// omitted) when no plugins are loaded, e.g. a TUI-only build with no
-    /// installs. See `telemetry::plugins`.
+    /// omitted) when no plugins are loaded. See `telemetry::plugins`.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub plugins_by_source: BTreeMap<String, u32>,
     /// Active-state for the plugins whose identity is safe to name: builtin

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -247,9 +247,8 @@ struct InstanceMetrics {
 
 /// Map an instance to its `(agent bucket, model bucket)` telemetry labels, both
 /// already coerced to the [`sanitize`] allowlist. Shared by [`aggregate_instances`]
-/// (point-in-time) and the serve windowed aggregator ([`aggregate`]) so both
-/// bucket sessions identically. The model bucket only exists in `serve` builds;
-/// elsewhere it is treated as absent (`unset`).
+/// (point-in-time) and the windowed aggregator ([`aggregate`]) so both bucket
+/// sessions identically.
 pub(crate) fn instance_buckets(inst: &Instance) -> (String, String) {
     // Prefer the canonical detection name; fall back to the raw tool string.
     // Either way it is coerced to an allowlisted bucket.
@@ -258,10 +257,7 @@ pub(crate) fn instance_buckets(inst: &Instance) -> (String, String) {
     } else {
         inst.detect_as.as_str()
     };
-    #[cfg(feature = "serve")]
     let model = inst.agent_model.as_deref();
-    #[cfg(not(feature = "serve"))]
-    let model: Option<&str> = None;
     (
         sanitize::agent_bucket(agent_src),
         sanitize::model_bucket(model).to_string(),
@@ -303,12 +299,7 @@ fn aggregate_instances(instances: &[Instance]) -> InstanceMetrics {
             crate::session::Status::Error => error += 1,
             _ => {}
         }
-        // Acp fields only exist in `serve` builds; treat them as absent
-        // otherwise so the aggregation stays surface-agnostic.
-        #[cfg(feature = "serve")]
         let is_structured = inst.is_structured();
-        #[cfg(not(feature = "serve"))]
-        let is_structured = false;
         if is_structured {
             acp += 1;
         }
@@ -400,8 +391,8 @@ pub fn build_usage_snapshot(
     if !opted_in_with(&config) {
         return None;
     }
-    // auth_mode / serve_mode are serve-only deployment metadata. Normalize here
-    // rather than trusting every caller to pass None, so a future non-serve call
+    // auth_mode / serve_mode are daemon-only deployment metadata. Normalize
+    // here rather than trusting every caller to pass None, so a future call
     // site can never leak them onto a TUI / CLI payload.
     debug_assert!(
         matches!(surface, Surface::Serve) || (auth_mode.is_none() && serve_mode.is_none()),

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -2,8 +2,8 @@
 //!
 //! This module is pure data plus selection logic, with no rendering or I/O, so
 //! every surface renders from one catalog. The TUI consumes it today; because
-//! it lives in the shared lib (not under `tui`), the `serve` server can expose
-//! the same catalog to the web dashboard later with no rework.
+//! it lives in the shared lib (not under `tui`), the daemon can expose the same
+//! catalog to the web dashboard later with no rework.
 //!
 //! Two kinds of tips:
 //! - **Rotation** tips are always eligible and surface passively (the badge +

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -2015,7 +2015,6 @@ impl Osc52Channel {
     /// Arm a read-only observer. `pipe-pane` is exclusive, so this uses the
     /// same cross-process owner lease as a VT grid and only runs when the grid
     /// transport is disabled for the displayed terminal pane.
-    #[cfg(feature = "serve")]
     pub(crate) fn acquire(name: &str) -> Option<Arc<Self>> {
         let deadline = crate::tmux::TmuxCommandDeadline::new();
         Self::acquire_with_deadline(name, &deadline)
@@ -2166,7 +2165,6 @@ impl Osc52Channel {
 
     /// Keep the exclusive pipe owner lease alive while the terminal snapshot
     /// worker still observes this pane.
-    #[cfg(feature = "serve")]
     pub(crate) fn refresh_owner_heartbeat(&self) {
         let deadline = crate::tmux::TmuxCommandDeadline::new();
         self.refresh_owner_heartbeat_with_deadline(&deadline);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -189,27 +189,22 @@ pub struct App {
     /// Set by `Action::OpenStructuredView` so the async main loop can pick it
     /// up and enter the acp view (which needs `event_stream` access
     /// the sync `execute_action` can't lend out).
-    #[cfg(feature = "serve")]
     pending_structured_view_open: Option<String>,
     /// Set by `Action::SwitchSessionView` so the async main loop can run
     /// the daemon switch POST (awaited; the sync handler can't).
-    #[cfg(feature = "serve")]
     pending_view_switch: Option<String>,
     /// Set by `Action::StartDaemonThenOpenStructured` (the Yes on the
     /// "start a local daemon?" confirm) so the async loop can spawn the
     /// daemon, wait for health, and then open the structured view.
-    #[cfg(feature = "serve")]
     pending_daemon_start_open: Option<String>,
     /// Set by `Action::SmartRenameNow` so the async loop can run the daemon
     /// `/smart-rename` POST for a structured session (#3039).
-    #[cfg(feature = "serve")]
     pending_smart_rename: Option<String>,
     /// Debounce for structured preview-on-select: the session the cursor
     /// settled on and when, so rapid list navigation doesn't connect a
     /// WebSocket per keystroke. The mounted view itself lives on
     /// `HomeView::structured_preview` (it is preview content); this App
     /// side only drives the async mount/unmount.
-    #[cfg(feature = "serve")]
     preview_mount_pending: Option<(String, std::time::Instant)>,
     /// Version of the install currently being attempted (auto or manual).
     /// Set when the install task is spawned; transferred to
@@ -507,15 +502,10 @@ impl App {
             mouse_captured: crate::tui::mouse_capture_requested(&config.session) && !mosh_active,
             mouse_capture_allowed: crate::tui::mouse_capture_requested(&config.session),
             mosh_active,
-            #[cfg(feature = "serve")]
             pending_structured_view_open: None,
-            #[cfg(feature = "serve")]
             pending_daemon_start_open: None,
-            #[cfg(feature = "serve")]
             preview_mount_pending: None,
-            #[cfg(feature = "serve")]
             pending_view_switch: None,
-            #[cfg(feature = "serve")]
             pending_smart_rename: None,
             pending_install_version: None,
             last_installed_version_in_session: None,
@@ -578,14 +568,11 @@ impl App {
         // blinks really fast"). Skip the pre-draw Hide while it's active,
         // the same treatment live-send gets. A preview shows no caret, so
         // it needs no skip.
-        #[cfg(feature = "serve")]
         let embedded_active = self
             .home
             .structured_preview
             .as_ref()
             .is_some_and(|v| v.is_active());
-        #[cfg(not(feature = "serve"))]
-        let embedded_active = false;
         let skip_hide = embedded_active
             || skip_predraw_cursor_hide(
                 self.home.live_send.is_some(),
@@ -858,7 +845,6 @@ impl App {
         const REFRESH_COOLDOWN: Duration = Duration::from_millis(15);
         let mut last_status_refresh = std::time::Instant::now();
         let mut last_metrics_sample = std::time::Instant::now();
-        #[cfg(feature = "serve")]
         let mut last_daemon_status_refresh = std::time::Instant::now();
         let mut last_disk_refresh = std::time::Instant::now();
         let mut last_spinner_redraw = std::time::Instant::now();
@@ -875,7 +861,6 @@ impl App {
         // than from a local tmux scrape, and `/api/sessions` costs the daemon
         // a few SQLite lookups per structured row. Half the tmux cadence
         // keeps a status dot feeling live while halving that request rate.
-        #[cfg(feature = "serve")]
         const DAEMON_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
         // Diagnostics-strip sampling. 1s keeps the sparkline responsive to a
@@ -943,10 +928,7 @@ impl App {
             // preview too (it streams into the pane), not just an active
             // view. Computed outside the select! so the arm's `expect` is
             // guarded by the same check that enables it.
-            #[cfg(feature = "serve")]
             let embedded_mounted = self.home.structured_preview.is_some();
-            #[cfg(not(feature = "serve"))]
-            let embedded_mounted = false;
 
             // All event sources are polled cooperatively via tokio::select!.
             // This ensures signal futures actually get scheduled (fixing #608
@@ -1041,7 +1023,6 @@ impl App {
                                         // composer, same as a real Paste
                                         // event. A merely-mounted preview
                                         // must not eat it.
-                                        #[cfg(feature = "serve")]
                                         if let Some(view) = self
                                             .home
                                             .structured_preview
@@ -1061,8 +1042,6 @@ impl App {
                                         } else {
                                             self.home.handle_paste(&paste_text);
                                         }
-                                        #[cfg(not(feature = "serve"))]
-                                        self.home.handle_paste(&paste_text);
                                     }
                                     if let Some(enter) = trailing_enter {
                                         if !self.should_quit {
@@ -1218,8 +1197,6 @@ impl App {
                             // transcript, which home cannot do), plus the
                             // "clicked off the pane while entered" drop back
                             // to preview so sidebar clicks keep selecting.
-                            #[cfg(feature = "serve")]
-                            {
                                 let in_pane = self.home.structured_preview.is_some()
                                     && self.home.preview_pane_area.contains(
                                         ratatui::layout::Position::from((
@@ -1274,7 +1251,6 @@ impl App {
                                     }
                                     continue;
                                 }
-                            }
                             // Footer toolbar: a left-click on a button
                             // synthesizes its shortcut and routes it through
                             // the full key handler, so clicking behaves
@@ -1320,7 +1296,6 @@ impl App {
                                 // Mirror the list double-click path: an acp
                                 // session only stashes its id, so drain and open
                                 // the structured view here too.
-                                #[cfg(feature = "serve")]
                                 if let Some(session_id) =
                                     self.pending_structured_view_open.take()
                                 {
@@ -1564,7 +1539,6 @@ impl App {
                                 // `execute_action` can't lend. Drain here so a
                                 // double-click on an acp session actually
                                 // opens it.
-                                #[cfg(feature = "serve")]
                                 if let Some(session_id) = self.pending_structured_view_open.take() {
                                     self.open_structured_view(&session_id).await?;
                                 }
@@ -1579,18 +1553,15 @@ impl App {
                                 // A [Yes] click on the switch-view confirm
                                 // stashes the switch; run it now, since this
                                 // click path never reaches the key-path drain.
-                                #[cfg(feature = "serve")]
                                 if let Some(session_id) = self.pending_view_switch.take() {
                                     self.perform_view_switch(&session_id, terminal).await;
                                 }
                                 // Same for a [Yes] click on the start-daemon
                                 // confirm from a structured-view open.
-                                #[cfg(feature = "serve")]
                                 if let Some(session_id) = self.pending_daemon_start_open.take() {
                                     self.start_daemon_then_open(&session_id, terminal).await;
                                 }
                                 // Same for an "Auto-name now" palette/menu click.
-                                #[cfg(feature = "serve")]
                                 if let Some(session_id) = self.pending_smart_rename.take() {
                                     self.perform_smart_rename(&session_id).await;
                                 }
@@ -1604,7 +1575,6 @@ impl App {
                             // view). A merely-mounted preview must NOT eat
                             // it: the user is driving the home screen, and a
                             // paste belongs to whatever home surface is up.
-                            #[cfg(feature = "serve")]
                             if let Some(view) = self
                                 .home
                                 .structured_preview
@@ -1662,30 +1632,16 @@ impl App {
                 // runs in the arm body where it can no longer be raced,
                 // so a mid-replay cancellation cannot corrupt the state.
                 ev = async {
-                    #[cfg(feature = "serve")]
-                    {
                         self.home.structured_preview
                             .as_mut()
                             .expect("guarded by embedded_mounted")
                             .next_event()
                             .await
-                    }
-                    #[cfg(not(feature = "serve"))]
-                    {
-                        std::future::pending::<()>().await
-                    }
                 }, if embedded_mounted => {
-                    #[cfg(feature = "serve")]
-                    {
                         if let Some(view) = self.home.structured_preview.as_mut() {
                             view.apply_event(ev).await;
                         }
                         self.draw(terminal)?;
-                    }
-                    #[cfg(not(feature = "serve"))]
-                    {
-                        let _: () = ev;
-                    }
                 }
                 _ = refresh_interval.tick() => {}
                 _ = preview_wake.notified() => {
@@ -1835,16 +1791,13 @@ impl App {
                 refresh_needed = true;
             }
 
-            #[cfg(feature = "serve")]
-            {
-                if last_daemon_status_refresh.elapsed() >= DAEMON_STATUS_REFRESH_INTERVAL {
-                    self.home.request_daemon_status_refresh();
-                    last_daemon_status_refresh = std::time::Instant::now();
-                }
-                if self.home.apply_daemon_status_updates() {
-                    refresh_needed = true;
-                    needs_full_refresh = true;
-                }
+            if last_daemon_status_refresh.elapsed() >= DAEMON_STATUS_REFRESH_INTERVAL {
+                self.home.request_daemon_status_refresh();
+                last_daemon_status_refresh = std::time::Instant::now();
+            }
+            if self.home.apply_daemon_status_updates() {
+                refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if self.home.apply_deletion_results() {
@@ -1900,7 +1853,6 @@ impl App {
                 // A structured session routes the post-create attach into
                 // `pending_structured_view_open`; drain it here (this tick
                 // path sits outside the key/click drains).
-                #[cfg(feature = "serve")]
                 if let Some(sid) = self.pending_structured_view_open.take() {
                     self.open_structured_view(&sid).await?;
                 }
@@ -2066,7 +2018,6 @@ impl App {
 
             // Preview-on-select: mount/drop the streaming transcript
             // preview to track the selected structured session (debounced).
-            #[cfg(feature = "serve")]
             if self.reconcile_structured_preview().await {
                 refresh_needed = true;
                 needs_full_refresh = true;
@@ -2075,7 +2026,6 @@ impl App {
             // Embedded structured view: expire its toast, surface queued
             // plugin notifications, and repaint on the same 120ms cadence
             // the full-screen view used so the composer caret blinks.
-            #[cfg(feature = "serve")]
             if let Some(view) = self.home.structured_preview.as_mut() {
                 let toast_changed = view.tick();
                 if toast_changed || last_spinner_redraw.elapsed() >= SPINNER_REDRAW_INTERVAL {
@@ -2872,7 +2822,6 @@ impl App {
         // previewed view (mounted but not entered) does NOT capture: list
         // navigation keeps working, and Enter enters it. Ctrl+Q leaves
         // interactive mode back to the read-only preview.
-        #[cfg(feature = "serve")]
         if self
             .home
             .structured_preview
@@ -3001,22 +2950,18 @@ impl App {
         // ('y' / Enter on the switch-view confirm) stashes the id during
         // `execute_action` above, and draining before `handle_key` would
         // sit on it until the next keypress (#2925).
-        #[cfg(feature = "serve")]
         if let Some(session_id) = self.pending_view_switch.take() {
             self.perform_view_switch(&session_id, terminal).await;
         }
 
-        #[cfg(feature = "serve")]
         if let Some(session_id) = self.pending_daemon_start_open.take() {
             self.start_daemon_then_open(&session_id, terminal).await;
         }
 
-        #[cfg(feature = "serve")]
         if let Some(session_id) = self.pending_structured_view_open.take() {
             self.open_structured_view(&session_id).await?;
         }
 
-        #[cfg(feature = "serve")]
         if let Some(session_id) = self.pending_smart_rename.take() {
             self.perform_smart_rename(&session_id).await;
         }
@@ -3030,7 +2975,6 @@ impl App {
     /// structured-view WS and the file watcher refreshes the row, so the TUI
     /// mutates no session state itself. A no-daemon state surfaces as a
     /// transient status rather than failing the loop (#3039).
-    #[cfg(feature = "serve")]
     async fn perform_smart_rename(&mut self, session_id: &str) {
         use crate::acp::client::{require_daemon, HttpClient, ManagerError};
 
@@ -3082,7 +3026,6 @@ impl App {
     /// `aoe serve`, so the spawn is part of the consented action rather
     /// than a hidden side effect. `terminal` is borrowed to paint the
     /// "Starting…" status before the (up to several seconds) wait.
-    #[cfg(feature = "serve")]
     async fn perform_view_switch(
         &mut self,
         session_id: &str,
@@ -3149,7 +3092,6 @@ impl App {
     /// when selected), connect now; and with no daemon at all, offer to
     /// start a localhost one (the Yes path resumes through
     /// `start_daemon_then_open`).
-    #[cfg(feature = "serve")]
     async fn open_structured_view(&mut self, session_id: &str) -> Result<()> {
         use crate::acp::client::{require_daemon, ManagerError};
 
@@ -3193,7 +3135,6 @@ impl App {
 
     /// Flip the mounted embedded view to interactive mode (exiting
     /// live-send first, since both own the preview pane and keyboard).
-    #[cfg(feature = "serve")]
     fn activate_embedded(&mut self) {
         self.home.exit_live_send_if_active();
         if let Some(v) = self.home.structured_preview.as_mut() {
@@ -3204,7 +3145,6 @@ impl App {
     /// Mount the embedded view against a located daemon in preview
     /// (read-only) state. The caller activates it if the user is
     /// entering rather than just previewing.
-    #[cfg(feature = "serve")]
     async fn connect_embedded_structured(
         &mut self,
         endpoint: crate::acp::client::DaemonEndpoint,
@@ -3232,7 +3172,6 @@ impl App {
     /// reported Ctrl+Q flash). The home view repaints the same preview
     /// rect the structured view drew into, so the ordinary diffed draw
     /// covers it cleanly, the same way exiting live-send does.
-    #[cfg(feature = "serve")]
     fn close_embedded_structured(&mut self) {
         self.home.structured_preview = None;
     }
@@ -3240,7 +3179,6 @@ impl App {
     /// The Yes path of the "start a local daemon?" confirm: spawn a
     /// localhost daemon with visible feedback, wait for it to become
     /// healthy, then mount + enter the embedded structured view.
-    #[cfg(feature = "serve")]
     async fn start_daemon_then_open(
         &mut self,
         session_id: &str,
@@ -3269,7 +3207,6 @@ impl App {
     /// while a daemon is already reachable (a down daemon leaves the
     /// "press Enter" placeholder). An active (entered) view is never
     /// disturbed. Returns true if the mount set changed (needs redraw).
-    #[cfg(feature = "serve")]
     async fn reconcile_structured_preview(&mut self) -> bool {
         // An entered view owns the selection and keyboard; leave it be,
         // but only while its session is still a live structured row AND
@@ -3568,7 +3505,6 @@ impl App {
             Action::RunBackgroundToolSession(id, tool_name) => {
                 self.run_background_tool_session(&id, &tool_name);
             }
-            #[cfg(feature = "serve")]
             Action::OpenStructuredView(id) => {
                 // Stash for the async main loop. The acp view needs
                 // `event_stream` access that this sync handler can't
@@ -3576,19 +3512,16 @@ impl App {
                 // we return.
                 self.pending_structured_view_open = Some(id);
             }
-            #[cfg(feature = "serve")]
             Action::SwitchSessionView(id) => {
                 // Same stash-for-the-async-loop pattern: the daemon POST
                 // must be awaited, which this sync handler can't do.
                 self.pending_view_switch = Some(id);
             }
-            #[cfg(feature = "serve")]
             Action::StartDaemonThenOpenStructured(id) => {
                 // Same stash pattern: spawning the daemon and waiting for
                 // its health check must be awaited.
                 self.pending_daemon_start_open = Some(id);
             }
-            #[cfg(feature = "serve")]
             Action::SmartRenameNow(id) => {
                 // Same stash pattern: the daemon POST must be awaited.
                 self.pending_smart_rename = Some(id);
@@ -3615,7 +3548,6 @@ impl App {
         session_id: &str,
         terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     ) -> Result<()> {
-        #[cfg(feature = "serve")]
         if self
             .home
             .get_instance(session_id)
@@ -4223,25 +4155,21 @@ pub enum Action {
     /// stashes the id in `pending_structured_view_open`; the main loop drains it
     /// after `execute_action` returns and runs the async acp loop
     /// against the borrowed terminal + event stream.
-    #[cfg(feature = "serve")]
     OpenStructuredView(String),
     /// Flip a session's persisted view (structured ↔ terminal) through the
     /// daemon's switch endpoints. Stashed in `pending_view_switch` (the
     /// POST needs the async loop) and drained alongside
     /// `pending_structured_view_open`; the daemon persists the change and
     /// the file watcher refreshes the row.
-    #[cfg(feature = "serve")]
     SwitchSessionView(String),
     /// The Yes on the "no daemon running, start a local one?" confirm
     /// shown when opening a structured view. Stashed in
     /// `pending_daemon_start_open` (spawn + health wait must be
     /// awaited) and drained alongside the other structured stashes.
-    #[cfg(feature = "serve")]
     StartDaemonThenOpenStructured(String),
     /// On-demand "Auto-name now" for a structured session. Stashed in
     /// `pending_smart_rename` (the daemon POST needs the async loop) and
     /// drained alongside the other structured stashes (#3039).
-    #[cfg(feature = "serve")]
     SmartRenameNow(String),
 }
 

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -141,12 +141,9 @@ impl CreationPoller {
         // pick the right profile's overrides; if it's left blank they'd silently
         // fall back to the global default profile.
         instance.source_profile = profile.clone();
-        #[cfg(feature = "serve")]
         if structured {
             builder::structured::apply_structured_choice(&mut instance);
         }
-        #[cfg(not(feature = "serve"))]
-        let _ = structured;
         let created_worktree = build_result.created_worktree;
         let created_workspace_worktrees = build_result.created_workspace_worktrees;
         let warnings = build_result.warnings;

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -89,14 +89,11 @@ pub struct PaletteCommand {
 /// keyboard dispatcher. Pure-navigation keys (j/k, arrows, h/l) are excluded.
 /// `Enter` (attach) and `Tab` (live-send) aren't relocatable keybindings, so
 /// they're appended explicitly rather than pulled from the registry.
-pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<PaletteCommand> {
+pub fn builtin_commands(strict_hotkeys: bool) -> Vec<PaletteCommand> {
     let mut cmds: Vec<PaletteCommand> = bindings::BINDINGS
         .iter()
         .filter_map(|b| {
             let meta = b.palette.as_ref()?;
-            if meta.serve_only && !serve_enabled {
-                return None;
-            }
             // Drop the unread toggle entirely when the feature is off, so the
             // palette can't invoke a removed binding.
             if b.id == bindings::ActionId::ToggleUnread && !crate::session::unread_enabled() {
@@ -502,7 +499,7 @@ mod tests {
     }
 
     fn make_dialog() -> CommandPaletteDialog {
-        CommandPaletteDialog::new(builtin_commands(false, false))
+        CommandPaletteDialog::new(builtin_commands(false))
     }
 
     #[test]
@@ -536,7 +533,7 @@ mod tests {
         // (e.g., moving Tab elsewhere) or accidentally regressing the
         // payload to `Key(Tab)` would break strict-mode users who reach
         // live-send only through the palette.
-        let cmds = builtin_commands(false, false);
+        let cmds = builtin_commands(false);
         let entry = cmds
             .iter()
             .find(|c| c.id == "live-send")
@@ -554,7 +551,7 @@ mod tests {
         // `Invoke(ActionId::…)` so `run_action` opens the picker directly.
         // Previously these synthesized `Key('o')` / `Key('g')`, which the
         // strict-mode typing-guard would have swallowed.
-        let cmds = builtin_commands(false, true);
+        let cmds = builtin_commands(true);
         let sort = cmds
             .iter()
             .find(|c| c.id == "pick-sort")
@@ -650,20 +647,12 @@ mod tests {
     }
 
     #[test]
-    fn serve_command_only_with_feature() {
-        let with = builtin_commands(true, false);
-        let without = builtin_commands(false, false);
-        assert!(with.iter().any(|c| c.id == "serve"));
-        assert!(!without.iter().any(|c| c.id == "serve"));
-    }
-
-    #[test]
     fn hotkey_labels_follow_strict_mode() {
         // Picks one entry whose label moves under strict mode and one whose
         // binding gets relocated to Ctrl. Catches regressions where strict
         // mode was forgotten when adding a new entry.
-        let normal = builtin_commands(false, false);
-        let strict = builtin_commands(false, true);
+        let normal = builtin_commands(false);
+        let strict = builtin_commands(true);
 
         let new_normal = normal.iter().find(|c| c.id == "new-session").unwrap();
         let new_strict = strict.iter().find(|c| c.id == "new-session").unwrap();

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -118,8 +118,7 @@ impl ContextMenuDialog {
     /// refusal and the web sidebar's `acp_can_fork` gating.
     ///
     /// `switch_view` is `None` when the row can't change views (non-ACP
-    /// tool, a non-serve build with no structured view to switch into, or a
-    /// terminal row while the structured-view opt-in is off), and
+    /// tool, or a terminal row while the structured-view opt-in is off), and
     /// `Some(is_structured)` when the entry should appear, with the label
     /// naming the view the switch lands on.
     pub fn for_session(

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -24,7 +24,6 @@ mod rename;
 mod repo_trust;
 mod restart;
 mod send_message;
-#[cfg(feature = "serve")]
 mod serve;
 mod skills_manager;
 mod snooze_duration;
@@ -61,9 +60,7 @@ pub use rename::{RenameData, RenameDialog, RenameMode};
 pub use repo_trust::{RepoTrustAction, RepoTrustDialog};
 pub use restart::{RestartData, RestartDialog};
 pub use send_message::SendMessageDialog;
-#[cfg(feature = "serve")]
 pub(crate) use serve::start_local_daemon_and_wait;
-#[cfg(feature = "serve")]
 pub use serve::{ServeAction, ServeView};
 pub use skills_manager::SkillsManagerDialog;
 pub use snooze_duration::SnoozeDurationDialog;

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -124,7 +124,7 @@ pub struct NewSessionData {
     /// another. `None` for an ordinary new session.
     pub fork_seed: Option<crate::session::ForkSeed>,
     /// Create the session in the structured (ACP) view instead of a tmux
-    /// terminal. Only submitted true for ACP-capable tools on serve builds;
+    /// terminal. Only submitted true for ACP-capable tools;
     /// validated at submit time via
     /// `builder::structured::validate_structured_choice`.
     pub structured: bool,
@@ -199,7 +199,7 @@ pub struct NewSessionDialog {
     pub(super) structured_enabled: bool,
     /// Whether the currently selected tool can back a structured-view
     /// session (registry entry or `agent_acp_cmd`). Recomputed whenever
-    /// the tool or profile changes; always false on non-serve builds.
+    /// the tool or profile changes.
     /// Gates the Structured field's visibility, so the field-index chains
     /// treat it exactly like `has_yolo` / `has_sandbox`.
     pub(super) structured_capable: bool,
@@ -389,9 +389,7 @@ fn handle_editable_list_key(
 }
 
 /// Whether `tool` can back a structured-view (ACP) session, judged against
-/// the resolved config. Always false without the serve feature: the binary
-/// then has no structured view to open, so the wizard must not offer one.
-#[cfg(feature = "serve")]
+/// the resolved config.
 fn compute_structured_capable(tool: &str, config: &crate::session::Config) -> bool {
     // Gated behind an opt-in setting: the structured view is still
     // maturing, so the new-session toggle is hidden unless the user
@@ -399,10 +397,6 @@ fn compute_structured_capable(tool: &str, config: &crate::session::Config) -> bo
     // is gated on the same setting (see `session_switch_view_target`).
     config.acp.offer_structured_in_new_session
         && crate::session::builder::structured::tool_acp_capable(tool, config)
-}
-#[cfg(not(feature = "serve"))]
-fn compute_structured_capable(_tool: &str, _config: &crate::session::Config) -> bool {
-    false
 }
 
 /// Build label/value pairs for non-default inherited sandbox settings.
@@ -2145,18 +2139,15 @@ impl NewSessionDialog {
         if !(self.structured_enabled && self.structured_capable) {
             return true;
         }
-        #[cfg(feature = "serve")]
-        {
-            let profile = self.selected_profile().to_string();
-            let config = self.resolve_config_for_path(&profile);
-            if let Err(msg) = crate::session::builder::structured::validate_structured_choice(
-                &self.available_tools[self.tool_index],
-                self.command_override.value(),
-                &config,
-            ) {
-                self.error_message = Some(msg);
-                return false;
-            }
+        let profile = self.selected_profile().to_string();
+        let config = self.resolve_config_for_path(&profile);
+        if let Err(msg) = crate::session::builder::structured::validate_structured_choice(
+            &self.available_tools[self.tool_index],
+            self.command_override.value(),
+            &config,
+        ) {
+            self.error_message = Some(msg);
+            return false;
         }
         true
     }

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -248,7 +248,7 @@ impl NewSessionDialog {
         }
         ci += 1;
 
-        // Structured view checkbox (only for ACP-capable tools on serve builds)
+        // Structured view checkbox (only for ACP-capable tools)
         if has_structured {
             let is_focused = self.focused_field == structured_field;
             let label_style = if is_focused {

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1365,10 +1365,9 @@ environment = ["THING=$REPO_THING"]
 
     dialog.path = Input::new(repo.path().to_string_lossy().to_string());
     // Field order (no profile picker, single tool): path 0, title 1, then
-    // the Structured row only when the serve build makes claude
-    // ACP-capable (reload_config_defaults recomputed it), then yolo,
-    // worktree, sandbox. Derive the offset so both feature builds target
-    // the sandbox row.
+    // the Structured row when claude is ACP-capable
+    // (reload_config_defaults recomputed it), then yolo, worktree,
+    // sandbox. Derive the offset so this targets the sandbox row.
     dialog.focused_field = 4 + usize::from(dialog.structured_capable);
     let result = dialog.handle_key(ctrl_key(KeyCode::Char('p')));
 

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -1996,6 +1996,13 @@ fn render_qr(_url: &str) -> String {
     String::new()
 }
 
+/// Shown in place of the QR when the dashboard bundle is not embedded.
+const API_ONLY_NOTICE: &str =
+    "No dashboard bundle in this build: the URL serves the REST API only, and a browser gets a 404.";
+
+/// Rows [`API_ONLY_NOTICE`] needs once wrapped at a usable terminal width.
+const API_ONLY_ROWS: u16 = 2;
+
 #[allow(clippy::too_many_arguments)]
 fn render_active(
     frame: &mut Frame,
@@ -2054,11 +2061,15 @@ fn render_active(
         ServeMode::Local => "local",
         ServeMode::Tunnel => "tunnel",
     };
+    // Without the bundle this screen hands out an API endpoint, not a
+    // dashboard, so the title says which one the user is looking at.
+    let title = if cfg!(feature = "web") {
+        format!(" Remote Access ({mode_label})")
+    } else {
+        format!(" Remote API Access ({mode_label})")
+    };
     let mut header_spans = vec![
-        Span::styled(
-            format!(" Remote Access ({mode_label})"),
-            Style::default().fg(title_color).bold(),
-        ),
+        Span::styled(title, Style::default().fg(title_color).bold()),
         Span::styled(
             format!("  open {}", format_elapsed(elapsed)),
             Style::default().fg(theme.dimmed),
@@ -2080,9 +2091,16 @@ fn render_active(
     let show_passphrase = matches!(mode, ServeMode::Tunnel);
     let show_kind_label = kind_label.is_some();
     let show_split_token = !url_fits_one_line && split_token.is_some();
+    // No bundle means no QR (nothing would answer a scan) and a 404 for any
+    // browser that follows the URL, so the screen says what it is good for
+    // instead of presenting a bare address.
+    let show_api_only = !cfg!(feature = "web");
 
     // Calculate total content height for vertical centering.
     let mut inner_height: u16 = qr_height + 1 /* spacer */ + 1 /* url */;
+    if show_api_only {
+        inner_height += API_ONLY_ROWS;
+    }
     if show_kind_label {
         inner_height += 1;
     }
@@ -2097,6 +2115,9 @@ fn render_active(
 
     let mut constraints = vec![Constraint::Length(v_pad)]; // top padding
     constraints.push(Constraint::Length(qr_height));
+    if show_api_only {
+        constraints.push(Constraint::Length(API_ONLY_ROWS));
+    }
     constraints.push(Constraint::Length(1)); // spacer after QR
     if show_kind_label {
         constraints.push(Constraint::Length(1));
@@ -2129,6 +2150,17 @@ fn render_active(
         chunks[idx],
     );
     idx += 1;
+
+    if show_api_only {
+        frame.render_widget(
+            Paragraph::new(API_ONLY_NOTICE)
+                .style(Style::default().fg(theme.dimmed))
+                .wrap(Wrap { trim: true })
+                .alignment(Alignment::Center),
+            chunks[idx],
+        );
+        idx += 1;
+    }
 
     // Spacer after QR
     idx += 1;
@@ -2624,6 +2656,22 @@ mod qr_seam {
             cfg!(feature = "web"),
             "QR code should be drawn only with the dashboard bundle:\n{screen}"
         );
+    }
+
+    /// A QR-less screen offering a bare URL reads as a dashboard link, and a
+    /// browser following it gets a bodiless 404. Both the title and the panel
+    /// have to say the endpoint is API-only, and neither may say it in a build
+    /// that does embed the bundle.
+    #[test]
+    fn active_screen_says_api_only_without_web() {
+        let screen = active_screen();
+        for needle in ["Remote API Access", "No dashboard bundle in this build:"] {
+            assert_eq!(
+                screen.contains(needle),
+                !cfg!(feature = "web"),
+                "{needle:?} belongs on the screen only without the dashboard bundle:\n{screen}"
+            );
+        }
     }
 }
 

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -5,18 +5,12 @@
 //! `$APP_DIR/serve.{pid,url,log,mode}` files, and runs `aoe serve --stop`
 //! to tear down. The daemon survives across TUI quits, just like tmux
 //! sessions or the CLI-invoked daemon path.
-//!
-//! Only compiled with the `serve` feature, since the tunnel integration
-//! (and the qrcode crate it needs) lives there.
-#![cfg(feature = "serve")]
 
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent};
-use qrcode::render::unicode::Dense1x2;
-use qrcode::QrCode;
 use rand::prelude::IndexedRandom;
 use rand::RngExt;
 use ratatui::prelude::*;
@@ -1979,6 +1973,29 @@ fn looks_like_iso_year(s: &str) -> bool {
     matches!(iter.next(), Some('-'))
 }
 
+/// The scannable block for `url`, as terminal rows. Empty without the
+/// dashboard bundle: a phone that scanned it would reach no page.
+#[cfg(feature = "web")]
+fn render_qr(url: &str) -> String {
+    use qrcode::render::unicode::Dense1x2;
+    use qrcode::QrCode;
+
+    match QrCode::new(url.as_bytes()) {
+        Ok(code) => code
+            .render::<Dense1x2>()
+            .quiet_zone(true)
+            .dark_color(Dense1x2::Dark)
+            .light_color(Dense1x2::Light)
+            .build(),
+        Err(_) => String::from("(QR unavailable; use the URL below)"),
+    }
+}
+
+#[cfg(not(feature = "web"))]
+fn render_qr(_url: &str) -> String {
+    String::new()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_active(
     frame: &mut Frame,
@@ -1999,16 +2016,7 @@ fn render_active(
     let url = &active_url.url;
     let kind_label = active_url.label.as_deref();
 
-    let qr_text = match QrCode::new(url.as_bytes()) {
-        Ok(code) => code
-            .render::<Dense1x2>()
-            .quiet_zone(true)
-            .dark_color(Dense1x2::Dark)
-            .light_color(Dense1x2::Light)
-            .build(),
-        Err(_) => String::from("(QR unavailable; use the URL below)"),
-    };
-
+    let qr_text = render_qr(url);
     let qr_lines: Vec<&str> = qr_text.lines().collect();
     let qr_height = qr_lines.len() as u16;
 

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -2566,6 +2566,68 @@ const PASSPHRASE_WORDS: &[&str] = &[
 ];
 
 #[cfg(test)]
+mod qr_seam {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// Unicode half-blocks the QR renderer draws with. Their presence is the
+    /// only way to tell a rendered code from an empty panel.
+    const QR_GLYPHS: [char; 3] = ['\u{2588}', '\u{2580}', '\u{2584}'];
+
+    fn active_screen() -> String {
+        let urls = vec![ServeUrl {
+            label: Some("lan".to_string()),
+            url: "http://192.168.1.42:8080/?t=abc123def456".to_string(),
+        }];
+        let mut term = Terminal::new(TestBackend::new(72, 26)).expect("terminal");
+        term.draw(|f| {
+            render_active(
+                f,
+                f.area(),
+                &Theme::default(),
+                ServeMode::Local,
+                &urls,
+                0,
+                None,
+                std::time::Duration::from_secs(42),
+                None,
+            )
+        })
+        .expect("draw");
+        let buf = term.backend().buffer().clone();
+        (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The URL is what a user needs off this screen, so it must survive the
+    /// QR being compiled out. Without the dashboard bundle the code is not
+    /// drawn (nothing would answer a scan of it), and the layout must absorb
+    /// the missing rows rather than leaving a gap or panicking on a
+    /// zero-height chunk.
+    #[test]
+    fn active_screen_keeps_the_url_and_drops_the_code_without_web() {
+        let screen = active_screen();
+        assert!(
+            screen.contains("http://192.168.1.42:8080/?t=abc123def456"),
+            "URL must render in both feature corners:\n{screen}"
+        );
+        let drawn = screen.chars().any(|c| QR_GLYPHS.contains(&c));
+        assert_eq!(
+            drawn,
+            cfg!(feature = "web"),
+            "QR code should be drawn only with the dashboard bundle:\n{screen}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -163,8 +163,6 @@ pub struct PaletteMeta {
     pub title: &'static str,
     pub keywords: &'static [&'static str],
     pub group: PaletteGroup,
-    /// Only included when the `serve` feature is on (just the Serve command).
-    pub serve_only: bool,
 }
 
 pub struct Binding {
@@ -273,9 +271,6 @@ pub fn resolve_action(key: &KeyEvent, strict: bool, ctx: &Ctx) -> Option<Resolve
 /// through this rather than the local registry, so it parses the raw chord
 /// string here. A chord string that does not parse never matches.
 ///
-/// Only the structured view (serve-gated) executes plugin commands, so this is
-/// unused in a bare-core build; gate it to avoid a dead-code warning there.
-#[cfg(feature = "serve")]
 pub fn keybind_matches(key_str: &str, key: &KeyEvent) -> bool {
     parse_chord(key_str).is_some_and(|chord| chord_matches(&chord, key))
 }
@@ -403,7 +398,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Toggle favorite",
             keywords: &["star", "pin", "fav"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -419,7 +413,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Toggle snooze",
             keywords: &["later", "defer", "wait"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     // --- terminal-view only ---
@@ -459,7 +452,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Show keyboard shortcuts",
             keywords: &["keys", "shortcuts"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     Binding {
@@ -472,7 +464,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Toggle system health strip",
             keywords: &["system", "health", "memory", "cpu", "pressure"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     Binding {
@@ -485,7 +476,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Open System Health",
             keywords: &["system", "health", "memory", "cpu", "agents", "processes"],
             group: PaletteGroup::Views,
-            serve_only: false,
         }),
     },
     Binding {
@@ -523,7 +513,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "New session",
             keywords: &["create", "add", "spawn"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -539,7 +528,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "New session from selection",
             keywords: &["create", "duplicate", "clone"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     // New session from a saved project. Follows the bare->Shift relocation
@@ -557,7 +545,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "New session from saved project",
             keywords: &["project", "saved", "registry", "create"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -573,7 +560,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Attach to paired terminal",
             keywords: &["shell", "host"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -589,7 +575,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Toggle Agent / Terminal view",
             keywords: &["switch", "shell"],
             group: PaletteGroup::Views,
-            serve_only: false,
         }),
     },
     Binding {
@@ -605,7 +590,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Send message to agent",
             keywords: &["prompt", "tell", "say"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -621,7 +605,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Respond to permission prompt",
             keywords: &["allow", "deny", "approve", "permission"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -637,7 +620,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Stop session / kill terminal",
             keywords: &["kill", "end", "halt", "terminal"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -653,7 +635,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Delete session or group",
             keywords: &["remove", "trash"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -669,7 +650,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Rename or move to group",
             keywords: &["title", "label", "move", "regroup"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -685,7 +665,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Edit worktree workdir name",
             keywords: &["worktree", "workdir", "directory", "branch", "rename"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -703,7 +682,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Add project to this session",
             keywords: &["repo", "attach", "worktree", "multi-repo", "workspace"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -719,7 +697,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Open diff view",
             keywords: &["git", "changes"],
             group: PaletteGroup::Views,
-            serve_only: false,
         }),
     },
     Binding {
@@ -735,7 +712,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Open serve (LAN / Tunnel)",
             keywords: &["web", "remote", "phone", "tunnel"],
             group: PaletteGroup::Settings,
-            serve_only: true,
         }),
     },
     Binding {
@@ -751,7 +727,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Open settings",
             keywords: &["preferences", "config"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     // Pin toggle shares `p` (Shift+P in strict) with Projects, but only fires
@@ -787,7 +762,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Manage projects",
             keywords: &["registry", "repos", "multi-repo", "workspace"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     Binding {
@@ -803,7 +777,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Switch profile",
             keywords: &["account", "switch"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     Binding {
@@ -819,7 +792,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Restart session",
             keywords: &["reload", "respawn", "reset"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     // `U` toggles read/unread, pinned to Shift+u in BOTH modes (matches the
@@ -841,7 +813,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Toggle read/unread",
             keywords: &["read", "unread", "seen", "flag", "viewed"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -868,7 +839,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Toggle archive",
             keywords: &["park", "stash", "done", "zzz"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     Binding {
@@ -884,7 +854,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Toggle preview info header",
             keywords: &["hide", "show", "info", "header", "preview"],
             group: PaletteGroup::Views,
-            serve_only: false,
         }),
     },
     Binding {
@@ -901,7 +870,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Sort order",
             keywords: &["order", "sort", "pick"],
             group: PaletteGroup::Views,
-            serve_only: false,
         }),
     },
     Binding {
@@ -917,7 +885,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Group by",
             keywords: &["group", "project", "pick"],
             group: PaletteGroup::Views,
-            serve_only: false,
         }),
     },
     Binding {
@@ -933,7 +900,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Jump to next waiting / idle session",
             keywords: &["jump", "next", "waiting", "idle"],
             group: PaletteGroup::Views,
-            serve_only: false,
         }),
     },
     // Tips overlay. No key chords: it's reached from the palette, the badge,
@@ -950,7 +916,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Show tips",
             keywords: &["tips", "hints", "learn", "discover", "did you know"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     // Palette-only: no default chord in either mode; the manager opens from
@@ -965,7 +930,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Manage plugins",
             keywords: &["plugin", "extension", "enable", "disable"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     // Palette-only: no default chord in either mode; the manager opens from
@@ -980,7 +944,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Manage skills",
             keywords: &["skill", "skills", "prompt"],
             group: PaletteGroup::Settings,
-            serve_only: false,
         }),
     },
     // Palette-only: Shift+F collides with strict-mode ToggleFavorite under
@@ -996,7 +959,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Fork session (resume context, diverge)",
             keywords: &["fork", "branch", "duplicate", "clone", "context", "resume"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
     // The mnemonic keys (a/A, n/N, r/R, t/T) are all taken and the home
@@ -1015,7 +977,6 @@ pub static BINDINGS: &[Binding] = &[
             title: "Auto-name now",
             keywords: &["rename", "title", "name", "auto", "smart", "generate"],
             group: PaletteGroup::Actions,
-            serve_only: false,
         }),
     },
 ];

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -12,7 +12,6 @@ use crate::session::config::{
 };
 use crate::session::{list_profiles, repo_config, resolve_config_or_warn, Item, Status};
 use crate::tui::app::Action;
-#[cfg(feature = "serve")]
 use crate::tui::dialogs::ServeAction;
 use crate::tui::dialogs::{
     builtin_commands, CommandPaletteDialog, ConfirmDialog, ContextMenuAction, ContextMenuDialog,
@@ -1039,7 +1038,6 @@ impl HomeView {
         // (see `wrapped_transcript`), so (row, column) slicing below maps
         // one-to-one onto the on-screen cells. Terminal previews keep
         // reading the tmux capture cache.
-        #[cfg(feature = "serve")]
         let structured_lines = self
             .structured_preview
             .as_ref()
@@ -1049,13 +1047,10 @@ impl HomeView {
                     .is_some_and(|id| id == v.session_id())
             })
             .map(|v| v.selection_text(width));
-        #[cfg(feature = "serve")]
         let lines = match structured_lines.as_ref() {
             Some(text) => text,
             None => self.active_preview_cache().parsed_text.as_ref()?,
         };
-        #[cfg(not(feature = "serve"))]
-        let lines = self.active_preview_cache().parsed_text.as_ref()?;
         // Resolve `from_bottom` distances to absolute indices against the
         // SAME `total_lines` the renderer used this frame, so the copied
         // range matches the painted highlight cell for cell.
@@ -1190,12 +1185,10 @@ impl HomeView {
                 None
             }
             "pull_sandbox_image" => self.pending_image_pull.take().map(Action::SpawnImagePull),
-            #[cfg(feature = "serve")]
             "switch_view" => self
                 .pending_switch_view_session
                 .take()
                 .map(Action::SwitchSessionView),
-            #[cfg(feature = "serve")]
             "start_daemon_structured" => self
                 .pending_daemon_start_session
                 .take()
@@ -1864,7 +1857,6 @@ impl HomeView {
         }
 
         // Handle serve view (full-screen takeover)
-        #[cfg(feature = "serve")]
         if let Some(ref mut serve) = self.serve_view {
             match serve.handle_key(key) {
                 ServeAction::Continue => return None,
@@ -3023,17 +3015,7 @@ impl HomeView {
             return false;
         };
         if inst.is_structured() {
-            #[cfg(feature = "serve")]
-            {
-                crate::session::fork::structured_fork_capable(
-                    &inst.tool,
-                    inst.agent_name.as_deref(),
-                )
-            }
-            #[cfg(not(feature = "serve"))]
-            {
-                false
-            }
+            crate::session::fork::structured_fork_capable(&inst.tool, inst.agent_name.as_deref())
         } else {
             crate::session::fork::terminal_agent_can_fork(&inst.tool)
         }
@@ -3045,42 +3027,33 @@ impl HomeView {
     /// always go back to a terminal; a terminal session can go structured
     /// only when its tool is ACP-capable and the `offer_structured_in_new_session`
     /// opt-in is on (the structured view is still maturing, so switching into it
-    /// is gated the same way the new-session toggle is). Serve builds only (the swap runs
-    /// through the daemon and the result needs a structured view to open).
+    /// is gated the same way the new-session toggle is).
     /// Archived / trashed / mid-lifecycle rows are excluded: their agent is
     /// deliberately stopped, and the swap would boot a worker or tmux pane
     /// behind the parked state.
     pub(super) fn session_switch_view_target(&self, id: &str) -> Option<bool> {
-        #[cfg(feature = "serve")]
+        let inst = self.get_instance(id)?;
+        if inst.is_archived()
+            || inst.is_trashed()
+            || matches!(inst.status, Status::Creating | Status::Deleting)
         {
-            let inst = self.get_instance(id)?;
-            if inst.is_archived()
-                || inst.is_trashed()
-                || matches!(inst.status, Status::Creating | Status::Deleting)
-            {
-                return None;
-            }
-            if inst.is_structured() {
-                return Some(true);
-            }
-            let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                &inst.source_profile,
-                std::path::Path::new(&inst.project_path),
-            );
-            // Switching a terminal session INTO the structured view is gated on
-            // the same opt-in as the new-session toggle: the structured view is
-            // still maturing, so don't offer to switch into it unless the user
-            // turned it on. The reverse direction (already-structured -> terminal)
-            // stays available above regardless, so a session can always get out.
-            (config.acp.offer_structured_in_new_session
-                && crate::session::builder::structured::tool_acp_capable(&inst.tool, &config))
-            .then_some(false)
+            return None;
         }
-        #[cfg(not(feature = "serve"))]
-        {
-            let _ = id;
-            None
+        if inst.is_structured() {
+            return Some(true);
         }
+        let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
+            &inst.source_profile,
+            std::path::Path::new(&inst.project_path),
+        );
+        // Switching a terminal session INTO the structured view is gated on
+        // the same opt-in as the new-session toggle: the structured view is
+        // still maturing, so don't offer to switch into it unless the user
+        // turned it on. The reverse direction (already-structured -> terminal)
+        // stays available above regardless, so a session can always get out.
+        (config.acp.offer_structured_in_new_session
+            && crate::session::builder::structured::tool_acp_capable(&inst.tool, &config))
+        .then_some(false)
     }
 
     /// Confirm before flipping the selected session's view. Enabling
@@ -3144,7 +3117,6 @@ impl HomeView {
     /// found no daemon running. Neutral tone: nothing is destroyed; the
     /// user is just about to run a background process they may not have
     /// expected. Remote setups keep their manual commands.
-    #[cfg(feature = "serve")]
     pub(in crate::tui) fn prompt_start_daemon_for_structured(&mut self, session_id: &str) {
         self.pending_daemon_start_session = Some(session_id.to_string());
         self.confirm_dialog = Some(
@@ -3165,7 +3137,6 @@ impl HomeView {
     /// archive or trash (those render their own placeholder pages, so a
     /// mounted view would be invisible while still streaming). Drives
     /// preview-on-select and the active-view liveness check.
-    #[cfg(feature = "serve")]
     pub(in crate::tui) fn selected_structured_session(&self) -> Option<String> {
         let id = self.selected_session.clone()?;
         let inst = self.get_instance(&id)?;
@@ -3180,7 +3151,6 @@ impl HomeView {
     /// Used by the embedded structured view open path: both modes route
     /// keystrokes away from the home view and paint the preview pane,
     /// so they cannot coexist.
-    #[cfg(feature = "serve")]
     pub(in crate::tui) fn exit_live_send_if_active(&mut self) {
         if let Some(state) = self.live_send.clone() {
             self.exit_live_send_and_restore_sizing(&state);
@@ -3209,9 +3179,7 @@ impl HomeView {
         // Pull the few parent fields we need into owned locals so the
         // immutable borrow of `self` is dropped before the mutable `self.`
         // calls below (dialog construction, info_dialog assignment). A
-        // structured view parent forks through ACP. The captured ACP session
-        // id is read into a local only under `serve`, since only that fork
-        // branch consumes it.
+        // structured view parent forks through ACP.
         let Some(parent) = self
             .selected_session
             .as_ref()
@@ -3225,9 +3193,7 @@ impl HomeView {
         let group_path = parent.group_path.clone();
         let title = parent.title.clone();
         let parent_is_structured = parent.is_structured();
-        #[cfg(feature = "serve")]
         let parent_agent_name = parent.agent_name.clone();
-        #[cfg(feature = "serve")]
         let parent_acp_session_id = parent.acp_session_id.clone();
 
         let seed = if parent_is_structured {
@@ -3235,52 +3201,32 @@ impl HomeView {
             // not the terminal resume-with-fork-flag path. The captured ACP
             // session id is the parent to fork from; without one there is no
             // conversation to fork yet.
-            #[cfg(feature = "serve")]
-            {
-                // Gate on the same predicate the REST create-guard and the web
-                // `acp_can_fork` projection use: a resume-only ACP agent (e.g.
-                // `aoe-agent`) has no fork strategy, so `session/fork` would be
-                // refused at the handshake and silently downgrade to
-                // `session/new`, handing the user an empty session they think is
-                // a fork. Refuse up front with the same info dialog terminal
-                // denial uses.
-                if !crate::session::fork::structured_fork_capable(
-                    &tool,
-                    parent_agent_name.as_deref(),
-                ) {
-                    self.info_dialog = Some(InfoDialog::new(
+            // Gate on the same predicate the REST create-guard and the web
+            // `acp_can_fork` projection use: a resume-only ACP agent (e.g.
+            // `aoe-agent`) has no fork strategy, so `session/fork` would be
+            // refused at the handshake and silently downgrade to
+            // `session/new`, handing the user an empty session they think is
+            // a fork. Refuse up front with the same info dialog terminal
+            // denial uses.
+            if !crate::session::fork::structured_fork_capable(&tool, parent_agent_name.as_deref()) {
+                self.info_dialog = Some(InfoDialog::new(
                         "Fork not supported",
                         &format!(
                             "The '{}' agent cannot fork a structured view session. Fork is available for agents that support the ACP fork capability, such as Claude.",
                             tool
                         ),
                     ));
-                    return;
-                }
-                let Some(acp_id) = parent_acp_session_id.filter(|s| !s.is_empty()) else {
-                    self.info_dialog = Some(InfoDialog::new(
+                return;
+            }
+            let Some(acp_id) = parent_acp_session_id.filter(|s| !s.is_empty()) else {
+                self.info_dialog = Some(InfoDialog::new(
                         "Nothing to fork yet",
                         "This session has no captured conversation to fork from. Send it at least one message first.",
                     ));
-                    return;
-                };
-                crate::session::ForkSeed::Structured {
-                    parent_acp_session_id: acp_id,
-                }
-            }
-            #[cfg(not(feature = "serve"))]
-            {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Fork not available in this build",
-                    "This `aoe` binary was built without the web dashboard \
-                     (a `--no-default-features` source build), so structured \
-                     view session forking is not included.\n\n\
-                     To fork this session:\n\
-                       \u{2022} Install a release build from GitHub Releases, or\n\
-                       \u{2022} Build from source with default features:\n\
-                         cargo build --release",
-                ));
                 return;
+            };
+            crate::session::ForkSeed::Structured {
+                parent_acp_session_id: acp_id,
             }
         } else {
             let child_id = crate::session::capture::generate_session_uuid();
@@ -3593,7 +3539,7 @@ impl HomeView {
     /// "Auto-name now": run the agent one-shot title generator for the
     /// selected still-default-named session, on demand and even when
     /// auto-rename-on-start is disabled (#3039). Terminal sessions rename via a
-    /// detached child; structured sessions go through the daemon (serve builds).
+    /// detached child; structured sessions go through the daemon.
     /// Best-effort: a 202-style "started", not a synchronous rename.
     fn auto_name_selected(&mut self) -> Option<Action> {
         let Some(id) = self.selected_session.clone() else {
@@ -3631,18 +3577,7 @@ impl HomeView {
         }
 
         if structured {
-            #[cfg(feature = "serve")]
-            {
-                return Some(Action::SmartRenameNow(id));
-            }
-            #[cfg(not(feature = "serve"))]
-            {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Unavailable",
-                    "Auto-naming a structured-view session needs a serve-enabled build.",
-                ));
-                return None;
-            }
+            return Some(Action::SmartRenameNow(id));
         }
 
         // Preflight the gates the detached child re-applies, so this action stops
@@ -3709,38 +3644,20 @@ impl HomeView {
     }
 
     fn open_serve(&mut self) {
-        #[cfg(feature = "serve")]
-        {
-            let web_disabled = crate::plugin::registry()
-                .get("aoe.web")
-                .is_some_and(|p| !p.enabled);
-            if web_disabled {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Web dashboard disabled",
-                    "The aoe.web plugin is disabled, so the web dashboard cannot \
+        let web_disabled = crate::plugin::registry()
+            .get("aoe.web")
+            .is_some_and(|p| !p.enabled);
+        if web_disabled {
+            self.info_dialog = Some(InfoDialog::new(
+                "Web dashboard disabled",
+                "The aoe.web plugin is disabled, so the web dashboard cannot \
                      be served.\n\n\
                      Re-enable it in Settings > Plugins (or run \
                      `aoe plugin enable aoe.web`), then press R again.",
-                ));
-                return;
-            }
-            self.serve_view = Some(crate::tui::dialogs::ServeView::new());
-        }
-        #[cfg(not(feature = "serve"))]
-        {
-            self.info_dialog = Some(InfoDialog::new(
-                "Serve unavailable",
-                "This `aoe` binary was built without the web dashboard \
-                 (a `--no-default-features` source build), so local network \
-                 serving and Cloudflare Tunnel integration are not included.\n\n\
-                 To serve to your phone (LAN / Tailscale / tunnel):\n\
-                   \u{2022} Install a release build from GitHub Releases, or\n\
-                   \u{2022} Build from source with default features:\n\
-                     cargo build --release\n\n\
-                 Once you have a `serve`-enabled binary, press R again to \
-                 open the serve dialog.",
             ));
+            return;
         }
+        self.serve_view = Some(crate::tui::dialogs::ServeView::new());
     }
 
     pub(super) fn open_settings(&mut self) {
@@ -3823,8 +3740,7 @@ impl HomeView {
     }
 
     fn open_command_palette(&mut self) {
-        let serve_enabled = cfg!(feature = "serve");
-        let mut entries: Vec<PaletteCommand> = builtin_commands(serve_enabled, self.strict_hotkeys);
+        let mut entries: Vec<PaletteCommand> = builtin_commands(self.strict_hotkeys);
 
         // Quit lives in the registry but is excluded from `builtin_commands`
         // (no palette metadata) so it can sit in the Settings group at the end;
@@ -4184,20 +4100,11 @@ impl HomeView {
                 return None;
             }
             if inst.is_structured() {
-                #[cfg(feature = "serve")]
-                {
-                    // The embedded structured view takes over the preview
-                    // pane; leave live-send first so the two don't fight
-                    // over it (mirrors `exit_live_send_before_attach`).
-                    self.exit_live_send_if_active();
-                    return Some(Action::OpenStructuredView(id));
-                }
-                #[cfg(not(feature = "serve"))]
-                {
-                    return Some(Action::SetTransientStatus(
-                        "Acp session: rebuild with default features to attach".to_string(),
-                    ));
-                }
+                // The embedded structured view takes over the preview
+                // pane; leave live-send first so the two don't fight
+                // over it (mirrors `exit_live_send_before_attach`).
+                self.exit_live_send_if_active();
+                return Some(Action::OpenStructuredView(id));
             }
         }
         match self.view_mode {
@@ -4946,8 +4853,7 @@ impl HomeView {
                 // View switching mirrors the web sidebar's per-session
                 // switch action: offered when a structured session can go
                 // back to a terminal, or a terminal session's tool is
-                // ACP-capable. Serve builds only; the swap runs through
-                // the daemon.
+                // ACP-capable. The swap runs through the daemon.
                 let switch_view = match &self.flat_items[idx] {
                     super::Item::Session { id, .. } => self.session_switch_view_target(id),
                     super::Item::Group { .. } => None,

--- a/src/tui/home/lifecycle.rs
+++ b/src/tui/home/lifecycle.rs
@@ -251,7 +251,6 @@ impl HomeView {
             plugin_manager_dialog: None,
             skills_manager_dialog: None,
             command_palette: None,
-            #[cfg(feature = "serve")]
             serve_view: None,
             update_confirm_dialog: None,
             telemetry_consent_dialog: None,
@@ -293,11 +292,8 @@ impl HomeView {
             pending_stop_tool: None,
             pending_image_pull: None,
             pending_switch_view_session: None,
-            #[cfg(feature = "serve")]
             pending_daemon_start_session: None,
-            #[cfg(feature = "serve")]
             structured_preview: None,
-            #[cfg(feature = "serve")]
             structured_preview_pending: false,
             pending_force_remove_session: None,
             pending_trash_session: None,
@@ -324,9 +320,7 @@ impl HomeView {
             system_health_discovered: user_config
                 .as_ref()
                 .is_some_and(|config| config.app_state.used_system_health),
-            #[cfg(feature = "serve")]
             daemon_status_poller: crate::tui::daemon_status_poller::DaemonStatusPoller::new(),
-            #[cfg(feature = "serve")]
             pending_daemon_status_refresh: false,
             deletion_poller: DeletionPoller::new(),
             stop_poller: StopPoller::new(),

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -49,7 +49,6 @@ use crate::tmux::AvailableTools;
 
 use super::creation_poller::{CreatedWorktreeInfo, CreationPoller, CreationRequest};
 use super::deletion_poller::DeletionPoller;
-#[cfg(feature = "serve")]
 use super::dialogs::ServeView;
 use super::dialogs::{
     AttachProjectDialog, ChangelogDialog, CommandPaletteDialog, ConfirmDialog, ContextMenuDialog,
@@ -273,7 +272,6 @@ pub struct HomeView {
     pub(super) plugin_manager_dialog: Option<crate::tui::dialogs::PluginManagerDialog>,
     pub(super) skills_manager_dialog: Option<crate::tui::dialogs::SkillsManagerDialog>,
     pub(super) command_palette: Option<CommandPaletteDialog>,
-    #[cfg(feature = "serve")]
     pub(super) serve_view: Option<ServeView>,
     pub(super) update_confirm_dialog: Option<UpdateConfirmDialog>,
     /// One-time opt-in popup for users who finished the walkthrough before
@@ -426,7 +424,6 @@ pub struct HomeView {
     pub(super) pending_switch_view_session: Option<String>,
     /// Session whose structured-view open is waiting on the "start a
     /// local daemon?" confirm (see `prompt_start_daemon_for_structured`).
-    #[cfg(feature = "serve")]
     pub(super) pending_daemon_start_session: Option<String>,
     /// The structured-view session mounted in the preview pane, if any:
     /// a streaming transcript that `render_preview` paints as the
@@ -435,7 +432,6 @@ pub struct HomeView {
     /// preview renderer, info header, and drag-select all compose with
     /// it; the `App` loop drives its async sides (connect, WS pump,
     /// active-mode key routing).
-    #[cfg(feature = "serve")]
     pub(in crate::tui) structured_preview:
         Option<crate::tui::structured_view::embedded::EmbeddedView>,
     /// True while the App's preview-on-select reconcile has picked a
@@ -443,7 +439,6 @@ pub struct HomeView {
     /// preview renderer shows a quiet placeholder instead of the wordy
     /// "press Enter" page, which otherwise flashes for the connect
     /// window on every selection.
-    #[cfg(feature = "serve")]
     pub(in crate::tui) structured_preview_pending: bool,
     /// Session to force-remove after the confirmation dialog is accepted
     pub(super) pending_force_remove_session: Option<String>,
@@ -486,9 +481,7 @@ pub struct HomeView {
 
     // Structured (ACP) rows: the tmux poller above bails on them, so their
     // status comes from the daemon instead. See `daemon_status_poller`.
-    #[cfg(feature = "serve")]
     pub(super) daemon_status_poller: super::daemon_status_poller::DaemonStatusPoller,
-    #[cfg(feature = "serve")]
     pub(super) pending_daemon_status_refresh: bool,
 
     // Performance: background deletion

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -282,12 +282,9 @@ impl HomeView {
         )?;
         let mut instance = build_result.instance;
         instance.source_profile = target_profile.clone();
-        #[cfg(feature = "serve")]
         if structured {
             builder::structured::apply_structured_choice(&mut instance);
         }
-        #[cfg(not(feature = "serve"))]
-        let _ = structured;
         let session_id = instance.id.clone();
 
         // Ensure target profile storage exists

--- a/src/tui/home/overlays.rs
+++ b/src/tui/home/overlays.rs
@@ -35,7 +35,6 @@ impl HomeView {
         }
 
         // Poll serve dialog for subprocess startup events.
-        #[cfg(feature = "serve")]
         if let Some(view) = &mut self.serve_view {
             if view.tick() {
                 changed = true;
@@ -94,10 +93,7 @@ impl HomeView {
     /// (the wheel-scroll on the dashboard preview won't work while it's
     /// off).
     pub fn wants_text_selection(&self) -> bool {
-        #[cfg(feature = "serve")]
         let serve_open = self.serve_view.is_some();
-        #[cfg(not(feature = "serve"))]
-        let serve_open = false;
 
         serve_open
             || self.info_dialog.is_some()
@@ -122,10 +118,7 @@ impl HomeView {
     /// gate off the fast path it's supposed to enable — that's why the
     /// fast path needs this method instead.
     pub(in crate::tui) fn has_non_live_send_overlay(&self) -> bool {
-        #[cfg(feature = "serve")]
         let serve_open = self.serve_view.is_some();
-        #[cfg(not(feature = "serve"))]
-        let serve_open = false;
 
         self.show_help
             || self.search_active
@@ -188,10 +181,7 @@ impl HomeView {
     }
 
     pub fn has_dialog(&self) -> bool {
-        #[cfg(feature = "serve")]
         let serve_open = self.serve_view.is_some();
-        #[cfg(not(feature = "serve"))]
-        let serve_open = false;
 
         self.live_send.is_some()
             || self.show_help

--- a/src/tui/home/pollers.rs
+++ b/src/tui/home/pollers.rs
@@ -697,7 +697,6 @@ impl HomeView {
         // is the exact failure mode the file lock is meant to prevent;
         // checking `daemon_pid()` first short-circuits the more expensive
         // lock acquisition in the common case.
-        #[cfg(feature = "serve")]
         if crate::cli::serve::daemon_pid().is_some() {
             return;
         }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -3728,9 +3728,16 @@ impl HomeView {
         // serve.mode file from disk on every frame.
         let mode_label = crate::cli::serve::cached_serve_mode_label();
         if crate::cli::serve::daemon_pid().is_some() {
+            // A build without the dashboard bundle answers the API only, so
+            // the badge must not read as "the dashboard is up".
+            let what = if cfg!(feature = "web") {
+                "Serving"
+            } else {
+                "Serving API"
+            };
             let label = match mode_label {
-                Some(m) => format!(" \u{25CF} Serving ({}) ", m),
-                None => " \u{25CF} Serving ".to_string(),
+                Some(m) => format!(" \u{25CF} {} ({}) ", what, m),
+                None => format!(" \u{25CF} {} ", what),
             };
             groups.push((
                 0,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -844,7 +844,6 @@ impl HomeView {
         }
 
         // Serve view takes over the whole screen
-        #[cfg(feature = "serve")]
         if let Some(ref serve) = self.serve_view {
             self.divider_col = None;
             self.main_area_width = 0;
@@ -1479,10 +1478,7 @@ impl HomeView {
     }
 
     fn has_overlay_above_search(&self) -> bool {
-        #[cfg(feature = "serve")]
         let serve_open = self.serve_view.is_some();
-        #[cfg(not(feature = "serve"))]
-        let serve_open = false;
 
         self.show_help
             || self.new_dialog.is_some()
@@ -2619,10 +2615,7 @@ impl HomeView {
             // transcript scrolls inside the embedded view); the generic
             // indicator below reads the tmux capture cache and home's
             // wheel offset, both of which are stale or empty for it.
-            #[cfg(feature = "serve")]
             let structured_mounted = self.structured_preview.is_some();
-            #[cfg(not(feature = "serve"))]
-            let structured_mounted = false;
             let scroll_indicator = if !self.show_preview_info && !structured_mounted {
                 let inner_height = area.height.saturating_sub(2);
                 let visible_height = inner_height as usize;
@@ -2758,65 +2751,62 @@ impl HomeView {
             // content: info header on top (same `i` toggle and layout as
             // the terminal previews), the streaming transcript below, and
             // the drag-select machinery pointed at the painted rows.
-            #[cfg(feature = "serve")]
-            {
-                let selected_id = self.selected_session.clone();
-                let mounted_matches = self
-                    .structured_preview
-                    .as_ref()
-                    .zip(selected_id.as_deref())
-                    .is_some_and(|(v, id)| v.session_id() == id);
-                if mounted_matches {
-                    // Take/put-back so the view's `&mut` render can't
-                    // fight the instance lookup's shared borrow of self.
-                    let mut view = self.structured_preview.take();
-                    let inst = selected_id.as_deref().and_then(|id| self.get_instance(id));
-                    let layout = preview::PreviewLayout::compute(
-                        inner,
-                        compact,
-                        self.show_preview_info,
-                        inst.map(preview::agent_info_height).unwrap_or(0),
+            let selected_id = self.selected_session.clone();
+            let mounted_matches = self
+                .structured_preview
+                .as_ref()
+                .zip(selected_id.as_deref())
+                .is_some_and(|(v, id)| v.session_id() == id);
+            if mounted_matches {
+                // Take/put-back so the view's `&mut` render can't
+                // fight the instance lookup's shared borrow of self.
+                let mut view = self.structured_preview.take();
+                let inst = selected_id.as_deref().and_then(|id| self.get_instance(id));
+                let layout = preview::PreviewLayout::compute(
+                    inner,
+                    compact,
+                    self.show_preview_info,
+                    inst.map(preview::agent_info_height).unwrap_or(0),
+                );
+                if let (Some(info_area), Some(inst)) = (layout.info, inst) {
+                    preview::Preview::render_info(
+                        frame,
+                        info_area,
+                        inst,
+                        theme,
+                        self.idle_decay_window,
                     );
-                    if let (Some(info_area), Some(inst)) = (layout.info, inst) {
-                        preview::Preview::render_info(
-                            frame,
-                            info_area,
-                            inst,
-                            theme,
-                            self.idle_decay_window,
-                        );
-                    }
-                    // No ` Output ` banner row: the transcript block has
-                    // its own titled border, so the banner slot stays a
-                    // blank separator under the header.
-                    let geometry = view
-                        .as_mut()
-                        .and_then(|v| v.render(frame, layout.output, theme));
-                    self.structured_preview = view;
-                    self.preview_pane_area = layout.output;
-                    if let Some(g) = geometry {
-                        self.preview_visible_rows = g.text_area.height as usize;
-                        self.preview_text_view = crate::tui::home::PreviewTextView {
-                            pane: g.text_area,
-                            first_line: g.first_line,
-                            total_lines: g.total_lines,
-                        };
-                    }
-                    self.paint_preview_selection(frame, theme);
-                    return;
                 }
-                if self.structured_preview_pending {
-                    // A mount is underway (or about to start): render a
-                    // quiet beat instead of the wordy "press Enter" page,
-                    // which otherwise flashes on every selection.
-                    let para = Paragraph::new(Line::from(Span::styled(
-                        "…",
-                        Style::default().fg(theme.dimmed),
-                    )))
-                    .alignment(Alignment::Center);
-                    frame.render_widget(para, inner);
-                    return;
+                // No ` Output ` banner row: the transcript block has
+                // its own titled border, so the banner slot stays a
+                // blank separator under the header.
+                let geometry = view
+                    .as_mut()
+                    .and_then(|v| v.render(frame, layout.output, theme));
+                self.structured_preview = view;
+                self.preview_pane_area = layout.output;
+                if let Some(g) = geometry {
+                    self.preview_visible_rows = g.text_area.height as usize;
+                    self.preview_text_view = crate::tui::home::PreviewTextView {
+                        pane: g.text_area,
+                        first_line: g.first_line,
+                        total_lines: g.total_lines,
+                    };
                 }
+                self.paint_preview_selection(frame, theme);
+                return;
+            }
+            if self.structured_preview_pending {
+                // A mount is underway (or about to start): render a
+                // quiet beat instead of the wordy "press Enter" page,
+                // which otherwise flashes on every selection.
+                let para = Paragraph::new(Line::from(Span::styled(
+                    "…",
+                    Style::default().fg(theme.dimmed),
+                )))
+                .alignment(Alignment::Center);
+                frame.render_widget(para, inner);
+                return;
             }
             self.render_structured_preview(frame, inner, theme);
             self.paint_preview_selection(frame, theme);
@@ -3736,23 +3726,20 @@ impl HomeView {
         // The TUI does not own the daemon, so we probe the PID file each
         // render. Mode comes from a PID-keyed cache so we don't read the
         // serve.mode file from disk on every frame.
-        #[cfg(feature = "serve")]
-        {
-            let mode_label = crate::cli::serve::cached_serve_mode_label();
-            if crate::cli::serve::daemon_pid().is_some() {
-                let label = match mode_label {
-                    Some(m) => format!(" \u{25CF} Serving ({}) ", m),
-                    None => " \u{25CF} Serving ".to_string(),
-                };
-                groups.push((
-                    0,
-                    None,
-                    vec![Span::styled(
-                        label,
-                        Style::default().fg(theme.running).bold(),
-                    )],
-                ));
-            }
+        let mode_label = crate::cli::serve::cached_serve_mode_label();
+        if crate::cli::serve::daemon_pid().is_some() {
+            let label = match mode_label {
+                Some(m) => format!(" \u{25CF} Serving ({}) ", m),
+                None => " \u{25CF} Serving ".to_string(),
+            };
+            groups.push((
+                0,
+                None,
+                vec![Span::styled(
+                    label,
+                    Style::default().fg(theme.running).bold(),
+                )],
+            ));
         }
 
         // Other-TUI indicator: shown only when more than one `aoe` TUI is

--- a/src/tui/home/status.rs
+++ b/src/tui/home/status.rs
@@ -196,7 +196,6 @@ impl HomeView {
     /// Request the daemon's view of every structured row's status
     /// (non-blocking). Skipped entirely when no structured session is
     /// loaded, so a terminal-only home view never talks to the daemon.
-    #[cfg(feature = "serve")]
     pub fn request_daemon_status_refresh(&mut self) {
         if self.pending_daemon_status_refresh {
             return;
@@ -235,7 +234,6 @@ impl HomeView {
     /// legible). The tmux producer has the same property via its own
     /// `is_archived()` short-circuit, so this is consistent rather than new,
     /// but unarchiving is the only way back.
-    #[cfg(feature = "serve")]
     fn daemon_status_applies_to(&self, inst: &Instance) -> bool {
         !self.recovery_in_flight.contains(&inst.id)
             && !self.restart_in_flight.contains(&inst.id)
@@ -245,7 +243,6 @@ impl HomeView {
 
     /// Apply any pending daemon-sourced statuses. Returns true if the
     /// caller should redraw.
-    #[cfg(feature = "serve")]
     pub fn apply_daemon_status_updates(&mut self) -> bool {
         use std::sync::mpsc::TryRecvError;
 
@@ -288,7 +285,6 @@ impl HomeView {
     /// trusted from the wire: the daemon's `view` and the local row's could
     /// disagree for a session mid-conversion, and the tmux poller owns
     /// terminal rows. Dropping the mismatch keeps one producer per row.
-    #[cfg(feature = "serve")]
     pub(in crate::tui) fn apply_daemon_status_update(
         &mut self,
         update: crate::tui::daemon_status_poller::DaemonStatusUpdate,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1663,7 +1663,6 @@ fn test_enter_on_session_returns_attach_action() {
     assert!(matches!(action, Some(Action::AttachSession(_))));
 }
 
-#[cfg(feature = "serve")]
 #[test]
 #[serial]
 fn test_enter_on_acp_session_opens_structured_view() {
@@ -5050,10 +5049,7 @@ fn test_strict_mode_ctrl_d_r_p_reach_secondary_actions() {
         "Ctrl+R in strict mode must NOT open the rename dialog (it targets serve)"
     );
     env.view.info_dialog = None;
-    #[cfg(feature = "serve")]
-    {
-        env.view.serve_view = None;
-    }
+    env.view.serve_view = None;
 
     // P follows the same relocation rule as D/R/T/N: the bare-`p` (primary)
     // action -> Shift+P, the Shift+P (secondary) action -> Ctrl+P. So in strict
@@ -6770,7 +6766,6 @@ fn fork_from_selection_preselects_parent_tool() {
 /// A structured (ACP) parent forks via the ACP `session/fork` handshake, so the
 /// seed must be `Structured` carrying the parent's captured ACP session id, not
 /// a terminal resume-with-fork-flag seed.
-#[cfg(feature = "serve")]
 #[test]
 #[serial]
 fn fork_from_selection_structured_parent_seeds_structured_fork() {
@@ -6803,7 +6798,6 @@ fn fork_from_selection_structured_parent_seeds_structured_fork() {
 
 /// A structured parent with no captured ACP session id yet has no conversation
 /// to fork; the dialog must not open and an explanatory info dialog is shown.
-#[cfg(feature = "serve")]
 #[test]
 #[serial]
 fn fork_from_selection_structured_parent_without_acp_id_denies() {
@@ -6835,7 +6829,6 @@ fn fork_from_selection_structured_parent_without_acp_id_denies() {
 /// the fork would silently downgrade to session/new at the handshake. This is
 /// the exact silent-downgrade the reviewer flagged; the gate mirrors the REST
 /// create guard and the web `acp_can_fork` projection.
-#[cfg(feature = "serve")]
 #[test]
 #[serial]
 fn fork_from_selection_structured_unforkable_agent_denies() {
@@ -8184,16 +8177,11 @@ fn wants_text_selection_tracks_copy_friendly_surfaces() {
     env.view.changelog_dialog = None;
     assert!(!env.view.wants_text_selection());
 
-    // serve_view is feature-gated; only assert it when the feature is on,
-    // since the field isn't present otherwise.
-    #[cfg(feature = "serve")]
-    {
-        use crate::tui::dialogs::ServeView;
-        env.view.serve_view = Some(ServeView::new());
-        assert!(env.view.wants_text_selection());
-        env.view.serve_view = None;
-        assert!(!env.view.wants_text_selection());
-    }
+    use crate::tui::dialogs::ServeView;
+    env.view.serve_view = Some(ServeView::new());
+    assert!(env.view.wants_text_selection());
+    env.view.serve_view = None;
+    assert!(!env.view.wants_text_selection());
 }
 
 // -- apply_one_status_update -------------------------------------------------
@@ -15410,7 +15398,6 @@ mod click_to_select {
 
     /// Acp-mode sessions are not tmux-backed, so click cannot
     /// enter live mode for them; selection still updates.
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn single_click_on_acp_session_returns_no_action() {
@@ -16911,12 +16898,6 @@ mod live_send_mode {
         );
     }
 
-    /// Acp-mode is a `serve` feature; the `structured_view` field on
-    /// Instance only exists when that feature is compiled in. Without
-    /// it, `is_structured()` is hard-coded to false and the gate is
-    /// a no-op, so there's nothing meaningful to verify in the default
-    /// build.
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn tab_does_not_start_live_send_for_acp_session() {
@@ -17458,7 +17439,6 @@ mod post_create_attach_mode {
         assert!(mode.is_none());
     }
 
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn returns_none_for_acp_session() {
@@ -17962,7 +17942,6 @@ mod default_attach_mode {
     /// `OpenStructuredView`/transient-status before we get to the view-mode
     /// match), so the resolver also returns None for them; the setting
     /// must not be able to misroute a structured view row into live mode.
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn acp_session_ignores_default_attach_mode() {
@@ -18043,7 +18022,6 @@ mod default_attach_mode {
     /// a structured row, structured for a terminal row whose tool is
     /// ACP-capable (only when the structured-view opt-in is on), and nothing
     /// for rows mid-lifecycle.
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn switch_view_target_gates_by_view_and_state() {
@@ -18070,7 +18048,6 @@ mod default_attach_mode {
     /// `offer_structured_in_new_session` opt-in, so with it off an ACP-capable
     /// terminal row offers no switch. A structured row can always switch back
     /// to terminal regardless, so a session is never stranded.
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn switch_view_target_gated_on_structured_opt_in() {
@@ -18091,7 +18068,6 @@ mod default_attach_mode {
 
     /// Accepting the switch-view confirm emits the action with the stashed
     /// session id, mirroring the other confirm-carrying actions.
-    #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn switch_view_confirm_dispatches_action_with_stashed_id() {
@@ -20717,7 +20693,6 @@ mod settings_scroll_wiring {
 /// `apply_acp_overlay_inplace`). Before this wiring existed the pill sat frozen
 /// at whatever creation or an explicit start/stop wrote, for the whole life of
 /// the session.
-#[cfg(feature = "serve")]
 mod daemon_status_apply_tests {
     use super::*;
     use crate::session::Status;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,7 +6,6 @@ mod attached_status_hooks;
 pub(crate) mod clipboard;
 mod components;
 mod creation_poller;
-#[cfg(feature = "serve")]
 mod daemon_status_poller;
 mod deletion_poller;
 pub mod dialogs;
@@ -14,19 +13,15 @@ pub mod diff;
 pub(crate) mod home;
 pub(crate) mod markdown;
 mod metrics_poller;
-#[cfg(feature = "serve")]
 pub(crate) mod open_url;
-#[cfg(feature = "serve")]
 pub(crate) mod plugin_ui;
 mod reconcile_poller;
-#[cfg(feature = "serve")]
 pub(crate) mod remote_home;
 pub(crate) mod responsive;
 mod restart_poller;
 pub mod settings;
 mod status_poller;
 mod stop_poller;
-#[cfg(feature = "serve")]
 pub(crate) mod structured_view;
 pub(crate) mod styles;
 mod trash_poller;
@@ -226,7 +221,6 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // sees a session list that doesn't reflect the daemon they pointed
     // us at. Tmux check + migrations are intentionally skipped here:
     // the remote machine owns those, this side is a pure client.
-    #[cfg(feature = "serve")]
     if let Some(endpoint) = crate::acp::client::discovery::discover_env() {
         let _ = startup_warning; // remote mode skips the local startup-warning channel
         let _ = profile;

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -9,14 +9,11 @@
 
 mod contrast;
 mod palette;
-#[cfg(feature = "serve")]
 mod resolved;
 mod themes;
 
 pub use contrast::has_min_contrast;
-#[cfg(feature = "serve")]
 pub use resolved::{resolve_theme, ResolvedTheme};
-#[cfg(any(feature = "serve", test))]
 pub use themes::ThemeAppearance;
 pub use themes::{idle_decay_window, Theme};
 

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -14,8 +14,6 @@
 //! Before this change the control socket did not exist, so the control
 //! connect below fails outright; that is the red state the fix turns green.
 
-#![cfg(feature = "serve")]
-
 use std::io::{Read, Write};
 use std::net::Shutdown;
 use std::os::unix::net::UnixStream;

--- a/tests/acp_runner_orphan.rs
+++ b/tests/acp_runner_orphan.rs
@@ -15,8 +15,6 @@
 //! which is safe under the test's own process group, and is exactly the
 //! path where the superseded-delete bug lived.
 
-#![cfg(feature = "serve")]
-
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};

--- a/tests/agent_lifecycle_cli.rs
+++ b/tests/agent_lifecycle_cli.rs
@@ -5,7 +5,7 @@
 //! isolated HOME:
 //!
 //! - `aoe agents` lists the deprecation notice under gemini;
-//! - `aoe acp doctor` (serve build) emits the notice line in text mode;
+//! - `aoe acp doctor` emits the notice line in text mode;
 //! - `aoe add` emits exactly one non-blocking warning after every built-in
 //!   resolution path, including default tools and command overrides.
 //!
@@ -129,7 +129,6 @@ fn aoe_agents_lists_deprecated_notice() {
     assert_eq!(stdout.matches("deprecated since").count(), 1, "{stdout}");
 }
 
-#[cfg(feature = "serve")]
 #[test]
 fn acp_doctor_text_emits_amber_lifecycle_notice() {
     let (_tmp, home, xdg) = isolated_dirs();

--- a/tests/daemon_core_web_optional.rs
+++ b/tests/daemon_core_web_optional.rs
@@ -1,0 +1,85 @@
+//! The daemon is core; only the dashboard bundle is optional (#3619).
+//!
+//! Drives the real `build_router` stack through `tower::ServiceExt::oneshot`
+//! (no socket bind) and asserts the split holds in whichever feature corner
+//! the suite is compiled for: the API is reachable either way, while the
+//! dashboard routes exist only under `web`. Without that assertion a stray
+//! `#[cfg(feature = "web")]` around an API route, or a dashboard route that
+//! leaked out of the gate, compiles clean and ships wrong.
+
+use agent_of_empires::server::test_support::{
+    build_router_for_test, build_test_app_state_with_policy,
+};
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use std::net::SocketAddr;
+use tower::ServiceExt;
+
+fn loopback_peer() -> SocketAddr {
+    "127.0.0.1:5555".parse().unwrap()
+}
+
+/// Status for `uri` through the full router stack. The host allowlist is
+/// seeded and no token is set, so `access_policy` and auth both pass and the
+/// status reflects routing alone. Without the allowlist every path answers
+/// 403 and the assertions below would prove nothing.
+async fn status_for(uri: &str) -> StatusCode {
+    let allowed: Vec<String> = ["localhost", "127.0.0.1", "::1"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let state = build_test_app_state_with_policy(Vec::new(), allowed, Vec::new(), None);
+    let app = build_router_for_test(state);
+    let mut req = Request::builder()
+        .uri(uri)
+        .header("host", "localhost")
+        .body(Body::empty())
+        .unwrap();
+    req.extensions_mut().insert(ConnectInfo(loopback_peer()));
+    app.oneshot(req).await.unwrap().status()
+}
+
+/// The REST surface is unconditional: a Node-free `cargo build` still answers
+/// it. This is the whole point of making the daemon core, so it is asserted in
+/// both feature corners rather than only under `web`.
+#[tokio::test]
+async fn api_routes_are_served_without_the_dashboard_bundle() {
+    assert_eq!(
+        status_for("/api/sessions").await,
+        StatusCode::OK,
+        "the daemon API must not depend on the dashboard bundle"
+    );
+}
+
+/// The SPA fallback and the Vite output live behind `web`. Without it a
+/// browser path must 404 rather than serve a stale or empty shell.
+#[cfg(not(feature = "web"))]
+#[tokio::test]
+async fn dashboard_routes_are_absent_without_web() {
+    for uri in ["/", "/sessions", "/assets/index-abc123.js", "/sw.js"] {
+        assert_eq!(
+            status_for(uri).await,
+            StatusCode::NOT_FOUND,
+            "{uri} must 404 in a build without the dashboard bundle"
+        );
+    }
+}
+
+/// With `web` the same paths resolve: `/assets/*` and the SPA fallback are
+/// registered, so a browser path reaches the embedded `index.html` instead of
+/// falling through to axum's default 404.
+#[cfg(feature = "web")]
+#[tokio::test]
+async fn spa_fallback_serves_the_bundle_with_web() {
+    assert_eq!(
+        status_for("/").await,
+        StatusCode::OK,
+        "the SPA fallback must serve index.html when the bundle is embedded"
+    );
+    assert_eq!(
+        status_for("/sessions").await,
+        StatusCode::OK,
+        "an unknown browser path must fall back to index.html, not 404"
+    );
+}

--- a/tests/e2e/acp_focus_isolation_e2e.rs
+++ b/tests/e2e/acp_focus_isolation_e2e.rs
@@ -14,13 +14,11 @@
 //! the client's decision, so the approval stays pending until the TUI
 //! resolves it.
 //!
-//! Compiled only with the default `serve` feature (excluded by `--no-default-features`) (structured view + `aoe add --structured-view`
-//! don't exist otherwise). Run via:
+//! Run via:
 //!
 //! ```sh
 //! cargo test --features e2e-tests --test e2e -- acp_focus_isolation
 //! ```
-#![cfg(feature = "serve")]
 
 use std::time::{Duration, Instant};
 

--- a/tests/e2e/acp_host_environment_e2e.rs
+++ b/tests/e2e/acp_host_environment_e2e.rs
@@ -27,13 +27,11 @@
 //! reopened for the structured view. It is asserted here rather than in its own
 //! live-daemon test so the coverage costs no extra daemon spawn.
 //!
-//! Compiled only with the `serve` feature (structured view and
-//! `aoe add --structured-view` do not exist otherwise). Run via:
+//! Run via:
 //!
 //! ```sh
-//! cargo test --features serve,e2e-tests --test e2e -- acp_host_environment
+//! cargo test --features e2e-tests --test e2e -- acp_host_environment
 //! ```
-#![cfg(feature = "serve")]
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/tests/e2e/acp_orphan_runner_recovery_e2e.rs
+++ b/tests/e2e/acp_orphan_runner_recovery_e2e.rs
@@ -17,12 +17,11 @@
 //! Without the fix this test hangs until the 45s prompt deadline and panics;
 //! with it, the prompt is accepted once the worker is recovered.
 //!
-//! Compiled only with the default `serve` feature (excluded by `--no-default-features`). Run via:
+//! Run via:
 //!
 //! ```sh
 //! cargo test --features e2e-tests --test e2e -- acp_orphan_runner_recovery
 //! ```
-#![cfg(feature = "serve")]
 
 use std::time::{Duration, Instant};
 

--- a/tests/e2e/acp_session_log_tee_e2e.rs
+++ b/tests/e2e/acp_session_log_tee_e2e.rs
@@ -8,12 +8,11 @@
 //! diagnostic. This proves a daemon-emitted, session-scoped `acp.protocol`
 //! breadcrumb now lands in the per-session log surfaced by `aoe acp logs`.
 //!
-//! Compiled only with the default `serve` feature (excluded by `--no-default-features`). Run via:
+//! Run via:
 //!
 //! ```sh
 //! cargo test --features e2e-tests --test e2e -- acp_session_log_tee
 //! ```
-#![cfg(feature = "serve")]
 
 use std::time::{Duration, Instant};
 

--- a/tests/e2e/acp_tool_cards_e2e.rs
+++ b/tests/e2e/acp_tool_cards_e2e.rs
@@ -11,12 +11,11 @@
 //! fake-ACP `tool_call` shape (toolCallId / kind / status / rawInput) is
 //! identical, so the TUI and the dashboard exercise the same wire data.
 //!
-//! Compiled only with the default `serve` feature (excluded by `--no-default-features`). Run via:
+//! Run via:
 //!
 //! ```sh
 //! cargo test --features e2e-tests --test e2e -- acp_tool_cards
 //! ```
-#![cfg(feature = "serve")]
 
 use std::time::{Duration, Instant};
 

--- a/tests/e2e/archive_structured.rs
+++ b/tests/e2e/archive_structured.rs
@@ -31,12 +31,11 @@
 //! without intrusive hooks; it stays covered by the handler's code comment and
 //! the `acp.rs:1304-1310` precedent.
 //!
-//! Compiled only with `--features serve`. Run via:
+//! Run via:
 //!
 //! ```sh
-//! cargo test --features serve,e2e-tests --test e2e -- archive_structured
+//! cargo test --features e2e-tests --test e2e -- archive_structured
 //! ```
-#![cfg(feature = "serve")]
 
 use std::process::Command;
 use std::time::{Duration, Instant};

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2273,7 +2273,6 @@ fn test_cli_session_show_json_reports_archived_and_precedence() {
 /// present but below-floor reads `[!! ]` with remediation instead of
 /// `[OK]`. Deleting the probe call from the listing loop fails here even
 /// though every unit-level decision test stays green.
-#[cfg(feature = "serve")]
 #[test]
 #[parallel]
 fn test_cli_acp_doctor_flags_below_floor_adapter() {
@@ -2303,7 +2302,6 @@ fn test_cli_acp_doctor_flags_below_floor_adapter() {
 
 /// Seed the pinned-bundle location `bundled_adapter_bin` resolves, with
 /// a fixture reporting `version`.
-#[cfg(feature = "serve")]
 fn seed_bundled_fixture(h: &TuiTestHarness, version: &str) {
     let bin = h.home_path().join(
         ".config/agent-of-empires-dev/acp-worker/adapters/claude-agent-acp/node_modules/.bin",
@@ -2323,7 +2321,6 @@ fn seed_bundled_fixture(h: &TuiTestHarness, version: &str) {
 /// because spawn switches to the bundle below-floor. This is the only
 /// end-to-end view of `bundled_copy_installed` +
 /// `bundled_copy_meets_floor`: unit tests inject that flag directly.
-#[cfg(feature = "serve")]
 #[test]
 #[parallel]
 fn test_cli_acp_doctor_compliant_bundle_silences_stale_path() {
@@ -2350,7 +2347,6 @@ fn test_cli_acp_doctor_compliant_bundle_silences_stale_path() {
 /// The mirror case: an installed but STALE pinned copy (below today's
 /// floor) must not silence the listing, since spawn picks it over the
 /// stale PATH copy and validate() rejects its handshake.
-#[cfg(feature = "serve")]
 #[test]
 #[parallel]
 fn test_cli_acp_doctor_stale_bundle_keeps_flagging() {
@@ -2378,7 +2374,6 @@ fn test_cli_acp_doctor_stale_bundle_keeps_flagging() {
 /// probe, so the pinned copy itself decides the verdict: compliant
 /// reads `[OK]`, stale reads `[!! ]` naming the bundled version. This
 /// is the stranded-pin cell after a floor bump.
-#[cfg(feature = "serve")]
 #[test]
 #[parallel]
 fn test_cli_acp_doctor_bundle_only_judged_by_pinned_copy() {

--- a/tests/e2e/fork_cli.rs
+++ b/tests/e2e/fork_cli.rs
@@ -502,9 +502,7 @@ fn fork_from_unlaunched_fork_is_refused() {
 /// the combination up front, BEFORE provisioning a scratch directory, so the
 /// refusal leaks nothing. Using `--scratch` here makes that leak observable:
 /// were the rejection still buried in the post-creation view block, a scratch
-/// dir would already exist by the time it fired. This flag only exists in
-/// `--features serve`.
-#[cfg(feature = "serve")]
+/// dir would already exist by the time it fired.
 #[test]
 #[parallel]
 fn fork_from_with_structured_view_is_refused() {

--- a/tests/e2e/fork_structured_e2e.rs
+++ b/tests/e2e/fork_structured_e2e.rs
@@ -24,13 +24,11 @@
 //!   3. the fork's one-shot `fork_pending` marker is cleared after the child id
 //!      lands.
 //!
-//! Compiled only with the default `serve` feature (the structured view and
-//! `aoe add --structured-view` do not exist otherwise). Run via:
+//! Run via:
 //!
 //! ```sh
 //! cargo test --test e2e -- fork_structured
 //! ```
-#![cfg(feature = "serve")]
 
 use std::path::PathBuf;
 use std::time::{Duration, Instant};

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -11,7 +11,6 @@
 //! convert it to a GIF via `agg`. Recordings are saved to
 //! `target/e2e-recordings/`. Both `asciinema` and `agg` must be on `$PATH`.
 
-#[cfg(feature = "serve")]
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -122,7 +121,6 @@ macro_rules! require_tmux {
 }
 pub(crate) use require_tmux;
 
-#[cfg(feature = "serve")]
 pub fn node_available() -> bool {
     Command::new("node")
         .arg("--version")
@@ -134,7 +132,6 @@ pub fn node_available() -> bool {
 /// Skip the calling test if Node.js is not installed. Acp e2e tests
 /// drive the shared `web/tests/helpers/fakeAcpAgent.mjs` fake agent, which
 /// is a Node script; without Node the worker can't speak ACP.
-#[cfg(feature = "serve")]
 macro_rules! require_node {
     () => {
         if !$crate::harness::node_available() {
@@ -143,7 +140,6 @@ macro_rules! require_node {
         }
     };
 }
-#[cfg(feature = "serve")]
 pub(crate) use require_node;
 
 // ---------------------------------------------------------------------------
@@ -161,7 +157,6 @@ pub(crate) use require_node;
 /// whichever daemon lost. Remembering what we have already issued closes the
 /// in-process half of the race; the ephemeral bind still covers ports taken by
 /// unrelated processes.
-#[cfg(feature = "serve")]
 pub fn pick_free_port() -> u16 {
     use std::collections::HashSet;
     use std::sync::{Mutex, OnceLock};
@@ -185,7 +180,6 @@ pub fn pick_free_port() -> u16 {
 /// `aoe serve --daemon` returns as soon as it has spawned the child, so a
 /// successful exit doesn't prove the child bound the port; this is the
 /// real signal that the daemon is up.
-#[cfg(feature = "serve")]
 pub fn wait_for_port(port: u16, timeout: Duration) -> bool {
     let start = Instant::now();
     while start.elapsed() < timeout {

--- a/tests/e2e/host_before_session_e2e.rs
+++ b/tests/e2e/host_before_session_e2e.rs
@@ -36,13 +36,11 @@
 //! `before_session` is trusted enough to set HOME or PATH, but never aoe's own
 //! auth token.
 //!
-//! Compiled only with the `serve` feature (structured view and
-//! `aoe add --structured-view` do not exist otherwise). Run via:
+//! Run via:
 //!
 //! ```sh
-//! cargo test --features serve,e2e-tests --test e2e -- host_before_session
+//! cargo test --features e2e-tests --test e2e -- host_before_session
 //! ```
-#![cfg(feature = "serve")]
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/tests/e2e/plugin_command_executor_e2e.rs
+++ b/tests/e2e/plugin_command_executor_e2e.rs
@@ -15,13 +15,11 @@
 //!   2. Pressing the action-less `refresh` chord POSTs the invoke endpoint and
 //!      the worker receives `plugin.command.invoke` (it writes the marker).
 //!
-//! Compiled only with the default `serve` feature (the structured view and the
-//! plugin host don't exist otherwise). Run via:
+//! Run via:
 //!
 //! ```sh
 //! cargo test --features e2e-tests --test e2e -- plugin_command_executor
 //! ```
-#![cfg(feature = "serve")]
 
 use std::time::{Duration, Instant};
 

--- a/tests/e2e/plugins.rs
+++ b/tests/e2e/plugins.rs
@@ -4,11 +4,11 @@
 //! start while the `aoe.web` plugin is disabled, and the command palette opens
 //! the plugin manager listing the builtins.
 //!
-//! Compiled only under `serve`: the sole bundled plugin is the serve-gated
+//! Compiled only under `web`: the sole bundled plugin is the `web`-gated
 //! `aoe.web`, so without that feature the builtin set is empty and there is
 //! nothing for these management-surface tests to exercise. The bare-core
 //! `--no-default-features` e2e leg skips this module by design.
-#![cfg(feature = "serve")]
+#![cfg(feature = "web")]
 
 use serial_test::parallel;
 

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -1,14 +1,11 @@
 //! E2E coverage for the serve dialog state machine.
 //!
 //! Targeted regression tests for the `R`-key ModePicker + Confirm flow
-//! introduced with the Tailscale Funnel transport picker. Compiled only
-//! with the default `serve` feature since the serve dialog doesn't exist
-//! under `--no-default-features`; run via:
+//! introduced with the Tailscale Funnel transport picker. Run via:
 //!
 //! ```sh
 //! cargo test --features e2e-tests --test e2e -- tui_serve_dialog
 //! ```
-#![cfg(feature = "serve")]
 
 use std::path::PathBuf;
 use std::time::{Duration, Instant};

--- a/tests/e2e/structured_tui_flows_e2e.rs
+++ b/tests/e2e/structured_tui_flows_e2e.rs
@@ -10,12 +10,11 @@
 //!
 //! Both stand up a real `aoe serve --daemon` and the shared Node
 //! fake-ACP agent so the daemon can actually spawn a worker for the
-//! structured session. Compiled only with the `serve` feature. Run:
+//! structured session. Run:
 //!
 //! ```sh
 //! cargo test --features e2e-tests --test e2e -- structured_tui_flows
 //! ```
-#![cfg(feature = "serve")]
 
 use std::time::Duration;
 

--- a/tests/integration/acp_midturn_resume.rs
+++ b/tests/integration/acp_midturn_resume.rs
@@ -14,7 +14,7 @@
 //! Skipped automatically if `node` is not on PATH.
 //!
 //! Note: the parent `main.rs` only compiles this module under
-//! `cfg(all(feature = "serve", debug_assertions))`. Debug-only because
+//! `cfg(debug_assertions)`. Debug-only because
 //! the watchdog grace is tunable via `AOE_RESUME_IDLE_GRACE_MS` only
 //! under `cfg(debug_assertions)` (see `resume_idle_grace()` in
 //! `src/acp/acp_client/connection.rs`); release builds would wait the full

--- a/tests/integration/acp_silent_orphan.rs
+++ b/tests/integration/acp_silent_orphan.rs
@@ -15,7 +15,7 @@
 //! Skipped automatically if `node` is missing.
 //!
 //! Note: the parent `main.rs` only compiles this module under
-//! `cfg(all(feature = "serve", debug_assertions))`. Debug-only because
+//! `cfg(debug_assertions)`. Debug-only because
 //! the watchdog grace is tunable via `AOE_SILENT_ORPHAN_GRACE_MS` /
 //! `AOE_SILENT_ORPHAN_FAST_GRACE_MS` only under `cfg(debug_assertions)`;
 //! release builds would wait the full 60s production default.

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -29,12 +29,6 @@ pub fn tmux_socket() -> PathBuf {
 }
 
 /// Path to the Node ACP test shim used by acp_* integration tests.
-///
-/// Gated on `feature = "serve"` because its only consumers are the
-/// structured view modules, which themselves only compile under that feature.
-/// Without the gate, `cargo clippy --all-targets` builds the integration
-/// suite WITHOUT serve and these helpers register as dead code.
-#[cfg(feature = "serve")]
 pub fn shim_path() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("acp-worker")
@@ -47,7 +41,6 @@ pub fn shim_path() -> std::path::PathBuf {
 /// that callers print before skipping. CI installs deps via `npm ci` in
 /// `acp-worker/test-shim/` before running the integration leg; local
 /// runs need the same one-shot setup, which the message points at.
-#[cfg(feature = "serve")]
 pub fn shim_ready() -> Result<(), String> {
     let node_ok = std::process::Command::new("node")
         .arg("--version")

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -26,27 +26,22 @@ mod session_id_acquisition;
 mod session_lifecycle;
 mod status_detection;
 mod storage_concurrency;
-#[cfg(feature = "serve")]
 mod terminal_smart_rename;
 mod tmux_reachability;
 mod tui_attach_detach;
 mod update_command;
 mod worktree_integration;
 
-#[cfg(feature = "serve")]
 mod acp_mcp;
 
-#[cfg(feature = "serve")]
 mod acp_smoke;
 
-#[cfg(feature = "serve")]
 mod acp_session_delete;
 
-#[cfg(feature = "serve")]
 mod acp_effort_respawn;
 
-#[cfg(all(feature = "serve", debug_assertions))]
+#[cfg(debug_assertions)]
 mod acp_midturn_resume;
 
-#[cfg(all(feature = "serve", debug_assertions))]
+#[cfg(debug_assertions)]
 mod acp_silent_orphan;

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -123,9 +123,8 @@ fn test_update_with_groups_and_instances_round_trip() -> Result<()> {
 /// other. Mirrors the structured view-handler / status-poll pattern: thread A
 /// mutates one field (`title`, simulating status poll), thread B mutates
 /// a different field (`notify_on_idle`, standing in for the structured view
-/// handler's `structured_view`; the latter is `#[cfg(feature = "serve")]`,
-/// `notify_on_idle` is always available and exhibits the same lost-update
-/// class). Both should land. Regression guard for review #5: a
+/// handler's `structured_view`). Both should land. Regression guard for
+/// review #5: a
 /// wholesale-replace closure (using a pre-lock snapshot) would lose one
 /// of the writes.
 #[test]

--- a/tests/integration/terminal_smart_rename.rs
+++ b/tests/integration/terminal_smart_rename.rs
@@ -3,8 +3,7 @@
 //! Exercises the detached `run_terminal_rename` runner against a real tmux pane
 //! and a fake `claude` one-shot shim: a still-civ-named session is renamed from
 //! its first turn (user story 1), and a manually-named session is never touched
-//! (user story 2). Runs under `serve` only because that is where the async test
-//! harness (`#[tokio::test]`) is wired; the code under test is not serve-gated.
+//! (user story 2).
 
 use std::io::Write as _;
 use std::os::unix::fs::PermissionsExt as _;

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -315,8 +315,8 @@ capabilities = ["net"]
     assert!(!plugin.needs_reapproval());
 
     // A builtin is always granted; re-approval is meaningless for it. Only
-    // checkable when a builtin is compiled in (`aoe.web` is serve-gated).
-    #[cfg(feature = "serve")]
+    // checkable when a builtin is compiled in, and `aoe.web` needs `web`.
+    #[cfg(feature = "web")]
     {
         let err = install::reapprove_consent("aoe.web")
             .unwrap_err()

--- a/tests/serve_cityhall_lockdown.rs
+++ b/tests/serve_cityhall_lockdown.rs
@@ -11,8 +11,6 @@
 //! DNS-rebinding gate and auth, so the only 403 source under test is the
 //! CityHall boundary (asserted via the body).
 
-#![cfg(feature = "serve")]
-
 use agent_of_empires::server::test_support::{
     build_router_for_test, build_test_app_state_cityhall,
 };

--- a/tests/serve_daemon_session_id_drain.rs
+++ b/tests/serve_daemon_session_id_drain.rs
@@ -1,7 +1,5 @@
 //! Integration coverage for the daemon-side session-id drain wiring.
 
-#![cfg(feature = "serve")]
-
 use std::path::Path;
 
 use agent_of_empires::server::test_support::{

--- a/tests/serve_disk_reload_helper_equivalence.rs
+++ b/tests/serve_disk_reload_helper_equivalence.rs
@@ -15,8 +15,6 @@
 //! exposed for this test (the merge invariants live below the HTTP API and
 //! cannot be observed end-to-end through `GET /api/sessions`).
 
-#![cfg(feature = "serve")]
-
 use agent_of_empires::server::test_support::build_test_app_state;
 use agent_of_empires::server::test_support::{
     reload_disk_only_for_test, reload_tmux_applied_for_test,

--- a/tests/serve_dns_rebinding_gate.rs
+++ b/tests/serve_dns_rebinding_gate.rs
@@ -8,8 +8,6 @@
 //! unauthenticated, non-loopback request). Mirrors the harness style of
 //! `serve_disk_reload_helper_equivalence.rs` via `build_test_app_state*`.
 
-#![cfg(feature = "serve")]
-
 use agent_of_empires::server::test_support::{
     build_router_for_test, build_test_app_state_with_policy,
 };

--- a/tests/serve_dynamic_profile_rewire.rs
+++ b/tests/serve_dynamic_profile_rewire.rs
@@ -13,8 +13,6 @@
 //!   trigger `add_profile_disk_watch` / `remove_profile_disk_watch` / `rename_profile_disk_watch` in production, so this layer guards
 //!   the daemon-boot path.
 
-#![cfg(feature = "serve")]
-
 mod common;
 mod home_isolation;
 
@@ -251,8 +249,7 @@ struct ServeDaemon {
 impl ServeDaemon {
     /// Spawn `aoe serve --no-auth --host 127.0.0.1 --port <free>` against
     /// a fresh `HOME`. Panics on startup failure so the test gives a
-    /// useful diagnostic. The whole file is `#![cfg(feature = "serve")]`,
-    /// so the binary always has the feature enabled at this point.
+    /// useful diagnostic.
     fn spawn() -> Self {
         let aoe = env!("CARGO_BIN_EXE_aoe");
         let home = tempfile::tempdir().expect("home tempdir");
@@ -275,10 +272,7 @@ impl ServeDaemon {
         if !wait_for_port(port, Duration::from_secs(15)) {
             let _ = child.kill();
             let _ = child.wait();
-            panic!(
-                "aoe serve did not bind 127.0.0.1:{} within 15s; likely missing serve feature",
-                port
-            );
+            panic!("aoe serve did not bind 127.0.0.1:{} within 15s", port);
         }
         Self {
             child: Some(child),

--- a/tests/serve_filewatch_propagation.rs
+++ b/tests/serve_filewatch_propagation.rs
@@ -12,8 +12,6 @@
 //! Storage::update -> notify_local_change -> dispatcher Local arm ->
 //! debounce-collapse with kernel echo -> subscriber receipt.
 
-#![cfg(feature = "serve")]
-
 mod home_isolation;
 
 use std::sync::Arc;

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -5,7 +5,7 @@
 ## Commands
 
 ```sh
-cargo build --features serve
+cargo build --features web
 cargo xtask dev
 cd web
 npm run format:check
@@ -13,8 +13,8 @@ npm run lint
 npx tsc -b
 ```
 
-`cargo xtask dev` runs the debug server on 8081 and Vite on 5173. A TUI-only
-build needs no JavaScript tooling. Use `npm run format` to fix oxfmt output;
+`cargo xtask dev` runs the debug server on 8081 and Vite on 5173. A build
+without `--features web` needs no JavaScript tooling. Use `npm run format` to fix oxfmt output;
 Prettier is not used.
 
 ## Tests

--- a/web/scripts/record-tui-demo.mjs
+++ b/web/scripts/record-tui-demo.mjs
@@ -12,7 +12,7 @@
 //   node web/scripts/record-tui-demo.mjs [--port 7683] [--out path.gif]
 //
 // Recipe (the script does not stand up the backend):
-//   1. Build:  cargo build --release --features serve   (or without --features serve)
+//   1. Build:  cargo build --release --features web   (or without --features web)
 //   2. Isolated profile with Claude creds + a git repo (see record-web-demo.mjs).
 //   3. Set live mode as the attach default for the profile's config.toml:
 //        [session]

--- a/web/scripts/record-web-demo.mjs
+++ b/web/scripts/record-web-demo.mjs
@@ -9,7 +9,7 @@
 //     --project /abs/path/to/repo [--port 8182] [--out path.gif]
 //
 // Recipe (the script does not stand up the backend):
-//   1. Build with the web dashboard:           cargo build --release --features serve
+//   1. Build with the web dashboard:           cargo build --release --features web
 //   2. Isolated profile with Claude creds:
 //        SB=/tmp/aoe-webdemo
 //        mkdir -p "$SB/home/.claude"

--- a/web/tests/helpers/liveGlobalSetup.ts
+++ b/web/tests/helpers/liveGlobalSetup.ts
@@ -8,10 +8,9 @@
 // - If `AOE_E2E_BINARY` is set and the file exists, do nothing.
 // - Else if `<repo>/target/release/aoe` exists, do nothing.
 // - Else run `cargo build --release --features web` from the repo root.
-//   `serve` is NOT a default feature (a plain build needs no Node/npm), and
-//   every live spec spawns `aoe serve`, so building without it yields a
-//   binary whose serve subcommand doesn't exist and every spec fails with
-//   "aoe serve died before ready (exit=2)".
+//   `web` is NOT a default feature (a plain build needs no Node/npm). A
+//   default build still runs `aoe serve`, but with no dashboard bundle
+//   embedded, so every live spec would load a 404 instead of the app.
 //
 // CI sets `AOE_E2E_BINARY` (see `.github/workflows/ci.yml`) so the build
 // happens in a dedicated job step where the output is visible. Local dev

--- a/web/tests/helpers/liveGlobalSetup.ts
+++ b/web/tests/helpers/liveGlobalSetup.ts
@@ -7,7 +7,7 @@
 // Behavior:
 // - If `AOE_E2E_BINARY` is set and the file exists, do nothing.
 // - Else if `<repo>/target/release/aoe` exists, do nothing.
-// - Else run `cargo build --release --features serve` from the repo root.
+// - Else run `cargo build --release --features web` from the repo root.
 //   `serve` is NOT a default feature (a plain build needs no Node/npm), and
 //   every live spec spawns `aoe serve`, so building without it yields a
 //   binary whose serve subcommand doesn't exist and every spec fails with
@@ -43,8 +43,8 @@ export default async function globalSetup(): Promise<void> {
     return;
   }
 
-  process.stdout.write(`[liveGlobalSetup] building aoe via 'cargo build --release --features serve'...\n`);
-  const result = spawnSync("cargo", ["build", "--release", "--features", "serve"], {
+  process.stdout.write(`[liveGlobalSetup] building aoe via 'cargo build --release --features web'...\n`);
+  const result = spawnSync("cargo", ["build", "--release", "--features", "web"], {
     cwd: repoRoot,
     stdio: "inherit",
   });

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-agent-of-empires = { path = "..", features = ["web"] }
+# Only `cli::Cli` is used, and that is feature-independent now that the
+# daemon is core. Staying on default features keeps `cargo xtask gen-docs`
+# free of the frontend build.
+agent-of-empires = { path = ".." }
 aoe-plugin-api = { path = "../aoe-plugin-api" }
 clap = { version = "4.6", features = ["derive"] }
 clap-markdown = "0.1"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-agent-of-empires = { path = "..", features = ["serve"] }
+agent-of-empires = { path = "..", features = ["web"] }
 aoe-plugin-api = { path = "../aoe-plugin-api" }
 clap = { version = "4.6", features = ["derive"] }
 clap-markdown = "0.1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -57,14 +57,14 @@ fn run_dev(_args: DevArgs) {
     std::process::exit(1);
 }
 
-/// Build the serve-enabled debug binary. Returns whether the build succeeded so
+/// Build the dashboard-enabled debug binary. Returns whether the build succeeded so
 /// the watch loop can keep the old backend running on a failed rebuild.
 #[cfg(unix)]
-fn build_serve() -> bool {
+fn build_web() -> bool {
     use std::process::Command;
-    eprintln!("[xtask dev] building aoe --features serve...");
+    eprintln!("[xtask dev] building aoe --features web...");
     Command::new("cargo")
-        .args(["build", "--features", "serve"])
+        .args(["build", "--features", "web"])
         .status()
         .map(|s| s.success())
         .unwrap_or_else(|e| {
@@ -141,7 +141,7 @@ fn is_watch_relevant(path: &Path) -> bool {
     )
 }
 
-/// Build the serve-enabled binary, then run it alongside the Vite dev server.
+/// Build the dashboard-enabled binary, then run it alongside the Vite dev server.
 /// Vite proxies `/api` and the AoE `/sessions/*` WebSocket relays to the
 /// backend via the `VITE_PROXY` env var it already honors. Each child runs in
 /// its own process group so a single Ctrl-C tears the whole tree down (npm
@@ -160,7 +160,7 @@ fn run_dev(args: DevArgs) {
 
     // Build up front so build output doesn't interleave with Vite's startup
     // and a broken build fails fast before either server comes up.
-    if !build_serve() {
+    if !build_web() {
         std::process::exit(1);
     }
 
@@ -339,7 +339,7 @@ fn run_dev(args: DevArgs) {
                 if Instant::now() >= at {
                     rebuild_at = None;
                     eprintln!("[xtask dev] change detected; rebuilding aoe...");
-                    if build_serve() {
+                    if build_web() {
                         if let Some(mut old) = serve.take() {
                             terminate_group(&mut old, Duration::from_secs(2));
                         }


### PR DESCRIPTION
## Description

Building from source without Node used to give you a terminal-only program. The background service that powers the phone and browser dashboard, the structured agent view, and the whole API were all left out of that build, which made it far less useful than it sounds and blocked planned work that needs the service to always be present. This change puts the background service in every build. The only optional piece now is the dashboard web page, which is the part that genuinely needs Node to compile. A plain build gives you a working service with no Node involved; one flag adds the dashboard on top. Build without the dashboard and the service still starts and answers requests, you just get a 404 if you point a browser at it.

Concretely: the daemon becomes unconditional and only the embedded bundle stays behind a cargo feature, renamed `serve` to `web`. About 700 `cfg(feature = "serve")` sites and their paired `not(serve)` fallback stubs are gone. `web` gates `src/server/assets.rs`, the `/assets/*` and SPA-fallback routes, `build_frontend()`, the `aoe.web` builtin, and a QR seam.

Three deviations from the issue, all forced by real call sites:

- **`aoe serve` is not hidden in a `web`-less build** (acceptance criterion 4). Per maintainer decision it starts a headless daemon instead, because hiding it would leave no way to start the daemon and would break the TUI structured view in exactly the build this refactor exists to enable. No new gating was needed: `web_disabled()` is already false when the `aoe.web` builtin is absent.
- **`mime_guess` stays core.** It backs the session file-read endpoint's Content-Type, not just embedded assets.
- **`webbrowser` stays core.** It backs the plugin host's `ui.open_url` and structured-view link activation.

A `web`-less build now says so where it used to imply a dashboard: the Remote Access
screen is titled `Remote API Access`, the space the QR occupied explains that the URL
serves the API only, and the home badge reads `Serving API`.

`serve` remains a deprecated alias for `web` for one release. `build.rs` warns when it is set, and a CI guard rejects any new `cfg(feature = "serve")` so the alias cannot silently diverge from `web`.

CI keeps a Node-free leg and a `web` leg: the rest leg drops to default features as `core-rest`, and a new bare-core step builds with `node`, `npm` and `npx` shadowed by failing stubs, which is what actually enforces the Node-free build.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Remote Access screen in a build with no dashboard bundle (72x26):

```
 Remote API Access (local)  open 42s
────────────────────────────────────────────────────────────────────────

  No dashboard bundle in this build: the URL serves the REST API only,
                        and a browser gets a 404.

                                 via lan
              URL: http://192.168.1.42:8080/?t=abc123def456
────────────────────────────────────────────────────────────────────────
                R: restart  S: stop  ?: help  Esc: close
```

Verified: `cargo build` (no npm invoked), `--no-default-features`, `--features web`, `--features serve` (warns), `cargo fmt`, `cargo clippy --all-features -- -D warnings`, all three `--all-targets` compile gates, `cargo xtask gen-docs` (no drift), and the Nix embedded-assets check. At default features: 6572 lib tests, 174 integration tests, and all six `tests/serve_*.rs` binaries pass. One of the six, `serve_dynamic_profile_rewire`, spawns a real `aoe serve` subprocess with no bundle embedded; the other five drive `build_router` in process.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior under test is which routes the daemon registers, which a router-level integration test pins precisely and far more cheaply than a full-binary test. `tests/daemon_core_web_optional.rs` drives the real `build_router` stack and asserts `/api/*` resolves in both feature corners while `/`, `/assets/*` and `/sw.js` 404 without `web` and the SPA fallback serves with it. The CLI side is covered by existing coverage that now runs in a new configuration: `tests/serve_dynamic_profile_rewire.rs` spawns a real `aoe serve` daemon at default features, so a headless daemon is booted end to end on every run. The other five `tests/serve_*.rs` binaries drive `build_router` in process rather than a subprocess.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**

The gate removal was applied by script and then reviewed by hand. Two defects that pass found this way are worth flagging for reviewers, since both are the kind a mechanical pass produces: a gate in `tests/plugin_install.rs` guarded an assertion about the `aoe.web` builtin and needed converting to `web` rather than deleting, and the first draft of the new test asserted `!= 404` on a path that was answering 403, so it proved nothing until the host allowlist was seeded.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3619

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- The daemon is now included in every build.
- The optional `web` feature now controls the dashboard bundle, dashboard routes, frontend build, `aoe.web`, and QR rendering.
- A default `cargo build` needs no Node.js and still provides the REST/WS API, authentication, push, ACP, structured views, and headless `aoe serve`.
- Dashboard paths return 404 when `web` is disabled.
- The deprecated `serve` feature remains as an alias for `web` for one release and emits a warning.
- The PR removes old `serve` gates across daemon, CLI, session, plugin, TUI, and test code.
- CI now checks both Node-free core builds and web-enabled builds.
- Documentation, release workflows, scripts, Nix configuration, and CLI help now use the `web` feature and describe API-only builds accurately.

Benefits:
- The daemon is available without dashboard build tooling.
- Core functionality no longer depends on an unrelated feature flag.
- Web-enabled builds retain the full dashboard experience.
- The feature split is clearer and easier to maintain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->