### PR TITLE
docs(fork): correct the inline structured-fork capability comment

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -480,7 +480,7 @@ impl SessionResponse {
             },
             // Shares `agent_is_structured_fork_capable` with the create-time
             // guard so the web "Fork" affordance and server-side acceptance
-            // cannot drift: forkable = ACP-capable AND a real fork strategy.
+            // cannot drift: forkable = built-in ACP adapter verified to fork.
             #[cfg(feature = "serve")]
             acp_can_fork: agent_is_structured_fork_capable(&inst.tool, inst.agent_name.as_deref()),
             // Same agent resolution as `acp_agent` above; computed once here so


### PR DESCRIPTION
## Description

`structured_fork_capable` matches `ForkStrategy::ClaudeFork` alone. The inline comment at the `acp_can_fork` construction site said `forkable = ACP-capable AND a real fork strategy`, which reads true for `codex` (`CodexFork`) and `opencode` (`Flag("--fork")`); both are registered ACP adapters that deliberately return false, as `src/session/fork.rs:55-61` explains.

#3671 corrected the field doc and the web mirror and left this one untouched. Caught by @zerone0x in #3655.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

One comment line; the predicate it describes is already pinned by `agent_is_structured_fork_capable` assertions at `src/server/api/sessions.rs:8762-8775`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via the Claude Code CLI.

**Any Additional AI Details you'd like to share:**

Follow-up to #3671. `cargo fmt --check` clean; `cargo clippy --features serve --all-targets` unchanged at the 7 pre-existing warnings, none in this file.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Updated the `acp_can_fork` comment to accurately describe `structured_fork_capable`.
- Clarified that only verified built-in ACP adapters support forking.
- Made no runtime or behavior changes.

### Benefits
- Keeps the documentation aligned with the actual fork capability.
- Prevents incorrect assumptions about Codex and OpenCode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->