### PR TITLE
fix(sv): rebuild the runtime on a fold change

### DIFF
--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -27,7 +27,12 @@
 // rattle spinner, ApprovalCard) and slot them into assistant-ui's
 // component-injection points.
 
-import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from "@assistant-ui/react";
+import {
+  AssistantRuntimeProvider,
+  useExternalStoreRuntime,
+  type ExternalStoreAdapter,
+  type ThreadMessageLike,
+} from "@assistant-ui/react";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { useAcpSession } from "../../hooks/useAcpSession";
@@ -42,6 +47,7 @@ import type {
 import { hasTodoArrayArgsText, parseJsonObject } from "../../lib/acpArgs";
 import { clearDraft, getDraftAttachments, setDraftAttachments } from "../../lib/acpDrafts";
 import { useHistoryWindow } from "../../hooks/useHistoryWindow";
+import { lastClearIndex } from "../../lib/acpHistoryWindow";
 import { canOfferEarlier, earlierAction } from "../../lib/historyScroll";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 import { type AgentProfile, DEFAULT_AGENT_PROFILE, isSubagentToolName } from "../../lib/agentProfiles";
@@ -123,19 +129,15 @@ export interface AcpContext {
   loadingEarlierHistory: boolean;
 }
 
-type ExternalStoreAdapter = Parameters<typeof useExternalStoreRuntime<ThreadMessageLike>>[0];
-
-/** Owns the external-store hook, so a change of `key` rebuilds the runtime.
+/** Owns the external-store hook so a change of `key` builds a fresh runtime.
  *
- *  The fold shortens the part list of a message it keeps. assistant-ui reads
- *  parts by absolute index, and its store keeps the committed list when a
- *  snapshot throws (upstream assistant-ui#5708). A stale part child then reads
- *  past the end, inside useSyncExternalStore, where React cannot recover. The
- *  ErrorBoundary then replaces the view.
- *
- *  The stale state is in the store, not in the children, so a remount of the
- *  message list is not enough. Only a new store fixes it. See #3640. */
-function RuntimeHost({ adapter, children }: { adapter: ExternalStoreAdapter; children: ReactNode }) {
+ *  A `/clear` shortens the part list of a message the fold keeps, and
+ *  assistant-ui reads parts by absolute index while keeping the committed list
+ *  when a snapshot throws (assistant-ui#5708). The stale part child then reads
+ *  past the end inside useSyncExternalStore, where React cannot recover, and
+ *  the ErrorBoundary replaces the view. The stale state lives in the store, so
+ *  remounting the message list is not enough. See #3640. */
+function RuntimeHost({ adapter, children }: { adapter: ExternalStoreAdapter<ThreadMessageLike>; children: ReactNode }) {
   const runtime = useExternalStoreRuntime<ThreadMessageLike>(adapter);
   return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
 }
@@ -253,7 +255,7 @@ export function AcpRuntime({
     [displayActivity, showClearedTurns],
   );
 
-  const adapter: ExternalStoreAdapter = {
+  const adapter: ExternalStoreAdapter<ThreadMessageLike> = {
     messages,
     isRunning: acp.state.turnActive,
     convertMessage: (m) => m,
@@ -332,21 +334,9 @@ export function AcpRuntime({
   );
 }
 
-/** Index of the row the fold starts at, or -1 if no `/clear` happened yet.
- *  The fold pins to the LAST clear, so repeated /clears collapse
- *  cumulatively. See #1101. */
-function lastClearIndex(rows: readonly ActivityRow[]): number {
-  for (let i = rows.length - 1; i >= 0; i -= 1) {
-    if (rows[i]!.kind === "session_cleared") return i;
-  }
-  return -1;
-}
-
-/** Identity of the fold point, for use as a React `key`.
- *
- *  The value changes only when the fold point moves, so an ordinary turn does
- *  not remount. `"all"` means nothing is folded; `"none"` means no `/clear`
- *  happened yet. Both are stable for the life of the session. See #3640. */
+/** React `key` identifying the current fold point: the id of the last `/clear`,
+ *  `"none"` before the first one, `"all"` when nothing is folded. Only a moved
+ *  fold changes it, so an ordinary turn does not rebuild the runtime. */
 export function clearFoldGeneration(rows: readonly ActivityRow[], showClearedTurns: boolean): string {
   if (showClearedTurns) return "all";
   const i = lastClearIndex(rows);
@@ -371,11 +361,9 @@ export function activityToThreadMessages(
   todosEnabled = true,
   profile: AgentProfile = DEFAULT_AGENT_PROFILE,
 ): ThreadMessageLike[] {
-  // Fold pre-clear turns by default. When the user has run `/clear`,
-  // earlier rows describe a conversation the model has forgotten; the
-  // banner in StructuredView surfaces a count + "show" toggle that lifts
-  // `showClearedTurns` to true. We pin to the LAST clear so multiple
-  // /clears collapse cumulatively. See #1101.
+  // Fold pre-clear turns by default: after a `/clear` those rows describe a
+  // conversation the model has forgotten. The ClearedTurnsBanner in
+  // StructuredView lifts `showClearedTurns` to reveal them. See #1101.
   let effectiveRows: readonly ActivityRow[] = rows;
   if (!showClearedTurns) {
     const start = lastClearIndex(rows);

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -123,6 +123,23 @@ export interface AcpContext {
   loadingEarlierHistory: boolean;
 }
 
+type ExternalStoreAdapter = Parameters<typeof useExternalStoreRuntime<ThreadMessageLike>>[0];
+
+/** Owns the external-store hook, so a change of `key` rebuilds the runtime.
+ *
+ *  The fold shortens the part list of a message it keeps. assistant-ui reads
+ *  parts by absolute index, and its store keeps the committed list when a
+ *  snapshot throws (upstream assistant-ui#5708). A stale part child then reads
+ *  past the end, inside useSyncExternalStore, where React cannot recover. The
+ *  ErrorBoundary then replaces the view.
+ *
+ *  The stale state is in the store, not in the children, so a remount of the
+ *  message list is not enough. Only a new store fixes it. See #3640. */
+function RuntimeHost({ adapter, children }: { adapter: ExternalStoreAdapter; children: ReactNode }) {
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>(adapter);
+  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+}
+
 /**
  * Wraps children in an `<AssistantRuntimeProvider>` driven by our
  * acp WS state. Children get a render-prop callback with the raw
@@ -230,7 +247,13 @@ export function AcpRuntime({
     [displayActivity, acp.state.turnActive, showClearedTurns, agentProfile],
   );
 
-  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+  // Read from the same rows as the fold, so the key and the truncation agree.
+  const foldGeneration = useMemo(
+    () => clearFoldGeneration(displayActivity, showClearedTurns),
+    [displayActivity, showClearedTurns],
+  );
+
+  const adapter: ExternalStoreAdapter = {
     messages,
     isRunning: acp.state.turnActive,
     convertMessage: (m) => m,
@@ -268,10 +291,10 @@ export function AcpRuntime({
       await acp.sendPrompt(text, attachments);
     },
     onCancel,
-  });
+  };
 
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
+    <RuntimeHost key={foldGeneration} adapter={adapter}>
       {children({
         state: acp.state,
         status: acp.status,
@@ -305,8 +328,29 @@ export function AcpRuntime({
         loadEarlierHistory,
         loadingEarlierHistory: loadingOlder,
       })}
-    </AssistantRuntimeProvider>
+    </RuntimeHost>
   );
+}
+
+/** Index of the row the fold starts at, or -1 if no `/clear` happened yet.
+ *  The fold pins to the LAST clear, so repeated /clears collapse
+ *  cumulatively. See #1101. */
+function lastClearIndex(rows: readonly ActivityRow[]): number {
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    if (rows[i]!.kind === "session_cleared") return i;
+  }
+  return -1;
+}
+
+/** Identity of the fold point, for use as a React `key`.
+ *
+ *  The value changes only when the fold point moves, so an ordinary turn does
+ *  not remount. `"all"` means nothing is folded; `"none"` means no `/clear`
+ *  happened yet. Both are stable for the life of the session. See #3640. */
+export function clearFoldGeneration(rows: readonly ActivityRow[], showClearedTurns: boolean): string {
+  if (showClearedTurns) return "all";
+  const i = lastClearIndex(rows);
+  return i < 0 ? "none" : rows[i]!.id;
 }
 
 /**
@@ -334,16 +378,8 @@ export function activityToThreadMessages(
   // /clears collapse cumulatively. See #1101.
   let effectiveRows: readonly ActivityRow[] = rows;
   if (!showClearedTurns) {
-    let lastClearIndex = -1;
-    for (let i = rows.length - 1; i >= 0; i -= 1) {
-      if (rows[i]!.kind === "session_cleared") {
-        lastClearIndex = i;
-        break;
-      }
-    }
-    if (lastClearIndex >= 0) {
-      effectiveRows = rows.slice(lastClearIndex);
-    }
+    const start = lastClearIndex(rows);
+    if (start >= 0) effectiveRows = rows.slice(start);
   }
 
   const messages: ThreadMessageLike[] = [];

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -34,6 +34,7 @@ import { AskUserQuestionCard } from "./AskUserQuestionCard";
 import { AcpFileRefContext } from "./AcpFileRefContext";
 import type { FileRef, FileRefSession } from "../../lib/fileRef";
 import { anchorIsStale, autoLoadDecision, isPinnedToBottom, scrollRestoreDelta } from "../../lib/historyScroll";
+import { lastClearIndex } from "../../lib/acpHistoryWindow";
 import { loadScrollState, saveScrollState } from "../../lib/acpScrollState";
 import { repinOnResize } from "../../lib/repinOnResize";
 import { ToolDensityToggle, ToolDisplayModeProvider, useToolDensityPref } from "./ToolDisplayMode";
@@ -340,22 +341,11 @@ function AcpChrome({
   onRestore?: () => Promise<boolean> | void;
   isSandboxed?: boolean;
 }) {
-  // Count how many activity rows precede the latest `session_cleared`
-  // divider so the banner can say "12 earlier turns hidden". The
-  // reducer always appends the divider as the last row at clear time,
-  // so the count is `lastClearIndex` (rows before it are the cleared
-  // history). See #1101.
-  const clearedSummary = (() => {
-    let lastClearIndex = -1;
-    for (let i = state.activity.length - 1; i >= 0; i -= 1) {
-      if (state.activity[i]!.kind === "session_cleared") {
-        lastClearIndex = i;
-        break;
-      }
-    }
-    if (lastClearIndex < 0) return null;
-    return { hiddenCount: lastClearIndex };
-  })();
+  // Rows preceding the latest `/clear` divider are the hidden history, so the
+  // divider's index is the count the banner reports ("12 earlier turns
+  // hidden"). See #1101.
+  const clearIndex = lastClearIndex(state.activity);
+  const clearedSummary = clearIndex < 0 ? null : { hiddenCount: clearIndex };
   // Composer prefill keyed for re-fires; set by the
   // ContextPrimerBanner on click. Local rather than on AcpState
   // because it's a one-shot UI action, not part of the event log.

--- a/web/src/components/acp/__tests__/AcpRuntime.clearFold.test.tsx
+++ b/web/src/components/acp/__tests__/AcpRuntime.clearFold.test.tsx
@@ -1,19 +1,13 @@
 // @vitest-environment jsdom
 //
-// #3640: `/clear` folds the pre-clear turns out of the transcript, which shortens
-// the part list of a message the fold keeps. assistant-ui reads parts by absolute
-// index, and its store keeps the committed list when a snapshot throws (upstream
-// assistant-ui#5708). A stale part child then reads past the end, inside
-// useSyncExternalStore, where React cannot recover, so the ErrorBoundary replaced
-// the conversation view.
+// #3640: a `/clear` moves the fold, which shortens the part list of a message
+// the fold keeps and left assistant-ui's store reading a stale part index (the
+// mechanism is on `RuntimeHost` in AcpRuntime). The fix rebuilds the runtime
+// when the fold moves, so these tests cover the key and the rebuild it drives.
 //
-// The stale state sits in the store, so the runtime is rebuilt when the fold point
-// moves. A remount of the message list alone was measured and did NOT stop the
-// failure. These tests cover the fold key and the rebuild it drives.
-//
-// The rendered failure is not asserted here. In jsdom the throw is swallowed, so
-// jsdom shows the same output before and after the fix. The browser check is the
-// procedure recorded on #3640.
+// The rendered failure is not asserted: jsdom swallows the throw and keeps the
+// stale list (assistant-ui#5708), so it looks identical before and after the
+// fix. The browser check is the manual procedure recorded on #3640.
 
 import { act, render } from "@testing-library/react";
 import { useEffect } from "react";
@@ -36,46 +30,13 @@ const TURNS: ActivityRow[] = [
   row("a2", "message", "second answer"),
 ];
 
-// The mocked session store reads this, so a test can reshape the transcript
-// between renders the way a `/clear` frame does.
+// Reshaped between renders the way a `/clear` frame does. AcpRuntime reads
+// `state` and hands the rest of the session straight to `children`, which these
+// tests ignore, so a state-only stub is enough.
 let activity: ActivityRow[] = TURNS;
 
 vi.mock("../../../hooks/useAcpSession", () => ({
-  useAcpSession: () => {
-    const state: AcpState = { ...emptyAcpState(), activity };
-    return {
-      state,
-      status: "open",
-      hasEverOpened: true,
-      reconnecting: false,
-      retryCount: 0,
-      retryCountdown: 0,
-      maxRetries: 5,
-      manualReconnect: () => {},
-      resolveApproval: async () => {},
-      resolveElicitation: async () => {},
-      sendPrompt: async () => {},
-      cancelPrompt: async () => {},
-      forceEndTurn: async () => {},
-      lastActivityRef: { current: 0 },
-      dismissError: () => {},
-      dismissPrimer: () => {},
-      dismissCompactionReminder: () => {},
-      removeQueuedPrompt: () => {},
-      editQueuedPrompt: () => {},
-      clearQueue: () => {},
-      sendQueuedNow: async () => {},
-      canSendQueuedNow: false,
-      sendNowInterruptsTurn: false,
-      dismissRejectedPrompt: () => {},
-      dismissModeSwitchFailed: () => {},
-      setConfigOption: async () => {},
-      dismissConfigOptionSwitchFailed: () => {},
-      loadOlder: async () => {},
-      hasMoreOlder: false,
-      loadingOlder: false,
-    };
-  },
+  useAcpSession: (): { state: AcpState } => ({ state: { ...emptyAcpState(), activity } }),
 }));
 
 import { AcpRuntime, clearFoldGeneration } from "../AcpRuntime";
@@ -102,9 +63,8 @@ describe("clearFoldGeneration (#3640)", () => {
 
 describe("AcpRuntime: runtime rebuild on a fold change (#3640)", () => {
   it("rebuilds the runtime when a clear lands, and keeps it across an ordinary turn", async () => {
-    // A fresh external store means a fresh mount of the provider subtree. The
-    // child counts its own mounts, which is what the rebuild is for: the stale
-    // store is what throws, so it must be replaced, not updated.
+    // A rebuilt store remounts the provider subtree, so the child's own mount
+    // count is the observable proof the store was replaced, not updated.
     let mounts = 0;
     const CountMounts = () => {
       useEffect(() => {

--- a/web/src/components/acp/__tests__/AcpRuntime.clearFold.test.tsx
+++ b/web/src/components/acp/__tests__/AcpRuntime.clearFold.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+//
+// #3640: `/clear` folds the pre-clear turns out of the transcript, which shortens
+// the part list of a message the fold keeps. assistant-ui reads parts by absolute
+// index, and its store keeps the committed list when a snapshot throws (upstream
+// assistant-ui#5708). A stale part child then reads past the end, inside
+// useSyncExternalStore, where React cannot recover, so the ErrorBoundary replaced
+// the conversation view.
+//
+// The stale state sits in the store, so the runtime is rebuilt when the fold point
+// moves. A remount of the message list alone was measured and did NOT stop the
+// failure. These tests cover the fold key and the rebuild it drives.
+//
+// The rendered failure is not asserted here. In jsdom the throw is swallowed, so
+// jsdom shows the same output before and after the fix. The browser check is the
+// procedure recorded on #3640.
+
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { emptyAcpState } from "../../../lib/acpTypes";
+import type { AcpState, ActivityRow } from "../../../lib/acpTypes";
+
+const row = (id: string, kind: ActivityRow["kind"], text: string): ActivityRow => ({
+  id,
+  kind,
+  text,
+  at: "2026-08-31T12:00:00Z",
+});
+
+const TURNS: ActivityRow[] = [
+  row("u1", "user_prompt", "first question"),
+  row("a1", "message", "first answer"),
+  row("u2", "user_prompt", "second question"),
+  row("a2", "message", "second answer"),
+];
+
+// The mocked session store reads this, so a test can reshape the transcript
+// between renders the way a `/clear` frame does.
+let activity: ActivityRow[] = TURNS;
+
+vi.mock("../../../hooks/useAcpSession", () => ({
+  useAcpSession: () => {
+    const state: AcpState = { ...emptyAcpState(), activity };
+    return {
+      state,
+      status: "open",
+      hasEverOpened: true,
+      reconnecting: false,
+      retryCount: 0,
+      retryCountdown: 0,
+      maxRetries: 5,
+      manualReconnect: () => {},
+      resolveApproval: async () => {},
+      resolveElicitation: async () => {},
+      sendPrompt: async () => {},
+      cancelPrompt: async () => {},
+      forceEndTurn: async () => {},
+      lastActivityRef: { current: 0 },
+      dismissError: () => {},
+      dismissPrimer: () => {},
+      dismissCompactionReminder: () => {},
+      removeQueuedPrompt: () => {},
+      editQueuedPrompt: () => {},
+      clearQueue: () => {},
+      sendQueuedNow: async () => {},
+      canSendQueuedNow: false,
+      sendNowInterruptsTurn: false,
+      dismissRejectedPrompt: () => {},
+      dismissModeSwitchFailed: () => {},
+      setConfigOption: async () => {},
+      dismissConfigOptionSwitchFailed: () => {},
+      loadOlder: async () => {},
+      hasMoreOlder: false,
+      loadingOlder: false,
+    };
+  },
+}));
+
+import { AcpRuntime, clearFoldGeneration } from "../AcpRuntime";
+
+describe("clearFoldGeneration (#3640)", () => {
+  it("changes only when the fold point moves", () => {
+    const cleared = [...TURNS, row("c1", "session_cleared", "cleared")];
+    const cases: [string, ActivityRow[], boolean, string][] = [
+      // No clear yet: one stable value for the whole session.
+      ["no clear", TURNS, false, "none"],
+      // A new turn on top does not move the fold point.
+      ["turn appended", [...TURNS, row("a3", "message", "third answer")], false, "none"],
+      // Cleared turns shown means no fold, so there is no truncation to guard.
+      ["cleared shown", cleared, true, "all"],
+      // Folded: pinned to the last clear, so each /clear yields a new value.
+      ["folded", cleared, false, "c1"],
+      ["folded twice", [...cleared, row("c2", "session_cleared", "cleared again")], false, "c2"],
+    ];
+    for (const [label, rows, showCleared, expected] of cases) {
+      expect(clearFoldGeneration(rows, showCleared), label).toBe(expected);
+    }
+  });
+});
+
+describe("AcpRuntime: runtime rebuild on a fold change (#3640)", () => {
+  it("rebuilds the runtime when a clear lands, and keeps it across an ordinary turn", async () => {
+    // A fresh external store means a fresh mount of the provider subtree. The
+    // child counts its own mounts, which is what the rebuild is for: the stale
+    // store is what throws, so it must be replaced, not updated.
+    let mounts = 0;
+    const CountMounts = () => {
+      useEffect(() => {
+        mounts += 1;
+      }, []);
+      return null;
+    };
+    const Harness = () => <AcpRuntime sessionId="s1">{() => <CountMounts />}</AcpRuntime>;
+
+    activity = TURNS;
+    const { rerender } = render(<Harness />);
+    const afterFirstRender = mounts;
+
+    // An ordinary turn must not rebuild, or every turn would drop the composer
+    // state and the scroll position.
+    activity = [...TURNS, row("a3", "message", "third answer")];
+    await act(async () => {
+      rerender(<Harness />);
+    });
+    expect(mounts, "an ordinary turn must not rebuild the runtime").toBe(afterFirstRender);
+
+    // The `/clear` divider moves the fold point, so the store must be replaced.
+    activity = [...activity, row("c1", "session_cleared", "Conversation cleared")];
+    await act(async () => {
+      rerender(<Harness />);
+    });
+    expect(mounts, "a clear must rebuild the runtime").toBe(afterFirstRender + 1);
+  });
+});

--- a/web/src/lib/acpHistoryWindow.ts
+++ b/web/src/lib/acpHistoryWindow.ts
@@ -77,11 +77,11 @@ export function historyWindowStart(rows: readonly ActivityRow[], visibleRows: nu
   return snapBackToSubagentParent(rows, start);
 }
 
-/** Index of the latest `/clear` divider, or -1 when cleared turns are
- *  shown (folding off) or there is no clear. Rows before it are hidden
- *  behind the ClearedTurnsBanner, not by the history window. */
-function lastClearedIndex(rows: readonly ActivityRow[], showClearedTurns: boolean): number {
-  if (showClearedTurns) return -1;
+/** Index of the latest `/clear` divider, or -1 when there is none. The fold
+ *  pins to the LAST clear so repeated /clears collapse cumulatively. The
+ *  message tree, the runtime key, and the ClearedTurnsBanner all measure the
+ *  fold from here, so they cannot disagree. See #1101. */
+export function lastClearIndex(rows: readonly ActivityRow[]): number {
   for (let i = rows.length - 1; i >= 0; i -= 1) {
     if (rows[i]!.kind === "session_cleared") return i;
   }
@@ -104,7 +104,9 @@ export function historyWindow(
   showClearedTurns: boolean,
 ): HistoryWindow {
   const start = historyWindowStart(rows, visibleRows);
-  const clearIndex = lastClearedIndex(rows, showClearedTurns);
+  // Pre-`/clear` rows are reached via the ClearedTurnsBanner, not by "Load
+  // earlier", so they must not make that control look live.
+  const clearIndex = showClearedTurns ? -1 : lastClearIndex(rows);
   const canLoadEarlier = clearIndex < 0 ? start > 0 : start > clearIndex;
   return { start, canLoadEarlier };
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1695,6 +1695,13 @@
       ]
     },
     {
+      "id": "acp.clear-fold-remount",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/acp/__tests__/AcpRuntime.clearFold.test.tsx"],
+      "components": ["web/src/components/acp/AcpRuntime.tsx"]
+    },
+    {
       "id": "diff-comments.storage-cleanup",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION

## Description

Fixes #3640. A `/clear` put the conversation view into the ErrorBoundary, and the view showed "Something went wrong". The session was never harmed: the reset succeeded and a page reload repaired the view.

The cause is at part level. The fold hides the turns above the last `session_cleared` row (#1101). That makes the part list of a message the fold keeps shorter. assistant-ui reads parts by absolute index, and its store keeps the committed list when a snapshot throws (upstream assistant-ui#5708). A stale part child then reads past the end, inside `useSyncExternalStore`, where React cannot recover. The error then goes to the ErrorBoundary.

The stale state is in the store, not in the children. `AcpRuntime` now holds the external-store hook in a small `RuntimeHost` component, and keys it on the id of the last `session_cleared` row. A move of the fold point builds a fresh store. An ordinary turn does not change the key, so it does not rebuild.

`lastClearIndex` is now one exported helper in `web/src/lib/acpHistoryWindow.ts`. The scan had existed in three places: that module already held a private copy, and `StructuredView` inlined a third for the banner's hidden-turn count. The message tree, the runtime key, and the banner now all read the one helper, so the fold cannot be measured two ways.

I confirmed the cause and the correction on a real session. The steps are in [this comment](https://github.com/agent-of-empires/agent-of-empires/issues/3640#issuecomment-5494429009). The transcript needs a message with more parts than the message that survives the fold. Each `/clear` also makes the transcript shorter, so the next `/clear` has no high part index left. That is why the fault looks intermittent.

The failure and the correction, from the same start shape:

```
crash: gen=cleared-3236 messages=4 parts=[1,1,1,20] -> messages=1 parts=[1]
       -> ERROR web.client: useClientLookup: index 5 out of bounds (length: 1)
fixed: gen=cleared-3236 messages=4 parts=[1,1,1,20] -> gen=cleared-3570 messages=2 parts=[1,1]
       -> no error, divider renders, composer works
```

The second commit carries the consolidation above plus three tidy-ups: assistant-ui's public `ExternalStoreAdapter<T>` in place of a hand-rolled `Parameters<typeof useExternalStoreRuntime<T>>[0]` alias, a session stub in the spec cut to the `state` the runtime actually reads (I re-checked that the rebuild assertion still fails when the key is removed), and one copy of the mechanism comment on `RuntimeHost` instead of three.

Notes for the reviewer:

- I first keyed only the message list. That variant is not enough. I measured it against a real session and it still failed, because the stale state is in the store. The history of that mistake is in the PR comments.
- A rebuild remounts the subtree under the provider, so the transcript loses its scroll position on a `/clear`. Text drafts persist to storage, so they survive.
- The fault occurs in the production build only. The React development build recovers from the throw, so `cargo xtask dev` does not show it.
- The library fault is still open: assistant-ui/assistant-ui#5708. This PR removes our trigger. It does not repair the library.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary <!-- no documentation change is necessary -->
- [ ] For UI changes: included screenshot or recording <!-- there is no visual change; the correction keeps the existing view alive -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: I added a Vitest spec and a `coverage-matrix.json` entry (`acp.clear-fold-remount`), but no Playwright spec. I wrote five live Playwright specs and ran each against a build with the correction removed. All five passed, so none of them reproduced the fault, and I removed all five. The fake ACP agent does not render the same parts as the real agent. jsdom is also blind to the failure, because it swallows the throw and keeps the stale list (assistant-ui#5708). The Vitest spec therefore covers the key: its value, and the fact that a clear moves it and an ordinary turn does not. I verified that the spec fails if the code does not move the key. The browser check is the manual procedure on #3640, which I ran before and after the correction. A reviewer may want more, and I can continue the search for a harness repro.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code, model Opus 5.

**Any Additional AI Details you'd like to share:**

Claude read the logs, measured the transcript shapes with temporary instrumentation, ran the experiments on a real session, and wrote the code and this text. I chose what to test, what to keep and what to file. Claude also wrote five Playwright specs that did not reproduce the fault; I had it delete them rather than keep a test that cannot fail.

- [x] I am an AI Agent filling out this form (check box if true)

