### PR TITLE
fix(sandbox)!: harden repo-scoped sandbox config

### DIFF
--- a/aoe-settings-derive/src/lib.rs
+++ b/aoe-settings-derive/src/lib.rs
@@ -7,10 +7,14 @@
 //! `crate::session::config::settings_schema::*`, so the derive is only meant for use
 //! inside the `agent-of-empires` crate.
 //!
-//! Section attribute (required):
+//! Section attribute (`name` and `category` required):
 //! ```ignore
 //! #[setting_section(name = "acp", category = "Acp")]
+//! #[setting_section(name = "session", category = "Session", repo_default = "deny")]
 //! ```
+//! `repo_default` ("allow" | "deny", default "allow") is the repo-config
+//! policy every field in the section inherits unless it declares its own
+//! `repo = "..."`.
 //!
 //! Per-field attribute:
 //! ```ignore
@@ -21,7 +25,8 @@
 //! Keys: `label`, `desc`, `category` (override the section default), `widget`,
 //! `min`, `max`, `step`, `multiline`, `mono`, `options` ("v:Label,v2:Label2"),
 //! `web` ("allow" | "elevation:reason" | "local_only:reason"),
-//! `repo` ("allow" | "deny": explicit repo-config override policy),
+//! `repo` ("allow" | "deny": repo-config override policy; defaults to the
+//!   section's `repo_default`),
 //! `validate` ("none" | "range:min[:max]" | "nonempty" | "memory_limit" |
 //!   "volume_list" | "env_list" | "port_mapping_list" | "network"),
 //! `global_only` (flag: field is shown but not profile-overridable),
@@ -44,6 +49,9 @@ pub fn derive_settings_section(input: TokenStream) -> TokenStream {
 struct SectionMeta {
     name: String,
     category: String,
+    /// Repo-config policy inherited by fields with no `repo = "..."` of their
+    /// own. `RepoPolicy::Allow` unless the section declares otherwise.
+    repo_default: proc_macro2::TokenStream,
 }
 
 fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
@@ -80,7 +88,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         }
         let widget = build_widget(field, &attrs)?;
         let web = build_web(field, &attrs)?;
-        let repo = build_repo_policy(field, &attrs)?;
+        let repo = build_repo_policy(field, &attrs, &section.repo_default)?;
         let validation = build_validation(field, &attrs)?;
         let overridable = !attrs.global_only;
         let advanced = attrs.advanced;
@@ -130,6 +138,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
 fn parse_section_meta(input: &DeriveInput) -> syn::Result<SectionMeta> {
     let mut name = None;
     let mut category = None;
+    let mut repo_default = None;
     for attr in &input.attrs {
         if !attr.path().is_ident("setting_section") {
             continue;
@@ -139,19 +148,38 @@ fn parse_section_meta(input: &DeriveInput) -> syn::Result<SectionMeta> {
                 name = Some(meta.value()?.parse::<LitStr>()?.value());
             } else if meta.path.is_ident("category") {
                 category = Some(meta.value()?.parse::<LitStr>()?.value());
+            } else if meta.path.is_ident("repo_default") {
+                repo_default = Some(meta.value()?.parse::<LitStr>()?);
             } else {
                 return Err(meta.error("unknown setting_section key"));
             }
             Ok(())
         })?;
     }
+    let repo_default = match repo_default {
+        None => quote!(RepoPolicy::Allow),
+        Some(lit) => match lit.value().as_str() {
+            "allow" => quote!(RepoPolicy::Allow),
+            "deny" => quote!(RepoPolicy::Deny),
+            other => {
+                return Err(syn::Error::new_spanned(
+                    lit,
+                    format!("unknown repo_default `{other}` (expected \"allow\" or \"deny\")"),
+                ))
+            }
+        },
+    };
     let name = name.ok_or_else(|| {
         syn::Error::new_spanned(input, "missing #[setting_section(name = \"...\")]")
     })?;
     let category = category.ok_or_else(|| {
         syn::Error::new_spanned(input, "missing #[setting_section(category = \"...\")]")
     })?;
-    Ok(SectionMeta { name, category })
+    Ok(SectionMeta {
+        name,
+        category,
+        repo_default,
+    })
 }
 
 #[derive(Default)]
@@ -304,9 +332,10 @@ fn build_web(field: &syn::Field, attrs: &FieldAttrs) -> syn::Result<proc_macro2:
 fn build_repo_policy(
     field: &syn::Field,
     attrs: &FieldAttrs,
+    section_default: &proc_macro2::TokenStream,
 ) -> syn::Result<proc_macro2::TokenStream> {
     let Some(spec) = attrs.repo.as_deref() else {
-        return Ok(quote!(RepoPolicy::Unspecified));
+        return Ok(section_default.clone());
     };
     let ts = match spec {
         "allow" => quote!(RepoPolicy::Allow),

--- a/aoe-settings-derive/src/lib.rs
+++ b/aoe-settings-derive/src/lib.rs
@@ -21,6 +21,7 @@
 //! Keys: `label`, `desc`, `category` (override the section default), `widget`,
 //! `min`, `max`, `step`, `multiline`, `mono`, `options` ("v:Label,v2:Label2"),
 //! `web` ("allow" | "elevation:reason" | "local_only:reason"),
+//! `repo` ("allow" | "deny": explicit repo-config override policy),
 //! `validate` ("none" | "range:min[:max]" | "nonempty" | "memory_limit" |
 //!   "volume_list" | "env_list" | "port_mapping_list" | "network"),
 //! `global_only` (flag: field is shown but not profile-overridable),
@@ -79,6 +80,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         }
         let widget = build_widget(field, &attrs)?;
         let web = build_web(field, &attrs)?;
+        let repo = build_repo_policy(field, &attrs)?;
         let validation = build_validation(field, &attrs)?;
         let overridable = !attrs.global_only;
         let advanced = attrs.advanced;
@@ -98,6 +100,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 description: #description.to_string(),
                 widget: #widget,
                 web_write: #web,
+                repo_policy: #repo,
                 profile_overridable: #overridable,
                 validation: #validation,
                 advanced: #advanced,
@@ -116,7 +119,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
             /// how every surface renders and guards these fields.
             pub fn settings_descriptors() -> ::std::vec::Vec<crate::session::config::settings_schema::FieldDescriptor> {
                 use crate::session::config::settings_schema::{
-                    FieldDescriptor, WidgetKind, WebWritePolicy, ValidationKind, SelectOption,
+                    FieldDescriptor, WidgetKind, WebWritePolicy, RepoPolicy, ValidationKind, SelectOption,
                 };
                 ::std::vec![ #(#descriptors),* ]
             }
@@ -161,6 +164,7 @@ struct FieldAttrs {
     category: Option<String>,
     widget: Option<String>,
     web: Option<String>,
+    repo: Option<String>,
     validate: Option<String>,
     options: Option<String>,
     min: Option<i64>,
@@ -195,6 +199,7 @@ fn parse_field_attrs(field: &syn::Field, field_name: &str) -> syn::Result<FieldA
                 "category" => out.category = Some(meta.value()?.parse::<LitStr>()?.value()),
                 "widget" => out.widget = Some(meta.value()?.parse::<LitStr>()?.value()),
                 "web" => out.web = Some(meta.value()?.parse::<LitStr>()?.value()),
+                "repo" => out.repo = Some(meta.value()?.parse::<LitStr>()?.value()),
                 "validate" => out.validate = Some(meta.value()?.parse::<LitStr>()?.value()),
                 "options" => out.options = Some(meta.value()?.parse::<LitStr>()?.value()),
                 "min" => out.min = Some(meta.value()?.parse::<LitInt>()?.base10_parse()?),
@@ -292,6 +297,26 @@ fn build_web(field: &syn::Field, attrs: &FieldAttrs) -> syn::Result<proc_macro2:
             field,
             format!("unknown web policy `{spec}`"),
         ));
+    };
+    Ok(ts)
+}
+
+fn build_repo_policy(
+    field: &syn::Field,
+    attrs: &FieldAttrs,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let Some(spec) = attrs.repo.as_deref() else {
+        return Ok(quote!(RepoPolicy::Unspecified));
+    };
+    let ts = match spec {
+        "allow" => quote!(RepoPolicy::Allow),
+        "deny" => quote!(RepoPolicy::Deny),
+        other => {
+            return Err(syn::Error::new_spanned(
+                field,
+                format!("unknown repo policy `{other}` (expected \"allow\" or \"deny\")"),
+            ))
+        }
     };
     Ok(ts)
 }

--- a/docs/development/adding-settings.md
+++ b/docs/development/adding-settings.md
@@ -68,6 +68,9 @@ Pick a `widget` for the field's type:
   web) or `local_only:<reason>` (host-execution surface the server rejects and
   the dashboard never renders, e.g. a binary path or command argv). Omit for a
   plain allow.
+- `repo`: `allow` or `deny`; whether a repo's `.agent-of-empires/config.toml`
+  may override the field. If absent, defaults to `allow` (or `deny` in the
+  `session` section). Global-only fields cannot be overridden by repos.
 - `category`: override the section's default TUI tab.
 - `advanced`: group the field under an "Advanced" fold on both surfaces.
 - `global_only`: shown but not profile-overridable (the dashboard adds an

--- a/docs/development/adding-settings.md
+++ b/docs/development/adding-settings.md
@@ -39,7 +39,9 @@ surfaces.
 ## Choosing the section and widget
 
 The section is the struct's `#[setting_section(name = "...", category = "...")]`.
-`name` is the `[section]` table in `config.toml`; `category` is the TUI tab.
+`name` is the `[section]` table in `config.toml`; `category` is the TUI tab. An
+optional `repo_default = "allow" | "deny"` sets the repo-config policy every
+field in the section inherits.
 
 Pick a `widget` for the field's type:
 
@@ -69,8 +71,9 @@ Pick a `widget` for the field's type:
   the dashboard never renders, e.g. a binary path or command argv). Omit for a
   plain allow.
 - `repo`: `allow` or `deny`; whether a repo's `.agent-of-empires/config.toml`
-  may override the field. If absent, defaults to `allow` (or `deny` in the
-  `session` section). Global-only fields cannot be overridden by repos.
+  may override the field. If absent, the field inherits the `repo_default` its
+  `#[setting_section(...)]` declares (`allow` unless stated; `session` declares
+  `deny`). Global-only fields are never repo-settable.
 - `category`: override the section's default TUI tab.
 - `advanced`: group the field under an "Advanced" fold on both surfaces.
 - `global_only`: shown but not profile-overridable (the dashboard adds an

--- a/docs/guides/apple-containers.md
+++ b/docs/guides/apple-containers.md
@@ -22,14 +22,10 @@ Set the runtime in `~/.agent-of-empires/config.toml`:
 container_runtime = "apple_container"
 ```
 
-Scope it to a single profile to keep Docker as the global default:
-
-```toml
-[profiles.apple]
-sandbox.container_runtime = "apple_container"
-```
-
-Use it with `aoe add --profile apple .`. The TUI **Sandbox** toggle uses this runtime automatically, and shows an error if the `container` daemon is not running.
+The runtime is global-only: every container call resolves it from the global
+config, so a profile or repo override is ignored. The TUI **Sandbox** toggle
+uses this runtime automatically, and shows an error if the `container` daemon
+is not running.
 
 ## Apple-Container-specific gotchas
 

--- a/docs/guides/podman.md
+++ b/docs/guides/podman.md
@@ -15,14 +15,9 @@ Set the runtime in `~/.config/agent-of-empires/config.toml` (Linux) or `~/.agent
 container_runtime = "podman"
 ```
 
-Scope it to a single profile to keep Docker as the global default:
-
-```toml
-[profiles.podman]
-sandbox.container_runtime = "podman"
-```
-
-Use it with `aoe add --profile podman .`, or pick the runtime per-session in the TUI under **Sandbox > Container Runtime**.
+The runtime is global-only: every container call resolves it from the global
+config, so a profile or repo override is ignored. Set it once here, or in the
+TUI under **Sandbox > Container Runtime** in the Global scope.
 
 ## Podman-specific gotchas
 

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -97,7 +97,7 @@ auto_cleanup = true
 default_terminal_mode = "host"   # "host" or "container"
 ```
 
-`enabled_by_default`, `default_image`, `extra_volumes` and `mount_ssh` are ignored from repo config (with a warning naming the keys): together they let a repo put you in a container you did not ask for, running an image it chose, with your filesystem and SSH keys mounted in. Set them in your global or profile config, or pass `--sandbox` / `--sandbox-image` per session.
+Security-sensitive sandbox settings are ignored from repo config (with a warning naming the keys): `enabled_by_default`, `default_image`, `container_runtime`, `extra_volumes`, `mount_ssh`, and `selinux_relabel`. Set them in global or profile config instead, or pass `--sandbox` / `--sandbox-image` per session. Global-only settings such as `container_runtime` are always read from the global config.
 
 List fields (`environment`, `volume_ignores`, `port_mappings`) accept either an array or a single string:
 

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -97,7 +97,7 @@ auto_cleanup = true
 default_terminal_mode = "host"   # "host" or "container"
 ```
 
-Security-sensitive sandbox settings are ignored from repo config (with a warning naming the keys): `enabled_by_default`, `default_image`, `container_runtime`, `extra_volumes`, `mount_ssh`, and `selinux_relabel`. Set them in global or profile config instead, or pass `--sandbox` / `--sandbox-image` per session. Global-only settings such as `container_runtime` are always read from the global config.
+Security-sensitive sandbox settings are ignored from repo config (with a warning naming the keys): `enabled_by_default`, `default_image`, `container_runtime`, `extra_volumes`, `mount_ssh`, and `selinux_relabel`. Set them in global or profile config instead, or pass `--sandbox` / `--sandbox-image` per session; `container_runtime` is global-only, so set it in the global config.
 
 List fields (`environment`, `volume_ignores`, `port_mappings`) accept either an array or a single string:
 

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -75,13 +75,10 @@ Container hooks get the same variables (forwarded via `docker exec -e`). Status-
 
 ```toml
 [session]
-default_tool = "opencode"   # Override the default agent for this repo
 agent_detect_as = { my-agent = "claude" }
 ```
 
-Any supported agent name (run `aoe add --help` to see the list).
-
-`default_tool` and `agent_detect_as` are the only `[session]` keys a repo may set. Everything else in that section is ignored from repo config (with a warning naming the keys), because fields like `custom_agents`, `agent_command_override`, `agent_extra_args`, `agent_acp_cmd` and `yolo_mode_default` decide what command AoE launches or how much it is allowed to do: set them in your global or profile config instead.
+`agent_detect_as` is the only `[session]` key a repo may set. Everything else in that section is ignored from repo config (with a warning naming the keys), because fields like `custom_agents`, `agent_command_override`, `agent_extra_args`, `agent_acp_cmd` and `yolo_mode_default` decide what command AoE launches or how much it is allowed to do: set them in your global or profile config instead. `default_tool` is denied too: session launch prefers an exact `custom_agents` match when resolving it, so a repo could otherwise select a user-defined host command.
 
 ### Sandbox
 
@@ -152,7 +149,7 @@ on_launch = ["npm install"]
 on_destroy = ["docker-compose down"]
 
 [session]
-default_tool = "claude"
+agent_detect_as = { my-agent = "claude" }
 
 [sandbox]
 environment = ["DATABASE_URL", "REDIS_URL", "NODE_ENV=development"]

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -2188,11 +2188,12 @@ pub(crate) fn build_container_config(
 
 /// Normalize the configured `sandbox.network` into the value passed to
 /// `--network`. Unset and `bridge` both map to `None` (runtime default, no
-/// flag). `host` is rejected here as defense in depth even though the settings
-/// validator already refuses it, because repo/profile TOML is only
-/// type-checked, not value-validated (a repo config could set it directly, the
-/// concern raised in #2706). Everything else (`none` or a named network) passes
-/// through verbatim.
+/// flag); `none` is canonicalized to lowercase. Anything the settings
+/// validator rejects (`host`, namespace-sharing forms like `container:` and
+/// `ns:`, malformed names) is dropped with a warning here too, because
+/// repo/profile TOML is only type-checked, not value-validated (a repo config
+/// could set it directly, the concern raised in #2706). Valid named networks
+/// pass through verbatim.
 fn sanitize_network(network: Option<&str>) -> Option<String> {
     let value = network.map(str::trim).filter(|v| !v.is_empty())?;
     if value.eq_ignore_ascii_case("bridge") {
@@ -2211,6 +2212,13 @@ fn sanitize_network(network: Option<&str>) -> Option<String> {
     // user-defined and case-sensitive).
     if value.eq_ignore_ascii_case("none") {
         return Some("none".to_string());
+    }
+    if let Err(reason) = crate::session::validate_network_format(value) {
+        tracing::warn!(
+            target: "session.profile",
+            "Ignoring sandbox.network = {value:?}: {reason}"
+        );
+        return None;
     }
     Some(value.to_string())
 }
@@ -2365,6 +2373,16 @@ mod tests {
     fn sanitize_network_rejects_host() {
         assert_eq!(sanitize_network(Some("host")), None);
         assert_eq!(sanitize_network(Some("Host")), None);
+    }
+
+    #[test]
+    fn sanitize_network_rejects_namespace_sharing_forms() {
+        // Repo/profile TOML is only type-checked, so `container:` (Docker) and
+        // `ns:` (Podman) must be rejected here, not just by the settings
+        // validator: either shares another namespace's network stack.
+        assert_eq!(sanitize_network(Some("container:abc")), None);
+        assert_eq!(sanitize_network(Some("ns:/var/run/netns/x")), None);
+        assert_eq!(sanitize_network(Some("has space")), None);
     }
 
     #[test]
@@ -3924,6 +3942,65 @@ mount_ssh = true
             crate::session::artifacts::CONTAINER_ARTIFACT_DIR,
             volume_pairs
         );
+    }
+
+    /// `sandbox.network` stays repo-overridable, but namespace-sharing forms
+    /// (`container:` on Docker, `ns:` on Podman) must be dropped at container
+    /// build, because repo/profile TOML is only type-checked, never
+    /// value-validated. `selinux_relabel` is repo-denied outright: `:z`
+    /// relabels host paths.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_drops_repo_network_escape_and_relabel() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        for network in ["container:victim", "ns:/var/run/netns/x"] {
+            let project_dir = TempDir::new().unwrap();
+            let config_dir = project_dir.path().join(".agent-of-empires");
+            fs::create_dir_all(&config_dir).unwrap();
+            fs::write(
+                config_dir.join("config.toml"),
+                format!("[sandbox]\nnetwork = \"{network}\"\nselinux_relabel = true\n"),
+            )
+            .unwrap();
+
+            git2::Repository::init(project_dir.path()).unwrap();
+
+            let sandbox_info = crate::session::instance::SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "test:latest".to_string(),
+                container_name: "test-container".to_string(),
+                extra_env: None,
+                custom_instruction: None,
+                before_start_env: Vec::new(),
+                container_workdir: None,
+            };
+
+            let config = build_container_config(
+                project_dir.path().to_str().unwrap(),
+                &sandbox_info,
+                ContainerAgentSelection::new("claude", None),
+                false,
+                "test-instance-id",
+                None,
+                "",
+            )
+            .unwrap();
+
+            assert_eq!(
+                config.network, None,
+                "repo-declared network {network:?} must be dropped"
+            );
+            assert!(
+                !config.selinux_relabel,
+                "repo-declared selinux_relabel must be dropped"
+            );
+        }
     }
 
     #[test]

--- a/src/session/config/mod.rs
+++ b/src/session/config/mod.rs
@@ -905,14 +905,17 @@ pub struct AppStateConfig {
 #[setting_section(name = "session", category = "Session")]
 pub struct SessionConfig {
     /// Default coding tool for new sessions. If not set or the tool is
-    /// unavailable, falls back to the first available tool. Only names a tool
-    /// the user configured (built-in or from their own `custom_agents`).
+    /// unavailable, falls back to the first available tool. Repo-denied: the
+    /// launch path exact-matches the user's `custom_agents` before built-ins,
+    /// so a repo could name a user-defined host command, and validating
+    /// against built-in names would not help because custom agents may
+    /// shadow them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[setting(
         label = "Default Tool",
         widget = "custom:default-tool",
         category = "Agents",
-        repo = "allow"
+        repo = "deny"
     )]
     pub default_tool: Option<String>,
 

--- a/src/session/config/mod.rs
+++ b/src/session/config/mod.rs
@@ -905,12 +905,14 @@ pub struct AppStateConfig {
 #[setting_section(name = "session", category = "Session")]
 pub struct SessionConfig {
     /// Default coding tool for new sessions. If not set or the tool is
-    /// unavailable, falls back to the first available tool.
+    /// unavailable, falls back to the first available tool. Only names a tool
+    /// the user configured (built-in or from their own `custom_agents`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[setting(
         label = "Default Tool",
         widget = "custom:default-tool",
-        category = "Agents"
+        category = "Agents",
+        repo = "allow"
     )]
     pub default_tool: Option<String>,
 
@@ -1122,7 +1124,8 @@ pub struct SessionConfig {
         label = "Agent Detect As",
         widget = "list",
         web = "local_only:part of the agent-command surface, edited locally only",
-        category = "Agents"
+        category = "Agents",
+        repo = "allow"
     )]
     pub agent_detect_as: HashMap<String, String>,
 
@@ -2272,7 +2275,8 @@ pub struct SandboxConfig {
     #[setting(
         label = "Enabled by Default",
         widget = "toggle",
-        web = "elevation:sandbox config affects host isolation"
+        web = "elevation:sandbox config affects host isolation",
+        repo = "deny"
     )]
     pub enabled_by_default: bool,
 
@@ -2281,7 +2285,8 @@ pub struct SandboxConfig {
     #[setting(
         label = "Default Image",
         widget = "text",
-        web = "elevation:sandbox config affects host isolation"
+        web = "elevation:sandbox config affects host isolation",
+        repo = "deny"
     )]
     pub default_image: String,
 
@@ -2292,6 +2297,7 @@ pub struct SandboxConfig {
         widget = "list",
         validate = "volume_list",
         web = "elevation:sandbox config affects host isolation",
+        repo = "deny",
         advanced
     )]
     pub extra_volumes: Vec<String>,
@@ -2362,8 +2368,8 @@ pub struct SandboxConfig {
     /// via the runtime's bridge), "none" for no network (isolates the agent but
     /// also cuts off its own model API unless a proxy is routed in), or a named
     /// network to attach a user-defined network with its own egress filtering.
-    /// "host" is rejected because sharing the host network namespace defeats
-    /// sandbox isolation.
+    /// "host" and namespace-sharing forms ("container:", "ns:") are rejected
+    /// because they defeat sandbox isolation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[setting(
         label = "Network",
@@ -2412,7 +2418,8 @@ pub struct SandboxConfig {
     #[setting(
         label = "Mount SSH",
         widget = "toggle",
-        web = "elevation:sandbox config affects host isolation"
+        web = "elevation:sandbox config affects host isolation",
+        repo = "deny"
     )]
     pub mount_ssh: bool,
 
@@ -2424,6 +2431,7 @@ pub struct SandboxConfig {
         label = "SELinux Relabel",
         widget = "toggle",
         web = "elevation:sandbox config affects host isolation",
+        repo = "deny",
         advanced
     )]
     pub selinux_relabel: bool,
@@ -2445,7 +2453,8 @@ pub struct SandboxConfig {
         label = "Container Runtime",
         widget = "select",
         options = "docker:Docker,podman:Podman,apple_container:Apple Container",
-        web = "elevation:sandbox config affects host isolation"
+        web = "elevation:sandbox config affects host isolation",
+        global_only
     )]
     pub container_runtime: ContainerRuntimeName,
 }

--- a/src/session/config/mod.rs
+++ b/src/session/config/mod.rs
@@ -902,7 +902,16 @@ pub struct AppStateConfig {
 
 /// Session-related configuration defaults
 #[derive(Debug, Clone, Serialize, Deserialize, SettingsSection)]
-#[setting_section(name = "session", category = "Session")]
+// `repo_default = "deny"`: most of this section is personal preference, but
+// several fields name or build the command AoE hands to tmux
+// (`custom_agents`, `agent_command_override`, `agent_extra_args`,
+// `agent_acp_cmd`, `smart_rename_agent`, `smart_rename_model`) or weaken the
+// agent's own permission gate (`yolo_mode_default`). Honoring those from a
+// checked-out repo is arbitrary host command execution at session launch, the
+// hazard that already keeps `host_hooks` out of `REPO_OVERRIDABLE_SECTIONS`.
+// Denying by default means a field added here later stays repo-denied until
+// someone marks it `repo = "allow"` (#3154).
+#[setting_section(name = "session", category = "Session", repo_default = "deny")]
 pub struct SessionConfig {
     /// Default coding tool for new sessions. If not set or the tool is
     /// unavailable, falls back to the first available tool. Repo-denied: the

--- a/src/session/config/profile_config.rs
+++ b/src/session/config/profile_config.rs
@@ -98,7 +98,14 @@ pub(super) fn validate_overrides_typecheck(overrides: &serde_json::Value) -> Res
 /// already-loaded `ProfileConfig` so the caller does not read+parse the
 /// profile file a second time.
 pub(crate) fn profile_config_ignored_keys(cfg: &ProfileConfig) -> Vec<String> {
-    let Ok(base) = merged_onto_default(&cfg.overrides_value()) else {
+    overrides_ignored_keys(&cfg.overrides_value())
+}
+
+/// Dotted paths of keys in a sparse override object that `Config` does not
+/// recognize. Shared by the profile probe above and the repo-config loader,
+/// whose `#[serde(flatten)]` maps absorb unknown keys the same way.
+pub(crate) fn overrides_ignored_keys(overrides: &serde_json::Value) -> Vec<String> {
+    let Ok(base) = merged_onto_default(overrides) else {
         return Vec::new();
     };
     let mut ignored = Vec::new();

--- a/src/session/config/repo_config.rs
+++ b/src/session/config/repo_config.rs
@@ -79,6 +79,10 @@ const REPO_OVERRIDABLE_SECTIONS: &[&str] = &["hooks", "session", "sandbox", "wor
 /// default means a field added to `SessionConfig` later stays repo-denied
 /// until someone marks it `repo = "allow"`.
 ///
+/// Even `default_tool` is denied despite only naming a tool: the launch path
+/// exact-matches the user's `custom_agents` before built-ins, so a repo could
+/// select a user-defined host command (see the field's doc comment).
+///
 /// Every other overridable section is a genuine team-shared surface, so its
 /// fields default to allowed and dangerous ones opt out with `repo = "deny"`
 /// on the field (e.g. the sandbox image and mount fields).
@@ -1688,7 +1692,7 @@ pub const INIT_TEMPLATE: &str = r#"# Agent of Empires - Repository Configuration
 # on_destroy = ["docker-compose down"]
 
 # [session]
-# default_tool = "claude"
+# agent_detect_as = { my-agent = "claude" }
 
 # [sandbox]
 # enabled_by_default = true
@@ -2035,9 +2039,36 @@ mod tests {
             merged.session.custom_agents.is_empty(),
             "repo-declared custom_agents must be dropped on merge"
         );
-        // `default_tool` stays repo-overridable (the documented use case); it
-        // can only name a tool the user configured, never a command.
-        assert_eq!(merged.session.default_tool.as_deref(), Some("repo-agent"));
+        assert_eq!(
+            merged.session.default_tool, None,
+            "repo-declared default_tool must be dropped on merge"
+        );
+    }
+
+    #[test]
+    fn test_repo_config_cannot_select_a_user_custom_agent() {
+        // The launch path exact-matches the user's `custom_agents` before
+        // built-ins when resolving `default_tool` (cli/add.rs), so a repo
+        // pointing it at a user-defined custom agent would launch that host
+        // command. Validating the value against built-in names would not
+        // close the hole because a custom agent may shadow a built-in name,
+        // so the field is repo-denied outright.
+        let mut global = Config::default();
+        global
+            .session
+            .custom_agents
+            .insert("deploy-helper".to_string(), "do-deploy --prod".to_string());
+        let repo: RepoConfig =
+            toml::from_str("[session]\ndefault_tool = \"deploy-helper\"\n").unwrap();
+        let merged = merge_repo_config(global, &repo);
+        assert_eq!(
+            merged.session.default_tool, None,
+            "repo must not select the user's custom agent"
+        );
+        assert!(
+            merged.session.custom_agents.contains_key("deploy-helper"),
+            "the user's own custom_agents are untouched"
+        );
     }
 
     #[test]
@@ -2071,8 +2102,8 @@ mod tests {
         assert!(merged.session.smart_rename_agent.is_empty());
         assert!(merged.session.smart_rename_model.is_empty());
         assert!(!merged.session.yolo_mode_default);
-        // The two allowed fields still come through.
-        assert_eq!(merged.session.default_tool.as_deref(), Some("codex"));
+        assert_eq!(merged.session.default_tool, None);
+        // The one allowed field still comes through.
         assert_eq!(
             merged.session.agent_detect_as.get("x").map(String::as_str),
             Some("claude")
@@ -2087,6 +2118,7 @@ mod tests {
                 "session.agent_config_dir",
                 "session.agent_extra_args",
                 "session.custom_agents",
+                "session.default_tool",
                 "session.smart_rename_agent",
                 "session.smart_rename_model",
                 "session.yolo_mode_default",
@@ -2104,7 +2136,7 @@ mod tests {
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("config.toml"),
-            "[session]\ncustom_agents = 7\ndefault_tool = \"codex\"\n",
+            "[session]\ncustom_agents = 7\nagent_detect_as = { my-agent = \"claude\" }\n",
         )
         .unwrap();
 
@@ -2112,7 +2144,14 @@ mod tests {
             .expect("a wrongly-typed denied field must not fail the load")
             .expect("config exists");
         let merged = merge_repo_config(Config::default(), &loaded);
-        assert_eq!(merged.session.default_tool.as_deref(), Some("codex"));
+        assert_eq!(
+            merged
+                .session
+                .agent_detect_as
+                .get("my-agent")
+                .map(String::as_str),
+            Some("claude")
+        );
         assert!(merged.session.custom_agents.is_empty());
     }
 
@@ -2124,7 +2163,11 @@ mod tests {
         let profile = ProfileConfig {
             description: None,
             overrides: serde_json::from_value(serde_json::json!({
-                "session": { "custom_agents": { "x": "sh -c pwned" }, "default_tool": "codex" },
+                "session": {
+                    "custom_agents": { "x": "sh -c pwned" },
+                    "default_tool": "codex",
+                    "agent_detect_as": { "my-agent": "claude" },
+                },
                 "acp": { "auto_approve": true },
             }))
             .unwrap(),
@@ -2135,14 +2178,15 @@ mod tests {
         save_repo_config(dir.path(), &repo).unwrap();
         let written = fs::read_to_string(dir.path().join(REPO_CONFIG_PATH)).unwrap();
         assert!(!written.contains("custom_agents"), "written: {written}");
-        assert!(written.contains("default_tool"), "written: {written}");
+        assert!(!written.contains("default_tool"), "written: {written}");
+        assert!(written.contains("agent_detect_as"), "written: {written}");
     }
 
     #[test]
     fn test_repo_may_override_field() {
         // (section, field, expected): field-declared repo policy and section defaults.
         let cases = [
-            ("session", "default_tool", true),
+            ("session", "default_tool", false),
             ("session", "agent_detect_as", true),
             ("sandbox", "memory_limit", true),
             ("worktree", "path_template", true),
@@ -2473,11 +2517,19 @@ mod tests {
     #[test]
     fn test_merge_repo_config_session() {
         let config = Config::default();
-        let repo: RepoConfig =
-            serde_json::from_value(serde_json::json!({"session": {"default_tool": "opencode"}}))
-                .unwrap();
+        let repo: RepoConfig = serde_json::from_value(
+            serde_json::json!({"session": {"agent_detect_as": {"my-agent": "claude"}}}),
+        )
+        .unwrap();
         let merged = merge_repo_config(config, &repo);
-        assert_eq!(merged.session.default_tool, Some("opencode".to_string()));
+        assert_eq!(
+            merged
+                .session
+                .agent_detect_as
+                .get("my-agent")
+                .map(String::as_str),
+            Some("claude")
+        );
     }
 
     #[test]

--- a/src/session/config/repo_config.rs
+++ b/src/session/config/repo_config.rs
@@ -2,9 +2,10 @@
 //!
 //! Allows repos to define hooks and override session/sandbox/worktree settings.
 //! Settings that are personal/global (theme, acp, web, logging) are
-//! intentionally not overridable at the repo level, and within `session` only
-//! the fields in `REPO_ALLOWED_SESSION_FIELDS` carry over: the rest name or
-//! build the command AoE launches.
+//! intentionally not overridable at the repo level. Within an overridable
+//! section, each field's `#[setting(repo = "allow" | "deny")]` attribute on its
+//! `Config` declaration is the policy; fields without one fall back to the
+//! section default (see `section_default_allows`).
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -65,62 +66,24 @@ use crate::session::mcp::project_mcp::ProjectMcpServer;
 /// section repo-overridable.
 const REPO_OVERRIDABLE_SECTIONS: &[&str] = &["hooks", "session", "sandbox", "worktree", "updates"];
 
-/// What a repo may set inside one overridable section (#3154).
-enum SectionPolicy {
-    /// Every field in the section carries over.
-    AllowAll,
-    /// Default-deny: only these fields carry over. Used where the section is
-    /// mostly personal settings with a few command-bearing ones, so a field
-    /// added later must be opted in rather than inherited.
-    AllowOnly(&'static [&'static str]),
-    /// Every field except these carries over. Used where the section is a
-    /// genuine team-shared surface with a few fields that can put attacker code
-    /// on the host.
-    DenyOnly(&'static [&'static str]),
-}
-
-/// Fields a repo may set inside the `session` section.
+/// The repo-override default for a section when the field's schema descriptor
+/// carries no explicit `#[setting(repo = ...)]` policy (#3154).
 ///
-/// `session` is mixed-trust: most of it is personal preference, but several
+/// `session` is default-deny: most of it is personal preference, but several
 /// fields name or build the command AoE hands to tmux (`custom_agents`,
 /// `agent_command_override`, `agent_extra_args`, `agent_acp_cmd`,
 /// `smart_rename_agent`, `smart_rename_model`) or weaken the agent's own
 /// permission gate (`yolo_mode_default`). Honoring those from a checked-out
 /// repo is arbitrary host command execution at session launch, the hazard that
-/// already keeps `host_hooks` out of [`REPO_OVERRIDABLE_SECTIONS`]. Listing the
-/// safe fields instead of the dangerous ones means a field added to
-/// `SessionConfig` later stays repo-denied until someone decides otherwise.
+/// already keeps `host_hooks` out of [`REPO_OVERRIDABLE_SECTIONS`]. Denying by
+/// default means a field added to `SessionConfig` later stays repo-denied
+/// until someone marks it `repo = "allow"`.
 ///
-/// `default_tool` is safe because it only names a tool the user configured
-/// (built-in or from their own global/profile `custom_agents`) and is never
-/// executed as a command; `agent_detect_as` only picks status-detection
-/// heuristics.
-const REPO_ALLOWED_SESSION_FIELDS: &[&str] = &["default_tool", "agent_detect_as"];
-
-/// Fields a repo may not set inside the `sandbox` section.
-///
-/// The rest of the section (resource limits, env passthrough, volume ignores,
-/// the custom instruction) is the point of repo-shared sandbox config and stays
-/// overridable. These four compose into the same no-prompt host compromise as
-/// the `session` launch fields: `enabled_by_default` puts a plain `aoe add`
-/// into a container the user never asked for, `default_image` chooses whose
-/// code runs in it, and `extra_volumes` / `mount_ssh` hand that code the host
-/// filesystem and the user's SSH keys.
-const REPO_DENIED_SANDBOX_FIELDS: &[&str] = &[
-    "enabled_by_default",
-    "default_image",
-    "extra_volumes",
-    "mount_ssh",
-];
-
-/// The repo-override policy for a section. Sections outside
-/// [`REPO_OVERRIDABLE_SECTIONS`] never reach here.
-fn section_policy(section: &str) -> SectionPolicy {
-    match section {
-        "session" => SectionPolicy::AllowOnly(REPO_ALLOWED_SESSION_FIELDS),
-        "sandbox" => SectionPolicy::DenyOnly(REPO_DENIED_SANDBOX_FIELDS),
-        _ => SectionPolicy::AllowAll,
-    }
+/// Every other overridable section is a genuine team-shared surface, so its
+/// fields default to allowed and dangerous ones opt out with `repo = "deny"`
+/// on the field (e.g. the sandbox image and mount fields).
+fn section_default_allows(section: &str) -> bool {
+    section != "session"
 }
 
 /// Repository-level configuration loaded from `.agent-of-empires/config.toml`.
@@ -151,6 +114,21 @@ impl RepoConfig {
     /// The overrides restricted to what a repo may set, as a JSON object.
     fn allowed_overrides(&self) -> serde_json::Value {
         serde_json::Value::Object(sanitize_repo_overrides(&self.overrides).0)
+    }
+
+    /// The overrides restricted to [`REPO_OVERRIDABLE_SECTIONS`], without the
+    /// per-field policy filter. Only for the unknown-key probe, which must see
+    /// a misspelled repo-denied field to call it a typo. Never merged.
+    fn overridable_sections(&self) -> serde_json::Value {
+        serde_json::Value::Object(
+            self.overrides
+                .iter()
+                .filter(|(section, value)| {
+                    REPO_OVERRIDABLE_SECTIONS.contains(&section.as_str()) && value.is_object()
+                })
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        )
     }
 }
 
@@ -369,10 +347,23 @@ pub fn load_repo_config(project_path: &Path) -> Result<Option<RepoConfig>> {
         );
     }
 
+    // Unknown keys sanitize cleanly and serde drops them on merge, so name
+    // them here (#3218). Before the field filter: a typo in a repo-denied
+    // field would otherwise read as a policy rejection.
+    let allowed = config.allowed_overrides();
+    let unknown = super::profile_config::overrides_ignored_keys(&config.overridable_sections());
+    if !unknown.is_empty() {
+        tracing::warn!(target: "session.store",
+            path = %config_path.display(),
+            ignored = %unknown.join(", "),
+            "Ignoring unrecognized keys in repo config"
+        );
+    }
+
     // Type-check the repo overrides by merging onto a default Config (the sparse
     // map accepts any JSON). A wrong-typed value surfaces as a load error here
     // rather than a merge-time panic; the caller degrades to profile config.
-    super::profile_config::validate_overrides_typecheck(&config.allowed_overrides())
+    super::profile_config::validate_overrides_typecheck(&allowed)
         .with_context(|| format!("Invalid override in {}", config_path.display()))?;
 
     Ok(Some(config))
@@ -446,10 +437,10 @@ pub fn merge_repo_config(config: Config, repo: &RepoConfig) -> Config {
 }
 
 /// Filter a sparse override map to what a repo may set: the repo-allowed
-/// sections, minus the per-section field policy (see [`section_policy`]). Also
-/// returns the dotted paths that were dropped, so callers can name them in a
-/// warning; the values are never reported, since a dropped command can carry
-/// secrets or terminal escape sequences.
+/// sections, minus each field's repo policy (see [`repo_may_override_field`]).
+/// Also returns the dotted paths that were dropped, so callers can name them
+/// in a warning; the values are never reported, since a dropped command can
+/// carry secrets or terminal escape sequences.
 fn sanitize_repo_overrides(
     overrides: &serde_json::Map<String, serde_json::Value>,
 ) -> (serde_json::Map<String, serde_json::Value>, Vec<String>) {
@@ -461,12 +452,8 @@ fn sanitize_repo_overrides(
             rejected.push(section.clone());
             continue;
         }
-        if matches!(section_policy(section), SectionPolicy::AllowAll) {
-            kept.insert(section.clone(), value.clone());
-            continue;
-        }
-        // A non-object section cannot be field-filtered, so it is dropped whole
-        // rather than merged unchecked.
+        // A non-object section cannot be field-filtered, so it is dropped
+        // whole rather than merged unchecked.
         let Some(fields) = value.as_object() else {
             rejected.push(section.clone());
             continue;
@@ -488,16 +475,26 @@ fn sanitize_repo_overrides(
     (kept, rejected)
 }
 
-/// Whether a repo's `.agent-of-empires/config.toml` may set this field. The
-/// TUI's Repo scope uses it so it never offers a field the merge path strips.
+/// Whether a repo's `.agent-of-empires/config.toml` may set this field.
+///
+/// Global-only fields cannot be overridden by repos. Otherwise the field's
+/// `#[setting(repo = "...")]` attribute decides, falling back to section
+/// defaults.
 pub fn repo_may_override_field(section: &str, field: &str) -> bool {
     if !REPO_OVERRIDABLE_SECTIONS.contains(&section) {
         return false;
     }
-    match section_policy(section) {
-        SectionPolicy::AllowAll => true,
-        SectionPolicy::AllowOnly(allowed) => allowed.contains(&field),
-        SectionPolicy::DenyOnly(denied) => !denied.contains(&field),
+    use super::settings_schema::RepoPolicy;
+    let Some(desc) = super::settings_schema::descriptor(section, field) else {
+        return section_default_allows(section);
+    };
+    if !desc.profile_overridable {
+        return false;
+    }
+    match desc.repo_policy {
+        RepoPolicy::Allow => true,
+        RepoPolicy::Deny => false,
+        RepoPolicy::Unspecified => section_default_allows(section),
     }
 }
 
@@ -2143,10 +2140,7 @@ mod tests {
 
     #[test]
     fn test_repo_may_override_field() {
-        // (section, field, expected) — the whitelist and denylist behavior
-        // across every scope the sanitizer / TUI query at runtime. tmux and
-        // sound rows guard #3229: their sections are not repo-overridable, so
-        // every field on them must answer false.
+        // (section, field, expected): field-declared repo policy and section defaults.
         let cases = [
             ("session", "default_tool", true),
             ("session", "agent_detect_as", true),
@@ -2154,6 +2148,9 @@ mod tests {
             ("worktree", "path_template", true),
             ("session", "custom_agents", false),
             ("sandbox", "default_image", false),
+            ("sandbox", "container_runtime", false),
+            ("sandbox", "selinux_relabel", false),
+            ("updates", "auto_update_plugins", false),
             ("acp", "auto_approve", false),
             ("tmux", "status_bar", false),
             ("tmux", "mouse", false),
@@ -2210,11 +2207,6 @@ mod tests {
 
     #[test]
     fn test_repo_config_cannot_force_a_sandbox_or_pick_its_image() {
-        // A repo could otherwise put a plain `aoe add` (no --sandbox) into a
-        // container it chose, with the host filesystem and the user's SSH keys
-        // mounted in: same no-prompt host compromise as the launch-command
-        // vector, so the four impactful fields are denied while the rest of the
-        // section stays team-shareable.
         let repo: RepoConfig = toml::from_str(
             r#"
             [sandbox]
@@ -2222,6 +2214,7 @@ mod tests {
             default_image = "attacker/img"
             extra_volumes = ["/:/host:rw"]
             mount_ssh = true
+            selinux_relabel = true
             memory_limit = "16g"
             volume_ignores = ["node_modules"]
         "#,
@@ -2236,7 +2229,7 @@ mod tests {
         assert_ne!(merged.sandbox.default_image, "attacker/img");
         assert!(merged.sandbox.extra_volumes.is_empty());
         assert!(!merged.sandbox.mount_ssh);
-        // The rest of the section is the point of repo-shared sandbox config.
+        assert!(!merged.sandbox.selinux_relabel);
         assert_eq!(merged.sandbox.memory_limit.as_deref(), Some("16g"));
         assert_eq!(merged.sandbox.volume_ignores, vec!["node_modules"]);
 
@@ -2248,8 +2241,32 @@ mod tests {
                 "sandbox.enabled_by_default",
                 "sandbox.extra_volumes",
                 "sandbox.mount_ssh",
+                "sandbox.selinux_relabel",
             ]
         );
+    }
+
+    #[test]
+    fn test_repo_config_cannot_set_global_only_field() {
+        let repo: RepoConfig = toml::from_str("[updates]\nauto_update_plugins = true\n").unwrap();
+        assert!(
+            !merge_repo_config(Config::default(), &repo)
+                .updates
+                .auto_update_plugins
+        );
+    }
+
+    #[test]
+    fn test_repo_config_unknown_sandbox_key_is_flagged() {
+        // #3218: unknown keys sanitize cleanly and serde drops them on merge.
+        let repo: RepoConfig = toml::from_str(
+            "[sandbox]\nprivildged = true\nmemory_limit = \"8g\"\n[session]\ndefualt_tool = \"claude\"\n",
+        )
+        .unwrap();
+        let ignored = crate::session::config::profile_config::overrides_ignored_keys(
+            &repo.overridable_sections(),
+        );
+        assert_eq!(ignored, vec!["sandbox.privildged", "session.defualt_tool"]);
     }
 
     #[test]

--- a/src/session/config/repo_config.rs
+++ b/src/session/config/repo_config.rs
@@ -4,8 +4,8 @@
 //! Settings that are personal/global (theme, acp, web, logging) are
 //! intentionally not overridable at the repo level. Within an overridable
 //! section, each field's `#[setting(repo = "allow" | "deny")]` attribute on its
-//! `Config` declaration is the policy; fields without one fall back to the
-//! section default (see `section_default_allows`).
+//! `Config` declaration is the policy; fields without one inherit the
+//! `repo_default` their `#[setting_section(...)]` declares.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -65,30 +65,6 @@ use crate::session::mcp::project_mcp::ProjectMcpServer;
 /// could never take effect. Wire those resolvers before making either
 /// section repo-overridable.
 const REPO_OVERRIDABLE_SECTIONS: &[&str] = &["hooks", "session", "sandbox", "worktree", "updates"];
-
-/// The repo-override default for a section when the field's schema descriptor
-/// carries no explicit `#[setting(repo = ...)]` policy (#3154).
-///
-/// `session` is default-deny: most of it is personal preference, but several
-/// fields name or build the command AoE hands to tmux (`custom_agents`,
-/// `agent_command_override`, `agent_extra_args`, `agent_acp_cmd`,
-/// `smart_rename_agent`, `smart_rename_model`) or weaken the agent's own
-/// permission gate (`yolo_mode_default`). Honoring those from a checked-out
-/// repo is arbitrary host command execution at session launch, the hazard that
-/// already keeps `host_hooks` out of [`REPO_OVERRIDABLE_SECTIONS`]. Denying by
-/// default means a field added to `SessionConfig` later stays repo-denied
-/// until someone marks it `repo = "allow"`.
-///
-/// Even `default_tool` is denied despite only naming a tool: the launch path
-/// exact-matches the user's `custom_agents` before built-ins, so a repo could
-/// select a user-defined host command (see the field's doc comment).
-///
-/// Every other overridable section is a genuine team-shared surface, so its
-/// fields default to allowed and dangerous ones opt out with `repo = "deny"`
-/// on the field (e.g. the sandbox image and mount fields).
-fn section_default_allows(section: &str) -> bool {
-    section != "session"
-}
 
 /// Repository-level configuration loaded from `.agent-of-empires/config.toml`.
 ///
@@ -481,25 +457,23 @@ fn sanitize_repo_overrides(
 
 /// Whether a repo's `.agent-of-empires/config.toml` may set this field.
 ///
-/// Global-only fields cannot be overridden by repos. Otherwise the field's
-/// `#[setting(repo = "...")]` attribute decides, falling back to section
-/// defaults.
+/// The field's `#[setting(repo = "...")]`, or the `repo_default` its section
+/// declares, is the policy; a global-only field is never repo-settable,
+/// because its value is read from the global config and an override would
+/// silently do nothing.
+///
+/// A key with no descriptor is denied whenever the section is in the settings
+/// schema: those sections describe every field a surface may touch, so an
+/// undescribed key is `#[setting(skip)]` or a typo. `hooks` has no schema
+/// section and stays open.
 pub fn repo_may_override_field(section: &str, field: &str) -> bool {
     if !REPO_OVERRIDABLE_SECTIONS.contains(&section) {
         return false;
     }
-    use super::settings_schema::RepoPolicy;
     let Some(desc) = super::settings_schema::descriptor(section, field) else {
-        return section_default_allows(section);
+        return !super::settings_schema::section_in_schema(section);
     };
-    if !desc.profile_overridable {
-        return false;
-    }
-    match desc.repo_policy {
-        RepoPolicy::Allow => true,
-        RepoPolicy::Deny => false,
-        RepoPolicy::Unspecified => section_default_allows(section),
-    }
+    desc.profile_overridable && desc.repo_policy == super::settings_schema::RepoPolicy::Allow
 }
 
 /// Convert a RepoConfig into a ProfileConfig for TUI editing.
@@ -2203,6 +2177,16 @@ mod tests {
             ("tmux", "vt_live", false),
             ("sound", "enabled", false),
             ("sound", "on_start", false),
+            // `hooks` has no `SettingsSection` derive, so its keys have no
+            // descriptors and the schema cannot speak for them.
+            ("hooks", "on_create", true),
+            ("hooks", "on_launch", true),
+            // A key the schema does describe the section of, but not itself:
+            // `#[setting(skip)]` or a typo, denied either way.
+            ("sandbox", "not_a_real_field", false),
+            ("session", "not_a_real_field", false),
+            ("worktree", "not_a_real_field", false),
+            ("updates", "not_a_real_field", false),
         ];
         for (section, field, expected) in cases {
             assert_eq!(

--- a/src/session/config/settings_schema/mod.rs
+++ b/src/session/config/settings_schema/mod.rs
@@ -32,7 +32,7 @@ pub use plugin::{
     PLUGIN_SECTION_PREFIX,
 };
 pub use policy::{strip_local_only, validate_patch, validate_patch_with, PatchRejection, Scope};
-pub use registry::{descriptor, runtime_schema, schema};
+pub use registry::{descriptor, runtime_schema, schema, section_in_schema};
 pub use resolved::{resolve, resolve_all, Candidate, ResolvedSetting, SettingSource};
 pub use validate::{validate_value, ValidationError};
 
@@ -211,12 +211,15 @@ pub enum WebWritePolicy {
     LocalOnly { reason: String },
 }
 
-/// Whether a repo config may override a field (`#[setting(repo = "...")]`).
+/// Whether a repo config may override a field. Declared per field with
+/// `#[setting(repo = "...")]`, or inherited from the section's
+/// `#[setting_section(repo_default = "...")]`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum RepoPolicy {
-    #[default]
-    Unspecified,
     Allow,
+    /// The default everywhere a policy is not derived, so a surface that grows
+    /// a field the schema does not describe fails closed.
+    #[default]
     Deny,
 }
 

--- a/src/session/config/settings_schema/mod.rs
+++ b/src/session/config/settings_schema/mod.rs
@@ -211,6 +211,15 @@ pub enum WebWritePolicy {
     LocalOnly { reason: String },
 }
 
+/// Whether a repo config may override a field (`#[setting(repo = "...")]`).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RepoPolicy {
+    #[default]
+    Unspecified,
+    Allow,
+    Deny,
+}
+
 /// Server-authoritative validation applied to an incoming value before it is
 /// merged. Min/max in [`WidgetKind`] is advisory UI metadata; this is the gate.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -297,7 +306,10 @@ pub struct FieldDescriptor {
     pub description: String,
     pub widget: WidgetKind,
     pub web_write: WebWritePolicy,
-    /// Whether a profile/repo may override this field. `false` means the
+    /// Repo-override policy declared on the field.
+    #[serde(skip)]
+    pub repo_policy: RepoPolicy,
+    /// Whether a profile may override this field. `false` means the
     /// value is global-only (the field is still shown, but not overridable).
     pub profile_overridable: bool,
     pub validation: ValidationKind,

--- a/src/session/config/settings_schema/plugin.rs
+++ b/src/session/config/settings_schema/plugin.rs
@@ -117,7 +117,8 @@ pub fn plugin_field_descriptors(
                 // Plugin settings are not host-execution surfaces; the settings
                 // PATCH endpoint is already elevation-gated by the auth layer.
                 web_write: WebWritePolicy::Allow,
-                repo_policy: RepoPolicy::Unspecified,
+                // Plugin sections are not repo-overridable.
+                repo_policy: RepoPolicy::Deny,
                 // Plugin settings are global, with no profile override.
                 profile_overridable: false,
                 validation,

--- a/src/session/config/settings_schema/plugin.rs
+++ b/src/session/config/settings_schema/plugin.rs
@@ -13,7 +13,7 @@ use serde_json::{json, Value};
 
 use super::{
     FieldDescriptor, ObjectFieldDescriptor, ObjectFieldWidget, OptionSource as SchemaOptionSource,
-    SelectOption, ValidationKind, WebWritePolicy, WidgetKind,
+    RepoPolicy, SelectOption, ValidationKind, WebWritePolicy, WidgetKind,
 };
 
 /// Prefix marking a virtual plugin settings section.
@@ -117,6 +117,7 @@ pub fn plugin_field_descriptors(
                 // Plugin settings are not host-execution surfaces; the settings
                 // PATCH endpoint is already elevation-gated by the auth layer.
                 web_write: WebWritePolicy::Allow,
+                repo_policy: RepoPolicy::Unspecified,
                 // Plugin settings are global, with no profile override.
                 profile_overridable: false,
                 validation,

--- a/src/session/config/settings_schema/registry.rs
+++ b/src/session/config/settings_schema/registry.rs
@@ -64,6 +64,14 @@ pub fn descriptor(section: &str, field: &str) -> Option<&'static FieldDescriptor
         .find(|d| d.section == section && d.field == field)
 }
 
+/// Whether the section is described by the settings schema at all. A section
+/// that is (every `#[derive(SettingsSection)]` config struct) declares every
+/// field a surface may touch, so a key it does not describe is `skip`ped or
+/// misspelled rather than merely undocumented.
+pub fn section_in_schema(section: &str) -> bool {
+    schema_ref().iter().any(|d| d.section == section)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,24 +174,46 @@ mod tests {
         assert!(!d.advanced);
     }
 
+    /// Every descriptor carries a resolved repo policy: its own
+    /// `#[setting(repo = ...)]` where it declares one, otherwise the
+    /// `repo_default` of its `#[setting_section(...)]`.
     #[test]
-    fn field_declared_repo_and_write_policies() {
+    fn field_repo_policy_resolves_from_field_then_section() {
         use super::super::RepoPolicy;
         for (section, field, expected) in [
+            // Declared on the field.
             ("sandbox", "extra_volumes", RepoPolicy::Deny),
-            ("sandbox", "container_runtime", RepoPolicy::Unspecified),
             ("sandbox", "selinux_relabel", RepoPolicy::Deny),
             ("session", "default_tool", RepoPolicy::Deny),
-            ("sandbox", "memory_limit", RepoPolicy::Unspecified),
+            ("session", "agent_detect_as", RepoPolicy::Allow),
+            // Inherited: `session` declares repo_default = "deny", every other
+            // section defaults to allow.
+            ("session", "yolo_mode_default", RepoPolicy::Deny),
+            ("sandbox", "memory_limit", RepoPolicy::Allow),
+            ("sandbox", "container_runtime", RepoPolicy::Allow),
+            ("worktree", "path_template", RepoPolicy::Allow),
         ] {
             let d = descriptor(section, field).unwrap_or_else(|| panic!("{section}.{field}"));
             assert_eq!(d.repo_policy, expected, "{section}.{field}");
         }
 
+        // A permissive policy does not make a global-only field settable; the
+        // repo gate checks `profile_overridable` first.
         assert!(
             !descriptor("sandbox", "container_runtime")
                 .unwrap()
                 .profile_overridable
         );
+    }
+
+    #[test]
+    fn section_in_schema_separates_derived_sections_from_hooks() {
+        assert!(section_in_schema("session"));
+        assert!(section_in_schema("sandbox"));
+        assert!(section_in_schema("worktree"));
+        assert!(section_in_schema("updates"));
+        // `hooks` is a repo-overridable section with no `SettingsSection`
+        // derive, so its keys have no descriptors and must not fail closed.
+        assert!(!section_in_schema("hooks"));
     }
 }

--- a/src/session/config/settings_schema/registry.rs
+++ b/src/session/config/settings_schema/registry.rs
@@ -12,6 +12,16 @@ use crate::status_hooks::StatusHookConfig;
 
 /// All settings descriptors, in section then field order.
 pub fn schema() -> Vec<FieldDescriptor> {
+    schema_ref().to_vec()
+}
+
+/// [`schema`] without the clone, for callers that only read.
+pub fn schema_ref() -> &'static [FieldDescriptor] {
+    static SCHEMA: std::sync::OnceLock<Vec<FieldDescriptor>> = std::sync::OnceLock::new();
+    SCHEMA.get_or_init(build_schema)
+}
+
+fn build_schema() -> Vec<FieldDescriptor> {
     let mut out = Vec::new();
     out.extend(ThemeConfig::settings_descriptors());
     out.extend(UpdatesConfig::settings_descriptors());
@@ -48,9 +58,9 @@ pub fn runtime_schema() -> Vec<FieldDescriptor> {
 }
 
 /// Look up a single field's descriptor by `section` and `field`.
-pub fn descriptor(section: &str, field: &str) -> Option<FieldDescriptor> {
-    schema()
-        .into_iter()
+pub fn descriptor(section: &str, field: &str) -> Option<&'static FieldDescriptor> {
+    schema_ref()
+        .iter()
         .find(|d| d.section == section && d.field == field)
 }
 
@@ -103,7 +113,7 @@ mod tests {
     #[test]
     fn session_row_tag_is_select_with_options() {
         let d = descriptor("session", "row_tag").expect("row_tag");
-        match d.widget {
+        match &d.widget {
             WidgetKind::Select { options } => {
                 let values: Vec<_> = options.iter().map(|o| o.value.as_str()).collect();
                 assert_eq!(values, ["none", "auto", "profile", "sandbox", "branch"]);
@@ -154,5 +164,26 @@ mod tests {
         assert!(d.advanced);
         let d = descriptor("acp", "default_agent").unwrap();
         assert!(!d.advanced);
+    }
+
+    #[test]
+    fn field_declared_repo_and_write_policies() {
+        use super::super::RepoPolicy;
+        for (section, field, expected) in [
+            ("sandbox", "extra_volumes", RepoPolicy::Deny),
+            ("sandbox", "container_runtime", RepoPolicy::Unspecified),
+            ("sandbox", "selinux_relabel", RepoPolicy::Deny),
+            ("session", "default_tool", RepoPolicy::Allow),
+            ("sandbox", "memory_limit", RepoPolicy::Unspecified),
+        ] {
+            let d = descriptor(section, field).unwrap_or_else(|| panic!("{section}.{field}"));
+            assert_eq!(d.repo_policy, expected, "{section}.{field}");
+        }
+
+        assert!(
+            !descriptor("sandbox", "container_runtime")
+                .unwrap()
+                .profile_overridable
+        );
     }
 }

--- a/src/session/config/settings_schema/registry.rs
+++ b/src/session/config/settings_schema/registry.rs
@@ -173,7 +173,7 @@ mod tests {
             ("sandbox", "extra_volumes", RepoPolicy::Deny),
             ("sandbox", "container_runtime", RepoPolicy::Unspecified),
             ("sandbox", "selinux_relabel", RepoPolicy::Deny),
-            ("session", "default_tool", RepoPolicy::Allow),
+            ("session", "default_tool", RepoPolicy::Deny),
             ("sandbox", "memory_limit", RepoPolicy::Unspecified),
         ] {
             let d = descriptor(section, field).unwrap_or_else(|| panic!("{section}.{field}"));

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -2578,7 +2578,7 @@ claude = "my-wrapper"
             cfg_dir.join("config.toml"),
             r#"
 [session]
-default_tool = "codex"
+agent_detect_as = { my-agent = "claude" }
 smart_rename_agent = "gemini"
 
 [session.agent_command_override]
@@ -2594,7 +2594,14 @@ claude = "repo-wrapper"
         // Pins that the repo file was actually discovered: an allowed field
         // from it lands, so the assertions below are about the boundary and
         // not about a fixture that silently never loaded.
-        assert_eq!(resolved.session.default_tool.as_deref(), Some("codex"));
+        assert_eq!(
+            resolved
+                .session
+                .agent_detect_as
+                .get("my-agent")
+                .map(String::as_str),
+            Some("claude")
+        );
         let cfg = resolve_smart_rename_config(&resolved.session);
         assert_eq!(
             cfg.rename_agent, "opencode",

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -1244,6 +1244,7 @@ mod tests {
             "session.agent_command_override",
             "session.agent_extra_args",
             "session.agent_acp_cmd",
+            "session.default_tool",
             "session.agent_config_dir",
         ] {
             assert!(
@@ -1255,12 +1256,11 @@ mod tests {
                 "{denied} must still be editable in Global scope"
             );
         }
-        for allowed in ["session.default_tool", "session.agent_detect_as"] {
-            assert!(
-                ident_present(&repo_rows, allowed),
-                "{allowed} stays repo-overridable"
-            );
-        }
+        let allowed = "session.agent_detect_as";
+        assert!(
+            ident_present(&repo_rows, allowed),
+            "{allowed} stays repo-overridable"
+        );
     }
 
     /// #3229: no field under Repo scope for a category whose section is not


### PR DESCRIPTION
## Description
Security fix, for issues discovered during the review of #3623

As flagged there by @jerome-benoit , `selinux_relabel` shouldn't be overridable on a per-repo basis, and `sandbox.network`  was only validating settings on interactive edits, allowing for escapes. Also before this PR, the TUI would offer to edit `container_runtime` but that would be ignored. And finally, a repo could run a host command by overriding `default_tool`.

There remain potential issues in related code:
- `sandbox.environment` allows inheriting env variables from outer context, arguably the per-repo overrides should be limited to inline assignments.
- `worktree.path_template` / `bare_repo_path_template` / `workspace_path_template` allow path escape.

I'm not knowledgeable enough to say if either or both of these things are violation of the security model of AOE, but flagging them as fishy.

## PR Type

- [ ] New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [X] New and existing tests pass
- [X] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [X] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [X] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [X] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
I forked some of these changes from #3623 which was authored by Kimi and Claude under my supervision.

**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Hardened repository configuration by blocking unsafe overrides of sandbox and session settings.
- Prevented repositories from selecting user-defined host commands through `session.default_tool`.
- Validated `sandbox.network` values and rejected namespace-sharing and invalid formats.
- Added schema metadata for repository override policies, with safer defaults for new settings.
- Clarified that `container_runtime` and `selinux_relabel` are global-only settings.
- Updated documentation, templates, and regression tests.
- Cached the settings schema for simpler and more efficient access.

## Benefits

These changes strengthen the repository trust boundary and prevent unsafe configuration from reaching sandbox creation. Future work could address inherited environment variables and path-template escape risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->