### PR TITLE
fix(acp): give prompt submission one per-session authority

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -3331,15 +3331,7 @@ impl<S: BroadcastSink> Supervisor<S> {
     #[cfg(test)]
     pub(crate) async fn test_insert_worker(&self, session_id: &str) {
         let (client, _tx) = AcpClient::fake_for_test(AcpSessionId(format!("acp-{session_id}")));
-        self.workers.lock().await.insert(
-            session_id.to_string(),
-            WorkerHandle {
-                client: Arc::new(client),
-                drain_task: tokio::spawn(async {}),
-                restart_history: vec![],
-                kind: WorkerKind::Stdio,
-            },
-        );
+        self.test_install_worker(session_id, client).await;
     }
 
     /// Like `test_insert_worker`, but the fake worker's command loop records
@@ -3353,6 +3345,15 @@ impl<S: BroadcastSink> Supervisor<S> {
     ) -> Arc<std::sync::Mutex<Vec<&'static str>>> {
         let (client, _tx, cmds) =
             AcpClient::fake_for_test_cmd_recording(AcpSessionId(format!("acp-{session_id}")));
+        self.test_install_worker(session_id, client).await;
+        cmds
+    }
+
+    /// Register `client` as this session's in-memory worker. Shared by the
+    /// `test_insert_worker*` fixtures so they differ only in which fake
+    /// client they build.
+    #[cfg(test)]
+    async fn test_install_worker(&self, session_id: &str, client: AcpClient) {
         self.workers.lock().await.insert(
             session_id.to_string(),
             WorkerHandle {
@@ -3362,7 +3363,6 @@ impl<S: BroadcastSink> Supervisor<S> {
                 kind: WorkerKind::Stdio,
             },
         );
-        cmds
     }
 
     /// Drop a fake in-memory worker inserted by `test_insert_worker`, freeing

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -3342,6 +3342,29 @@ impl<S: BroadcastSink> Supervisor<S> {
         );
     }
 
+    /// Like `test_insert_worker`, but the fake worker's command loop records
+    /// every `ClientCmd` it receives. Lets a test count how many prompts
+    /// actually reached the agent, which is the only place a lost prompt is
+    /// visible: `send_prompt` returns Ok as soon as the command is queued.
+    #[cfg(test)]
+    pub(crate) async fn test_insert_worker_cmd_recording(
+        &self,
+        session_id: &str,
+    ) -> Arc<std::sync::Mutex<Vec<&'static str>>> {
+        let (client, _tx, cmds) =
+            AcpClient::fake_for_test_cmd_recording(AcpSessionId(format!("acp-{session_id}")));
+        self.workers.lock().await.insert(
+            session_id.to_string(),
+            WorkerHandle {
+                client: Arc::new(client),
+                drain_task: tokio::spawn(async {}),
+                restart_history: vec![],
+                kind: WorkerKind::Stdio,
+            },
+        );
+        cmds
+    }
+
     /// Drop a fake in-memory worker inserted by `test_insert_worker`, freeing
     /// the capacity slot for the next reconciler tick.
     #[cfg(test)]

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -557,6 +557,13 @@ async fn sessions_turn_send(
 
     let result = async {
         deps.policy.admit_turn(&plugin_id)?;
+        // Same per-session submission authority the HTTP surfaces and the
+        // queue drain take, so a plugin turn cannot land between the drain's
+        // idle check and its send (#3621).
+        let _submission = deps
+            .session_service
+            .prompt_submission(&req.session_id)
+            .await;
         deps.session_service
             .send_turn(
                 &SessionCaller::Plugin {

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -557,6 +557,25 @@ async fn sessions_turn_send(
 
     let result = async {
         deps.policy.admit_turn(&plugin_id)?;
+        // Reject an unknown session before claiming the submission guard:
+        // `prompt_submission` auto-vivifies a lock-registry entry for any id
+        // it is asked for, and nothing ever prunes it, so a plugin probing
+        // distinct nonexistent ids could otherwise grow the registry without
+        // bound within its turn quota.
+        if !deps
+            .session_service
+            .instances
+            .read()
+            .await
+            .iter()
+            .any(|i| i.id == req.session_id)
+        {
+            return Err(DispatchError::with_kind(
+                codes::INVALID_PARAMS,
+                "session_not_found",
+                "session not found",
+            ));
+        }
         // Same per-session submission authority the HTTP surfaces and the
         // queue drain take, so a plugin turn cannot land between the drain's
         // idle check and its send (#3621).
@@ -849,5 +868,33 @@ mod tests {
             assert_eq!(err.code, expected_code, "{session}");
             assert_eq!(kind(&err), expected_kind, "{session}");
         }
+    }
+
+    /// `prompt_submission` auto-vivifies a per-session lock-registry entry
+    /// and nothing ever prunes one, so a plugin probing distinct nonexistent
+    /// session ids must be refused before the guard is claimed, or the
+    /// registry grows without bound within the caller's turn quota.
+    #[tokio::test]
+    async fn turn_send_does_not_grow_the_lock_registry_for_nonexistent_sessions() {
+        let (deps, _dir) = test_deps(Vec::new());
+        let ctx = ctx_with(&["session.prompt"]);
+
+        for i in 0..5 {
+            let err = dispatch(
+                &deps,
+                &ctx,
+                "sessions.turn.send",
+                &serde_json::json!({ "session_id": format!("sess-gone-{i}"), "text": "hi" }),
+            )
+            .await
+            .expect_err("must be refused");
+            assert_eq!(kind(&err), "session_not_found");
+        }
+
+        assert_eq!(
+            deps.session_service.prompt_locks_len().await,
+            0,
+            "an id that was never admitted must not leave a lock-registry entry behind"
+        );
     }
 }

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1572,9 +1572,11 @@ async fn drain_pending_initial_turns(state: &Arc<AppState>) {
 /// so a follow-up queued behind a busy turn drains with no client tab open.
 /// Candidates are idle
 /// (turn ended), structured, live sessions with a non-empty queue; the drain
-/// itself re-checks state under the per-instance lock and applies the
-/// `/clear`-boundary split. Gating on `is_running` here means the worker is
-/// live, so the drain can hold the instance lock across delivery safely.
+/// itself re-checks state under the session's prompt-submission guard and
+/// applies the `/clear`-boundary split. `is_running` is also true for a resume
+/// that holds a reservation but has no worker yet, so the drain may park on
+/// the readiness wait; it must never hold `instance_lock` while it does, since
+/// that is the lock the resume needs to finish (#3621).
 async fn drain_queued_prompts(state: &Arc<AppState>) {
     // Snapshot `(id, is_idle_dormant)`: dormant sessions have no live worker
     // but are excluded from the resume pass, so wake-on-drain must clear their
@@ -1600,9 +1602,9 @@ async fn drain_queued_prompts(state: &Arc<AppState>) {
         let service = Arc::clone(&state.session_service);
         if state.acp_supervisor.is_running(&id).await {
             // Live (or mid-respawn) worker: drain now. `drain_queued_prompts_once`
-            // holds the instance lock across delivery, which is safe only because
-            // a live worker makes `send_turn`'s resume a no-op (no spawn under the
-            // lock, so the #3172 re-entrant-spawn deadlock cannot occur).
+            // delivers under the session's prompt-submission guard, so a
+            // mid-respawn worker is simply waited for rather than deadlocked
+            // against (#3621).
             crate::task_util::spawn_supervised(
                 "acp.queue_drain",
                 crate::task_util::PanicPolicy::Log,
@@ -1809,10 +1811,13 @@ pub(crate) enum ResumeTrigger {
 /// session, so there is no double-spawn. Returns `Err(CapacityFull)` when
 /// the worker cap is reached so the handler can surface 503. See #1748.
 ///
-/// Callers MUST NOT hold the session's `instance_lock` while awaiting the
-/// worker this kicks: the detached task takes that same lock inside
-/// `build_spawn_request`, so a caller that holds it stalls the spawn for
-/// its whole `WORKER_READY_TIMEOUT` wait and then gives up. See #3172.
+/// NOTHING may hold the session's `instance_lock` while awaiting worker
+/// readiness, whether or not it kicked the resume itself: the detached task
+/// takes that same lock inside `build_spawn_request`, so a holder stalls the
+/// spawn for its whole `WORKER_READY_TIMEOUT` wait and then gives up. A
+/// reservation already in flight makes `is_running` true, so a waiter can park
+/// on a resume it never triggered; that is how the queue drain hit this
+/// without ever calling here. See #3172 and #3621.
 pub(crate) async fn trigger_resume_background(
     service: &Arc<SessionService>,
     id: &str,

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1503,8 +1503,9 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
 
 /// Spawn a detached drain for every session that still carries a persisted
 /// `pending_initial_turn` and has a live worker to receive it (#2897). The
-/// drain itself claims a per-session slot and runs under the instance lock,
-/// so overlapping ticks and the create fast path cannot double-deliver.
+/// drain itself claims a per-session slot and runs under the session's
+/// prompt-submission guard, so overlapping ticks and the create fast path
+/// cannot double-deliver.
 /// Triaged sessions are skipped like everywhere else in the reconciler; the
 /// turn stays persisted and delivers if the session is ever un-triaged.
 /// Queue the rate-limit-interrupted prompt as the session's next turn so a

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -3383,12 +3383,12 @@ mod tests {
         });
 
         // Let the handler reach its parked wait. It cannot return until the
-        // reservation drops, so anything past the lock scope is enough.
+        // reservation drops, so anything past the wake is enough.
         tokio::time::sleep(Duration::from_millis(300)).await;
 
         // The 2s budget is far under the 10s `WORKER_READY_TIMEOUT` the
         // pre-fix handler holds the lock for, and far over the microseconds
-        // the fixed one needs to clear and release.
+        // `touch_on_prompt_and_wake_if_sunk` holds it now.
         let inst_lock = state.instance_lock(&id).await;
         let acquired = tokio::time::timeout(Duration::from_secs(2), inst_lock.lock()).await;
         assert!(

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1334,29 +1334,29 @@ pub async fn acp_prompt(
         Ok(a) => a,
         Err((code, msg)) => return (code, msg).into_response(),
     };
+    // Claim the session's prompt-submission authority for the rest of the
+    // handler: the decision below and the dispatch it picks must be one
+    // atomic step. Releasing between them let a queue drain read a fold this
+    // prompt had not published into yet, so both delivered and whichever lost
+    // the agent's race came back `agent_busy` after its queue row was already
+    // retired (#3621).
+    //
+    // This is emphatically NOT `instance_lock`. `send_turn` ->
+    // `trigger_resume_background` detaches a task that calls
+    // `build_spawn_request`, which takes that lock, so a handler holding it
+    // could not let its own spawn start and burned `WORKER_READY_TIMEOUT`
+    // waiting for it (#3172).
+    let _submission = state.session_service.prompt_submission(&id).await;
     // A fresh user prompt supersedes any queued rate-limit resume
     // continuation, so drop it before sending: otherwise the reconciler could
     // later replay the older interrupted prompt after this newer one (#3028).
-    // The clear alone runs under the per-session `instance_lock`, and the
-    // guard is dropped before `send_turn`. Mutual exclusion with the
-    // pending-turn drain is enough to keep the #3028 ordering: the drain
-    // holds this same lock across its whole snapshot -> reload -> send ->
-    // clear, so whichever side wins the lock, the stale continuation can
-    // never be published after this newer prompt. If the drain wins it
-    // delivers first; if we win, the drain then reads None and returns.
-    //
-    // Holding the guard across `send_turn` is what broke #3172:
-    // `send_turn` -> `trigger_resume_background` detaches a task that calls
-    // `build_spawn_request`, which takes this very lock, so the spawn could
-    // not start until this handler released it, and the handler was busy
-    // burning `WORKER_READY_TIMEOUT` waiting for that spawn. Resume +
-    // publish + forward still live in the shared service so the plugin host
-    // delivers turns through the same path (#2897).
-    {
-        let inst_lock = state.instance_lock(&id).await;
-        let _serialized = inst_lock.lock().await;
-        state.session_service.clear_pending_initial_turn(&id).await;
-    }
+    // The pending-turn drain holds this same guard across its whole
+    // snapshot -> reload -> send -> clear, so whichever side wins it, the
+    // stale continuation can never be published after this newer prompt. If
+    // the drain wins it delivers first; if we win, the drain then reads None
+    // and returns. Resume + publish + forward live in the shared service so
+    // the plugin host delivers turns through the same path (#2897).
+    state.session_service.clear_pending_initial_turn(&id).await;
     // Decide here so every client follows the same send, steer, or queue rules.
     let dispatch = {
         let control = crate::server::acp_ws::fold_control_state(&state, &id).await;
@@ -1486,6 +1486,11 @@ pub async fn acp_prompt_diff_comments(
             return (StatusCode::NOT_FOUND, "session not found").into_response();
         }
     }
+    // This opens a turn (`UserDiffCommentsPrompt` folds to `turn_active`) just
+    // as an ordinary prompt does, so it takes the same submission authority:
+    // otherwise it can publish between a queue drain's idle check and its
+    // send, and the agent rejects whichever of the two it sees second (#3621).
+    let _submission = state.session_service.prompt_submission(&id).await;
     // Idle-dormant wake: respawn synchronously-reserved + detached so the
     // send_prompt below waits for the worker instead of 404ing. Mirrors
     // acp_prompt. See #1748.
@@ -3410,6 +3415,109 @@ mod tests {
                 .iter()
                 .any(|(_, e)| matches!(e, Event::UserPromptSent { .. })),
             "a prompt no worker ever received must not reach the event store"
+        );
+    }
+
+    /// #3621: deciding a prompt's disposition and acting on it is one step, so
+    /// a direct prompt cannot slip between a queue drain's idle check and the
+    /// moment its prompt reaches the agent.
+    ///
+    /// The drain reads the control fold, reloads attachments, and only then
+    /// sends; `send_turn` flips the fold to `turn_active` when it publishes. A
+    /// direct prompt whose own fold read landed inside that window also
+    /// decided "idle", so both pushed a `ClientCmd::Prompt`. The agent takes
+    /// the first and answers the second `agent_busy` — but `send_prompt`
+    /// reports success as soon as the command is queued, so the drain has
+    /// already retired the rows it sent. The follow-up is then gone from
+    /// durable queue state having never been delivered.
+    ///
+    /// Both halves are asserted: the direct prompt parks while the drain owns
+    /// the session, and a drain that runs against the turn the direct prompt
+    /// started leaves its row queued instead of retiring it into a rejection.
+    #[tokio::test]
+    async fn a_direct_prompt_and_the_queue_drain_cannot_both_own_the_same_turn() {
+        use std::time::Duration;
+
+        let mut inst = crate::session::Instance::new("race-3621", "/tmp/aoe-3621-race");
+        inst.id = "sess-3621-race".to_string();
+        inst.view = crate::session::View::Structured;
+        inst.status = crate::session::Status::Idle;
+        let id = inst.id.clone();
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+
+        // A worker that records what actually reaches the ACP command loop.
+        let cmds = state
+            .acp_supervisor
+            .test_insert_worker_cmd_recording(&id)
+            .await;
+        state
+            .session_service
+            .enqueue_prompt(
+                &id,
+                "q1".into(),
+                "queued follow-up".into(),
+                vec![],
+                None,
+                "t0".into(),
+            )
+            .await
+            .expect("session exists");
+
+        // Stand in for a drain that has decided to deliver and has not
+        // published yet: it owns the session's submission slot for that whole
+        // span.
+        let drain_owns_it = state.session_service.prompt_submission(&id).await;
+
+        let handler = tokio::spawn({
+            let state = Arc::clone(&state);
+            let id = id.clone();
+            async move {
+                acp_prompt(
+                    State(state),
+                    Path(id),
+                    Ok(Json(PromptRequest {
+                        text: "typed while the drain was mid-delivery".to_string(),
+                        attachments: Vec::new(),
+                        prompt_id: None,
+                    })),
+                )
+                .await
+                .into_response()
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !handler.is_finished(),
+            "a direct prompt must not decide its disposition while a drain owns the session"
+        );
+
+        drop(drain_owns_it);
+        let response = tokio::time::timeout(Duration::from_secs(30), handler)
+            .await
+            .expect("the handler must finish once the drain releases the session")
+            .expect("handler task must not panic");
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        // Its publish is what makes the fold read `turn_active`, so the drain
+        // that follows must park the queued row rather than deliver it into
+        // the turn this prompt just started.
+        state.session_service.drain_queued_prompts_once(&id).await;
+        assert_eq!(
+            state
+                .session_service
+                .queued_prompts_snapshot(&id)
+                .await
+                .len(),
+            1,
+            "the queued follow-up survives for the next tick instead of being retired into an agent_busy rejection"
+        );
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            *cmds.lock().expect("cmd log mutex poisoned"),
+            ["prompt"],
+            "exactly one prompt reaches the agent; a second would be refused as agent_busy"
         );
     }
 

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1339,13 +1339,9 @@ pub async fn acp_prompt(
     // atomic step. Releasing between them let a queue drain read a fold this
     // prompt had not published into yet, so both delivered and whichever lost
     // the agent's race came back `agent_busy` after its queue row was already
-    // retired (#3621).
-    //
-    // This is emphatically NOT `instance_lock`. `send_turn` ->
-    // `trigger_resume_background` detaches a task that calls
-    // `build_spawn_request`, which takes that lock, so a handler holding it
-    // could not let its own spawn start and burned `WORKER_READY_TIMEOUT`
-    // waiting for it (#3172).
+    // retired (#3621). Not `instance_lock`, for the reason `prompt_submission`
+    // documents: holding that one here stalls this handler's own resume
+    // (#3172).
     let _submission = state.session_service.prompt_submission(&id).await;
     // A fresh user prompt supersedes any queued rate-limit resume
     // continuation, so drop it before sending: otherwise the reconciler could

--- a/src/server/api/queue.rs
+++ b/src/server/api/queue.rs
@@ -100,6 +100,15 @@ pub async fn queue_enqueue(
         )
             .into_response();
     }
+    // Re-enqueuing an existing id rewrites that row's text and replaces its
+    // buffered blobs, so it is a queue mutation of exactly the kind
+    // `edit_queued_prompt` and `remove_queued_prompt` are serialized against:
+    // landing inside a drain's snapshot-to-send window means the old text goes
+    // to the agent and `retire_drained_rows` then deletes the row and the
+    // freshly buffered bytes (#3621). Claimed here rather than in
+    // `buffer_and_enqueue` because the prompt endpoint's `Queued` disposition
+    // reaches that helper already holding the guard, and it is not reentrant.
+    let _submission = state.session_service.prompt_submission(&id).await;
     // Depth cap. Re-enqueuing an existing id replaces that row rather than
     // adding one, so it must not count against a full queue.
     {
@@ -308,4 +317,58 @@ pub async fn queue_clear(
     }
     state.session_service.clear_queued_prompts(&id).await;
     StatusCode::NO_CONTENT.into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Instance;
+    use std::time::Duration;
+
+    /// #3621: `POST /queue` rewrites an existing row's text and blobs when the
+    /// client re-posts its id, so it must wait for an in-flight delivery the
+    /// same way an edit does. Otherwise the drain sends the pre-rewrite text
+    /// and then retires the row, dropping what the client just posted.
+    #[tokio::test]
+    async fn a_re_enqueue_waits_for_an_in_flight_delivery() {
+        let mut inst = Instance::new("queue-enq", "/tmp/aoe-3621-enqueue");
+        inst.id = "sess-3621-enq".to_string();
+        inst.view = crate::session::View::Structured;
+        inst.status = crate::session::Status::Idle;
+        let id = inst.id.clone();
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+
+        // Stand in for a drain holding the session across snapshot -> send.
+        let delivering = state.session_service.prompt_submission(&id).await;
+        let enqueue = tokio::spawn({
+            let state = Arc::clone(&state);
+            let id = id.clone();
+            async move {
+                queue_enqueue(
+                    State(state),
+                    Path(id),
+                    Ok(Json(EnqueueRequest {
+                        id: "q1".to_string(),
+                        text: "rewritten".to_string(),
+                        created_at: None,
+                        origin_device: None,
+                        attachments: Vec::new(),
+                    })),
+                )
+                .await
+                .into_response()
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !enqueue.is_finished(),
+            "an enqueue must not rewrite a row a delivery has already snapshotted"
+        );
+        drop(delivering);
+        let response = tokio::time::timeout(Duration::from_secs(10), enqueue)
+            .await
+            .expect("the enqueue lands once the delivery releases the session")
+            .expect("enqueue task must not panic");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1295,6 +1295,10 @@ pub async fn rename_session(
 
     // Serialize against other mutations on this session (start, delete,
     // worktree edit) so the tied git move and the metadata write don't race.
+    // Prompt submission has its own authority and never takes `instance_lock`
+    // (#3621), so hold that one too or a queue drain lands a follow-up on the
+    // worker this quiesces for the move. Submission first, as it documents.
+    let _submission = state.session_service.prompt_submission(&id).await;
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
@@ -1749,6 +1753,10 @@ pub async fn set_worktree_name(
 
     // Serialize against other mutations on this session (start, delete,
     // another rename) so the git ops and the metadata write don't race.
+    // Prompt submission has its own authority and never takes `instance_lock`
+    // (#3621), so hold that one too or a queue drain lands a follow-up on the
+    // worker this quiesces for the move. Submission first, as it documents.
+    let _submission = state.session_service.prompt_submission(&id).await;
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
@@ -4300,6 +4308,7 @@ async fn purge_session_artifacts(
                         &state.mutation_epoch,
                     );
                     state.instance_locks.write().await.remove(id);
+                    state.session_service.forget_prompt_lock(id).await;
                     Ok((true, result.messages))
                 }
                 crate::session::deletion::DeletionDisposition::KeptRestored => {
@@ -4431,6 +4440,7 @@ async fn purge_session_artifacts(
         remove_instance(&mut instances, id, &state.mutation_epoch);
     }
     state.instance_locks.write().await.remove(id);
+    state.session_service.forget_prompt_lock(id).await;
     if let Some(entry) = recent_entry {
         if let Err(e) = crate::session::record_recent_project(entry) {
             tracing::warn!(target: "http.api.sessions",

--- a/src/server/attach_project.rs
+++ b/src/server/attach_project.rs
@@ -20,7 +20,9 @@
 //! turn in flight" and then acting is not enough because a turn can start in the
 //! gap. So the whole sequence is held under the per-session `instance_lock`, the
 //! same lock the tied-worktree rename holds across its `git worktree move` plus
-//! metadata write, and the turn probe runs inside it.
+//! metadata write, and the turn probe runs inside it. Since #3621 that takes two
+//! locks, not one: prompt submission has its own per-session authority and never
+//! takes `instance_lock`, so the barrier holds `prompt_submission` outside it.
 //!
 //! ## Why the split against the session-domain half
 //!
@@ -87,6 +89,13 @@ pub(crate) async fn attach_project(
     repo_path: &Path,
     on_existing: ExistingBranch,
 ) -> Result<(AttachOutcome, WorkerOutcome), AttachError> {
+    // `instance_lock` alone stopped being the whole barrier once prompt
+    // submission moved to its own authority (#3621): the queue drains and every
+    // prompt endpoint serialize on `prompt_submission` and never take
+    // `instance_lock`, so a reconciler tick could otherwise deliver a queued
+    // follow-up to the worker this is about to stop and retire the row as sent.
+    // Claimed first, which is the order `prompt_submission` documents.
+    let _submission = state.session_service.prompt_submission(id).await;
     let inst_lock = state.instance_lock(id).await;
     // Held across the turn probe, the stop, the persist and the start. Releasing
     // it between any two of those is what would let a prompt land against a

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -499,8 +499,10 @@ impl SessionService {
         // Ownership gate, before ANY side effect (no wake, resume, publish,
         // or forward for a denied caller): a plugin may deliver turns only
         // to sessions it created. Ownership is immutable after creation, so
-        // a read snapshot suffices; deliberately no instance_lock here (the
-        // pending-turn drain calls this while holding it).
+        // a read snapshot suffices. Deliberately no instance_lock anywhere in
+        // this function: it waits on worker readiness below, and the resume it
+        // waits for needs that lock to finish (#3172, #3621). Callers own the
+        // per-session ordering through [`Self::prompt_submission`] instead.
         let (acp_mode_id, yolo_mode) = {
             let instances = self.instances.read().await;
             let Some(inst) = instances.iter().find(|i| i.id == id) else {
@@ -988,6 +990,12 @@ impl SessionService {
     /// the batch, so it retries on every reconciler tick, nothing behind it
     /// ever drains, and the idle reaper (which skips a session with a queue)
     /// keeps its worker alive forever.
+    ///
+    /// Takes [`Self::prompt_submission`] for the same reason
+    /// `remove_queued_prompt` does: the drain snapshots its batch and only
+    /// then sends, so an unserialized edit landing inside that window is
+    /// written to a row the drain has already copied. It delivers the old
+    /// text and retires the row, and the edit is lost with nothing to retry.
     #[cfg(feature = "serve")]
     pub(crate) async fn edit_queued_prompt(
         self: &Arc<Self>,
@@ -995,6 +1003,7 @@ impl SessionService {
         prompt_id: String,
         text: String,
     ) -> EditQueuedOutcome {
+        let _serialized = self.prompt_submission(id).await;
         self.mutate_instance_persisted(id, move |inst| {
             match inst.queued_prompts.iter_mut().find(|q| q.id == prompt_id) {
                 Some(q) if text.trim().is_empty() && q.attachments.is_empty() => {
@@ -1047,8 +1056,14 @@ impl SessionService {
 
     /// Drop every queued prompt for a session, plus every attachment blob
     /// buffered for those prompts.
+    ///
+    /// Serialized against delivery like the other queue mutations: clearing
+    /// inside the drain's snapshot-to-send window empties the durable rows
+    /// while the batch the drain already copied still goes to the agent, so
+    /// the user watches the queue empty and then sees it sent anyway.
     #[cfg(feature = "serve")]
     pub(crate) async fn clear_queued_prompts(self: &Arc<Self>, id: &str) {
+        let _serialized = self.prompt_submission(id).await;
         let cleared_ids = self
             .mutate_instance_persisted(id, move |inst| {
                 let ids: Vec<String> = inst.queued_prompts.iter().map(|q| q.id.clone()).collect();
@@ -1372,6 +1387,13 @@ impl SessionService {
     ///    lock would stall the very resume it is waiting for and give up after
     ///    `WORKER_READY_TIMEOUT`. This lock is deliberately distinct so the two
     ///    never overlap; where both are genuinely needed, take this one first.
+    ///
+    /// One input escapes the hold: `acp_prompt` samples `woke_idle_dormant`
+    /// from `touch_on_prompt_and_wake_if_sunk` before claiming the guard,
+    /// because that helper takes `instance_lock`. A stale `true` only forces
+    /// `send_turn`'s resume trigger, which answers `AlreadyResuming` or
+    /// `AlreadyRunning` for a worker that is already there, so it costs a
+    /// lookup rather than a wrong disposition.
     #[cfg(feature = "serve")]
     pub(crate) async fn prompt_submission(&self, id: &str) -> tokio::sync::OwnedMutexGuard<()> {
         let lock = {
@@ -2098,6 +2120,80 @@ mod tests {
             1,
             "no worker ever arrived, so the batch stays queued for the next tick"
         );
+    }
+
+    /// Every queue mutation that can race a delivery waits for it.
+    ///
+    /// The drain snapshots its batch and only then sends, so a mutation
+    /// landing inside that window changes rows the agent is already about to
+    /// receive: an edit is delivered as its old text and then retired, losing
+    /// the new text with nothing to retry, and a clear empties the durable
+    /// queue for a batch that goes out anyway. `remove_queued_prompt` was
+    /// already serialized for this reason; `edit` and `clear` were not.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn queue_mutations_wait_for_an_in_flight_delivery() {
+        use std::time::Duration;
+
+        let mut inst = Instance::new("queue-mut", "/tmp/aoe-queue-mutations");
+        inst.id = "sess-mut".to_string();
+        inst.view = crate::session::View::Structured;
+        inst.status = crate::session::Status::Idle;
+        let service = crate::server::test_support::build_test_app_state(vec![inst])
+            .session_service
+            .clone();
+        service
+            .enqueue_prompt(
+                "sess-mut",
+                "q1".into(),
+                "original".into(),
+                vec![],
+                None,
+                "t0".into(),
+            )
+            .await
+            .expect("session exists");
+
+        // Stand in for a drain holding the session across snapshot -> send.
+        let delivering = service.prompt_submission("sess-mut").await;
+        let edit = tokio::spawn({
+            let service = Arc::clone(&service);
+            async move {
+                service
+                    .edit_queued_prompt("sess-mut", "q1".into(), "edited".into())
+                    .await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !edit.is_finished(),
+            "an edit must not rewrite a row a delivery has already snapshotted"
+        );
+        drop(delivering);
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(10), edit)
+                .await
+                .expect("the edit lands once the delivery releases the session")
+                .expect("edit task must not panic"),
+            EditQueuedOutcome::Updated
+        ));
+
+        let delivering = service.prompt_submission("sess-mut").await;
+        let clear = tokio::spawn({
+            let service = Arc::clone(&service);
+            async move { service.clear_queued_prompts("sess-mut").await }
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !clear.is_finished(),
+            "a clear must not empty the queue out from under a delivery"
+        );
+        drop(delivering);
+        tokio::time::timeout(Duration::from_secs(10), clear)
+            .await
+            .expect("the clear lands once the delivery releases the session")
+            .expect("clear task must not panic");
+        assert!(service.queued_prompts_snapshot("sess-mut").await.is_empty());
     }
 
     /// Queueing a follow-up is a user gesture, so it must advance

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -640,7 +640,7 @@ impl SessionService {
             service: Arc::clone(self),
             id: id.to_string(),
         };
-        let _serialized = self.prompt_submission(id).await;
+        let _submission = self.prompt_submission(id).await;
         let Some((text, attachment_refs, profile, caller)) = ({
             let instances = self.instances.read().await;
             instances.iter().find(|i| i.id == id).and_then(|i| {
@@ -1009,7 +1009,7 @@ impl SessionService {
         prompt_id: String,
         text: String,
     ) -> EditQueuedOutcome {
-        let _serialized = self.prompt_submission(id).await;
+        let _submission = self.prompt_submission(id).await;
         self.mutate_instance_persisted(id, move |inst| {
             match inst.queued_prompts.iter_mut().find(|q| q.id == prompt_id) {
                 Some(q) if text.trim().is_empty() && q.attachments.is_empty() => {
@@ -1043,7 +1043,7 @@ impl SessionService {
         id: &str,
         prompt_id: String,
     ) -> bool {
-        let _serialized = self.prompt_submission(id).await;
+        let _submission = self.prompt_submission(id).await;
         let prompt_id_cleanup = prompt_id.clone();
         let removed = self
             .mutate_instance_persisted(id, move |inst| {
@@ -1069,7 +1069,7 @@ impl SessionService {
     /// the user watches the queue empty and then sees it sent anyway.
     #[cfg(feature = "serve")]
     pub(crate) async fn clear_queued_prompts(self: &Arc<Self>, id: &str) {
-        let _serialized = self.prompt_submission(id).await;
+        let _submission = self.prompt_submission(id).await;
         let cleared_ids = self
             .mutate_instance_persisted(id, move |inst| {
                 let ids: Vec<String> = inst.queued_prompts.iter().map(|q| q.id.clone()).collect();
@@ -1196,7 +1196,7 @@ impl SessionService {
             service: Arc::clone(self),
             id: id.to_string(),
         };
-        let _serialized = self.prompt_submission(id).await;
+        let _submission = self.prompt_submission(id).await;
 
         let (caller, agent_key, queue) = {
             let instances = self.instances.read().await;
@@ -1374,10 +1374,13 @@ impl SessionService {
     }
 
     /// The session's single prompt-submission authority: hold this guard
-    /// across the whole decide-then-dispatch step, so queue/steer/fresh-turn
-    /// ownership is settled atomically for every surface that can start a turn
-    /// (the `/acp/prompt` handler, the plugin host's `sessions.turn.send`, the
-    /// queue drain, and the pending-initial-turn drain). See #3621.
+    /// across the whole decide-then-dispatch step, so the `Sent` / `Steered` /
+    /// `Queued` disposition ([`crate::acp::dispatch::PromptDispatch`]) is
+    /// settled atomically for every surface that can start a turn (both prompt
+    /// endpoints, the plugin host's `sessions.turn.send`, the queue drain, and
+    /// the pending-initial-turn drain). The quiesce barriers that stop a worker
+    /// under it (`attach_project`, the tied-worktree renames) hold it too, so a
+    /// drain cannot deliver into a worker they are about to stop. See #3621.
     ///
     /// Two rules make this work, and neither is optional:
     ///
@@ -1417,6 +1420,23 @@ impl SessionService {
                 .clone(),
         };
         lock.lock_owned().await
+    }
+
+    /// Drop a deleted session's submission lock, mirroring the `instance_locks`
+    /// removal the same delete paths already do. The registry is keyed by
+    /// session id and nothing prunes it otherwise, so without this a long-lived
+    /// daemon retains one entry per session it has ever seen.
+    #[cfg(feature = "serve")]
+    pub(crate) async fn forget_prompt_lock(&self, id: &str) {
+        self.prompt_locks.write().await.remove(id);
+    }
+
+    /// Registry size for a test asserting `prompt_locks` stays bounded (e.g.
+    /// does not grow for ids that were never admitted past an existence
+    /// check).
+    #[cfg(all(test, feature = "serve"))]
+    pub(crate) async fn prompt_locks_len(&self) -> usize {
+        self.prompt_locks.read().await.len()
     }
 }
 

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -949,6 +949,12 @@ impl SessionService {
     /// edges kept recency fresh by accident; dropping that stamp is what made
     /// the missing gesture-side write observable in the attention sort and the
     /// TUI activity column.
+    ///
+    /// Deliberately does NOT take [`Self::prompt_submission`]: `acp_prompt`
+    /// calls this through `buffer_and_enqueue` while already holding it, and
+    /// the guard is not reentrant. The `queue_enqueue` handler claims it
+    /// instead, so the row rewrite this does for an existing id still cannot
+    /// land inside a drain's snapshot-to-send window.
     #[cfg(feature = "serve")]
     pub(crate) async fn enqueue_prompt(
         self: &Arc<Self>,

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -194,9 +194,13 @@ pub struct SessionService {
     pending_drains: std::sync::Mutex<std::collections::HashSet<String>>,
     /// Per-session persist locks for `mutate_instance_persisted`, held across
     /// snapshot AND disk write so the two cannot be reordered. Distinct from
-    /// `instance_locks`: the drain holds that one across `send_turn` and then
-    /// calls this path, so reusing it would self-deadlock.
+    /// the other two: the drains hold `prompt_locks` across `send_turn` and
+    /// then call this path, so reusing either would self-deadlock.
     persist_locks: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Per-session prompt-submission locks. See
+    /// [`SessionService::prompt_submission`].
+    #[cfg(feature = "serve")]
+    prompt_locks: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 /// Who is asking the session service to act. Constructed only by the
@@ -289,6 +293,7 @@ impl SessionService {
             create_in_flight: std::sync::Mutex::new(HashMap::new()),
             pending_drains: std::sync::Mutex::new(std::collections::HashSet::new()),
             persist_locks: RwLock::new(HashMap::new()),
+            prompt_locks: RwLock::new(HashMap::new()),
         }
     }
 
@@ -610,9 +615,11 @@ impl SessionService {
     ///
     /// Single drain owner: callers (the create fast path and the reconciler
     /// tick) race through the `pending_drains` claim, and the delivery runs
-    /// under the per-instance lock, so the turn cannot be published twice
-    /// concurrently. A delivery failure leaves the field set; the reconciler
-    /// tick retries once the worker is live. Clearing writes memory first,
+    /// under the session's [`Self::prompt_submission`] guard, so the turn
+    /// cannot be published twice concurrently and a direct prompt cannot
+    /// decide its own disposition mid-delivery. A delivery failure leaves the
+    /// field set; the reconciler tick retries once the worker is live.
+    /// Clearing writes memory first,
     /// then disk: a crash (or failed persist) between the forward and the
     /// disk clear re-delivers after restart, which is the documented
     /// at-least-once contract.
@@ -631,8 +638,7 @@ impl SessionService {
             service: Arc::clone(self),
             id: id.to_string(),
         };
-        let inst_lock = self.instance_lock(id).await;
-        let _serialized = inst_lock.lock().await;
+        let _serialized = self.prompt_submission(id).await;
         let Some((text, attachment_refs, profile, caller)) = ({
             let instances = self.instances.read().await;
             instances.iter().find(|i| i.id == id).and_then(|i| {
@@ -1008,9 +1014,9 @@ impl SessionService {
     /// Remove a queued prompt by id. Returns `true` if a row was removed. Also
     /// drops any attachment bytes buffered for that prompt so they don't leak.
     ///
-    /// Takes the per-instance lock the drain holds across its whole
-    /// snapshot -> send -> retire, so a removal cannot land in the middle of a
-    /// delivery. Without it the web's "Send now" (which removes the row, then
+    /// Takes the [`Self::prompt_submission`] guard the drain holds across its
+    /// whole snapshot -> send -> retire, so a removal cannot land in the middle
+    /// of a delivery. Without it the web's "Send now" (which removes the row, then
     /// POSTs the same text itself) could tap inside the drain window: the drain
     /// already holds its own copy of the batch, so both would deliver and the
     /// agent would see the prompt twice. Serialized, the removal either beats
@@ -1022,8 +1028,7 @@ impl SessionService {
         id: &str,
         prompt_id: String,
     ) -> bool {
-        let inst_lock = self.instance_lock(id).await;
-        let _serialized = inst_lock.lock().await;
+        let _serialized = self.prompt_submission(id).await;
         let prompt_id_cleanup = prompt_id.clone();
         let removed = self
             .mutate_instance_persisted(id, move |inst| {
@@ -1135,17 +1140,23 @@ impl SessionService {
     /// Drain the leading batch of a session's server-owned queue into the live
     /// worker once the current turn has ended. Mirrors
     /// `drain_pending_initial_turn`'s single-owner `pending_drains` claim +
-    /// per-instance-lock delivery, so a batch is never sent twice concurrently.
+    /// [`Self::prompt_submission`] delivery, so a batch is never sent twice
+    /// concurrently and the idle check below cannot be invalidated by a direct
+    /// prompt deciding its own disposition before this one reaches the agent.
     ///
     /// Only drains an idle turn, and asks the live control fold rather than
     /// `Instance.status`: dispatch parks a prompt on that fold, so gating the
     /// delivery on the lagging status mirror lets the drain hand a queued
     /// prompt to the turn it was parked behind.
     ///
-    /// Callers (the reconciler tick) gate on `is_running`, so the worker is
-    /// live and `send_turn` will not spawn, making it safe to hold the instance
-    /// lock across delivery (the #3172 re-entrant-spawn deadlock cannot occur on
-    /// a live worker). The `/clear`-boundary split matches the client
+    /// The reconciler tick gates on `is_running`, which is also true for a
+    /// resume that has reserved its slot but has no worker yet, so `send_turn`
+    /// here can park on `WORKER_READY_TIMEOUT`. That is why delivery must not
+    /// hold `instance_lock`: the resume being waited for takes it inside
+    /// `build_spawn_request`, and holding it stalled the drain for the whole
+    /// timeout and left the queue for a later retry (#3621).
+    ///
+    /// The `/clear`-boundary split matches the client
     /// (`useAcpSession`): a clear-command row fires as its own turn; a leading
     /// run of non-clear rows combines into one with blank-line separators.
     /// A batch's buffered attachment bytes are reloaded and forwarded with it.
@@ -1164,8 +1175,7 @@ impl SessionService {
             service: Arc::clone(self),
             id: id.to_string(),
         };
-        let inst_lock = self.instance_lock(id).await;
-        let _serialized = inst_lock.lock().await;
+        let _serialized = self.prompt_submission(id).await;
 
         let (caller, agent_key, queue) = {
             let instances = self.instances.read().await;
@@ -1340,6 +1350,45 @@ impl SessionService {
             .entry(id.to_string())
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
+    }
+
+    /// The session's single prompt-submission authority: hold this guard
+    /// across the whole decide-then-dispatch step, so queue/steer/fresh-turn
+    /// ownership is settled atomically for every surface that can start a turn
+    /// (the `/acp/prompt` handler, the plugin host's `sessions.turn.send`, the
+    /// queue drain, and the pending-initial-turn drain). See #3621.
+    ///
+    /// Two rules make this work, and neither is optional:
+    ///
+    /// 1. **Decide and dispatch under one hold.** Dispatch reads
+    ///    [`Self::fold_control_state`], and the fold flips to `turn_active` at
+    ///    the publish choke point inside `send_turn`. Deciding under this lock
+    ///    means the loser of a race reads the winner's publish and parks,
+    ///    rather than pushing a second `ClientCmd::Prompt` at a busy agent that
+    ///    answers `PromptRejected(agent_busy)` after the queue row is retired.
+    /// 2. **Never `instance_lock`.** `send_turn` waits on worker readiness, and
+    ///    the resume it waits for builds its spawn request under `instance_lock`
+    ///    (`acp_reconciler::build_spawn_request`). A submitter that held that
+    ///    lock would stall the very resume it is waiting for and give up after
+    ///    `WORKER_READY_TIMEOUT`. This lock is deliberately distinct so the two
+    ///    never overlap; where both are genuinely needed, take this one first.
+    #[cfg(feature = "serve")]
+    pub(crate) async fn prompt_submission(&self, id: &str) -> tokio::sync::OwnedMutexGuard<()> {
+        let lock = {
+            let guard = self.prompt_locks.read().await;
+            guard.get(id).cloned()
+        };
+        let lock = match lock {
+            Some(lock) => lock,
+            None => self
+                .prompt_locks
+                .write()
+                .await
+                .entry(id.to_string())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone(),
+        };
+        lock.lock_owned().await
     }
 }
 
@@ -1961,6 +2010,93 @@ mod tests {
             service.queued_prompts_snapshot("sess-mid-turn").await.len(),
             1,
             "a turn is in flight, so the drain must leave the queue for the next tick"
+        );
+    }
+
+    /// #3621: the queue drain must leave `instance_lock` free while it waits
+    /// for a worker.
+    ///
+    /// The reconciler starts the drain on `is_running`, which is also true for
+    /// a resume that has reserved its slot but has not produced a worker yet.
+    /// The drain then parks in `send_turn`'s readiness wait, and the resume it
+    /// is parked on cannot finish, because `build_spawn_request` needs that
+    /// same lock. Pre-fix the two sat on each other for the whole
+    /// `WORKER_READY_TIMEOUT`, after which the drain gave up and left the batch
+    /// for a later tick.
+    ///
+    /// A held `ResumeReservation` stands in for the spawn in flight, the same
+    /// fixture `acp::wake_prompt_frees_instance_lock_and_publishes_nothing_without_a_worker`
+    /// uses: it makes `wait_for_worker` park exactly as it does mid-respawn,
+    /// with no process, sandbox, or agent involved.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn the_queue_drain_frees_instance_lock_while_it_waits_for_a_resuming_worker() {
+        use crate::acp::supervisor::{ResumeKind, ResumeReservationOutcome};
+        use std::time::Duration;
+
+        let mut inst = Instance::new("queue-3621", "/tmp/aoe-3621-drain");
+        inst.id = "sess-3621".to_string();
+        inst.view = crate::session::View::Structured;
+        inst.status = crate::session::Status::Idle;
+        let service = crate::server::test_support::build_test_app_state(vec![inst])
+            .session_service
+            .clone();
+
+        // Deliverable text, so the drain reaches `send_turn` rather than
+        // retiring an undeliverable husk on the way.
+        service
+            .enqueue_prompt(
+                "sess-3621",
+                "q1".into(),
+                "follow-up".into(),
+                vec![],
+                None,
+                "t0".into(),
+            )
+            .await
+            .expect("session exists");
+
+        // Hold the reservation for the whole probe so no worker can land.
+        let reservation = match service
+            .acp_supervisor
+            .begin_resume("sess-3621", ResumeKind::Spawn)
+            .await
+            .expect("begin_resume must not error under capacity")
+        {
+            ResumeReservationOutcome::Reserved(r) => r,
+            ResumeReservationOutcome::AlreadyPresent => panic!("expected a fresh reservation"),
+        };
+
+        let drain = tokio::spawn({
+            let service = Arc::clone(&service);
+            async move { service.drain_queued_prompts_once("sess-3621").await }
+        });
+
+        // Let the drain reach its parked readiness wait. It cannot return
+        // until the reservation drops, so anything past delivery is enough.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // The 2s budget is far under the 10s `WORKER_READY_TIMEOUT` the
+        // pre-fix drain holds the lock for, and far over what the fixed one
+        // needs, since it never takes the lock at all.
+        let inst_lock = service.instance_lock("sess-3621").await;
+        let acquired = tokio::time::timeout(Duration::from_secs(2), inst_lock.lock()).await;
+        assert!(
+            acquired.is_ok(),
+            "the drain must leave instance_lock free for the resume's build_spawn_request"
+        );
+        drop(acquired);
+
+        drop(reservation);
+        tokio::time::timeout(Duration::from_secs(30), drain)
+            .await
+            .expect("the drain must finish once the reservation drops")
+            .expect("drain task must not panic");
+
+        assert_eq!(
+            service.queued_prompts_snapshot("sess-3621").await.len(),
+            1,
+            "no worker ever arrived, so the batch stays queued for the next tick"
         );
     }
 


### PR DESCRIPTION
## Description

If you type a follow-up while the agent is busy, it gets parked in a queue and delivered once the agent frees up. Two things could go wrong with that delivery. If the agent's process happened to be restarting at that moment, the delivery would wait ten seconds and then give up, because it was holding the very thing the restart needed in order to finish. And if you sent another message at the same instant a queued one was going out, both reached the agent at once; the agent takes one and refuses the other, but the queue had already discarded its copy, so that message was lost with no trace. This makes each session hand out one turn at a time, so the two can no longer collide, and stops a delivery from blocking the restart it is waiting on.

Both gaps in #3621 were reproduced against the code before any fix. The second one is real but via the opposite interleaving to the one reported: the drain holds `instance_lock` throughout, so a direct prompt that has not yet reached its pending-turn cleanup blocks there and reads a post-publish fold. The reachable window is a direct prompt clearing that scope, yielding at `fold_control_state`, and the drain then reading a stale-idle fold.

Every surface that can open a turn now takes one per-session prompt-submission guard held across decide and dispatch: both prompt endpoints, the plugin host's `sessions.turn.send`, both drains, and the queued-row removal that must exclude a delivery. It is deliberately distinct from `instance_lock` so a submitter never blocks the resume it is waiting for, which is what keeps #3172 fixed.

`drain_pending_initial_turn` and `remove_queued_prompt` had to move onto the same guard rather than being optional extras: the former is what gives the handler's `clear_pending_initial_turn` its mutual exclusion (#3028), and the latter's contract is documented as "the lock the drain holds". `edit_queued_prompt`, `clear_queued_prompts`, and the re-post branch of `enqueue_prompt` were never serialized against delivery either, so they are folded in: an edit inside the drain's snapshot-to-send window is delivered as its old text and then retired, and a clear empties the queue for a batch that sends anyway. Both are pre-existing rather than introduced here, but the authority is the thing that closes them.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt --check`, `cargo clippy --features serve`, and `cargo check` (no serve) are clean. `cargo test --features serve --lib`: 6487 passed, 3 failed. All three failures are pre-existing and environmental, not related to this change: two use a `chmod 0o000` fixture that cannot hold when the suite runs as root (verified: uid 0 reads the file anyway, so the fixture's own precondition assertion is what fails), and `hooks_install::test_content_shows_settings_path` asserts a hardcoded `.claude/settings.json` while this environment sets `CLAUDE_CONFIG_DIR=/root/.claude-personal`. `process::tests::run_with_timeout_process_group_kills_descendants` also failed once under full-suite load and passes in isolation, so it is flaky here rather than affected by this change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: both regressions are lock-ordering races in the daemon, and the cheapest thing that can catch them deterministically is a Rust unit test. Four were added. `the_queue_drain_frees_instance_lock_while_it_waits_for_a_resuming_worker` parks the drain on a held `ResumeReservation` and asserts `instance_lock` stays free, and fails pre-fix because the drain creates the shared lock entry it then holds for the full timeout. `a_direct_prompt_and_the_queue_drain_cannot_both_own_the_same_turn` asserts a direct prompt cannot dispatch while a drain owns the session, that the queued row survives instead of being retired into a rejection, and that exactly one `ClientCmd::Prompt` reaches the agent. `queue_mutations_wait_for_an_in_flight_delivery` covers the two newly serialized queue mutations, and `a_re_enqueue_waits_for_an_in_flight_delivery` covers the re-post path, where `POST /queue` with an already-queued id rewrites that row in place. A full-binary e2e test would have to win a scheduling race to observe any of them.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any Additional AI Details you'd like to share:**

Issue #3621 was filed against code merged hours earlier and had not been confirmed by anyone. Both claims were verified against the code first, including checking that the control fold updates synchronously at the publish choke point, since an asynchronously updated fold would have made a lock insufficient.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3621


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a shared per-session prompt-submission guard.
- Serialized direct prompts, plugin submissions, queue delivery, edits, clears, removals, and re-enqueues.
- Prevented queue delivery from blocking worker resumes while waiting for worker readiness.
- Cleaned up prompt guards when sessions are deleted and rejected unknown plugin sessions before creating guards.
- Added deterministic tests for respawn stalls, concurrent dispatch, and queue mutation races.
- Updated documentation and test helpers.

## Benefits

- Prevents queued prompts from stalling during worker respawn.
- Prevents concurrent submissions from losing queued messages.
- Preserves prompt ownership, queue order, and worker quiescence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->