### PR TITLE
fix(status): restore Vibe's vertical activity text and braille-only spinner

### DIFF
--- a/src/tmux/detect/manifests/vibe.toml
+++ b/src/tmux/detect/manifests/vibe.toml
@@ -42,14 +42,14 @@ id = "spinner"
 priority = 960
 
 # Loose on purpose: these words are matched anywhere in the window, which is
-# the behaviour this detector has always had. Textual renders a status word one
-# character per line in a narrow pane, so the window is concatenated to read it
-# back as a word.
+# the behaviour this detector has always had. A pane too narrow for the status
+# word makes Textual stack it one character per row, so the window is unstacked
+# first to read it back as a word.
 [[rules]]
 id = "activity_word"
 state = "running"
 priority = 955
-region = "concatenated_recent"
+region = "unstacked_recent"
 contains_any = [
   "running",
   "reading",

--- a/src/tmux/detect/manifests/vibe.toml
+++ b/src/tmux/detect/manifests/vibe.toml
@@ -34,21 +34,22 @@ region = "whole_recent"
 visible = true
 line_regex = ['(?i)^\s*\x{203A}\s*\S']
 
+# Braille only: Vibe's Textual spinner draws no other frame, and a middle dot
+# or bullet is ordinary separator punctuation in its parked output.
 [[rules]]
+extends = "spinner"
 id = "spinner"
-state = "running"
 priority = 960
-region = "whole_recent"
-visible = true
-line_regex = ['[\x{00B7}\x{2722}\x{2733}\x{2736}\x{273B}\x{273D}\x{25CF}\x{2800}-\x{28FF}]']
 
 # Loose on purpose: these words are matched anywhere in the window, which is
-# the behaviour this detector has always had.
+# the behaviour this detector has always had. Textual renders a status word one
+# character per line in a narrow pane, so the window is concatenated to read it
+# back as a word.
 [[rules]]
 id = "activity_word"
 state = "running"
 priority = 955
-region = "whole_recent"
+region = "concatenated_recent"
 contains_any = [
   "running",
   "reading",

--- a/src/tmux/detect/region.rs
+++ b/src/tmux/detect/region.rs
@@ -19,6 +19,7 @@ pub(super) struct Screen<'a> {
     osc_title: &'a str,
     joined: OnceLock<String>,
     collapsed: OnceLock<String>,
+    concatenated: OnceLock<String>,
     above_input_box: OnceLock<Option<String>>,
     prompt_box_body: OnceLock<Option<String>>,
     after_last_rule: OnceLock<String>,
@@ -124,6 +125,9 @@ pub(super) enum Region {
     /// Recent lines with runs of ASCII whitespace collapsed to one space, so a
     /// footer hint that word-wrapped mid-phrase still reads as one string.
     CollapsedRecent,
+    /// Recent lines trimmed and concatenated with no separator, so a word a
+    /// Textual TUI renders one character per line reads as one word.
+    ConcatenatedRecent,
     /// The last `n` non-empty lines.
     BottomLines(usize),
     /// The transcript line the input box's status slot sits on: the live
@@ -191,6 +195,7 @@ impl Region {
         Some(match raw {
             "whole_recent" => Region::WholeRecent,
             "collapsed_recent" => Region::CollapsedRecent,
+            "concatenated_recent" => Region::ConcatenatedRecent,
             "last_non_empty_above_prompt_box" => Region::AboveInputBox,
             "prompt_box_body" => Region::PromptBoxBody,
             "after_last_horizontal_rule" => Region::AfterLastRule,
@@ -214,6 +219,7 @@ impl<'a> Screen<'a> {
             osc_title,
             joined: OnceLock::new(),
             collapsed: OnceLock::new(),
+            concatenated: OnceLock::new(),
             above_input_box: OnceLock::new(),
             prompt_box_body: OnceLock::new(),
             after_last_rule: OnceLock::new(),
@@ -236,6 +242,9 @@ impl<'a> Screen<'a> {
             Region::CollapsedRecent => self
                 .collapsed
                 .get_or_init(|| collapse_ascii_whitespace(self.joined())),
+            Region::ConcatenatedRecent => self
+                .concatenated
+                .get_or_init(|| self.recent.iter().map(|l| l.trim()).collect()),
             Region::BottomLines(n) => {
                 // Bottom-n is a suffix of the joined recent window, so it is
                 // sliced from it rather than joined again per rule.

--- a/src/tmux/detect/region.rs
+++ b/src/tmux/detect/region.rs
@@ -11,11 +11,11 @@ use std::sync::OnceLock;
 /// against it. Regions are computed lazily: a capture whose first rule
 /// matches never pays for the rest.
 pub(super) struct Screen<'a> {
-    /// Non-empty lines, most recent [`RECENT_LINES`] of them. Claude parks the
-    /// cursor below its output and small responses sit in a tall pane, so the
-    /// blank tail carries nothing and filtering it keeps window sizes
-    /// meaningful.
-    recent: Vec<&'a str>,
+    /// Every non-empty line. Claude parks the cursor below its output and small
+    /// responses sit in a tall pane, so the blank tail carries nothing and
+    /// filtering it keeps window sizes meaningful. Each region slices its own
+    /// window off the end of this.
+    non_empty: Vec<&'a str>,
     osc_title: &'a str,
     joined: OnceLock<String>,
     collapsed: OnceLock<String>,
@@ -31,6 +31,12 @@ pub(super) struct Screen<'a> {
 /// fit well inside this, and a shorter window would drop the completion line
 /// on a pane whose box carries several rows of chrome.
 const RECENT_LINES: usize = 30;
+
+/// How far back [`Region::ConcatenatedRecent`] reaches. A Textual pane narrow
+/// enough to stack a status word one character per line spends a whole line on
+/// each character, so [`RECENT_LINES`] is not deep enough to hold one word plus
+/// the chrome under it.
+const CONCATENATED_LINES: usize = 50;
 
 /// A landmark line a manifest names so its rules can be scoped relative to it:
 /// the divider a finished turn draws, the rule pair around an input box, an
@@ -209,13 +215,11 @@ impl Region {
 
 impl<'a> Screen<'a> {
     pub(super) fn new(clean_screen: &'a str, osc_title: &'a str) -> Self {
-        let non_empty: Vec<&str> = clean_screen
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .collect();
-        let start = non_empty.len().saturating_sub(RECENT_LINES);
         Self {
-            recent: non_empty[start..].to_vec(),
+            non_empty: clean_screen
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .collect(),
             osc_title,
             joined: OnceLock::new(),
             collapsed: OnceLock::new(),
@@ -242,17 +246,20 @@ impl<'a> Screen<'a> {
             Region::CollapsedRecent => self
                 .collapsed
                 .get_or_init(|| collapse_ascii_whitespace(self.joined())),
-            Region::ConcatenatedRecent => self
-                .concatenated
-                .get_or_init(|| self.recent.iter().map(|l| l.trim()).collect()),
+            Region::ConcatenatedRecent => self.concatenated.get_or_init(|| {
+                self.window(CONCATENATED_LINES)
+                    .iter()
+                    .map(|l| l.trim())
+                    .collect()
+            }),
             Region::BottomLines(n) => {
                 // Bottom-n is a suffix of the joined recent window, so it is
                 // sliced from it rather than joined again per rule.
-                let start = self.recent.len().saturating_sub(n);
+                let start = self.recent().len().saturating_sub(n);
                 if start == 0 {
                     return std::borrow::Cow::Borrowed(self.joined());
                 }
-                let skipped: usize = self.recent[..start].iter().map(|l| l.len() + 1).sum();
+                let skipped: usize = self.recent()[..start].iter().map(|l| l.len() + 1).sum();
                 &self.joined()[skipped..]
             }
             Region::AboveInputBox => self
@@ -272,14 +279,14 @@ impl<'a> Screen<'a> {
             Region::FromPromptMarker => {
                 self.from_marker
                     .get_or_init(|| match self.marker_index(prompt_marker) {
-                        Some(idx) => self.recent[idx..].join("\n"),
+                        Some(idx) => self.recent()[idx..].join("\n"),
                         None => self.joined().to_string(),
                     })
             }
             Region::BeforePromptMarker => {
                 self.before_marker
                     .get_or_init(|| match self.marker_index(prompt_marker) {
-                        Some(idx) => self.recent[..idx].join("\n"),
+                        Some(idx) => self.recent()[..idx].join("\n"),
                         None => self.joined().to_string(),
                     })
             }
@@ -288,15 +295,15 @@ impl<'a> Screen<'a> {
             // capture they run against is discarded at the end of the poll.
             Region::AfterMarker(name, limit) => {
                 return std::borrow::Cow::Owned(match markers.get(name) {
-                    Some(marker) => match marker.resolve(&self.recent) {
+                    Some(marker) => match marker.resolve(self.recent()) {
                         Some(idx) => {
-                            let after = &self.recent[idx + 1..];
+                            let after = &self.recent()[idx + 1..];
                             let start = limit.map_or(0, |n| after.len().saturating_sub(n));
                             after[start..].join("\n")
                         }
                         None if marker.absent_is_whole => {
-                            let start = limit.map_or(0, |n| self.recent.len().saturating_sub(n));
-                            self.recent[start..].join("\n")
+                            let start = limit.map_or(0, |n| self.recent().len().saturating_sub(n));
+                            self.recent()[start..].join("\n")
                         }
                         None => String::new(),
                     },
@@ -306,11 +313,11 @@ impl<'a> Screen<'a> {
             Region::AboveMarker(name, n) => {
                 let marker = markers.get(name);
                 return std::borrow::Cow::Owned(
-                    match marker.and_then(|m| m.resolve(&self.recent)) {
-                        Some(idx) => self.recent[idx.saturating_sub(n)..idx].join("\n"),
+                    match marker.and_then(|m| m.resolve(self.recent())) {
+                        Some(idx) => self.recent()[idx.saturating_sub(n)..idx].join("\n"),
                         None => {
                             let window = marker.and_then(|m| m.max_depth).unwrap_or(n);
-                            self.recent[self.recent.len().saturating_sub(window)..].join("\n")
+                            self.recent()[self.recent().len().saturating_sub(window)..].join("\n")
                         }
                     },
                 );
@@ -318,24 +325,34 @@ impl<'a> Screen<'a> {
         })
     }
 
+    /// The last `n` non-empty lines.
+    fn window(&self, n: usize) -> &[&'a str] {
+        &self.non_empty[self.non_empty.len().saturating_sub(n)..]
+    }
+
+    /// The window every line-oriented region reads.
+    fn recent(&self) -> &[&'a str] {
+        self.window(RECENT_LINES)
+    }
+
     /// The last line matching any of the manifest's prompt-marker patterns.
     fn marker_index(&self, prompt_marker: &[regex::Regex]) -> Option<usize> {
-        self.recent
+        self.recent()
             .iter()
             .rposition(|line| prompt_marker.iter().any(|re| re.is_match(line)))
     }
 
     fn joined(&self) -> &str {
-        self.joined.get_or_init(|| self.recent.join("\n"))
+        self.joined.get_or_init(|| self.recent().join("\n"))
     }
 
     fn compute_above_input_box(&self) -> Option<String> {
         let box_top = self
-            .recent
+            .recent()
             .iter()
             .rposition(|l| l.trim_start().starts_with('❯'))
-            .unwrap_or(self.recent.len());
-        self.recent[..box_top]
+            .unwrap_or(self.recent().len());
+        self.recent()[..box_top]
             .iter()
             .rev()
             .find(|l| !line_is_input_box_chrome(l))
@@ -343,19 +360,19 @@ impl<'a> Screen<'a> {
     }
 
     fn compute_prompt_box_body(&self) -> Option<String> {
-        self.recent
+        self.recent()
             .iter()
             .rposition(|l| l.trim_start().starts_with('❯'))
-            .map(|idx| self.recent[idx].to_string())
+            .map(|idx| self.recent()[idx].to_string())
     }
 
     fn compute_after_last_rule(&self) -> String {
         match self
-            .recent
+            .recent()
             .iter()
             .rposition(|l| line_is_horizontal_rule(l.trim()))
         {
-            Some(idx) => self.recent[idx + 1..].join("\n"),
+            Some(idx) => self.recent()[idx + 1..].join("\n"),
             None => self.joined().to_string(),
         }
     }

--- a/src/tmux/detect/region.rs
+++ b/src/tmux/detect/region.rs
@@ -16,6 +16,10 @@ pub(super) struct Screen<'a> {
     /// blank tail carries nothing and filtering it keeps window sizes
     /// meaningful.
     recent: Vec<&'a str>,
+    /// Whether a blank row sat above each [`Self::recent`] line. Blank rows are
+    /// dropped from the window, so this is the only thing left that says two
+    /// stacked characters came from different blocks rather than one word.
+    blank_before: Vec<bool>,
     osc_title: &'a str,
     joined: OnceLock<String>,
     collapsed: OnceLock<String>,
@@ -211,13 +215,21 @@ impl Region {
 
 impl<'a> Screen<'a> {
     pub(super) fn new(clean_screen: &'a str, osc_title: &'a str) -> Self {
-        let non_empty: Vec<&str> = clean_screen
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .collect();
+        let mut non_empty: Vec<&str> = Vec::new();
+        let mut blank_before: Vec<bool> = Vec::new();
+        let mut after_blank = false;
+        for line in clean_screen.lines() {
+            if line.trim().is_empty() {
+                after_blank = true;
+                continue;
+            }
+            non_empty.push(line);
+            blank_before.push(std::mem::take(&mut after_blank));
+        }
         let start = non_empty.len().saturating_sub(RECENT_LINES);
         Self {
             recent: non_empty[start..].to_vec(),
+            blank_before: blank_before[start..].to_vec(),
             osc_title,
             joined: OnceLock::new(),
             collapsed: OnceLock::new(),
@@ -244,7 +256,9 @@ impl<'a> Screen<'a> {
             Region::CollapsedRecent => self
                 .collapsed
                 .get_or_init(|| collapse_ascii_whitespace(self.joined())),
-            Region::UnstackedRecent => self.unstacked.get_or_init(|| unstack(&self.recent)),
+            Region::UnstackedRecent => self
+                .unstacked
+                .get_or_init(|| unstack(&self.recent, &self.blank_before)),
             Region::BottomLines(n) => {
                 // Bottom-n is a suffix of the joined recent window, so it is
                 // sliced from it rather than joined again per rule.
@@ -407,19 +421,23 @@ fn line_is_update_banner(trimmed: &str) -> bool {
 /// character per row, and a run of such rows is the word; anything wider is
 /// ordinary content, so it keeps its own line and cannot be glued to the text
 /// under it.
-fn unstack(lines: &[&str]) -> String {
+///
+/// A blank row ends a run for the same reason: characters either side of one
+/// came from different blocks, so they are not one word.
+fn unstack(lines: &[&str], blank_before: &[bool]) -> String {
     let mut out: Vec<String> = Vec::new();
     let mut run = String::new();
-    for line in lines {
+    for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
-        if trimmed.chars().count() == 1 {
-            run.push_str(trimmed);
-            continue;
-        }
-        if !run.is_empty() {
+        let stacked = trimmed.chars().count() == 1;
+        if (!stacked || blank_before[i]) && !run.is_empty() {
             out.push(std::mem::take(&mut run));
         }
-        out.push((*line).to_string());
+        if stacked {
+            run.push_str(trimmed);
+        } else {
+            out.push((*line).to_string());
+        }
     }
     if !run.is_empty() {
         out.push(run);

--- a/src/tmux/detect/region.rs
+++ b/src/tmux/detect/region.rs
@@ -11,15 +11,15 @@ use std::sync::OnceLock;
 /// against it. Regions are computed lazily: a capture whose first rule
 /// matches never pays for the rest.
 pub(super) struct Screen<'a> {
-    /// Every non-empty line. Claude parks the cursor below its output and small
-    /// responses sit in a tall pane, so the blank tail carries nothing and
-    /// filtering it keeps window sizes meaningful. Each region slices its own
-    /// window off the end of this.
-    non_empty: Vec<&'a str>,
+    /// Non-empty lines, most recent [`RECENT_LINES`] of them. Claude parks the
+    /// cursor below its output and small responses sit in a tall pane, so the
+    /// blank tail carries nothing and filtering it keeps window sizes
+    /// meaningful.
+    recent: Vec<&'a str>,
     osc_title: &'a str,
     joined: OnceLock<String>,
     collapsed: OnceLock<String>,
-    concatenated: OnceLock<String>,
+    unstacked: OnceLock<String>,
     above_input_box: OnceLock<Option<String>>,
     prompt_box_body: OnceLock<Option<String>>,
     after_last_rule: OnceLock<String>,
@@ -31,12 +31,6 @@ pub(super) struct Screen<'a> {
 /// fit well inside this, and a shorter window would drop the completion line
 /// on a pane whose box carries several rows of chrome.
 const RECENT_LINES: usize = 30;
-
-/// How far back [`Region::ConcatenatedRecent`] reaches. A Textual pane narrow
-/// enough to stack a status word one character per line spends a whole line on
-/// each character, so [`RECENT_LINES`] is not deep enough to hold one word plus
-/// the chrome under it.
-const CONCATENATED_LINES: usize = 50;
 
 /// A landmark line a manifest names so its rules can be scoped relative to it:
 /// the divider a finished turn draws, the rule pair around an input box, an
@@ -131,9 +125,11 @@ pub(super) enum Region {
     /// Recent lines with runs of ASCII whitespace collapsed to one space, so a
     /// footer hint that word-wrapped mid-phrase still reads as one string.
     CollapsedRecent,
-    /// Recent lines trimmed and concatenated with no separator, so a word a
-    /// Textual TUI renders one character per line reads as one word.
-    ConcatenatedRecent,
+    /// Recent lines with runs of single-character lines glued back into one
+    /// line, so a word a Textual pane stacks one character per row reads as a
+    /// word. Wider lines keep their newline, so this cannot spell a word out
+    /// of two ordinary lines that only meet at their ends.
+    UnstackedRecent,
     /// The last `n` non-empty lines.
     BottomLines(usize),
     /// The transcript line the input box's status slot sits on: the live
@@ -201,7 +197,7 @@ impl Region {
         Some(match raw {
             "whole_recent" => Region::WholeRecent,
             "collapsed_recent" => Region::CollapsedRecent,
-            "concatenated_recent" => Region::ConcatenatedRecent,
+            "unstacked_recent" => Region::UnstackedRecent,
             "last_non_empty_above_prompt_box" => Region::AboveInputBox,
             "prompt_box_body" => Region::PromptBoxBody,
             "after_last_horizontal_rule" => Region::AfterLastRule,
@@ -215,15 +211,17 @@ impl Region {
 
 impl<'a> Screen<'a> {
     pub(super) fn new(clean_screen: &'a str, osc_title: &'a str) -> Self {
+        let non_empty: Vec<&str> = clean_screen
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .collect();
+        let start = non_empty.len().saturating_sub(RECENT_LINES);
         Self {
-            non_empty: clean_screen
-                .lines()
-                .filter(|l| !l.trim().is_empty())
-                .collect(),
+            recent: non_empty[start..].to_vec(),
             osc_title,
             joined: OnceLock::new(),
             collapsed: OnceLock::new(),
-            concatenated: OnceLock::new(),
+            unstacked: OnceLock::new(),
             above_input_box: OnceLock::new(),
             prompt_box_body: OnceLock::new(),
             after_last_rule: OnceLock::new(),
@@ -246,20 +244,15 @@ impl<'a> Screen<'a> {
             Region::CollapsedRecent => self
                 .collapsed
                 .get_or_init(|| collapse_ascii_whitespace(self.joined())),
-            Region::ConcatenatedRecent => self.concatenated.get_or_init(|| {
-                self.window(CONCATENATED_LINES)
-                    .iter()
-                    .map(|l| l.trim())
-                    .collect()
-            }),
+            Region::UnstackedRecent => self.unstacked.get_or_init(|| unstack(&self.recent)),
             Region::BottomLines(n) => {
                 // Bottom-n is a suffix of the joined recent window, so it is
                 // sliced from it rather than joined again per rule.
-                let start = self.recent().len().saturating_sub(n);
+                let start = self.recent.len().saturating_sub(n);
                 if start == 0 {
                     return std::borrow::Cow::Borrowed(self.joined());
                 }
-                let skipped: usize = self.recent()[..start].iter().map(|l| l.len() + 1).sum();
+                let skipped: usize = self.recent[..start].iter().map(|l| l.len() + 1).sum();
                 &self.joined()[skipped..]
             }
             Region::AboveInputBox => self
@@ -279,14 +272,14 @@ impl<'a> Screen<'a> {
             Region::FromPromptMarker => {
                 self.from_marker
                     .get_or_init(|| match self.marker_index(prompt_marker) {
-                        Some(idx) => self.recent()[idx..].join("\n"),
+                        Some(idx) => self.recent[idx..].join("\n"),
                         None => self.joined().to_string(),
                     })
             }
             Region::BeforePromptMarker => {
                 self.before_marker
                     .get_or_init(|| match self.marker_index(prompt_marker) {
-                        Some(idx) => self.recent()[..idx].join("\n"),
+                        Some(idx) => self.recent[..idx].join("\n"),
                         None => self.joined().to_string(),
                     })
             }
@@ -295,15 +288,15 @@ impl<'a> Screen<'a> {
             // capture they run against is discarded at the end of the poll.
             Region::AfterMarker(name, limit) => {
                 return std::borrow::Cow::Owned(match markers.get(name) {
-                    Some(marker) => match marker.resolve(self.recent()) {
+                    Some(marker) => match marker.resolve(&self.recent) {
                         Some(idx) => {
-                            let after = &self.recent()[idx + 1..];
+                            let after = &self.recent[idx + 1..];
                             let start = limit.map_or(0, |n| after.len().saturating_sub(n));
                             after[start..].join("\n")
                         }
                         None if marker.absent_is_whole => {
-                            let start = limit.map_or(0, |n| self.recent().len().saturating_sub(n));
-                            self.recent()[start..].join("\n")
+                            let start = limit.map_or(0, |n| self.recent.len().saturating_sub(n));
+                            self.recent[start..].join("\n")
                         }
                         None => String::new(),
                     },
@@ -313,11 +306,11 @@ impl<'a> Screen<'a> {
             Region::AboveMarker(name, n) => {
                 let marker = markers.get(name);
                 return std::borrow::Cow::Owned(
-                    match marker.and_then(|m| m.resolve(self.recent())) {
-                        Some(idx) => self.recent()[idx.saturating_sub(n)..idx].join("\n"),
+                    match marker.and_then(|m| m.resolve(&self.recent)) {
+                        Some(idx) => self.recent[idx.saturating_sub(n)..idx].join("\n"),
                         None => {
                             let window = marker.and_then(|m| m.max_depth).unwrap_or(n);
-                            self.recent()[self.recent().len().saturating_sub(window)..].join("\n")
+                            self.recent[self.recent.len().saturating_sub(window)..].join("\n")
                         }
                     },
                 );
@@ -325,34 +318,24 @@ impl<'a> Screen<'a> {
         })
     }
 
-    /// The last `n` non-empty lines.
-    fn window(&self, n: usize) -> &[&'a str] {
-        &self.non_empty[self.non_empty.len().saturating_sub(n)..]
-    }
-
-    /// The window every line-oriented region reads.
-    fn recent(&self) -> &[&'a str] {
-        self.window(RECENT_LINES)
-    }
-
     /// The last line matching any of the manifest's prompt-marker patterns.
     fn marker_index(&self, prompt_marker: &[regex::Regex]) -> Option<usize> {
-        self.recent()
+        self.recent
             .iter()
             .rposition(|line| prompt_marker.iter().any(|re| re.is_match(line)))
     }
 
     fn joined(&self) -> &str {
-        self.joined.get_or_init(|| self.recent().join("\n"))
+        self.joined.get_or_init(|| self.recent.join("\n"))
     }
 
     fn compute_above_input_box(&self) -> Option<String> {
         let box_top = self
-            .recent()
+            .recent
             .iter()
             .rposition(|l| l.trim_start().starts_with('❯'))
-            .unwrap_or(self.recent().len());
-        self.recent()[..box_top]
+            .unwrap_or(self.recent.len());
+        self.recent[..box_top]
             .iter()
             .rev()
             .find(|l| !line_is_input_box_chrome(l))
@@ -360,19 +343,19 @@ impl<'a> Screen<'a> {
     }
 
     fn compute_prompt_box_body(&self) -> Option<String> {
-        self.recent()
+        self.recent
             .iter()
             .rposition(|l| l.trim_start().starts_with('❯'))
-            .map(|idx| self.recent()[idx].to_string())
+            .map(|idx| self.recent[idx].to_string())
     }
 
     fn compute_after_last_rule(&self) -> String {
         match self
-            .recent()
+            .recent
             .iter()
             .rposition(|l| line_is_horizontal_rule(l.trim()))
         {
-            Some(idx) => self.recent()[idx + 1..].join("\n"),
+            Some(idx) => self.recent[idx + 1..].join("\n"),
             None => self.joined().to_string(),
         }
     }
@@ -417,6 +400,31 @@ fn line_is_update_banner(trimmed: &str) -> bool {
     (trimmed.starts_with('✔') || trimmed.starts_with('✓'))
         && lower.contains("update")
         && (lower.contains("restart") || lower.contains("installed"))
+}
+
+/// Glue each run of single-character lines into one line, leaving wider lines
+/// alone. A Textual pane too narrow for its status word stacks the word one
+/// character per row, and a run of such rows is the word; anything wider is
+/// ordinary content, so it keeps its own line and cannot be glued to the text
+/// under it.
+fn unstack(lines: &[&str]) -> String {
+    let mut out: Vec<String> = Vec::new();
+    let mut run = String::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.chars().count() == 1 {
+            run.push_str(trimmed);
+            continue;
+        }
+        if !run.is_empty() {
+            out.push(std::mem::take(&mut run));
+        }
+        out.push((*line).to_string());
+    }
+    if !run.is_empty() {
+        out.push(run);
+    }
+    out.join("\n")
 }
 
 pub(super) fn collapse_ascii_whitespace(text: &str) -> String {

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2266,11 +2266,12 @@ Do you want to proceed?\n\
         assert!(!vibe_rule_matches("spinner", vertical));
         assert!(!vibe_rule_matches("trailing_ellipsis", vertical));
 
-        // A pane narrow enough to stack the word is narrow enough to stack the
-        // chrome under it, so the word sits well above the line-oriented
-        // window and only the deeper concatenated one still reaches it.
-        let buried = format!("{vertical}\n{}", "x\n".repeat(40));
-        assert_eq!(detect_vibe_status(&buried), Status::Running);
+        // Only stacked runs are glued: two ordinary lines that happen to meet
+        // mid-word stay separate, so they cannot spell an activity word
+        // neither of them contains.
+        let glued = "finished a long run\nning total of 3 files";
+        assert_eq!(detect_vibe_status(glued), Status::Idle);
+        assert!(!vibe_rule_matches("activity_word", glued));
 
         // Ellipsis indicates ongoing activity
         assert_eq!(detect_vibe_status("Working…"), Status::Running);

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -169,6 +169,11 @@ mod tests {
         super::super::detect::rule_matches("claude", rule, &strip_ansi(content), "", None)
     }
 
+    /// Whether one of Vibe's manifest rules matches a fixture.
+    fn vibe_rule_matches(rule: &str, content: &str) -> bool {
+        super::super::detect::rule_matches("vibe", rule, content, "", None)
+    }
+
     /// A `waiting` write left behind by a prompt the user cancelled: the write
     /// nothing clears, which is why the screen has to be able to outrank it.
     fn stale_wait() -> Option<super::super::detect::HookObservation> {
@@ -2252,11 +2257,14 @@ Do you want to proceed?\n\
         assert_eq!(detect_vibe_status("Writing changes"), Status::Running);
         assert_eq!(detect_vibe_status("Generating code"), Status::Running);
 
-        // Vertical text (Vibe's Textual TUI renders one char per line)
-        assert_eq!(
-            detect_vibe_status("⠋\nR\nu\nn\nn\ni\nn\ng\nb\na\ns\nh\n…"),
-            Status::Running
-        );
+        // Vertical text (Vibe's Textual TUI renders one char per line). No
+        // spinner and no trailing ellipsis, so the activity word alone has to
+        // carry it.
+        let vertical = "R\nu\nn\nn\ni\nn\ng";
+        assert_eq!(detect_vibe_status(vertical), Status::Running);
+        assert!(vibe_rule_matches("activity_word", vertical));
+        assert!(!vibe_rule_matches("spinner", vertical));
+        assert!(!vibe_rule_matches("trailing_ellipsis", vertical));
 
         // Ellipsis indicates ongoing activity
         assert_eq!(detect_vibe_status("Working…"), Status::Running);
@@ -2289,6 +2297,10 @@ Do you want to proceed?\n\
         assert_eq!(detect_vibe_status("some random output"), Status::Idle);
         assert_eq!(detect_vibe_status("file saved successfully"), Status::Idle);
         assert_eq!(detect_vibe_status("Done!"), Status::Idle);
+
+        // A middle dot is separator punctuation in parked output; Vibe's
+        // Textual spinner is braille and draws no other frame.
+        assert_eq!(detect_vibe_status("main · 3 files changed"), Status::Idle);
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -2273,6 +2273,12 @@ Do you want to proceed?\n\
         assert_eq!(detect_vibe_status(glued), Status::Idle);
         assert!(!vibe_rule_matches("activity_word", glued));
 
+        // A blank row ends a run too: the window drops blank lines, so without
+        // this the halves of two separate blocks would stack into one word.
+        let split = "R\nu\nn\n\nn\ni\nn\ng";
+        assert_eq!(detect_vibe_status(split), Status::Idle);
+        assert!(!vibe_rule_matches("activity_word", split));
+
         // Ellipsis indicates ongoing activity
         assert_eq!(detect_vibe_status("Working…"), Status::Running);
         assert_eq!(detect_vibe_status("Loading..."), Status::Running);

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -171,7 +171,7 @@ mod tests {
 
     /// Whether one of Vibe's manifest rules matches a fixture.
     fn vibe_rule_matches(rule: &str, content: &str) -> bool {
-        super::super::detect::rule_matches("vibe", rule, content, "", None)
+        super::super::detect::rule_matches("vibe", rule, &strip_ansi(content), "", None)
     }
 
     /// A `waiting` write left behind by a prompt the user cancelled: the write
@@ -2265,6 +2265,12 @@ Do you want to proceed?\n\
         assert!(vibe_rule_matches("activity_word", vertical));
         assert!(!vibe_rule_matches("spinner", vertical));
         assert!(!vibe_rule_matches("trailing_ellipsis", vertical));
+
+        // A pane narrow enough to stack the word is narrow enough to stack the
+        // chrome under it, so the word sits well above the line-oriented
+        // window and only the deeper concatenated one still reaches it.
+        let buried = format!("{vertical}\n{}", "x\n".repeat(40));
+        assert_eq!(detect_vibe_status(&buried), Status::Running);
 
         // Ellipsis indicates ongoing activity
         assert_eq!(detect_vibe_status("Working…"), Status::Running);


### PR DESCRIPTION
## Description

When Vibe is working in a narrow pane, its Textual interface sometimes draws its status word sideways, one letter per line, so "Running" appears as a vertical stack of single characters. The old detection code glued those lines back together before looking for the word, but the rewrite in #3600 stopped doing that, so a session in that state was reported as idle even though the agent was busy. The same rewrite also started treating a middle dot as a spinner, and a middle dot is ordinary punctuation in Vibe's output, so a parked session sitting on a line like `main · 3 files changed` was reported as running forever. This change puts both behaviours back: the status word is read from a glued-together copy of the recent lines again, and only Vibe's real braille spinner counts as a spinner.

Both halves were reproduced against the current code before changing anything. `detect_vibe_status("R\nu\nn\nn\ni\nn\ng")` returned `Idle`, and `detect_vibe_status("main · 3 files changed")` returned `Running`.

Changes:

- New `unstacked_recent` region: the recent lines, with each run of single-character lines glued back into one line. That is the shape Textual actually produces when a pane is too narrow for the status word. Wider lines keep their own line, so the region is `whole_recent` plus the stacked case. `activity_word` reads it instead of `whole_recent`.
- `spinner` now extends the shared braille-only template that every other braille-spinner agent already uses. Vibe's frame set was braille only before #3600; the manifest had picked up Claude's `·✢✳✶✻✽●` set.
- The retained vertical fixture carried both a spinner and a trailing ellipsis, so either could decide the result and it never exercised the contract it named. It now carries neither, and asserts which rule fires. A second fixture pins the narrowing: `a long run` above `ning total` stays Idle.

Deliberately narrower than the old detector. The pre-#3600 code concatenated its whole 50-line window with no separator, which had two costs this does not pay:

- A 50-line activity window outranked by 30-line rules. `activity_word` sits at priority 955 under `menu_footer`, `command_warning`, `approval_option` and `cursor_line`, which all read 30 lines. At 50, a finished turn's `Reading src/foo.rs` sitting 31 to 50 lines up pinned a parked session on Running with nothing able to override it, which is the failure #3600 was written to kill. Gluing only stacked runs means one window depth serves every region and the gap disappears.
- Cross-line glue. Joining every line end to end spelled words out of two ordinary lines that met mid-word.

The tradeoff: a stacked word buried deeper than `RECENT_LINES` is missed, where the old detector reached 50. That costs a case nobody has reported and buys back the stale-Running window, which is the case #3627's own sibling issues are about.

One judgement call worth a reviewer's eye: the spinner is now the whole `[⠀-⣿]` block from the shared template. The historical Vibe set was 17 specific frames and did not include U+2800 BRAILLE PATTERN BLANK, so this is slightly wider than a literal restore. Consistency with the six agents already on that template seemed worth more than an inline 17-glyph list.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is pure status-detection logic over a captured pane string, so the Rust unit tests in `status_detection.rs` are the cheapest test that catches the regression. An e2e test would need a live Vibe binary rendering a narrow pane to reproduce the vertical case.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via the Claude Code CLI

**Any Additional AI Details you'd like to share:**

The issue was filed from a static review with no build or test run. Both claims were reproduced locally against the current code first, then fixed. Two review agents then read the diff cold. The first caught that the initial commit narrowed the concatenated window from 50 lines to 30; the second caught that widening it back to 50 reintroduced a stale-Running window that no higher-priority rule could reach. The third commit resolves both by gluing only stacked runs at a single window depth. `cargo fmt`, `cargo clippy --all-targets` and `cargo test` were run. Two unrelated tests fail in this sandbox: `wait_until_ready_errs_with_pane_tail_when_pane_dies_immediately` passes in isolation and only fails under the parallel run, and `test_content_shows_settings_path` asserts a `.claude/settings.json` path this environment relocates. Neither is reachable from Vibe status detection.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3627


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Restores detection of vertically stacked Vibe activity words.
- Limits spinner detection to supported Braille characters.
- Prevents unrelated lines and blank rows from combining into activity words.
- Adds focused tests for stacked activity text and middle-dot separators.

## Benefits

Vibe sessions now report running and idle states more accurately. The changes reduce false running reports from ordinary punctuation and prevent stale or unrelated output from affecting detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->