### PR TITLE
refactor(tmux): drop the orphaned resize_window chain

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -901,13 +901,11 @@ async fn handle_live_ws(
                                 let owned = tokio::task::spawn_blocking(move || {
                                     let session = crate::tmux::Session::from_name(&name);
                                     if session.claim_size_owner(&who, SIZE_OWNER_TTL) {
-                                    session.resize_window_if_owner(&who, cols, rows)
+                                        session.resize_window_if_owner(&who, cols, rows)
                                     } else {
                                         false
                                     }
-
                                 })
-
                                 .await
                                 .unwrap_or(false);
                                 settings.is_owner.store(owned, Ordering::Relaxed);

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1631,8 +1631,8 @@ fn pane_dead_from_cache(name: &str) -> Option<bool> {
 }
 
 /// Repopulate [`PANE_META_CACHE`]. The timestamp is stamped even when the
-/// query fails, so a tmux outage costs one fork per [`CACHE_TTL`] instead of
-/// one per row per frame.
+/// query fails, so a tmux outage costs one fork per poller cycle
+/// ([`CACHE_TTL`] / 2) instead of one per row per frame.
 fn publish_pane_meta_cache(
     refresh_id: u64,
     data: Option<std::sync::Arc<HashMap<String, PaneMetadata>>>,
@@ -3140,10 +3140,10 @@ mod tests {
     fn a_failed_pane_snapshot_is_an_answer_so_rows_do_not_re_fork() {
         // `refresh_pane_meta_cache` stamps `time` even when `batch_pane_metadata`
         // fails, and `pane_dead_from_cache` gates on `time` alone. That pairing is
-        // what bounds a tmux outage to one fork per CACHE_TTL instead of one per
-        // row per frame: if a fresh-but-empty snapshot resolved to `None`, every
-        // Tool row would drive another doomed refresh, which is the per-row fork
-        // this whole change removes.
+        // what bounds a tmux outage to one fork per poller cycle (CACHE_TTL / 2)
+        // instead of one per row per frame: if a fresh-but-empty snapshot
+        // resolved to `None`, every Tool row would drive another doomed refresh,
+        // which is the per-row fork this whole change removes.
         let guard = PaneMetaCacheGuard::capture();
         guard.force_failed_refresh();
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1477,80 +1477,6 @@ impl Session {
         let _ = crate::tmux::run_tmux_command_with_timeout(&mut command);
     }
 
-    /// Resize the session's first window so its pane's visible content area
-    /// becomes `cols` x `rows`. Best-effort: a missing session or a tmux ENOENT
-    /// is swallowed so a transient failure never blocks a render.
-    ///
-    /// Every caller (the web live view, the mobile live view, the TUI's passive
-    /// preview sync) works in pane/content geometry, not tmux window geometry:
-    /// they render the pane, not the tmux status bar. tmux `resize-window` sizes
-    /// the *window*, and vertical chrome (the status bar) shrinks the pane below
-    /// it, so a naive `resize-window -y rows` yields a `rows - chrome` pane and
-    /// the live owner loop then re-asserts forever against a target it can never
-    /// reach (#2766). We measure the chrome live and add it back, so the pane
-    /// lands at exactly `rows`. Cols need no adjustment: a single pane spans the
-    /// full window width, and the status bar is horizontal.
-    ///
-    /// Also used to keep a detached agent's pane sized to the visible preview
-    /// area: a full-screen agent is sized to whatever terminal it was last
-    /// attached from, so without this it renders taller than the preview window
-    /// and the bottom-anchored capture clips the top rows (worse when the info
-    /// header steals rows). Mirrors what live-send does through its worker.
-    ///
-    /// NOTE: tmux's `resize-window -x -y` silently flips the window-size option
-    /// to `manual`, so any later `attach-session` must call
-    /// [`reset_size_to_latest_client`](Self::reset_size_to_latest_client) first
-    /// or the window stays pinned at these preview dimensions.
-    pub fn resize_window(&self, cols: u16, rows: u16) -> bool {
-        let deadline = crate::tmux::TmuxCommandDeadline::new();
-        self.resize_window_with_deadline(cols, rows, &deadline)
-    }
-
-    pub(crate) fn resize_window_with_deadline(
-        &self,
-        cols: u16,
-        rows: u16,
-        deadline: &crate::tmux::TmuxCommandDeadline,
-    ) -> bool {
-        if cols == 0 || rows == 0 || !self.exists_with_deadline(deadline) {
-            return false;
-        }
-        self.resize_window_after_exists_with_deadline(cols, rows, deadline)
-    }
-
-    pub(crate) fn resize_window_after_exists_with_deadline(
-        &self,
-        cols: u16,
-        rows: u16,
-        deadline: &crate::tmux::TmuxCommandDeadline,
-    ) -> bool {
-        if cols == 0 || rows == 0 {
-            return false;
-        }
-        // Query the same window/pane the capture streams (:^.0), so the
-        // measured chrome matches the pane whose height the owner loop checks.
-        let pane_target = format!("{}:^.0", self.name);
-        let window_rows = self
-            .pane_chrome_rows_with_deadline(&pane_target, deadline)
-            .map(|chrome| rows.saturating_add(chrome))
-            .unwrap_or(rows);
-        let window_target = format!("{}:^", self.name);
-        let mut command = crate::tmux::tmux_command();
-        command.args([
-            "resize-window",
-            "-t",
-            &window_target,
-            "-x",
-            &cols.to_string(),
-            "-y",
-            &window_rows.to_string(),
-        ]);
-        deadline
-            .run(&mut command)
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-
     /// Read the live vertical chrome (status-bar rows) for pane_target from
     /// tmux. None when the geometry cannot be read; callers then size the
     /// window with no chrome adjustment (the pre-#2766 behavior).
@@ -1585,7 +1511,8 @@ impl Session {
     /// attach, the mobile capture viewer, and the TUI's preview sync), each
     /// living in a different process. The lock lives in tmux user options so
     /// every process sees the same owner and only the owner calls
-    /// [`resize_window`](Self::resize_window); non-owners render best-effort.
+    /// [`resize_window_if_owner`](Self::resize_window_if_owner); non-owners
+    /// render best-effort.
     ///
     /// Steals the lock when the current holder's heartbeat is older than
     /// `ttl`, so a crashed or disconnected owner self-heals. A queue-local

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -749,8 +749,8 @@ pub(super) fn sample_debounce_wait_ms(
         .max(1)
 }
 /// Capture cadence when the worker is just keeping the home-list preview warm
-/// (no live-send). Matches the old render-driven `PREVIEW_REFRESH_MS` throttle
-/// so moving the fork off the render thread doesn't raise the idle fork rate.
+/// (no live-send). Matches the render-driven throttle it replaces, so moving
+/// the fork off the render thread doesn't raise the idle fork rate.
 const LIVE_CAPTURE_INTERVAL_IDLE_MS: u64 = 250;
 /// Maximum interval between authoritative snapshots while a live VT grid is
 /// otherwise supplying preview frames. This preserves upstream's bounded
@@ -914,8 +914,8 @@ fn frame_needs_publish(
 /// fresh content without ever forking on the render thread, and a switch
 /// swaps the target in place instead of spawning a new thread. The capture
 /// cadence adapts (`set_live`): tight while live-send is attached,
-/// `PREVIEW_REFRESH_MS`-matched otherwise so the background preview costs
-/// no more idle forks than the old render-driven throttle did.
+/// `LIVE_CAPTURE_INTERVAL_IDLE_MS` otherwise so the background preview costs
+/// no more idle forks than the render-driven throttle it replaces did.
 pub(in crate::tui) struct LiveCaptureWorker {
     /// Lines the render loop wants captured (height + scrollback + buffer).
     /// `0` means "not set yet"; the worker skips capturing until the first


### PR DESCRIPTION
## Description

#3537 rerouted every resize caller to the ownership-guarded variants and left `resize_window` and its two callees with no callers. A single `pub` on the entry point silences the dead-code lint for the whole chain, so CI cannot catch it. The surviving `tests/` references are negative assertions; `pane_chrome_rows_with_deadline` stays for `resize_window_if_format_with_deadline`.

Also repoints a doc link that would dangle, retargets two comments naming the deleted `PREVIEW_REFRESH_MS`, corrects two comments stating a fork budget the snapshot poller halved to `CACHE_TTL / 2`, and fixes an under-indented line inside the nested `spawn_blocking` in `live_ws.rs` that `cargo fmt --check` does not reach.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

No behavior change: unreachable code and comment corrections only. Local run of the full lib suite passes at 4836, with `cargo fmt`, `cargo clippy --features serve --all-targets`, and `cargo doc --no-deps --features serve` clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Found during a cross-model review of #3537.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9euFqwhiTCwc3orc9Hggp

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed unused, unguarded tmux window-resizing methods.
- Kept resizing through owner-guarded paths.
- Updated comments and documentation to match current behavior.
- Fixed indentation in the live WebSocket resize handler.

## Benefits

- Reduces unused code and maintenance overhead.
- Keeps resize ownership rules clear.
- Improves documentation accuracy.
- No behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->