### PR TITLE
docs: drop stale aoe-agent fallback claims from ACP comments

### DIFF
--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -293,7 +293,7 @@ pub const PRIME_AGENT: AgentProfile = AgentProfile {
     yolo_mode_id: None,
 };
 
-/// aoe's bundled multi-provider agent. Treated as Claude-equivalent
+/// aoe's own multi-provider agent. Treated as Claude-equivalent
 /// for now (Vercel AI SDK 6 with Claude as one of the providers); the
 /// claude_capabilities subset is the safest reference until aoe-agent
 /// has its own conventions.

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -68,8 +68,8 @@ impl AgentRegistry {
     }
 
     /// Returns a registry seeded with one entry per aoe tool that has
-    /// a published ACP server, plus our own `aoe-agent` as a generic
-    /// multi-provider fallback. Each entry is keyed on the same name
+    /// a published ACP server, plus aoe's own multi-provider
+    /// `aoe-agent`. Each entry is keyed on the same name
     /// the tmux view uses (claude / opencode / gemini / codex /
     /// vibe / pi / omp) so the spawn path can map `instance.tool`
     /// directly to a registry key.

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -68,11 +68,10 @@ impl AgentRegistry {
     }
 
     /// Returns a registry seeded with one entry per aoe tool that has
-    /// a published ACP server, plus aoe's own multi-provider
-    /// `aoe-agent`. Each entry is keyed on the same name
-    /// the tmux view uses (claude / opencode / gemini / codex /
-    /// vibe / pi / omp) so the spawn path can map `instance.tool`
-    /// directly to a registry key.
+    /// a published ACP server, plus aoe's own multi-provider `aoe-agent`.
+    /// Each entry is keyed on the same name the tmux view uses (claude /
+    /// opencode / gemini / codex / vibe / pi / omp) so the spawn path can
+    /// map `instance.tool` directly to a registry key.
     ///
     /// Sources verified against
     /// <https://agentclientprotocol.com/get-started/agents.md>

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -35,10 +35,6 @@
 //! is published; the UI renders an amber callout in the transcript so
 //! the user knows prior turns are no longer in the model's context.
 //!
-//! `aoe-agent` does not yet advertise `load_session`, so its UI
-//! transcript replays from this store on restart but the model itself
-//! starts fresh each spawn (tracked in #1005).
-//!
 //! ## Lifecycle
 //!
 //! Per-session rows are dropped on session delete and on

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -35,9 +35,9 @@
 //! is published; the UI renders an amber callout in the transcript so
 //! the user knows prior turns are no longer in the model's context.
 //!
-//! The bundled `aoe-agent` does not yet advertise `load_session`, so
-//! its UI transcript replays from this store on restart but the model
-//! itself starts fresh each spawn (tracked in #1005).
+//! `aoe-agent` does not yet advertise `load_session`, so its UI
+//! transcript replays from this store on restart but the model itself
+//! starts fresh each spawn (tracked in #1005).
 //!
 //! ## Lifecycle
 //!

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -4,7 +4,7 @@
 //! the ACP handshake failure path so the user sees the correct command
 //! for whichever agent they tried to spawn.
 
-/// Friendly binary token for aoe's bundled multi-provider agent. Shared by the
+/// Friendly binary token for aoe's own multi-provider agent. Shared by the
 /// registry's spawn registration and [`env_allowlist_for`] so the two cannot
 /// drift onto different spellings (which would silently drop the agent's
 /// provider keys). Distinct from `AgentSpec.command`, whose value for this
@@ -66,7 +66,7 @@ pub fn npm_package_for(binary: &str) -> Option<&'static str> {
 /// [`AOE_AGENT_BINARY`]), NOT `AgentSpec.command`. `command` for `aoe-agent`
 /// carries a `${aoe_data_dir}/...` placeholder that is substituted at
 /// spawn time (`supervisor.rs`), so keying on it here would silently
-/// miss the bundled agent.
+/// miss that agent.
 pub fn env_allowlist_for(binary: &str) -> &'static [&'static str] {
     match binary {
         // Existing Claude adapter contract, previously supplied through

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -505,11 +505,12 @@ pub struct SpawnRequest {
     /// session. Distinct from [`Self::agent`]: `agent` is what
     /// `pick_agent_for_tool` resolved the tool to for ACP spawning, and can
     /// differ from the tool on an explicit override, a custom agent with no
-    /// configured ACP command (falls back to `"aoe-agent"`), or the
-    /// `switch-agent` path (the tool stays fixed while `agent` becomes the new
-    /// backend). Tool-scoped `host_hooks.before_session` env (`AOE_TOOL`) uses
-    /// this field so it agrees with the terminal view rather than with
-    /// whatever ACP backend happened to serve the request.
+    /// configured ACP command (falls back to the configured
+    /// `acp.default_agent`), or the `switch-agent` path (the tool stays fixed
+    /// while `agent` becomes the new backend). Tool-scoped
+    /// `host_hooks.before_session` env (`AOE_TOOL`) uses this field so it
+    /// agrees with the terminal view rather than with whatever ACP backend
+    /// happened to serve the request.
     pub tool: String,
     pub cwd: PathBuf,
     pub additional_dirs: Vec<PathBuf>,

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1580,9 +1580,9 @@ pub(crate) fn registry_lifecycle(name: &str) -> AgentLifecycle {
 /// Today only claude qualifies: `claude-agent-acp`'s `session/new` UUID is
 /// the claude SDK session id in `~/.claude/projects/*.jsonl`, exactly what
 /// `claude --resume` reads. `claude-code` is the legacy alias for the same
-/// adapter. codex-acp and the bundled `aoe-agent` do not share a
-/// CLI-resumable store, so a claude session whose adapter was swapped to one
-/// of them does not qualify.
+/// adapter. codex-acp and `aoe-agent` do not share a CLI-resumable store, so
+/// a claude session whose adapter was swapped to one of them does not
+/// qualify.
 pub fn acp_transcript_cli_resumable(tool: &str, acp_agent: &str) -> bool {
     tool == "claude" && matches!(acp_agent, "claude" | "claude-code")
 }

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -767,8 +767,8 @@ pub(crate) fn command_present(command: &str) -> bool {
     // runtime against the app data dir, so the literal string contains
     // both `${` and `/`. Check the placeholder branch FIRST — otherwise
     // the `/`-branch tries to stat a literal path containing `${...}`
-    // and reports "missing" for every placeholder-based agent
-    // (notably `aoe-agent`, our bundled multi-provider fallback).
+    // and reports "missing" for every placeholder-based agent (notably
+    // `aoe-agent`).
     if command.contains("${") {
         true
     } else if command.contains('/') || command.contains('\\') {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -225,8 +225,8 @@ pub struct SessionResponse {
     pub acp_agent: Option<String>,
     /// True when this session's agent can run a structured ACP `session/fork`:
     /// it is ACP-capable AND declares a real fork strategy. Resume-only ACP
-    /// agents (e.g. the bundled `aoe-agent`, which advertises `loadSession` but
-    /// not `session/fork`) are ACP-capable yet not forkable, so gating the web
+    /// agents (e.g. `aoe-agent`, which advertises `loadSession` but not
+    /// `session/fork`) are ACP-capable yet not forkable, so gating the web
     /// "Fork" action on `acp_session_id` alone would offer a dead-end button
     /// that fails at the `session/fork` handshake. The true capability is only
     /// advertised transiently during the handshake, so this projects the static

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -1045,8 +1045,8 @@ pub mod structured {
     /// inherits a registry-backed base through `[session.agent_detect_as]`
     /// (e.g. a Claude wrapper that only overrides profile/oauth locations).
     /// Mirrors the server create path's capability re-validation; deliberately
-    /// NOT the aoe-agent fallback (`pick_acp_agent_name`), which would make
-    /// every tool look capable.
+    /// NOT the configured-default fallback (`pick_acp_agent_name`), which
+    /// would make every tool look capable.
     pub fn tool_acp_capable(tool: &str, config: &crate::session::Config) -> bool {
         crate::acp::agent_registry::AgentRegistry::with_defaults()
             .get(tool)

--- a/src/session/fork.rs
+++ b/src/session/fork.rs
@@ -60,8 +60,8 @@ fn builtin_acp_registry() -> &'static crate::acp::AgentRegistry {
 /// refuse. Only `ClaudeFork` is checked here until another agent's ACP adapter
 /// is confirmed to support the handshake.
 ///
-/// The bundled `aoe-agent` is ACP-capable (it is in the ACP registry) but is
-/// not a fork-capable agent, so it reads false: it is absent from `get_agent`
+/// `aoe-agent` is ACP-capable (it is in the ACP registry) but is not a
+/// fork-capable agent, so it reads false: it is absent from `get_agent`
 /// (only agents with a published fork strategy are members), so the
 /// `get_agent(..).is_some_and(..)` clause is false for it, the same path custom
 /// agents take (no custom agent currently exposes a structured fork). Treating

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -485,7 +485,7 @@ pub struct Instance {
     /// session's tool.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_name: Option<String>,
-    /// Optional model id forwarded to the selected ACP agent (e.g.,
+    /// Optional model id, injected at spawn as `AOE_AGENT_MODEL` (e.g.,
     /// "claude-opus-4-7", "gpt-5", "llama3.3:ollama").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_model: Option<String>,

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -486,7 +486,8 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_name: Option<String>,
     /// Optional model id, injected at spawn as `AOE_AGENT_MODEL` (e.g.,
-    /// "claude-opus-4-7", "gpt-5", "llama3.3:ollama").
+    /// "claude-opus-4-7", "gpt-5", "llama3.3:ollama"). Only `aoe-agent`
+    /// reads that variable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_model: Option<String>,
     /// Reasoning effort ("thought level") this session was explicitly pinned

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -485,8 +485,8 @@ pub struct Instance {
     /// session's tool.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_name: Option<String>,
-    /// Optional model id forwarded to aoe-agent (e.g., "claude-opus-4-7",
-    /// "gpt-5", "llama3.3:ollama").
+    /// Optional model id forwarded to the selected ACP agent (e.g.,
+    /// "claude-opus-4-7", "gpt-5", "llama3.3:ollama").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_model: Option<String>,
     /// Reasoning effort ("thought level") this session was explicitly pinned

--- a/web/src/components/__tests__/ForkSessionAction.test.tsx
+++ b/web/src/components/__tests__/ForkSessionAction.test.tsx
@@ -140,7 +140,7 @@ describe("SessionRow Fork affordance gating", () => {
   });
 
   it("hides Fork on a resume-only structured row (captured id but not fork-capable)", () => {
-    // e.g. the bundled aoe-agent: advertises loadSession and mints an
+    // e.g. aoe-agent: advertises loadSession and mints an
     // acp_session_id, but does not advertise session/fork. Gating on the id
     // alone would offer a dead-end button that fails at the handshake.
     const ws = workspace("w-resume-only", [

--- a/web/src/components/__tests__/ForkSessionAction.test.tsx
+++ b/web/src/components/__tests__/ForkSessionAction.test.tsx
@@ -140,9 +140,9 @@ describe("SessionRow Fork affordance gating", () => {
   });
 
   it("hides Fork on a resume-only structured row (captured id but not fork-capable)", () => {
-    // e.g. aoe-agent: advertises loadSession and mints an
-    // acp_session_id, but does not advertise session/fork. Gating on the id
-    // alone would offer a dead-end button that fails at the handshake.
+    // e.g. aoe-agent: advertises loadSession and mints an acp_session_id,
+    // but does not advertise session/fork. Gating on the id alone would
+    // offer a dead-end button that fails at the handshake.
     const ws = workspace("w-resume-only", [
       session({ view: "structured", acp_session_id: "acp-parent", acp_can_fork: false }),
     ]);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -172,8 +172,8 @@ export interface SessionResponse {
   clear_aliases?: string[];
   /** True when this session's agent can run a structured ACP `session/fork`:
    *  it is ACP-capable AND declares a real fork strategy. Resume-only ACP
-   *  agents (e.g. `aoe-agent`, which advertises `loadSession` but
-   *  not `session/fork`) are ACP-capable yet not forkable. The sidebar gates the
+   *  agents (e.g. `aoe-agent`, which advertises `loadSession` but not
+   *  `session/fork`) are ACP-capable yet not forkable. The sidebar gates the
    *  "Fork" action on this together with `acp_session_id` so a resume-only row
    *  never shows a dead-end fork button. Absent (read as not-forkable) for
    *  terminal sessions and non-forkable agents. */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -172,7 +172,7 @@ export interface SessionResponse {
   clear_aliases?: string[];
   /** True when this session's agent can run a structured ACP `session/fork`:
    *  it is ACP-capable AND declares a real fork strategy. Resume-only ACP
-   *  agents (e.g. the bundled `aoe-agent`, which advertises `loadSession` but
+   *  agents (e.g. `aoe-agent`, which advertises `loadSession` but
    *  not `session/fork`) are ACP-capable yet not forkable. The sidebar gates the
    *  "Fork" action on this together with `acp_session_id` so a resume-only row
    *  never shows a dead-end fork button. Absent (read as not-forkable) for


### PR DESCRIPTION
## Description

Four internal comments still described the old behavior, where a structured-view session that could not resolve its own agent fell back to a fixed agent named `aoe-agent`. That stopped being true in #3583: the fallback is now whichever agent the config names as the ACP default. Several comments also called `aoe-agent` bundled, which it is not, since it is still unpackaged (#3553). This corrects the wording so anyone reading the code sees how agent selection and packaging actually work today. Nothing about how the program runs changes.

Each cited comment was checked against the current code before editing, and the fix was widened past the four in the issue to every comment repeating the same two claims, including the two TypeScript mirrors in `web/`. Review also caught a third stale claim in the same paragraph as one of the edits: `event_store.rs` said `aoe-agent` does not advertise `load_session`, which stopped being true when #1005 closed. That paragraph is deleted. Diff is comment-only.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --features serve --all-targets`, and `cargo test --features serve` all run clean apart from 3 sandbox-only failures: two fixtures force a read error with `chmod 000`, which does not hold when running as root, and one asserts a `.claude/settings.json` path while the sandbox sets `CLAUDE_CONFIG_DIR`. That last one passes with the variable unset. 6485 tests pass; none of the 3 relate to this diff. For `web/`: `npm run format:check`, `npm run lint`, `npx tsc -b`, and `npm run test:unit` (3713 tests) all pass.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the two `web/` edits are comments, so no coverage-matrix entry applies)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Skipped a test, because: the diff changes only comments, so there is no behavior a test could pin.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 (1M context), via the Claude Code CLI.

**Any Additional AI Details you'd like to share:** The model verified each claim in the issue against the current code before editing, and confirmed the diff touches only comment lines.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updated ACP documentation to match current agent-selection behavior.

- Replaced stale fixed or bundled `aoe-agent` fallback descriptions.
- Clarified configured-default and selected ACP agent behavior.
- Documented `agent_model` handling through `AOE_AGENT_MODEL`.
- Removed an inaccurate `load_session` claim.
- Updated matching web documentation and comments.
- Preserved all runtime behavior.

These changes improve documentation accuracy and reduce confusion during future ACP changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->