### PR TITLE
fix(tests): isolate opencode data paths in the live harness

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   // under tests/capture/ also spawns a real `aoe serve` and runs via
   // playwright.capture.config.ts; keep it out of the mocked suite.
   testIgnore: ["**/live/**", "**/capture/**"],
+  // Playwright specs are `.spec.ts` here; `.test.ts` is vitest (the harness
+  // helpers have their own cases). Without this, Playwright's default glob
+  // collects those too and the run dies importing vitest.
+  testMatch: "**/*.spec.ts",
   timeout: 30000,
   retries: process.env.CI ? 1 : 0,
   // Mocked specs share one `vite preview` server and otherwise touch no

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -1,7 +1,7 @@
 // Live-backend test harness for Playwright.
 //
 // `spawnAoeServe()` boots a real `aoe serve` subprocess against an isolated
-// filesystem root (`HOME`, `XDG_CONFIG_HOME`, `TMPDIR`, `TMUX_TMPDIR`) and a
+// filesystem root (`HOME`, the XDG bases, `TMPDIR`, `TMUX_TMPDIR`) and a
 // per-worker port range, returns a `ServeHandle`, and cleans up after the
 // test via `stop()`. Designed for fresh-process-per-test isolation: each
 // test gets its own root, its own port, its own tmux socket.
@@ -18,6 +18,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import { expect } from "@playwright/test";
+import { isolateEnv } from "./isolatedEnv";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -100,7 +101,7 @@ export interface ServeHandle {
   /** Directory prepended to PATH (contains the fake `claude` shim). */
   shimBin: string;
   /**
-   * The exact env (isolated HOME / XDG_CONFIG_HOME / TMPDIR / PATH with the
+   * The exact env (isolated HOME / XDG bases / TMPDIR / PATH with the
    * shim) the daemon and seed ran with. Specs that drive `aoe` CLI
    * subprocesses against the same isolated state (e.g. `aoe session rename`
    * from a peer process) MUST pass this as `spawnSync(..., { env })`. Passing
@@ -592,10 +593,11 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
   const shortBase = process.platform === "win32" ? tmpdir() : "/tmp";
   const home = realpathSync(mkdtempSync(join(shortBase, `aoe-pw-w${opts.workerIndex}-p${opts.parallelIndex}-`)));
   const xdg = join(home, "config");
+  const xdgData = join(home, "share");
   const tmp = join(home, "tmp");
   const tmuxTmp = join(home, "tmux");
   const shimBin = join(home, "bin");
-  for (const dir of [xdg, tmp, tmuxTmp, shimBin]) {
+  for (const dir of [xdg, xdgData, tmp, tmuxTmp, shimBin]) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
   const fakeAcpDebugLog = join(home, "fake-acp.log");
@@ -608,11 +610,9 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
   const authMode: AuthMode = opts.authMode ?? "none";
 
   const seedEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    HOME: home,
-    XDG_CONFIG_HOME: xdg,
-    TMPDIR: tmp,
-    TMUX_TMPDIR: tmuxTmp,
+    // The isolated HOME is only isolated if nothing overrides where the agents
+    // read their config and data from. See `isolatedEnv.ts`.
+    ...isolateEnv(process.env, { home, xdgConfig: xdg, xdgData, tmp, tmuxTmp }),
     PATH: `${shimBin}:${process.env.PATH ?? ""}`,
     // Lift the runner-socket appearance deadline. The `aoe
     // __acp-runner` shim re-execs the debug `aoe` binary, which
@@ -655,17 +655,6 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     // TMUX_TMPDIR.
     AOE_TMUX_SOCKET: tmuxSocketPath(home),
   };
-
-  // The isolated HOME is only isolated if nothing overrides where the agents
-  // read their config from. A developer shell that exports CLAUDE_CONFIG_DIR
-  // (or the Codex / Cursor equivalents) leaks it into `aoe serve` through the
-  // `...process.env` spread above, and the daemon then scans the developer's
-  // real `~/.claude` instead of the tree the spec seeded: acp-import-claude-
-  // session and acp-keep-context-round-trip fail deterministically, locally
-  // only, which reads as "the suite is broken on my machine".
-  for (const leak of ["CLAUDE_CONFIG_DIR", "CODEX_HOME", "CURSOR_CONFIG_DIR"]) {
-    delete seedEnv[leak];
-  }
 
   if (authMode === "token") {
     if (typeof opts.tokenLifetimeSecs === "number") {
@@ -856,11 +845,7 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
           // aoe binds its own `-S <socket>` (#2608), not the default socket
           // under TMUX_TMPDIR, so kill the server on that explicit socket.
           spawnSync("tmux", ["-S", tmuxSocketPath(home), "kill-server"], {
-            env: {
-              ...process.env,
-              HOME: home,
-              TMUX_TMPDIR: join(home, "tmux"),
-            },
+            env: seedEnv,
             stdio: "ignore",
           });
         } catch {

--- a/web/tests/helpers/gitFixture.ts
+++ b/web/tests/helpers/gitFixture.ts
@@ -15,6 +15,11 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 const GIT_ENV = {
+  // Fixtures run under the developer's `~/.gitconfig` otherwise, so a global
+  // `commit.gpgsign` or `core.hooksPath` decides whether a live spec passes.
+  // Identity and the initial branch are pinned below and by `init -b`.
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
   GIT_AUTHOR_NAME: "t",
   GIT_AUTHOR_EMAIL: "t@t",
   GIT_COMMITTER_NAME: "t",

--- a/web/tests/helpers/isolatedEnv.test.ts
+++ b/web/tests/helpers/isolatedEnv.test.ts
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { INHERITED_PATH_VARS, isolateEnv, type IsolatedPaths } from "./isolatedEnv";
+
+const HOME = "/tmp/aoe-pw-w0-p0-test";
+const HOST = "/host/dev";
+const PATHS: IsolatedPaths = {
+  home: HOME,
+  xdgConfig: join(HOME, "config"),
+  xdgData: join(HOME, "share"),
+  tmp: join(HOME, "tmp"),
+  tmuxTmp: join(HOME, "tmux"),
+};
+
+describe("isolateEnv", () => {
+  // #3622: XDG_DATA_HOME and OPENCODE_DB reached the daemon, which reads both
+  // to find opencode's session database.
+  it("leaves no inherited path pointing outside the test home", () => {
+    const env = isolateEnv(
+      {
+        HOME: HOST,
+        XDG_CONFIG_HOME: `${HOST}/.config`,
+        XDG_DATA_HOME: `${HOST}/.local/share`,
+        OPENCODE_DB: `${HOST}/.local/share/opencode/opencode.db`,
+        CLAUDE_CONFIG_DIR: `${HOST}/.claude`,
+        AOE_DAEMON_URL: "http://a-real-daemon.internal:8080",
+        TMPDIR: `${HOST}/tmp`,
+        LANG: "en_US.UTF-8",
+      },
+      PATHS,
+    );
+
+    for (const [name, value] of Object.entries(env)) {
+      expect(`${name}=${value}`).not.toContain(HOST);
+    }
+    expect(env.XDG_DATA_HOME).toBe(PATHS.xdgData);
+    // Not a path, but it would point the harness's own `aoe` calls at it.
+    expect(env.AOE_DAEMON_URL).toBeUndefined();
+    expect(env.LANG).toBe("en_US.UTF-8");
+  });
+
+  // The daemon resolves agent paths from its own env, so every new agent adds
+  // a way for a live spec to reach host state. Drive the assertion off `src/`
+  // rather than off a list here, which would fall behind it.
+  it("drops every path variable src/ reads, whatever the name", () => {
+    const names = daemonPathVars();
+    expect(names).toEqual(expect.arrayContaining(["CLAUDE_CONFIG_DIR", "OPENCODE_DB", "VIBE_HOME", "XDG_DATA_HOME"]));
+
+    const hostile: NodeJS.ProcessEnv = {};
+    for (const name of names) hostile[name] = `${HOST}/${name.toLowerCase()}`;
+    const env = isolateEnv(hostile, PATHS);
+
+    const survived = Object.entries(env)
+      .filter(([, value]) => value?.startsWith(HOST))
+      .map(([name]) => name);
+    expect(survived.sort()).toEqual(names.filter((name) => INHERITED_PATH_VARS.has(name)).sort());
+  });
+});
+
+/** Every variable naming a path that `src/` mentions, e.g. `KIMI_CODE_HOME`. */
+function daemonPathVars(): string[] {
+  const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "src");
+  const names = new Set<string>();
+  for (const file of rustFiles(srcDir)) {
+    for (const [, name] of readFileSync(file, "utf8").matchAll(
+      /"([A-Z][A-Z0-9_]*_(?:HOME|DIR|DB|PATH|CREDENTIALS))"/g,
+    )) {
+      if (name) names.add(name);
+    }
+  }
+  return [...names].sort();
+}
+
+function rustFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return rustFiles(path);
+    return entry.name.endsWith(".rs") ? [path] : [];
+  });
+}

--- a/web/tests/helpers/isolatedEnv.ts
+++ b/web/tests/helpers/isolatedEnv.ts
@@ -1,0 +1,74 @@
+// Environment isolation for the live harness.
+//
+// `spawnAoeServe` starts from `process.env` so the daemon inherits PATH,
+// locale, and proxy settings. Anything inherited that names a config, data,
+// or credential location escapes the temporary HOME, because the daemon
+// resolves agent state from its own environment (`resolve_agent_home` in
+// `src/session/capture.rs`, the opencode readers, the XDG bases). A developer
+// or CI shell exporting one of them points a live spec at real agent state.
+//
+// Listing those names does not hold: `src/` reads more than a dozen and gains
+// one per agent integration, and a missed name leaks silently. So anything
+// shaped like a path override is dropped, and the few the child genuinely
+// needs are named instead. Dropping one of those breaks the run loudly, which
+// is the safe direction to fail in.
+
+/** Directories the harness owns, all inside the temporary test HOME. */
+export interface IsolatedPaths {
+  home: string;
+  xdgConfig: string;
+  xdgData: string;
+  tmp: string;
+  tmuxTmp: string;
+}
+
+/** Shape of a variable naming a path: `CODEX_HOME`, `OPENCODE_DB`, `PI_CONFIG_DIR`. */
+const PATH_VAR = /^[A-Z][A-Z0-9_]*_(HOME|DIR|DB|PATH|CREDENTIALS)$/;
+
+/**
+ * Not path shaped, but `discovery::discover()` prefers them over the local
+ * daemon, so every `aoe` call the harness makes with this env, teardown's
+ * `acp stop --all` included, would hit the developer's own daemon and kill
+ * its workers.
+ */
+const DAEMON_TARGET_VARS = new Set(["AOE_DAEMON_TOKEN", "AOE_DAEMON_URL"]);
+
+/**
+ * Path variables the child keeps: toolchain and system locations, never agent
+ * state. `XDG_RUNTIME_DIR` is the one XDG base not redirected, because it
+ * names the host's session sockets rather than a data tree.
+ */
+export const INHERITED_PATH_VARS = new Set([
+  "CARGO_HOME",
+  "DYLD_FALLBACK_LIBRARY_PATH",
+  "DYLD_LIBRARY_PATH",
+  "GIT_EXEC_PATH",
+  "LD_LIBRARY_PATH",
+  "RUSTUP_HOME",
+  "SSL_CERT_DIR",
+  "XDG_RUNTIME_DIR",
+]);
+
+/**
+ * Copy of `parentEnv` with every agent path pointed inside the test HOME.
+ *
+ * The bases the harness owns are redirected; the rest are dropped, which
+ * leaves the daemon on its `$HOME`-relative fallback (`XDG_STATE_HOME` ->
+ * `$HOME/.local/state`, and so on), already inside the test home.
+ */
+export function isolateEnv(parentEnv: NodeJS.ProcessEnv, paths: IsolatedPaths): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(parentEnv)) {
+    if (DAEMON_TARGET_VARS.has(name)) continue;
+    if (PATH_VAR.test(name) && !INHERITED_PATH_VARS.has(name)) continue;
+    env[name] = value;
+  }
+  return {
+    ...env,
+    HOME: paths.home,
+    XDG_CONFIG_HOME: paths.xdgConfig,
+    XDG_DATA_HOME: paths.xdgData,
+    TMPDIR: paths.tmp,
+    TMUX_TMPDIR: paths.tmuxTmp,
+  };
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -84,14 +84,15 @@ export default defineConfig(({ mode, command }) => {
       // there. `scripts/merge-coverage.mjs` reads either layout.
       sourcemap: collectCoverage ? (env.AOE_COVERAGE_INLINE_SOURCEMAP === "1" ? "inline" : true) : false,
     },
-    // Vitest unit tests live alongside source as `*.test.ts(x)`. Playwright
-    // suites under `tests/` use the same `.spec.ts` extension Playwright
-    // expects but aren't valid vitest tests, so we explicitly exclude them.
+    // Vitest unit tests live alongside source as `*.test.ts(x)`, plus the
+    // node-only live-harness helpers under `tests/helpers/`. Playwright suites
+    // under `tests/` use the `.spec.ts` extension Playwright expects but
+    // aren't valid vitest tests, so we explicitly exclude them.
     test: {
-      include: ["src/**/*.{test,spec}.{ts,tsx}"],
+      include: ["src/**/*.{test,spec}.{ts,tsx}", "tests/helpers/**/*.test.ts"],
       // Type-level tests (`*.types.test.ts`) run under the typecheck runner
       // below, not the runtime runner, so keep them out of `include`.
-      exclude: ["tests/**", "node_modules/**", "dist/**", "src/**/*.types.test.ts"],
+      exclude: ["tests/**/*.spec.{ts,tsx}", "node_modules/**", "dist/**", "src/**/*.types.test.ts"],
       // `expectTypeOf` assertions in `*.types.test.ts` are checked by tsc.
       // A failing assertion surfaces as a type error. Scoped to the
       // dedicated type-test files so the rest of the suite stays fast.


### PR DESCRIPTION
## Description

Live tests boot a real server against a throwaway home directory so they never touch the developer's own data. That isolation had a hole. The harness copied the whole shell environment into the server, including the two variables that say where OpenCode keeps its session database. On a machine where either one is set, a live test read the developer's real OpenCode database instead of the empty one in its temporary home, so the suite behaved differently depending on whose machine it ran on. The harness now builds the child environment in one place, points those directories inside the temporary home, and drops the overrides it cannot redirect.

Details:

- `web/tests/helpers/isolatedEnv.ts` is the single owner of the spawned env. It redirects the bases the harness owns (`HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `TMPDIR`, `TMUX_TMPDIR`) and drops every other inherited variable shaped like a path override. Enumerating names does not hold: `src/` resolves more than a dozen agent paths from its own env through `resolve_agent_home` (`VIBE_HOME`, `GEMINI_CLI_HOME`, `COPILOT_CONFIG_DIR`, `KIMI_CODE_HOME`, `HERMES_HOME`, the `PI_*` and `PRIME_AGENT_*` set) and gains one per integration. The handful of toolchain paths the child still needs are named explicitly, so a miss there breaks the run loudly instead of leaking silently.
- `isolatedEnv.test.ts` drives its assertion off the names in `src/` rather than a list of its own: it poisons every one of them and fails if any survives. Under the earlier enumerate-the-names approach this test reports 25 leaking variables.
- `AOE_DAEMON_URL` and `AOE_DAEMON_TOKEN` are dropped too. They are not path shaped, but `discovery::discover()` prefers them over the local daemon, so teardown's `aoe acp stop --all` ran against the developer's own daemon and killed its ACP workers.
- `playwright.config.ts` pins `testMatch` to `*.spec.ts`. Playwright's default glob also matches `*.test.ts`, so the mocked suite tried to run the new vitest file.
- `gitFixture.ts` pins `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` off. Fixtures ran under the developer's `~/.gitconfig`, where `commit.gpgsign` or `core.hooksPath` could decide whether a live spec passes.
- Vitest now collects `tests/helpers/**/*.test.ts`.

Fixes #3622

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No user-visible surface changes, so no screenshot applies. Verified: oxfmt, eslint, `tsc -b`, full Vitest (354 files, 3715 tests), mocked Playwright collection, `cargo fmt`, `cargo clippy --all-targets --features serve`, `cargo test`, plus `golden-path.spec.ts` and `right-panel-files.spec.ts` run live with `XDG_DATA_HOME`, `OPENCODE_DB`, `VIBE_HOME` and `GEMINI_CLI_HOME` poisoned in the parent shell.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The regression is a Vitest case on the harness helper, which is the cheapest tier that catches it.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:**

Issue claims were reproduced against the cited lines before any code was written, and the new test was confirmed to fail without the fix.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR was authored by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V7Zi9aw6qAmZMRY5B5pL4
