### PR TITLE
fix(acp): align aoe-agent node, sdk and model contracts

### DIFF
--- a/acp-worker/aoe-agent/package.json
+++ b/acp-worker/aoe-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aoe-agent",
   "version": "0.0.1",
-  "description": "Multi-provider ACP agent for the Agent of Empires structured view. Wraps Vercel AI SDK 6 in an ACP server.",
+  "description": "Multi-provider ACP agent for the Agent of Empires structured view. Wraps Vercel AI SDK 7 in an ACP server.",
   "type": "module",
   "main": "src/index.ts",
   "bin": {

--- a/acp-worker/aoe-agent/src/index.ts
+++ b/acp-worker/aoe-agent/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * aoe-agent: ACP server wrapping Vercel AI SDK 6.
+ * aoe-agent: ACP server wrapping Vercel AI SDK 7.
  *
  * One Node process per structured-view session. Accepts ACP requests from aoe
  * (the Rust ACP client) on stdin/stdout, drives a Vercel AI SDK loop
@@ -288,6 +288,12 @@ function serialiseToolOutput(output: unknown): Record<string, unknown> {
   return { value: output };
 }
 
+/**
+ * Map an `AOE_AGENT_MODEL` id onto a provider. Anthropic, OpenAI and
+ * Google only, by bare prefix or an explicit `provider:` prefix.
+ * Anything else hits the Anthropic fallback, so local-model ids are not
+ * a valid configuration until an openai-compatible branch exists.
+ */
 function pickModel(modelId: string) {
   if (modelId.startsWith("claude-") || modelId.startsWith("anthropic:")) {
     return anthropic(modelId.replace(/^anthropic:/, ""));

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -86,7 +86,7 @@ aoe add . --agent codex --model gpt-5       # pick an ACP agent + model (implies
 ## Requirements
 
 - aoe built with `--features serve`.
-- Node.js 22+ on `PATH` (the structured view spawns an ACP agent subprocess; `aoe-agent` declares `engines.node: >=22.0.0` and is started with `node --experimental-strip-types`).
+- Node.js 22+ on `PATH` (the structured view spawns an ACP agent subprocess; `aoe-agent` declares `engines.node: >=22.0.0`).
 - For Claude Code, a `claude login` session.
 
 If Node is missing or too old, the session falls back to the terminal view with an actionable warning. Verify with `aoe acp doctor`:

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -29,7 +29,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 | `omp` | `omp acp` (native) | `curl -fsSL https://omp.sh/install \| sh` | provider environment or OMP login |
 | `kimi` | `kimi acp` (native) | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | `kimi login`, or provider env |
 | `prime-agent` | `prime-agent --mode acp` (native) | `curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh \| sh` | `/login` once, or provider env |
-| `aoe-agent` | in-tree (Vercel AI SDK 6) | not yet packaged; needs a local build of `acp-worker/aoe-agent` (#3553) | provider env vars |
+| `aoe-agent` | in-tree (Vercel AI SDK 7) | not yet packaged; needs a local build of `acp-worker/aoe-agent` (#3553) | provider env vars |
 
 Gemini CLI is deprecated upstream for individual accounts since 2026-06-18. Enterprise and API-key authentication remain valid; Antigravity CLI is the replacement for consumer accounts.
 
@@ -86,7 +86,7 @@ aoe add . --agent codex --model gpt-5       # pick an ACP agent + model (implies
 ## Requirements
 
 - aoe built with `--features serve`.
-- Node.js 20+ on `PATH` (the structured view spawns an ACP agent subprocess; `aoe-agent` needs Node 20+ for Vercel AI SDK 6).
+- Node.js 22+ on `PATH` (the structured view spawns an ACP agent subprocess; `aoe-agent` declares `engines.node: >=22.0.0` and is started with `node --experimental-strip-types`).
 - For Claude Code, a `claude login` session.
 
 If Node is missing or too old, the session falls back to the terminal view with an actionable warning. Verify with `aoe acp doctor`:

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -35,10 +35,10 @@ handshake times out after 30s.
 
 ### `aoe acp doctor` says Node is missing
 
-Install Node.js 20 or newer:
+Install Node.js 22 or newer:
 
 - macOS: `brew install node`
-- Linux: `apt install nodejs` or `nvm install 20`
+- Linux: `apt install nodejs` or `nvm install 22`
 - Windows: download from <https://nodejs.org/>
 
 Then re-run `aoe acp doctor` to verify. If you have Node installed in a

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,10 @@
             # assets/pi, the extension src/session/instance.rs materializes so
             # pi can publish its own conversation id, and
             # docker/Dockerfile, which the agent_compat test embeds to pin the
-            # sandbox npm floor (the aoe-test and aoe-clippy checks compile test
-            # code, so they need it even though the packages do not).
+            # sandbox npm floor, and acp-worker/aoe-agent/package.json, which
+            # the acp::node test embeds to pin `engines.node` to
+            # MIN_NODE_MAJOR (the aoe-test and aoe-clippy checks compile test
+            # code, so they need these even though the packages do not).
             # `scripts/check-nix-embedded-assets.py` fails CI if a new embedded
             # asset lands without being added here.
             src = pkgs.lib.fileset.toSource {
@@ -45,6 +47,7 @@
               fileset = pkgs.lib.fileset.unions [
                 (craneLib.fileset.commonCargoSources ./.)
                 ./acp-worker/adapters
+                ./acp-worker/aoe-agent/package.json
                 ./assets
                 ./docker
               ];

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -294,7 +294,7 @@ pub const PRIME_AGENT: AgentProfile = AgentProfile {
 };
 
 /// aoe's own multi-provider agent. Treated as Claude-equivalent
-/// for now (Vercel AI SDK 6 with Claude as one of the providers); the
+/// for now (Vercel AI SDK 7 with Claude as one of the providers); the
 /// claude_capabilities subset is the safest reference until aoe-agent
 /// has its own conventions.
 pub const AOE_AGENT: AgentProfile = AgentProfile {

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -5,7 +5,7 @@
 //! - aoe is an ACP **client**.
 //! - Backends are ACP **agents** spawned as subprocesses.
 //! - Day-one backends: `claude-code` (Anthropic's official ACP adapter) and
-//!   `aoe-agent` (our Node binary, Vercel AI SDK 6).
+//!   `aoe-agent` (our Node binary, Vercel AI SDK 7).
 //! - File-system access (`fs/*`) and terminal execution (`terminal/*`) are
 //!   delegated from the agent to aoe via ACP. aoe owns the disk; the agent
 //!   only orchestrates the model.

--- a/src/acp/node.rs
+++ b/src/acp/node.rs
@@ -19,9 +19,8 @@ use thiserror::Error;
 use tracing::{debug, info, warn};
 
 /// The minimum Node major version aoe-agent supports. Pinned to the
-/// `engines.node` field in `acp-worker/aoe-agent/package.json`: aoe-agent
-/// runs its TypeScript sources under `node --experimental-strip-types`,
-/// which needs Node 22.
+/// `engines.node` field in `acp-worker/aoe-agent/package.json` by
+/// `package_engines_matches_min_node_major`.
 pub const MIN_NODE_MAJOR: u32 = 22;
 
 /// The pinned Node version aoe downloads when no host Node is found.

--- a/src/acp/node.rs
+++ b/src/acp/node.rs
@@ -18,9 +18,11 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
-/// The minimum Node major version aoe-agent supports. Matches the
-/// `engines.node` field in `acp-worker/aoe-agent/package.json`.
-pub const MIN_NODE_MAJOR: u32 = 20;
+/// The minimum Node major version aoe-agent supports. Pinned to the
+/// `engines.node` field in `acp-worker/aoe-agent/package.json`: aoe-agent
+/// runs its TypeScript sources under `node --experimental-strip-types`,
+/// which needs Node 22.
+pub const MIN_NODE_MAJOR: u32 = 22;
 
 /// The pinned Node version aoe downloads when no host Node is found.
 /// Bumping this requires bumping the SHA-256 below at the same time.
@@ -96,12 +98,7 @@ fn verify_path(path: &Path, source: NodeSource) -> Result<ResolvedNode, NodeErro
         });
     }
     let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let major = parse_major(&raw).ok_or_else(|| NodeError::TooOld {
-        path: path.to_path_buf(),
-        found: raw.clone(),
-        min: MIN_NODE_MAJOR,
-    })?;
-    if major < MIN_NODE_MAJOR {
+    if meets_minimum(&raw) != Some(true) {
         return Err(NodeError::TooOld {
             path: path.to_path_buf(),
             found: raw,
@@ -120,6 +117,14 @@ fn parse_major(raw: &str) -> Option<u32> {
     let trimmed = raw.trim_start_matches('v');
     let major_str = trimmed.split('.').next()?;
     major_str.parse::<u32>().ok()
+}
+
+/// Whether a raw `node --version` string satisfies [`MIN_NODE_MAJOR`].
+/// `None` for unrecognisable output, which callers must treat as "not
+/// proven compatible" rather than as a pass. The spawn path and
+/// `aoe acp doctor` share this so their verdicts cannot diverge.
+pub fn meets_minimum(raw: &str) -> Option<bool> {
+    parse_major(raw).map(|major| major >= MIN_NODE_MAJOR)
 }
 
 fn which(binary: &str) -> Option<PathBuf> {
@@ -306,6 +311,43 @@ mod tests {
         assert_eq!(parse_major("v20.0.0"), Some(20));
         assert_eq!(parse_major("18.17.1"), Some(18));
         assert_eq!(parse_major("not a version"), None);
+    }
+
+    #[test]
+    fn meets_minimum_is_inclusive_at_the_boundary() {
+        for (raw, expected) in [
+            (format!("v{}.9.9", MIN_NODE_MAJOR - 1), Some(false)),
+            (format!("v{MIN_NODE_MAJOR}.0.0"), Some(true)),
+            (format!("{MIN_NODE_MAJOR}.0.0"), Some(true)),
+            (format!("v{}.0.0", MIN_NODE_MAJOR + 1), Some(true)),
+            ("not a version".to_string(), None),
+            (String::new(), None),
+        ] {
+            assert_eq!(meets_minimum(&raw), expected, "for {raw:?}");
+        }
+    }
+
+    #[test]
+    fn package_engines_matches_min_node_major() {
+        // package.json cannot read a Rust const, so `engines.node` is the
+        // one restatement of the floor outside this module. Assert it
+        // tracks the gate so a bump that forgets one side fails CI instead
+        // of letting a host pass `aoe acp doctor` and fail at spawn.
+        let manifest = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/acp-worker/aoe-agent/package.json"
+        ));
+        let json: serde_json::Value = serde_json::from_str(manifest).expect("valid package.json");
+        let engines = json["engines"]["node"]
+            .as_str()
+            .expect("package.json declares engines.node");
+        let declared = parse_major(engines.trim_start_matches(">="))
+            .unwrap_or_else(|| panic!("unparseable engines.node range {engines:?}"));
+        assert_eq!(declared, MIN_NODE_MAJOR, "engines.node is {engines:?}");
+
+        // The runtime we download when the host has none must clear the
+        // same bar, or `download` returns a Node `verify_path` rejects.
+        assert_eq!(meets_minimum(PINNED_NODE_VERSION), Some(true));
     }
 
     #[test]

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -737,7 +737,7 @@ fn check_node() -> NodeStatus {
     let (version, meets_minimum) = match output {
         Ok(out) if out.status.success() => {
             let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            let meets = parse_node_major(&raw).map(|m| m >= 20);
+            let meets = node::meets_minimum(&raw);
             (Some(raw), meets)
         }
         _ => (None, None),
@@ -748,12 +748,6 @@ fn check_node() -> NodeStatus {
         version,
         meets_minimum,
     }
-}
-
-fn parse_node_major(raw: &str) -> Option<u32> {
-    let trimmed = raw.trim_start_matches('v');
-    let major_str = trimmed.split('.').next()?;
-    major_str.parse::<u32>().ok()
 }
 
 fn find_in_path(binary: &str) -> Option<String> {
@@ -1253,14 +1247,6 @@ fn event_kind(event: &crate::acp::Event) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_node_major_works() {
-        assert_eq!(parse_node_major("v22.21.0"), Some(22));
-        assert_eq!(parse_node_major("v20.0.0"), Some(20));
-        assert_eq!(parse_node_major("18.17.1"), Some(18));
-        assert_eq!(parse_node_major("not a version"), None);
-    }
 
     #[test]
     fn registry_lifecycle_mirrors_agents_registry() {

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -486,8 +486,9 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_name: Option<String>,
     /// Optional model id, injected at spawn as `AOE_AGENT_MODEL` (e.g.,
-    /// "claude-opus-4-7", "gpt-5", "llama3.3:ollama"). Only `aoe-agent`
-    /// reads that variable.
+    /// "claude-opus-4-7", "gpt-5", "gemini-2.5-pro"). Only `aoe-agent` reads
+    /// it, and it routes Anthropic, OpenAI and Google ids only, by bare
+    /// prefix or an explicit `anthropic:`/`openai:`/`google:` prefix.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_model: Option<String>,
     /// Reasoning effort ("thought level") this session was explicitly pinned


### PR DESCRIPTION
## Description

Fixes #3653.

`aoe-agent`'s runtime and model contract was stated in several places that disagreed with each other. This aligns all of them and adds the drift guards.

**Node minimum (20 vs 22).** `MIN_NODE_MAJOR` was 20 and its doc claimed it matched the package, but `acp-worker/aoe-agent/package.json` declares `engines.node: >=22.0.0`. Node 22 is the real floor, not a preference: `aoe-agent` ships TypeScript sources and its `start` script is `node --experimental-strip-types`, a flag that does not exist before Node 22.6. So a Node 20 host could read `[OK] Node runtime` from `aoe acp doctor` and then fail at spawn. Raised the constant to 22 rather than relaxing `engines.node`, which would have made the doctor bless a runtime that cannot start the agent. Every other Node reference in the repo (`docker/Dockerfile`, `release.yml`, CI) is already on 22, so nothing else moves.

`aoe acp doctor` also kept its own `parse_node_major` plus a hardcoded `m >= 20`, a second copy of the boundary that had already drifted. `check_node` now calls the new `node::meets_minimum`, so the doctor's verdict and the spawn path's gate cannot diverge again. `meets_minimum` returns `None` for unreadable `node --version` output, which the call site's `unwrap_or(false)` treats as "not proven compatible" rather than as a pass.

**AI SDK major (6 vs 7).** The package depends on `ai` `^7.0.77` while the description, `src/acp/agent_profiles.rs`, `src/acp/mod.rs`, the agent's own file header and `docs/structured-view.md` all still said SDK 6. Updated to 7.

**`llama3.3:ollama`.** Took the smaller change: replaced the example with `gemini-2.5-pro`. The scope allowed implementing a provider branch instead "if the code clearly already supports an OpenAI-compatible provider path", and it does not. `@ai-sdk/openai-compatible` is a declared dependency but is never imported, and `pickModel` has no branch for it, so the advertised id falls through to `return anthropic(modelId)` and silently selects the wrong provider. Making it work would mean a new import, a base-URL setting to point at the Ollama endpoint, and settings/env plumbing to carry it, which is a feature, not a docs correction. I left the unused dependency in place so that feature is not blocked, and instead documented the routed set at both ends: on `Instance.agent_model` and above `pickModel`, which now states explicitly that anything outside Anthropic/OpenAI/Google hits the Anthropic fallback. `gemini-2.5-pro` is the example `aoe add --model` and `docs/cli/reference.md` already use.

`flake.nix`: the new test embeds `acp-worker/aoe-agent/package.json` with `include_str!`, and the Cargo source filter keeps only `*.rs`/`*.toml`, so the path is unioned into `commonArgs.src`. This is the same treatment `docker/Dockerfile` already gets for the `agent_compat` pin test. `scripts/check-nix-embedded-assets.py` passes.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

Two tests in `src/acp/node.rs`, plus the removal of the now-dead `parse_node_major` test in `src/cli/acp.rs` (its coverage moved to the shared helper):

- `meets_minimum_is_inclusive_at_the_boundary` is the boundary test the issue asks for. Table-driven over the three majors around `MIN_NODE_MAJOR` (below, exactly at, above), written against the constant rather than a literal so a future bump keeps testing the new boundary, plus the unparseable and empty cases that must stay `None`.
- `package_engines_matches_min_node_major` parses the real `engines.node` out of the manifest and asserts it equals `MIN_NODE_MAJOR`, so bumping one side alone fails CI instead of shipping the drift this issue is about. It also asserts `PINNED_NODE_VERSION` clears the same bar, since otherwise `download` would hand `verify_path` a runtime it rejects.

`acp-worker/aoe-agent`: `node --experimental-strip-types --test test/*.ts` passes (5/5) on Node 22.19.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the `aoe acp doctor` change is a version-comparison boundary, and an e2e test would assert against whatever Node the runner happens to have rather than against the boundary. The unit test above covers it directly and cheaply, which is what AGENTS.md asks for.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Claude Code)

**Any Additional AI Details you'd like to share:**

Note on local verification: this environment has no C toolchain (`cc` is absent and the sandbox cannot install one), so `cargo build`/`test`/`clippy` could not be run locally; `cargo fmt` and `scripts/check-nix-embedded-assets.py` were run and pass, and the Node test suite was run. Please lean on CI for the Rust checks.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Raised the minimum Node.js version to 22 across runtime checks, package metadata, and documentation.
- Added shared Node.js validation and boundary tests.
- Updated AI SDK references from version 6 to version 7.
- Replaced the unsupported Ollama example with `gemini-2.5-pro`.
- Documented supported model routing and fallback behavior.
- Updated Nix asset handling to include `package.json`.

## Benefits

- Keeps runtime checks, package requirements, and documentation consistent.
- Prevents unsupported model examples from selecting the wrong provider.
- Improves maintenance through shared validation and manifest-based tests.

Node tests, formatting, and embedded-asset checks pass. Rust checks remain unverified because the local environment lacks a C toolchain.

## Further enhancement

Add explicit Ollama or OpenAI-compatible provider support if local-model routing is required in the future.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->