### PR TITLE
fix(acp): complete the per-session prompt-submission barrier

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -299,6 +299,11 @@ for the full model.
 **Ownership.** `sessions.turn.send` only reaches a session the calling plugin
 created; a plugin cannot deliver turns to a user's or another plugin's session.
 
+**Busy sessions.** A turn aimed at a session whose agent is already running a
+non-steerable turn (or cancelling, or compacting) is refused with a retryable
+`agent_busy` rather than accepted and dropped. A stopped or dormant session is
+not busy: the host resumes it and waits.
+
 **Idempotency.** `sessions.create` accepts an `idempotency_key` scoped to the
 plugin: retrying with the same key and payload returns the existing session
 (`created: false`); a different payload under the same key is a conflict.

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -557,32 +557,37 @@ async fn sessions_turn_send(
 
     let result = async {
         deps.policy.admit_turn(&plugin_id)?;
-        // Reject an unknown session before claiming the submission guard:
-        // `prompt_submission` auto-vivifies a lock-registry entry for any id
-        // it is asked for, and nothing ever prunes it, so a plugin probing
-        // distinct nonexistent ids could otherwise grow the registry without
-        // bound within its turn quota.
-        if !deps
+        // Same per-session submission authority the HTTP surfaces and the
+        // queue drain take, and the same disposition decided under it, so a
+        // plugin turn cannot land between the drain's idle check and its send
+        // (#3621, #3649). An unknown session is refused here rather than by
+        // `send_turn`, so a plugin probing distinct nonexistent ids cannot
+        // grow the lock registry within its turn quota.
+        let Some((_submission, dispatch)) = deps
             .session_service
-            .instances
-            .read()
+            .begin_prompt_submission(&req.session_id, false)
             .await
-            .iter()
-            .any(|i| i.id == req.session_id)
-        {
+        else {
             return Err(DispatchError::with_kind(
                 codes::INVALID_PARAMS,
                 "session_not_found",
                 "session not found",
             ));
+        };
+        // A cold worker is not a refusal on this path: `send_turn` resumes it
+        // and waits, which is how a scheduler wakes a session it created. The
+        // turn gates are, because a second prompt at a busy non-steerable
+        // agent is refused asynchronously and the plugin would have been told
+        // its turn landed.
+        if let crate::acp::dispatch::PromptDispatch::Queued { reason } = dispatch {
+            if !matches!(reason, crate::acp::dispatch::QueueReason::WorkerDown) {
+                return Err(DispatchError::with_kind(
+                    codes::SERVICE_UNAVAILABLE,
+                    "agent_busy",
+                    "the session's agent is mid-turn; retry when it finishes",
+                ));
+            }
         }
-        // Same per-session submission authority the HTTP surfaces and the
-        // queue drain take, so a plugin turn cannot land between the drain's
-        // idle check and its send (#3621).
-        let _submission = deps
-            .session_service
-            .prompt_submission(&req.session_id)
-            .await;
         deps.session_service
             .send_turn(
                 &SessionCaller::Plugin {
@@ -868,6 +873,69 @@ mod tests {
             assert_eq!(err.code, expected_code, "{session}");
             assert_eq!(kind(&err), expected_kind, "{session}");
         }
+    }
+
+    /// #3649: a plugin turn is a turn-starting surface, so it must settle a
+    /// disposition under the submission guard instead of forwarding
+    /// unconditionally once the guard is its own. `send_prompt` acknowledges
+    /// the channel enqueue, so the pre-fix path answered `{}` for a prompt the
+    /// agent then refused as `agent_busy`, and the plugin's audit trail
+    /// recorded a turn that never ran.
+    #[tokio::test]
+    async fn turn_send_refuses_a_turn_another_submission_already_started() {
+        use std::time::Duration;
+
+        let mut inst = Instance::new("plugin-3649", "/tmp/aoe-3649-plugin");
+        inst.id = "sess-3649".to_string();
+        inst.view = crate::session::View::Structured;
+        inst.status = crate::session::Status::Idle;
+        inst.created_by_plugin = Some("cron".to_string());
+        let (deps, _dir) = test_deps(vec![inst]);
+        let cmds = deps
+            .session_service
+            .acp_supervisor
+            .test_insert_worker_cmd_recording("sess-3649")
+            .await;
+
+        let winner = deps.session_service.prompt_submission("sess-3649").await;
+        let send = tokio::spawn({
+            let deps = Arc::clone(&deps);
+            async move {
+                dispatch(
+                    &deps,
+                    &ctx_with(&["session.prompt"]),
+                    "sessions.turn.send",
+                    &serde_json::json!({ "session_id": "sess-3649", "text": "hi" }),
+                )
+                .await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !send.is_finished(),
+            "a plugin turn must not decide its disposition while another submission owns the session"
+        );
+
+        // What the winner does before releasing: publishing is the choke point
+        // that flips the control fold to `turn_active`.
+        deps.session_service
+            .acp_supervisor
+            .publish_user_prompt_with_attachments("sess-3649", "the winning turn".into(), &[], None)
+            .await;
+        drop(winner);
+
+        let err = tokio::time::timeout(Duration::from_secs(10), send)
+            .await
+            .expect("the RPC must finish once the winner releases the session")
+            .expect("dispatch task must not panic")
+            .expect_err("a turn that cannot start must not report success");
+        assert_eq!(err.code, codes::SERVICE_UNAVAILABLE);
+        assert_eq!(kind(&err), "agent_busy");
+        assert_eq!(
+            *cmds.lock().expect("cmd log mutex poisoned"),
+            Vec::<&'static str>::new(),
+            "nothing may reach the agent behind the running turn"
+        );
     }
 
     /// `prompt_submission` auto-vivifies a per-session lock-registry entry

--- a/src/server/acp_ws.rs
+++ b/src/server/acp_ws.rs
@@ -491,7 +491,8 @@ const COLD_STATE_FIELDS: [&str; 5] = [
 /// Identity fields to seed a fresh `AcpState` with: the reducer corrects
 /// `agent` on any `AgentSwitched`, but a fold that never sees one keeps this
 /// seed, so both the WS connection fold and the on-demand
-/// [`fold_control_state`] must start from the same place.
+/// [`crate::server::session_service::SessionService::fold_control_state`]
+/// must start from the same place.
 async fn seed_identity(state: &AppState, session_id: &str) -> (AgentName, Option<String>) {
     let instances = state.instances.read().await;
     instances
@@ -504,12 +505,6 @@ async fn seed_identity(state: &AppState, session_id: &str) -> (AgentName, Option
             )
         })
         .unwrap_or_else(|| (AgentName(String::new()), None))
-}
-
-/// The daemon's current control state for a session, for HTTP handlers that
-/// hold `AppState`. See [`crate::server::session_service::SessionService::fold_control_state`].
-pub(crate) async fn fold_control_state(state: &AppState, session_id: &str) -> AcpState {
-    state.session_service.fold_control_state(session_id).await
 }
 
 fn fold_connect_history(
@@ -1055,7 +1050,7 @@ mod tests {
                 prompt_id: None,
             },
         );
-        let folded = fold_control_state(&state, "s-fold").await;
+        let folded = state.session_service.fold_control_state("s-fold").await;
         assert!(folded.turn_active, "the prompt opened a turn");
         assert!(folded.steering, "capabilities survive the fold");
         assert!(!folded.cancelling);
@@ -1078,7 +1073,7 @@ mod tests {
                 escalates_at: chrono::Utc::now(),
             },
         );
-        let folded = fold_control_state(&state, "s-fold").await;
+        let folded = state.session_service.fold_control_state("s-fold").await;
         assert!(folded.cancelling);
         assert_eq!(
             crate::acp::dispatch::decide(
@@ -1100,7 +1095,7 @@ mod tests {
                 reason: "cancelled".into(),
             },
         );
-        let folded = fold_control_state(&state, "s-fold").await;
+        let folded = state.session_service.fold_control_state("s-fold").await;
         assert!(!folded.turn_active, "Stopped closed the turn");
         assert!(!folded.cancelling, "and cleared the pending cancel");
         assert_eq!(
@@ -1117,7 +1112,7 @@ mod tests {
         // An unknown session folds to a default (idle) state rather than
         // erroring, so a prompt for a session the daemon has not seen is not
         // parked forever on a phantom turn.
-        let unknown = fold_control_state(&state, "s-missing").await;
+        let unknown = state.session_service.fold_control_state("s-missing").await;
         assert!(!unknown.turn_active);
     }
 

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1334,15 +1334,21 @@ pub async fn acp_prompt(
         Ok(a) => a,
         Err((code, msg)) => return (code, msg).into_response(),
     };
-    // Claim the session's prompt-submission authority for the rest of the
-    // handler: the decision below and the dispatch it picks must be one
-    // atomic step. Releasing between them let a queue drain read a fold this
-    // prompt had not published into yet, so both delivered and whichever lost
-    // the agent's race came back `agent_busy` after its queue row was already
-    // retired (#3621). Not `instance_lock`, for the reason `prompt_submission`
-    // documents: holding that one here stalls this handler's own resume
-    // (#3172).
-    let _submission = state.session_service.prompt_submission(&id).await;
+    // Claim the session's prompt-submission authority and decide under it, so
+    // every client follows the same send, steer, or queue rules and the
+    // decision and the dispatch it picks are one atomic step. Releasing
+    // between them let a queue drain read a fold this prompt had not published
+    // into yet, so both delivered and whichever lost the agent's race came
+    // back `agent_busy` after its queue row was already retired (#3621).
+    // `woke_idle_dormant` is passed rather than re-read: the wake above
+    // already cleared the marker, so the instance now says "awake".
+    let Some((_submission, dispatch)) = state
+        .session_service
+        .begin_prompt_submission(&id, woke_idle_dormant)
+        .await
+    else {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    };
     // A fresh user prompt supersedes any queued rate-limit resume
     // continuation, so drop it before sending: otherwise the reconciler could
     // later replay the older interrupted prompt after this newer one (#3028).
@@ -1353,18 +1359,6 @@ pub async fn acp_prompt(
     // and returns. Resume + publish + forward live in the shared service so
     // the plugin host delivers turns through the same path (#2897).
     state.session_service.clear_pending_initial_turn(&id).await;
-    // Decide here so every client follows the same send, steer, or queue rules.
-    let dispatch = {
-        let control = crate::server::acp_ws::fold_control_state(&state, &id).await;
-        let liveness = crate::acp::dispatch::WorkerLiveness {
-            running: state.acp_supervisor.is_running(&id).await,
-            // `touch_on_prompt_and_wake_if_sunk` above already cleared the marker for a
-            // dormant session, so read the pre-clear answer it returned rather
-            // than the instance, which now says "awake".
-            idle_dormant: woke_idle_dormant,
-        };
-        crate::acp::dispatch::decide(&control, liveness)
-    };
     if let crate::acp::dispatch::PromptDispatch::Queued { reason } = dispatch {
         // Park it on the server-owned queue the turn-end drain already
         // services. A client-minted id reconciles the caller's optimistic row;
@@ -1455,6 +1449,33 @@ pub async fn acp_prompt(
     }
 }
 
+/// Why a diff-comments prompt cannot start a turn right now. Each reason is
+/// transient, and the dialog keeps the user's comments and shows the text, so
+/// the answer is "try again", not a lost review.
+fn diff_comments_not_now(reason: crate::acp::dispatch::QueueReason) -> axum::response::Response {
+    use crate::acp::dispatch::QueueReason;
+    match reason {
+        QueueReason::WorkerDown => {
+            (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
+        }
+        QueueReason::TurnActive => (
+            StatusCode::CONFLICT,
+            "the agent is mid-turn; wait for it to finish, then send the comments again",
+        )
+            .into_response(),
+        QueueReason::Cancelling => (
+            StatusCode::CONFLICT,
+            "the turn is still cancelling; send the comments again once it stops",
+        )
+            .into_response(),
+        QueueReason::Compacting => (
+            StatusCode::CONFLICT,
+            "the agent is compacting its context; send the comments again when it finishes",
+        )
+            .into_response(),
+    }
+}
+
 /// `POST /api/sessions/{id}/acp/prompt/diff-comments`: the typed
 /// successor to the diff-comments sentinel hack. The frontend sends the
 /// structured review plus the `assembled_markdown` it previewed; the
@@ -1476,17 +1497,23 @@ pub async fn acp_prompt_diff_comments(
         Err(rej) => return rej.into_response(),
     };
     let woke_idle_dormant = touch_on_prompt_and_wake_if_sunk(&state, &id).await;
-    {
-        let instances = state.instances.read().await;
-        if !instances.iter().any(|i| i.id == id) {
-            return (StatusCode::NOT_FOUND, "session not found").into_response();
-        }
-    }
     // This opens a turn (`UserDiffCommentsPrompt` folds to `turn_active`) just
-    // as an ordinary prompt does, so it takes the same submission authority:
-    // otherwise it can publish between a queue drain's idle check and its
-    // send, and the agent rejects whichever of the two it sees second (#3621).
-    let _submission = state.session_service.prompt_submission(&id).await;
+    // as an ordinary prompt does, so it takes the same submission authority
+    // and settles the same disposition under it (#3621, #3649).
+    let Some((_submission, dispatch)) = state
+        .session_service
+        .begin_prompt_submission(&id, woke_idle_dormant)
+        .await
+    else {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    };
+    // A typed diff-comments prompt has no queue row to park on, so anything
+    // but send-or-steer is refused here rather than published and then
+    // rejected asynchronously as `agent_busy`, which would strand the card in
+    // the transcript and lose the review the user just wrote.
+    if let crate::acp::dispatch::PromptDispatch::Queued { reason } = dispatch {
+        return diff_comments_not_now(reason);
+    }
     // Idle-dormant wake: respawn synchronously-reserved + detached so the
     // send_prompt below waits for the worker instead of 404ing. Mirrors
     // acp_prompt. See #1748.
@@ -3514,6 +3541,85 @@ mod tests {
             *cmds.lock().expect("cmd log mutex poisoned"),
             ["prompt"],
             "exactly one prompt reaches the agent; a second would be refused as agent_busy"
+        );
+    }
+
+    /// #3649: the diff-comments endpoint is a turn-starting surface, so it
+    /// must settle a disposition under the submission guard rather than
+    /// publish and forward unconditionally once it gets the guard.
+    ///
+    /// The winner of the guard is standing in for a queue drain that publishes
+    /// its prompt before releasing. `send_prompt` reports success as soon as
+    /// the command is queued, so a loser that forwarded anyway would answer
+    /// 202, leave a `UserDiffCommentsPrompt` card in the transcript, and only
+    /// then have the agent refuse the prompt as `agent_busy`.
+    #[tokio::test]
+    async fn diff_comments_refuse_to_open_a_turn_another_submission_started() {
+        use std::time::Duration;
+
+        let mut inst = crate::session::Instance::new("dc-3649", "/tmp/aoe-3649-diff");
+        inst.id = "sess-3649-diff".to_string();
+        inst.view = crate::session::View::Structured;
+        inst.status = crate::session::Status::Idle;
+        let id = inst.id.clone();
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+        let cmds = state
+            .acp_supervisor
+            .test_insert_worker_cmd_recording(&id)
+            .await;
+
+        let winner = state.session_service.prompt_submission(&id).await;
+        let handler = tokio::spawn({
+            let state = Arc::clone(&state);
+            let id = id.clone();
+            async move {
+                acp_prompt_diff_comments(
+                    State(state),
+                    Path(id),
+                    Ok(Json(DiffCommentsPromptRequest {
+                        intro: String::new(),
+                        outro: String::new(),
+                        is_multi_repo: false,
+                        comments: Vec::new(),
+                        assembled_markdown: "review this".to_string(),
+                    })),
+                )
+                .await
+                .into_response()
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !handler.is_finished(),
+            "diff comments must not decide their disposition while another submission owns the session"
+        );
+
+        // What the winner does before it releases: the publish is the choke
+        // point that flips the fold to `turn_active`.
+        state
+            .acp_supervisor
+            .publish_user_prompt_with_attachments(&id, "the winning turn".into(), &[], None)
+            .await;
+        drop(winner);
+
+        let response = tokio::time::timeout(Duration::from_secs(10), handler)
+            .await
+            .expect("the handler must finish once the winner releases the session")
+            .expect("handler task must not panic");
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            *cmds.lock().expect("cmd log mutex poisoned"),
+            Vec::<&'static str>::new(),
+            "nothing may reach the agent: the refusal is the whole point"
+        );
+        let published = state
+            .acp_event_store
+            .replay_from(&id, 0)
+            .into_iter()
+            .any(|(_, e)| matches!(e, Event::UserDiffCommentsPrompt { .. }));
+        assert!(
+            !published,
+            "a refused review must not leave a card in the transcript"
         );
     }
 

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -835,6 +835,15 @@ pub async fn shutdown_acp(
     if let Some(resp) = super::cityhall_block(&state) {
         return resp;
     }
+    // Worker-stopping barrier: submission guard before any teardown, per
+    // `prompt_submission` (#3650).
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    };
     match state.acp_supervisor.shutdown(&id).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => supervisor_error_response("shutdown failed", &e),
@@ -957,6 +966,15 @@ pub async fn switch_acp_agent(
     if target.is_empty() {
         return (StatusCode::BAD_REQUEST, "target is required").into_response();
     }
+    // Worker-stopping barrier: submission guard before any teardown, per
+    // `prompt_submission` (#3650).
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    };
 
     // Look up the instance first: custom agents are profile-specific, so
     // validation needs the session's source_profile and project_path. This
@@ -2217,12 +2235,15 @@ pub async fn acp_disable(
     if let Some(resp) = super::cityhall_block(&state) {
         return resp;
     }
-    {
-        let instances = state.instances.read().await;
-        if !instances.iter().any(|i| i.id == id) {
-            return (StatusCode::NOT_FOUND, "session not found").into_response();
-        }
-    }
+    // Worker-stopping barrier: submission guard before any teardown, per
+    // `prompt_submission` (#3650).
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    };
     let inst_lock = state.instance_lock(&id).await;
     let _guard = inst_lock.lock().await;
     let (mut instance, profile) = {
@@ -3621,6 +3642,64 @@ mod tests {
             !published,
             "a refused review must not leave a card in the transcript"
         );
+    }
+
+    /// The ACP-side half of the #3650 worker-stopping barrier. `shutdown_acp`,
+    /// `switch_acp_agent` and `acp_disable` all tear the worker down, so a
+    /// queue drain mid-delivery must finish first: `send_turn` respawns a
+    /// worker it finds gone, which would undo the shutdown and, for the
+    /// switch, deliver the prompt to the agent the user just switched away
+    /// from.
+    #[tokio::test]
+    async fn worker_stopping_acp_endpoints_wait_for_an_in_flight_submission() {
+        use std::time::Duration;
+
+        async fn call(which: &str, state: Arc<AppState>, id: String) -> axum::response::Response {
+            match which {
+                "shutdown" => shutdown_acp(State(state), Path(id)).await.into_response(),
+                "switch" => switch_acp_agent(
+                    State(state),
+                    Path(id),
+                    Json(SwitchAgentRequest {
+                        target: "codex".to_string(),
+                        model: None,
+                        reason: None,
+                    }),
+                )
+                .await
+                .into_response(),
+                "disable" => acp_disable(State(state), Path(id)).await.into_response(),
+                other => unreachable!("unknown handler {other}"),
+            }
+        }
+
+        for which in ["shutdown", "switch", "disable"] {
+            let mut inst = crate::session::Instance::new("acp-3650", "/tmp/aoe-3650-acp");
+            inst.id = format!("sess-3650-acp-{which}");
+            inst.view = crate::session::View::Structured;
+            inst.status = crate::session::Status::Idle;
+            let id = inst.id.clone();
+            let state = crate::server::test_support::build_test_app_state(vec![inst]);
+
+            let delivering = state.session_service.prompt_submission(&id).await;
+            let handler = tokio::spawn({
+                let state = Arc::clone(&state);
+                let id = id.clone();
+                async move { call(which, state, id).await }
+            });
+
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert!(
+                !handler.is_finished(),
+                "{which} must not tear the worker down under an in-flight submission"
+            );
+
+            drop(delivering);
+            tokio::time::timeout(Duration::from_secs(10), handler)
+                .await
+                .unwrap_or_else(|_| panic!("{which} must finish once the submission releases"))
+                .unwrap_or_else(|e| panic!("{which} task must not panic: {e}"));
+        }
     }
 
     #[tokio::test]

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -10463,11 +10463,24 @@ mod tests {
     /// these tests only need to observe that it waits for one.
     #[cfg(feature = "serve")]
     fn delete_race_state(id: &str) -> std::sync::Arc<crate::server::AppState> {
-        let mut inst = Instance::new("delete-3650", "/tmp/aoe-3650-delete");
-        inst.id = id.to_string();
-        inst.view = crate::session::View::Structured;
-        inst.status = Status::Idle;
-        crate::server::test_support::build_test_app_state(vec![inst])
+        delete_race_state_for(&[id])
+    }
+
+    /// [`delete_race_state`] for a workspace: every id shares the shape, so a
+    /// sibling teardown can be observed the same way the owner's is.
+    #[cfg(feature = "serve")]
+    fn delete_race_state_for(ids: &[&str]) -> std::sync::Arc<crate::server::AppState> {
+        let instances = ids
+            .iter()
+            .map(|id| {
+                let mut inst = Instance::new("delete-3650", "/tmp/aoe-3650-delete");
+                inst.id = (*id).to_string();
+                inst.view = crate::session::View::Structured;
+                inst.status = Status::Idle;
+                inst
+            })
+            .collect();
+        crate::server::test_support::build_test_app_state(instances)
     }
 
     /// #3650: prompt submission moved off `instance_lock`, so a permanent
@@ -10545,6 +10558,53 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(10), workspace)
             .await
             .expect("the workspace teardown lands once the submission releases")
+            .expect("workspace task must not panic");
+
+        // Workspace teardown, on a sibling's guard. The owner's is free, so
+        // the plan loop reaches the sibling and must park there: the owner is
+        // ordered last, and a sibling torn down under a live delivery is the
+        // case #3650 names alongside the direct delete.
+        let state = delete_race_state_for(&["sess-3650-sib", "sess-3650-ws-owner"]);
+        let delivering = state
+            .session_service
+            .prompt_submission("sess-3650-sib")
+            .await;
+        let workspace = tokio::spawn({
+            let state = std::sync::Arc::clone(&state);
+            async move {
+                purge_workspace_artifacts(
+                    &state,
+                    "sess-3650-ws-owner".to_string(),
+                    vec![
+                        ("sess-3650-sib".to_string(), DeleteSessionBody::default()),
+                        (
+                            "sess-3650-ws-owner".to_string(),
+                            DeleteSessionBody::default(),
+                        ),
+                    ],
+                    false,
+                )
+                .await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !workspace.is_finished(),
+            "a workspace teardown must wait for a sibling's in-flight submission"
+        );
+        assert!(
+            state
+                .instances
+                .read()
+                .await
+                .iter()
+                .all(|i| i.status == Status::Idle),
+            "no row may be marked Deleting while the sibling's submission is in flight"
+        );
+        drop(delivering);
+        tokio::time::timeout(Duration::from_secs(10), workspace)
+            .await
+            .expect("the workspace teardown lands once the sibling submission releases")
             .expect("workspace task must not panic");
     }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2924,6 +2924,15 @@ pub async fn update_session_archive(
         Err(rej) => return rej.into_response(),
     };
 
+    // Worker-stopping barrier: submission guard before `instance_lock`, per
+    // `prompt_submission` (#3650).
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return super::session_not_found();
+    };
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
@@ -3071,6 +3080,15 @@ pub async fn trash_session(
     }
     let body = body.map(|Json(body)| body).unwrap_or_default();
 
+    // Worker-stopping barrier: submission guard before `instance_lock`, per
+    // `prompt_submission` (#3650).
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return super::session_not_found();
+    };
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
     let (profile, snapshot) = {
@@ -3667,6 +3685,15 @@ pub async fn stop_session(
         return super::read_only_response();
     }
 
+    // Worker-stopping barrier: submission guard before `instance_lock`, per
+    // `prompt_submission` (#3650).
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return super::session_not_found();
+    };
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
@@ -4048,6 +4075,15 @@ pub async fn update_session_snooze(
         }
     }
 
+    // Worker-stopping barrier: submission guard before `instance_lock`, per
+    // `prompt_submission` (#3650).
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return super::session_not_found();
+    };
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
@@ -10535,6 +10571,81 @@ mod tests {
             "submission authority is taken first"
         );
         assert!(inst_lock < purge, "both are held across the teardown");
+    }
+
+    /// #3650's barrier applies to every handler that stops a worker, not just
+    /// the ones that delete a session. `drain_queued_prompts_once` reads the
+    /// status and the trashed/archived/snoozed flags once under the submission
+    /// guard and only then reaches `send_turn`, which respawns a worker it
+    /// finds gone. So a stop that lands inside that window is undone: the user
+    /// presses Stop and the session comes back running the queued prompt.
+    ///
+    /// Before #3639 the drain held `instance_lock` across delivery and these
+    /// four handlers were excluded by it. They take the submission guard now
+    /// for the same reason `attach_project` and the tied renames do.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn worker_stopping_handlers_wait_for_an_in_flight_submission() {
+        use std::time::Duration;
+
+        async fn call(
+            which: &str,
+            state: std::sync::Arc<crate::server::AppState>,
+            id: String,
+        ) -> axum::response::Response {
+            match which {
+                "stop" => stop_session(State(state), Path(id)).await.into_response(),
+                "trash" => trash_session(State(state), Path(id), None)
+                    .await
+                    .into_response(),
+                "archive" => update_session_archive(
+                    State(state),
+                    Path(id),
+                    Ok(Json(UpdateArchiveBody {
+                        archived: true,
+                        kill_pane: true,
+                    })),
+                )
+                .await
+                .into_response(),
+                "snooze" => update_session_snooze(
+                    State(state),
+                    Path(id),
+                    Ok(Json(UpdateSnoozeBody { minutes: Some(30) })),
+                )
+                .await
+                .into_response(),
+                other => unreachable!("unknown handler {other}"),
+            }
+        }
+
+        for which in ["stop", "trash", "archive", "snooze"] {
+            let id = format!("sess-3650-{which}");
+            let state = delete_race_state(&id);
+            let delivering = state.session_service.prompt_submission(&id).await;
+            let handler = tokio::spawn({
+                let state = std::sync::Arc::clone(&state);
+                let id = id.clone();
+                async move { call(which, state, id).await }
+            });
+
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert!(
+                !handler.is_finished(),
+                "{which} must not quiesce a worker a submission is mid-delivery on"
+            );
+            assert_eq!(
+                state.instances.read().await[0].status,
+                Status::Idle,
+                "{which} must not have touched the session yet"
+            );
+
+            drop(delivering);
+            tokio::time::timeout(Duration::from_secs(10), handler)
+                .await
+                .unwrap_or_else(|_| panic!("{which} must finish once the submission releases"))
+                .unwrap_or_else(|e| panic!("{which} task must not panic: {e}"));
+        }
     }
 
     /// #3651: `prompt_submission` auto-vivifies a registry entry for whatever

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1297,8 +1297,15 @@ pub async fn rename_session(
     // worktree edit) so the tied git move and the metadata write don't race.
     // Prompt submission has its own authority and never takes `instance_lock`
     // (#3621), so hold that one too or a queue drain lands a follow-up on the
-    // worker this quiesces for the move. Submission first, as it documents.
-    let _submission = state.session_service.prompt_submission(&id).await;
+    // worker this quiesces for the move. Submission first, as it documents,
+    // and via the admission form so an unknown id allocates neither lock.
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return super::session_not_found();
+    };
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
@@ -1755,8 +1762,15 @@ pub async fn set_worktree_name(
     // another rename) so the git ops and the metadata write don't race.
     // Prompt submission has its own authority and never takes `instance_lock`
     // (#3621), so hold that one too or a queue drain lands a follow-up on the
-    // worker this quiesces for the move. Submission first, as it documents.
-    let _submission = state.session_service.prompt_submission(&id).await;
+    // worker this quiesces for the move. Submission first, as it documents,
+    // and via the admission form so an unknown id allocates neither lock.
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return super::session_not_found();
+    };
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
@@ -4618,6 +4632,17 @@ pub(crate) async fn purge_expired_trash(state: &Arc<AppState>) {
             continue;
         }
 
+        // Submission authority before `instance_lock`, as the permanent
+        // `DELETE` path takes them: teardown must not start under an in-flight
+        // queue drain (#3650). A row that vanished since the snapshot is
+        // skipped here rather than below.
+        let Some(_submission) = state
+            .session_service
+            .prompt_submission_for_session(&id)
+            .await
+        else {
+            continue;
+        };
         let lock = state.instance_lock(&id).await;
         let _guard = lock.lock().await;
 
@@ -4676,10 +4701,20 @@ pub async fn delete_session(
 
     let body = body.map(|Json(b)| b).unwrap_or_default();
 
-    // Acquire per-instance lock to serialize concurrent mutations.
-    // Owned guard so it can move into the detached deletion task below and
-    // stay held until the bookkeeping finishes, rather than only until this
-    // request future is dropped.
+    // Serialize concurrent mutations. Prompt submission first, per
+    // `prompt_submission`: a queue drain snapshots an idle turn under that
+    // guard and never takes `instance_lock`, so without it the delivery runs
+    // against a worker, worktree and transcript this is tearing down (#3650).
+    // Both guards are owned so they move into the detached deletion task below
+    // and stay held until the bookkeeping finishes, rather than only until
+    // this request future is dropped.
+    let Some(submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return super::session_not_found();
+    };
     let lock = state.instance_lock(&id).await;
     let guard = lock.lock_owned().await;
 
@@ -4710,6 +4745,7 @@ pub async fn delete_session(
     // until the bookkeeping finishes.
     let join = tokio::spawn(async move {
         let _guard = guard;
+        let _submission = submission;
 
         // Mark as Deleting so polling clients see the status change
         {
@@ -4876,15 +4912,16 @@ fn workspace_dirty_message(instance: &Instance) -> Option<String> {
 /// shared-worktree owner last (see [`order_workspace_deletion`]). Each session
 /// goes through the shared [`purge_session_artifacts`].
 ///
-/// The owner's instance lock is acquired up front and held for the whole
-/// teardown, and the dirty-worktree gate is re-checked under that lock right
-/// before any sibling is torn down. This serializes the dirty check with the
-/// teardown so dirty + non-force stays all-or-nothing even if the worktree is
-/// dirtied between the handler preflight and now, and it cannot deadlock: a
-/// session belongs to exactly one workspace, so two workspace deletes never
-/// contend for each other's locks, and single-session deletes only ever hold
-/// one lock at a time. Sibling locks are then taken one at a time. A session
-/// already gone (a retention purge won the race) is skipped, not failed; a
+/// The owner's submission guard and instance lock are acquired up front and
+/// held for the whole teardown, and the dirty-worktree gate is re-checked
+/// under them right before any sibling is torn down. This serializes the dirty
+/// check with the teardown so dirty + non-force stays all-or-nothing even if
+/// the worktree is dirtied between the handler preflight and now, and it
+/// cannot deadlock: a session belongs to exactly one workspace, so two
+/// workspace deletes never contend for each other's locks, and single-session
+/// deletes only ever hold one session's locks at a time. Sibling locks are
+/// then taken one session at a time. A session already gone (a retention purge
+/// won the race) is skipped, not failed; a
 /// pre-owner failure aborts before the worktree is removed, so the shared
 /// worktree keeps its live owning session rather than being orphaned. A
 /// session whose row a concurrent restore kept (`removed == false`) is reported
@@ -4899,7 +4936,12 @@ async fn purge_workspace_artifacts(
     let mut failed = Vec::new();
     let mut messages = Vec::new();
 
-    // Hold the owner lock across the entire teardown (see doc comment).
+    // Hold the owner's locks across the entire teardown (see doc comment).
+    // `None` only when the owner row already vanished; the plan loop skips it.
+    let _owner_submission = state
+        .session_service
+        .prompt_submission_for_session(&owner_id)
+        .await;
     let owner_lock = state.instance_lock(&owner_id).await;
     let _owner_guard = owner_lock.lock_owned().await;
 
@@ -4923,12 +4965,18 @@ async fn purge_workspace_artifacts(
     }
 
     for (id, body) in plan {
-        // The owner lock is already held; only siblings need their own lock,
+        // The owner's locks are already held; only siblings need their own,
         // one at a time. Re-locking the owner here would self-deadlock.
-        let _sibling_guard = if id == owner_id {
+        let _sibling_locks = if id == owner_id {
             None
         } else {
-            Some(state.instance_lock(&id).await.lock_owned().await)
+            Some((
+                state
+                    .session_service
+                    .prompt_submission_for_session(&id)
+                    .await,
+                state.instance_lock(&id).await.lock_owned().await,
+            ))
         };
 
         let instance = {
@@ -10371,6 +10419,189 @@ mod tests {
             "default",
             project.path()
         ));
+    }
+
+    /// Build one structured, idle session with an empty `source_profile`, so
+    /// `purge_session_artifacts` refuses on its first line. The teardown that
+    /// follows is what a delete must not start under an in-flight submission;
+    /// these tests only need to observe that it waits for one.
+    #[cfg(feature = "serve")]
+    fn delete_race_state(id: &str) -> std::sync::Arc<crate::server::AppState> {
+        let mut inst = Instance::new("delete-3650", "/tmp/aoe-3650-delete");
+        inst.id = id.to_string();
+        inst.view = crate::session::View::Structured;
+        inst.status = Status::Idle;
+        crate::server::test_support::build_test_app_state(vec![inst])
+    }
+
+    /// #3650: prompt submission moved off `instance_lock`, so a permanent
+    /// delete that takes only `instance_lock` no longer excludes a queue drain
+    /// that snapshotted an idle turn and is on its way to `send_turn`. The
+    /// delete would then stop the worker, purge the transcript and remove the
+    /// worktree under a delivery already in flight.
+    ///
+    /// Each permanent-delete path is checked the same way: hold the session's
+    /// submission guard (standing in for that drain) and assert the delete
+    /// parks before any teardown, then completes once the guard drops.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn permanent_deletion_waits_for_an_in_flight_submission() {
+        use std::time::Duration;
+
+        // Direct delete.
+        let state = delete_race_state("sess-3650-direct");
+        let delivering = state
+            .session_service
+            .prompt_submission("sess-3650-direct")
+            .await;
+        let delete = tokio::spawn({
+            let state = std::sync::Arc::clone(&state);
+            async move {
+                delete_session(
+                    State(state),
+                    Path("sess-3650-direct".to_string()),
+                    Some(Json(DeleteSessionBody::default())),
+                )
+                .await
+                .into_response()
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !delete.is_finished(),
+            "a delete must not tear a session down under an in-flight submission"
+        );
+        assert_eq!(
+            state.instances.read().await[0].status,
+            Status::Idle,
+            "the session must not even be marked Deleting yet"
+        );
+        drop(delivering);
+        tokio::time::timeout(Duration::from_secs(10), delete)
+            .await
+            .expect("the delete lands once the submission releases the session")
+            .expect("delete task must not panic");
+
+        // Workspace teardown, on the owner's own guard.
+        let state = delete_race_state("sess-3650-owner");
+        let delivering = state
+            .session_service
+            .prompt_submission("sess-3650-owner")
+            .await;
+        let workspace = tokio::spawn({
+            let state = std::sync::Arc::clone(&state);
+            async move {
+                purge_workspace_artifacts(
+                    &state,
+                    "sess-3650-owner".to_string(),
+                    vec![("sess-3650-owner".to_string(), DeleteSessionBody::default())],
+                    false,
+                )
+                .await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !workspace.is_finished(),
+            "a workspace teardown must wait for the owner's in-flight submission"
+        );
+        drop(delivering);
+        tokio::time::timeout(Duration::from_secs(10), workspace)
+            .await
+            .expect("the workspace teardown lands once the submission releases")
+            .expect("workspace task must not panic");
+    }
+
+    /// The retention purge's copy of the same barrier. It resolves profile
+    /// config, which reads the user's global config, before it reaches the
+    /// guard, so the race above cannot cover it without reading user state.
+    /// The lock order is asserted in the source instead.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn the_retention_purge_takes_submission_before_the_instance_lock() {
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/server/api/sessions.rs"),
+        )
+        .unwrap();
+        let start = source
+            .find("pub(crate) async fn purge_expired_trash")
+            .unwrap();
+        let body = &source[start..];
+        let submission = body.find("prompt_submission_for_session(&id)").unwrap();
+        let inst_lock = body.find("state.instance_lock(&id).await").unwrap();
+        let purge = body.find("purge_session_artifacts(").unwrap();
+        assert!(
+            submission < inst_lock,
+            "submission authority is taken first"
+        );
+        assert!(inst_lock < purge, "both are held across the teardown");
+    }
+
+    /// #3651: `prompt_submission` auto-vivifies a registry entry for whatever
+    /// id it is handed and nothing prunes it, so every externally reachable
+    /// mutation that claims it must prove the session exists first. Otherwise
+    /// an authenticated client grows daemon memory with random ids.
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn session_mutations_allocate_no_prompt_lock_for_an_unknown_id() {
+        let state = crate::server::test_support::build_test_app_state(Vec::new());
+        let service = std::sync::Arc::clone(&state.session_service);
+
+        for i in 0..3 {
+            let id = format!("sess-gone-{i}");
+            assert_eq!(
+                rename_session(
+                    State(std::sync::Arc::clone(&state)),
+                    Path(id.clone()),
+                    Ok(Json(RenameSessionBody {
+                        title: "new title".to_string(),
+                        rename_branch: false,
+                    })),
+                )
+                .await
+                .into_response()
+                .status(),
+                StatusCode::NOT_FOUND
+            );
+            assert_eq!(
+                set_worktree_name(
+                    State(std::sync::Arc::clone(&state)),
+                    Path(id.clone()),
+                    Ok(Json(SetWorktreeNameBody {
+                        name: "new-dir".to_string(),
+                        rename_branch: false,
+                    })),
+                )
+                .await
+                .into_response()
+                .status(),
+                StatusCode::NOT_FOUND
+            );
+            assert!(matches!(
+                crate::server::attach_project::attach_project(
+                    &state,
+                    &id,
+                    std::path::Path::new("/tmp"),
+                    crate::session::attach_project::ExistingBranch::Refuse,
+                )
+                .await,
+                Err(crate::server::attach_project::AttachError::NotFound)
+            ));
+            assert!(matches!(
+                service
+                    .edit_queued_prompt(&id, "q1".to_string(), "text".to_string())
+                    .await,
+                crate::server::session_service::EditQueuedOutcome::NotFound
+            ));
+            assert!(!service.remove_queued_prompt(&id, "q1".to_string()).await);
+            service.clear_queued_prompts(&id).await;
+        }
+
+        assert_eq!(
+            service.prompt_locks_len().await,
+            0,
+            "an id that was never admitted must not leave a lock-registry entry behind"
+        );
     }
 
     #[test]

--- a/src/server/attach_project.rs
+++ b/src/server/attach_project.rs
@@ -94,8 +94,15 @@ pub(crate) async fn attach_project(
     // prompt endpoint serialize on `prompt_submission` and never take
     // `instance_lock`, so a reconciler tick could otherwise deliver a queued
     // follow-up to the worker this is about to stop and retire the row as sent.
-    // Claimed first, which is the order `prompt_submission` documents.
-    let _submission = state.session_service.prompt_submission(id).await;
+    // Claimed first, which is the order `prompt_submission` documents, and in
+    // the admission form so an unknown id allocates neither lock.
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(id)
+        .await
+    else {
+        return Err(AttachError::NotFound);
+    };
     let inst_lock = state.instance_lock(id).await;
     // Held across the turn probe, the stop, the persist and the start. Releasing
     // it between any two of those is what would let a prompt land against a

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -1009,7 +1009,9 @@ impl SessionService {
         prompt_id: String,
         text: String,
     ) -> EditQueuedOutcome {
-        let _submission = self.prompt_submission(id).await;
+        let Some(_submission) = self.prompt_submission_for_session(id).await else {
+            return EditQueuedOutcome::NotFound;
+        };
         self.mutate_instance_persisted(id, move |inst| {
             match inst.queued_prompts.iter_mut().find(|q| q.id == prompt_id) {
                 Some(q) if text.trim().is_empty() && q.attachments.is_empty() => {
@@ -1043,7 +1045,9 @@ impl SessionService {
         id: &str,
         prompt_id: String,
     ) -> bool {
-        let _submission = self.prompt_submission(id).await;
+        let Some(_submission) = self.prompt_submission_for_session(id).await else {
+            return false;
+        };
         let prompt_id_cleanup = prompt_id.clone();
         let removed = self
             .mutate_instance_persisted(id, move |inst| {
@@ -1069,7 +1073,9 @@ impl SessionService {
     /// the user watches the queue empty and then sees it sent anyway.
     #[cfg(feature = "serve")]
     pub(crate) async fn clear_queued_prompts(self: &Arc<Self>, id: &str) {
-        let _submission = self.prompt_submission(id).await;
+        let Some(_submission) = self.prompt_submission_for_session(id).await else {
+            return;
+        };
         let cleared_ids = self
             .mutate_instance_persisted(id, move |inst| {
                 let ids: Vec<String> = inst.queued_prompts.iter().map(|q| q.id.clone()).collect();
@@ -1378,9 +1384,12 @@ impl SessionService {
     /// `Queued` disposition ([`crate::acp::dispatch::PromptDispatch`]) is
     /// settled atomically for every surface that can start a turn (both prompt
     /// endpoints, the plugin host's `sessions.turn.send`, the queue drain, and
-    /// the pending-initial-turn drain). The quiesce barriers that stop a worker
-    /// under it (`attach_project`, the tied-worktree renames) hold it too, so a
-    /// drain cannot deliver into a worker they are about to stop. See #3621.
+    /// the pending-initial-turn drain). The barriers that stop a worker under
+    /// it (`attach_project`, the tied-worktree renames, and every permanent
+    /// delete) hold it too, so a drain cannot deliver into a worker they are
+    /// about to stop or a session they are about to erase. See #3621 and
+    /// #3650. Callers that have not yet proved the session exists take
+    /// [`Self::prompt_submission_for_session`] instead.
     ///
     /// Two rules make this work, and neither is optional:
     ///
@@ -1420,6 +1429,62 @@ impl SessionService {
                 .clone(),
         };
         lock.lock_owned().await
+    }
+
+    /// [`Self::prompt_submission`] for a caller that has not yet proved the
+    /// session exists. `None` means "do not act", and no registry entry is
+    /// left behind for an id that was never admitted: the registry
+    /// auto-vivifies per id it is asked for and nothing else prunes it, so an
+    /// authenticated client probing random ids would otherwise grow it for the
+    /// daemon's lifetime (#3651).
+    ///
+    /// The re-check under the guard is what makes a permanent delete a
+    /// barrier (#3650). A delete holds this guard across its irreversible
+    /// teardown and removes the session row before dropping its lock, so both
+    /// a waiter parked on that lock and one that vivified a fresh entry after
+    /// `forget_prompt_lock` observe the removal and decline.
+    #[cfg(feature = "serve")]
+    pub(crate) async fn prompt_submission_for_session(
+        &self,
+        id: &str,
+    ) -> Option<tokio::sync::OwnedMutexGuard<()>> {
+        if !self.session_exists(id).await {
+            return None;
+        }
+        let guard = self.prompt_submission(id).await;
+        if !self.session_exists(id).await {
+            drop(guard);
+            self.forget_prompt_lock(id).await;
+            return None;
+        }
+        Some(guard)
+    }
+
+    /// Claim the session's submission authority and settle the prompt's
+    /// disposition under it, so every turn-starting surface decides and
+    /// dispatches as one step instead of dispatching unconditionally after
+    /// the wait (#3649). `None` for a session that no longer exists.
+    #[cfg(feature = "serve")]
+    pub(crate) async fn begin_prompt_submission(
+        &self,
+        id: &str,
+        idle_dormant: bool,
+    ) -> Option<(
+        tokio::sync::OwnedMutexGuard<()>,
+        crate::acp::dispatch::PromptDispatch,
+    )> {
+        let guard = self.prompt_submission_for_session(id).await?;
+        let liveness = crate::acp::dispatch::WorkerLiveness {
+            running: self.acp_supervisor.is_running(id).await,
+            idle_dormant,
+        };
+        let dispatch = crate::acp::dispatch::decide(&self.fold_control_state(id).await, liveness);
+        Some((guard, dispatch))
+    }
+
+    #[cfg(feature = "serve")]
+    async fn session_exists(&self, id: &str) -> bool {
+        self.instances.read().await.iter().any(|i| i.id == id)
     }
 
     /// Drop a deleted session's submission lock, mirroring the `instance_locks`

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -1385,12 +1385,13 @@ impl SessionService {
     /// settled atomically for every surface that can start a turn (both prompt
     /// endpoints, the plugin host's `sessions.turn.send`, the queue drain, and
     /// the pending-initial-turn drain). Every barrier that quiesces a worker
-    /// holds it too (`attach_project`, the tied-worktree renames, stop, trash,
-    /// archive, snooze, and every permanent delete), so a drain cannot deliver
-    /// into a worker they are about to stop or a session they are about to
-    /// erase. The drain reads status and the trashed/archived/snoozed flags
-    /// once and then resurrects a worker it finds gone, so a quiesce that
-    /// lands inside that window is simply undone. See #3621 and #3650. Callers that have not yet proved the session exists take
+    /// holds it too: stop, trash, archive, snooze, ACP shutdown, agent switch,
+    /// ACP disable, `attach_project`, the tied-worktree renames, and every
+    /// permanent delete. The drain reads status and the
+    /// trashed/archived/snoozed flags once and then reaches `send_turn`, which
+    /// respawns a worker it finds gone, so a quiesce landing inside that window
+    /// is undone and a delete races teardown against a live delivery. See
+    /// #3621 and #3650. Callers that have not yet proved the session exists take
     /// [`Self::prompt_submission_for_session`] instead.
     ///
     /// Two rules make this work, and neither is optional:

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -1390,7 +1390,10 @@ impl SessionService {
     /// permanent delete. The drain reads status and the
     /// trashed/archived/snoozed flags once and then reaches `send_turn`, which
     /// respawns a worker it finds gone, so a quiesce landing inside that window
-    /// is undone and a delete races teardown against a live delivery. See
+    /// is undone and a delete races teardown against a live delivery. The
+    /// supervisor's reapers stay outside this: they drop a handle rather than
+    /// start a turn, so the worst they do to a delivery in flight is fail it,
+    /// and a failed delivery leaves its rows queued for the next tick. See
     /// #3621 and #3650. Callers that have not yet proved the session exists take
     /// [`Self::prompt_submission_for_session`] instead.
     ///

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -1384,11 +1384,13 @@ impl SessionService {
     /// `Queued` disposition ([`crate::acp::dispatch::PromptDispatch`]) is
     /// settled atomically for every surface that can start a turn (both prompt
     /// endpoints, the plugin host's `sessions.turn.send`, the queue drain, and
-    /// the pending-initial-turn drain). The barriers that stop a worker under
-    /// it (`attach_project`, the tied-worktree renames, and every permanent
-    /// delete) hold it too, so a drain cannot deliver into a worker they are
-    /// about to stop or a session they are about to erase. See #3621 and
-    /// #3650. Callers that have not yet proved the session exists take
+    /// the pending-initial-turn drain). Every barrier that quiesces a worker
+    /// holds it too (`attach_project`, the tied-worktree renames, stop, trash,
+    /// archive, snooze, and every permanent delete), so a drain cannot deliver
+    /// into a worker they are about to stop or a session they are about to
+    /// erase. The drain reads status and the trashed/archived/snoozed flags
+    /// once and then resurrects a worker it finds gone, so a quiesce that
+    /// lands inside that window is simply undone. See #3621 and #3650. Callers that have not yet proved the session exists take
     /// [`Self::prompt_submission_for_session`] instead.
     ///
     /// Two rules make this work, and neither is optional:


### PR DESCRIPTION
## Description

Post-merge follow-ups to #3639, which gave prompt submission a per-session
authority but left three gaps in it.

**#3649 - complete per-session dispatch.** `sessions.turn.send` and
`POST /acp/prompt/diff-comments` acquired the guard and then dispatched
unconditionally. `send_prompt` returns `Ok` on channel enqueue, so a submission
that lost the race published its prompt at an already-busy agent, reported
success, and had the prompt refused asynchronously as `agent_busy`. Both
surfaces now go through `SessionService::begin_prompt_submission`, which claims
the guard and settles the `PromptDispatch` under it. The plugin path returns a
retryable `agent_busy`; a cold worker is not a refusal there, since `send_turn`
resumes and waits, which is how a scheduler wakes a session it created. The
diff-comments path has no queue row to park on, so it refuses (409, or 503 for
a down worker) before publishing instead of stranding a card in the transcript.
The send dialog already keeps the user's comments and shows the response text,
so no web change was needed.

**#3650 - serialize permanent deletion.** Direct delete, retention purge, and
workspace teardown took only `instance_lock`, which no longer excludes a drain
that snapshotted an idle queued turn. All three now take the submission guard
before `instance_lock` and hold it across the irreversible teardown.

**#3651 - no lock allocation for unknown sessions.** Rename, worktree-name,
project attach, and queue edit/remove/clear claimed the guard before proving
the session exists, so distinct nonexistent ids grew `prompt_locks` for the
daemon's lifetime. They now go through `prompt_submission_for_session`, which
admits before it allocates and re-checks under the guard. That re-check is also
what closes #3650's last window: a delete removes the session row before
dropping its lock, so both a waiter parked on that lock and one that vivified a
fresh entry observe the removal and decline.

**Completes the same #3650 class for every worker-stopping surface.** The
lifecycle gestures (stop, trash, archive, snooze) and the ACP teardown
endpoints (shutdown, switch-agent, disable) quiesced the worker without the
submission guard. The drain reads status once and then reaches `send_turn`,
which respawns a worker it finds gone, so the drain could resurrect a session
the user had just stopped, or hand a queued prompt to the agent they had just
switched away from. The supervisor's reapers stay
outside the barrier: they drop a handle rather than start a turn, so the worst
they do to a delivery in flight is fail it, and a failed delivery leaves its
rows queued for the next tick.

Two known gaps, both deliberate. `queue_enqueue` still pairs its own existence
check with a raw `prompt_submission`, so a session deleted in that window can
leave one `prompt_locks` entry; that is bounded by real session ids, not the
unbounded growth #3651 is about. And every lifecycle gesture can now block
behind a drain holding the guard across `send_turn`, whose readiness wait is
bounded by `WORKER_READY_TIMEOUT` (10s), so Stop can feel unresponsive for that
long against a resuming worker. That is the trade the barrier buys: the
alternative is the stop being silently undone.

Also removes `acp_ws::fold_control_state`, now unused.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Three lib tests fail in my sandbox for environment reasons, unrelated to this
branch and unchanged from `main`: two fixtures `chmod 000` a file and assert the
read fails (the sandbox runs as uid 0, which bypasses that), and
`hooks_install::tests::test_content_shows_settings_path` reads
`CLAUDE_CONFIG_DIR`, which is set here; unsetting it makes that test pass.
Everything else passes with `--features serve`, plus `cargo fmt` and
`cargo clippy` with no new warnings.

## Test Coverage Analysis

Each fix has a test that fails without it and passes here (verified by
reverting each fix in place):

- `plugin::session_api::tests::turn_send_refuses_a_turn_another_submission_already_started`
  - pre-fix: returns `{}` for a prompt the agent refuses.
- `server::api::acp::tests::diff_comments_refuse_to_open_a_turn_another_submission_started`
  - pre-fix: 202 plus a published card.
- `server::api::sessions::tests::permanent_deletion_waits_for_an_in_flight_submission`
  - direct delete and workspace teardown; pre-fix the delete marks the session
    `Deleting` under a held submission guard.
- `server::api::sessions::tests::the_retention_purge_takes_submission_before_the_instance_lock`
  - the retention path resolves profile config (which reads the user's global
    config) before it reaches the guard, so a hermetic race test is not
    possible there; the lock order is asserted in the source instead, following
    the existing precedent in that file.
- `server::api::sessions::tests::permanent_deletion_waits_for_an_in_flight_submission`
  also covers the workspace **sibling** guard, ordered ahead of the owner.
- `server::api::sessions::tests::worker_stopping_handlers_wait_for_an_in_flight_submission`
  - stop, trash, archive, snooze as table cases; pre-fix each quiesces the
    worker while a submission is mid-delivery.
- `server::api::acp::tests::worker_stopping_acp_endpoints_wait_for_an_in_flight_submission`
  - shutdown, switch-agent, disable, same shape.
- `server::api::sessions::tests::session_mutations_allocate_no_prompt_lock_for_an_unknown_id`
  - pre-fix: 3 registry entries for 3 unknown ids.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

The three issues were drafted by Codex from a static review. Each claim was
re-checked against the code and reproduced with a failing test before any fix
was written. No claim was disproved.

- [x] I am an AI Agent filling out this form (check box if true)

