### PR TITLE
fix(tui): publish a capture-pane frame before arming the VT channel on retarget

### DIFF
--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -24,8 +24,8 @@ pub struct CachedPreview<'a> {
     pub text: Option<&'a Text<'static>>,
     /// No frame has landed for the displayed session yet, so an empty
     /// `text` says nothing about its pane: paint nothing rather than the
-    /// "No output available" hint, which would blink for the one or two
-    /// frames a just-selected session takes to fill.
+    /// "No output available" hint, which would blink while a just-selected
+    /// session fills.
     pub pending: bool,
 }
 
@@ -929,5 +929,54 @@ mod tests {
             });
             assert_eq!(terminal_info_height(&inst), 3);
         }
+    }
+
+    /// Rows of a rendered terminal preview, for the hint assertions below.
+    fn terminal_preview_rows(pending: bool) -> Vec<String> {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        let theme = crate::tui::styles::load_theme("empire");
+        let instance = Instance::new("pane", "/tmp/pane");
+        let mut terminal = Terminal::new(TestBackend::new(60, 12)).unwrap();
+        terminal
+            .draw(|frame| {
+                Preview::render_terminal_preview(
+                    frame,
+                    frame.area(),
+                    &instance,
+                    true,
+                    CachedPreview::new(None, pending),
+                    0,
+                    &theme,
+                    false,
+                    false,
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn empty_preview_hint_waits_for_the_first_frame() {
+        let hint = |pending| {
+            terminal_preview_rows(pending)
+                .iter()
+                .any(|row| row.contains("No output available"))
+        };
+        assert!(
+            hint(false),
+            "an empty frame for the displayed session paints the hint"
+        );
+        assert!(
+            !hint(true),
+            "no frame yet for the displayed session paints nothing"
+        );
     }
 }

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -20,14 +20,18 @@ use crate::tui::styles::Theme;
 /// frame. See `PreviewCache::ensure_parsed` for the parse-and-cache
 /// contract.
 pub struct CachedPreview<'a> {
-    /// `None` means the source `content` was empty (no pane bytes
-    /// yet, or just cleared); callers render their own placeholder.
+    /// `None` means the source `content` was empty.
     pub text: Option<&'a Text<'static>>,
+    /// No frame has landed for the displayed session yet, so an empty
+    /// `text` says nothing about its pane: paint nothing rather than the
+    /// "No output available" hint, which would blink for the one or two
+    /// frames a just-selected session takes to fill.
+    pub pending: bool,
 }
 
 impl<'a> CachedPreview<'a> {
-    pub fn from_text(text: Option<&'a Text<'static>>) -> Self {
-        Self { text }
+    pub fn new(text: Option<&'a Text<'static>>, pending: bool) -> Self {
+        Self { text, pending }
     }
 }
 
@@ -260,7 +264,7 @@ impl Preview {
                 scroll_offset,
                 Style::default().fg(theme.text),
             );
-        } else {
+        } else if !cached_output.pending {
             let hint = Paragraph::new("No output available")
                 .style(Style::default().fg(theme.dimmed))
                 .alignment(Alignment::Center);
@@ -476,7 +480,7 @@ impl Preview {
                 scroll_offset,
                 Style::default().fg(theme.text),
             );
-        } else {
+        } else if !cached_output.pending {
             let hint = Paragraph::new("No output available")
                 .style(Style::default().fg(theme.dimmed))
                 .alignment(Alignment::Center);

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -806,6 +806,71 @@ fn authoritative_refresh_is_quiet(chunk_timing: Option<(u64, u64)>) -> bool {
 /// one cheap failed attempt per interval rather than one per 25ms tick.
 const VT_REARM_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
+/// How long a selection must rest on a pane before the worker arms a channel
+/// for it. Arming is a chain of tmux forks plus a forwarder spawn that blocks
+/// the worker, so a selection moving through the list must not start one per
+/// row; until it rests, each row costs one `capture-pane` fork.
+#[cfg(unix)]
+const CHANNEL_ARM_SETTLE: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Whether this cycle may start arming a pane channel (VT grid or OSC 52
+/// observer): the selection has rested for `CHANNEL_ARM_SETTLE`, no channel
+/// is held or being armed, and the retry throttle has elapsed.
+#[cfg(unix)]
+fn channel_arm_due(
+    arm_after: Option<std::time::Instant>,
+    armed_or_pending: bool,
+    last_arm: Option<std::time::Instant>,
+    now: std::time::Instant,
+) -> bool {
+    arm_after.is_none_or(|t| now >= t)
+        && !armed_or_pending
+        && last_arm.is_none_or(|t| now.duration_since(t) >= VT_REARM_INTERVAL)
+}
+
+/// A channel arm running off the worker thread, so its chain of tmux forks
+/// and the forwarder spawn never delay a frame. The result is tagged with the
+/// target generation it was started for; a stale one is dropped, and dropping
+/// the last `Arc` of a channel shuts it down.
+#[cfg(unix)]
+struct PendingArm<T> {
+    generation: u64,
+    result: std::sync::mpsc::Receiver<Option<std::sync::Arc<T>>>,
+}
+
+#[cfg(unix)]
+impl<T: Send + Sync + 'static> PendingArm<T> {
+    fn spawn(
+        name: String,
+        generation: u64,
+        nudge: CaptureWake,
+        arm: impl FnOnce(&str, &crate::tmux::TmuxCommandDeadline) -> Option<std::sync::Arc<T>>
+            + Send
+            + 'static,
+    ) -> Self {
+        let (sender, result) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let deadline = crate::tmux::TmuxCommandDeadline::new();
+            // A send to a stopped worker fails and drops the channel here.
+            let _ = sender.send(arm(&name, &deadline));
+            signal_capture_wake(&nudge);
+        });
+        Self { generation, result }
+    }
+
+    /// The channel a finished arm produced for `generation`. `None` while
+    /// the arm is still running, failed, or finished for another generation.
+    fn take(pending: &mut Option<Self>, generation: u64) -> Option<std::sync::Arc<T>> {
+        let done = match pending.as_ref()?.result.try_recv() {
+            Ok(done) => done,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return None,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => None,
+        };
+        let current = pending.take().is_some_and(|p| p.generation == generation);
+        done.filter(|_| current)
+    }
+}
+
 /// Cloneable handle that nudges a [`LiveCaptureWorker`] out of its
 /// inter-capture wait. Handed to [`LiveSendWorker`] so a dispatched
 /// keystroke batch triggers an immediate capture of the typed echo rather
@@ -1278,11 +1343,24 @@ impl LiveCaptureWorker {
             // recreated under the same name, e.g. a session restart) retries
             // on a throttle instead of either re-arming every 25ms tick or
             // latching onto the capture fallback until the user switches
-            // panes. Reset on target change so a new pane arms immediately.
+            // panes. Reset on target change so a new pane arms once settled.
             #[cfg(unix)]
             let mut last_vt_arm: Option<std::time::Instant> = None;
             #[cfg(unix)]
             let mut last_osc52_arm: Option<std::time::Instant> = None;
+            // Earliest arm for the current target (`channel_arm_due`), and the
+            // arms in flight for it or an earlier target.
+            #[cfg(unix)]
+            let mut arm_after: Option<std::time::Instant> = None;
+            #[cfg(unix)]
+            let mut pending_vt_arm: Option<PendingArm<crate::tmux::vt::VtChannel>> = None;
+            #[cfg(unix)]
+            let mut pending_osc52_arm: Option<
+                PendingArm<crate::tmux::vt::Osc52Channel>,
+            > = None;
+            // When the current target was first seen, until its first frame
+            // publishes; traces the retarget-to-first-frame interval.
+            let mut retarget_seen: Option<std::time::Instant> = None;
             // Panes in the target window, refreshed on the lazy
             // `PANE_COUNT_PROBE_MS` cadence. The seed only covers the window
             // between arming and the first probe, which runs on the first cycle
@@ -1321,6 +1399,10 @@ impl LiveCaptureWorker {
                 // the old generation for the consumer to drop.
                 let generation_now = generation_cell.load(Ordering::Relaxed);
                 let command_deadline = crate::tmux::TmuxCommandDeadline::new();
+                #[cfg(unix)]
+                let mut stale_vt = None;
+                #[cfg(unix)]
+                let mut stale_osc52 = None;
                 // A retarget resets the dedup so the new generation's first
                 // frame always publishes, even in an ABA switch A -> B -> A
                 // that happens entirely between worker cycles and leaves the
@@ -1336,21 +1418,43 @@ impl LiveCaptureWorker {
                     // pane's floor or debounce hold.
                     last_published_at = None;
                     pending_since = None;
-                    // Tear down a VT source armed for the old target (also fires
-                    // on retarget-to-empty), disabling its `pipe-pane`, and allow
-                    // a fresh arm attempt for the new target.
+                    retarget_seen = Some(std::time::Instant::now());
+                    // Detach the channels armed for the old target (also fires
+                    // on retarget-to-empty); they are shut down after this
+                    // cycle's frame so the teardown fork never precedes the new
+                    // pane's first frame. An arm still in flight is left to
+                    // finish; its result carries the old generation and is
+                    // dropped on arrival.
                     #[cfg(unix)]
                     {
-                        shutdown_vt_source(&mut vt_source, &command_deadline);
+                        stale_vt = vt_source.take();
                         last_vt_arm = None;
+                        arm_after = Some(std::time::Instant::now() + CHANNEL_ARM_SETTLE);
                         next_authoritative_capture = None;
-                        shutdown_osc52_source(&mut osc52_source, &command_deadline);
+                        stale_osc52 = osc52_source.take();
                         osc52_seen = 0;
                         last_osc52_arm = None;
                     }
                     pane_count = 1;
                     last_pane_probe = None;
                     composite_layout = None;
+                }
+                // Adopt finished arms before the enable checks below so a
+                // setting toggled off meanwhile tears the channel down at once.
+                #[cfg(unix)]
+                if let Some(v) = PendingArm::take(&mut pending_vt_arm, generation_now) {
+                    // Event-driven echo: the channel pokes our nudge condvar
+                    // on every grid change, so the wait below ends the moment
+                    // output lands instead of after a poll interval.
+                    v.set_change_wakeup(nudge_thread.clone());
+                    next_authoritative_capture =
+                        Some(std::time::Instant::now() + AUTHORITATIVE_CAPTURE_INTERVAL);
+                    vt_source = Some(v);
+                }
+                #[cfg(unix)]
+                if let Some(source) = PendingArm::take(&mut pending_osc52_arm, generation_now) {
+                    osc52_seen = source.clipboard_sequence();
+                    osc52_source = Some(source);
                 }
                 // `[tmux] vt_live`, re-read every cycle. Toggling off while a
                 // channel is armed tears it down (disabling its `pipe-pane`);
@@ -1411,17 +1515,20 @@ impl LiveCaptureWorker {
                     }
                     #[cfg(unix)]
                     if observe_osc52
-                        && osc52_source.is_none()
-                        && last_osc52_arm.is_none_or(|t| t.elapsed() >= VT_REARM_INTERVAL)
+                        && channel_arm_due(
+                            arm_after,
+                            osc52_source.is_some() || pending_osc52_arm.is_some(),
+                            last_osc52_arm,
+                            std::time::Instant::now(),
+                        )
                     {
                         last_osc52_arm = Some(std::time::Instant::now());
-                        osc52_source = crate::tmux::vt::Osc52Channel::acquire_with_deadline(
-                            &name,
-                            &command_deadline,
-                        );
-                        if let Some(source) = osc52_source.as_ref() {
-                            osc52_seen = source.clipboard_sequence();
-                        }
+                        pending_osc52_arm = Some(PendingArm::spawn(
+                            name.clone(),
+                            generation_now,
+                            nudge_thread.clone(),
+                            crate::tmux::vt::Osc52Channel::acquire_with_deadline,
+                        ));
                     }
                     #[cfg(unix)]
                     if osc52_source
@@ -1439,11 +1546,12 @@ impl LiveCaptureWorker {
                     #[cfg(not(unix))]
                     let clipboard_now: Option<String> = None;
                     // Acquire one frame + cursor. Default: sample the in-process
-                    // vt100 grid, arming a `pipe-pane -IO` channel on first use
-                    // for this target (cursor and alt/mouse flags come
-                    // authoritatively from the grid). If arming fails (tmux too
-                    // old, stopped pane), fall back to a `capture-pane` fork for
-                    // this pane and retry on the `VT_REARM_INTERVAL` throttle.
+                    // vt100 grid, arming a `pipe-pane -IO` channel once the
+                    // selection rests on this target (cursor and alt/mouse
+                    // flags come authoritatively from the grid). Until it is
+                    // armed, or if arming fails (tmux too old, stopped pane),
+                    // one `capture-pane` fork serves this pane, and a failure
+                    // retries on the `VT_REARM_INTERVAL` throttle.
                     // Capture-path policy: outside live-send, empty captures
                     // are FORWARDED (a missing or killed pane must surface
                     // as "No output available", not stale bytes); during
@@ -1452,24 +1560,19 @@ impl LiveCaptureWorker {
                     let forward_empty = forward_empty_policy || !live_cell.load(Ordering::Relaxed);
                     #[cfg(unix)]
                     let (capture, cursor_now) = if vt_enabled {
-                        if vt_source.is_none()
-                            && last_vt_arm.is_none_or(|t| t.elapsed() >= VT_REARM_INTERVAL)
-                        {
+                        if channel_arm_due(
+                            arm_after,
+                            vt_source.is_some() || pending_vt_arm.is_some(),
+                            last_vt_arm,
+                            std::time::Instant::now(),
+                        ) {
                             last_vt_arm = Some(std::time::Instant::now());
-                            vt_source = crate::tmux::vt::VtChannel::acquire_with_deadline(
-                                &name,
-                                &command_deadline,
-                            );
-                            // Event-driven echo: the channel pokes our nudge
-                            // condvar on every grid change, so the wait below
-                            // ends the moment output lands instead of after
-                            // the remainder of a poll interval.
-                            if let Some(v) = vt_source.as_ref() {
-                                v.set_change_wakeup(nudge_thread.clone());
-                                next_authoritative_capture = Some(
-                                    std::time::Instant::now() + AUTHORITATIVE_CAPTURE_INTERVAL,
-                                );
-                            }
+                            pending_vt_arm = Some(PendingArm::spawn(
+                                name.clone(),
+                                generation_now,
+                                nudge_thread.clone(),
+                                crate::tmux::vt::VtChannel::acquire_with_deadline,
+                            ));
                         }
                         // A channel whose forwarder has disconnected stops
                         // updating its grid; drop it and fall back to capture
@@ -1628,6 +1731,13 @@ impl LiveCaptureWorker {
                                     last_published_cursor = cursor_now;
                                     last_published_at = Some(std::time::Instant::now());
                                     pending_since = None;
+                                    if let Some(seen) = retarget_seen.take() {
+                                        tracing::debug!(
+                                            pane = %name,
+                                            elapsed_ms = seen.elapsed().as_millis() as u64,
+                                            "preview: first frame after retarget"
+                                        );
+                                    }
                                     wake.notify_one();
                                 } else {
                                     // Held by the floor and/or the debounce:
@@ -1647,6 +1757,11 @@ impl LiveCaptureWorker {
                             }
                         }
                     }
+                }
+                #[cfg(unix)]
+                {
+                    shutdown_vt_source(&mut stale_vt, &command_deadline);
+                    shutdown_osc52_source(&mut stale_osc52, &command_deadline);
                 }
                 // Nothing deferred this cycle means no frame is being held, so
                 // clear the debounce hold and let the next repaint's latency cap
@@ -1688,6 +1803,16 @@ impl LiveCaptureWorker {
                 let ms = match defer_wait_ms {
                     Some(wait) => ms.min(wait),
                     None => ms,
+                };
+                // Start the settled arm on time rather than after a full idle
+                // interval.
+                #[cfg(unix)]
+                let ms = match arm_after.filter(|_| vt_source.is_none() && pending_vt_arm.is_none())
+                {
+                    Some(t) if t > std::time::Instant::now() => ms
+                        .min((t - std::time::Instant::now()).as_millis() as u64)
+                        .max(1),
+                    _ => ms,
                 };
                 let _ = wait_for_capture_wake(
                     &nudge_thread,
@@ -3432,6 +3557,94 @@ mod tests {
         let frame = worker.take_latest().expect("injected capture frame");
         assert_eq!(frame.generation, u64::MAX);
         assert!(!worker.frame_is_current(&frame));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn channel_arm_waits_for_settle_and_throttle() {
+        let now = std::time::Instant::now();
+        let settled = Some(now - std::time::Duration::from_millis(1));
+        let resting = Some(now + std::time::Duration::from_millis(100));
+        let cases = [
+            ("unsettled selection", resting, false, None, false),
+            ("settled, first attempt", settled, false, None, true),
+            ("no settle window", None, false, None, true),
+            ("already armed or in flight", settled, true, None, false),
+            (
+                "recent failed attempt",
+                settled,
+                false,
+                Some(now - std::time::Duration::from_secs(1)),
+                false,
+            ),
+            (
+                "throttle elapsed",
+                settled,
+                false,
+                Some(now - VT_REARM_INTERVAL),
+                true,
+            ),
+        ];
+        for (case, arm_after, armed, last_arm, expected) in cases {
+            assert_eq!(
+                channel_arm_due(arm_after, armed, last_arm, now),
+                expected,
+                "{case}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_arm_delivers_only_the_current_generation() {
+        let wake: CaptureWake =
+            std::sync::Arc::new((std::sync::Mutex::new(0), std::sync::Condvar::new()));
+        let (release, gate) = std::sync::mpsc::channel::<()>();
+        let mut pending = Some(PendingArm::spawn(
+            "pane".into(),
+            7,
+            wake.clone(),
+            move |name, _| {
+                gate.recv().ok()?;
+                Some(std::sync::Arc::new(name.to_string()))
+            },
+        ));
+        assert!(
+            PendingArm::take(&mut pending, 7).is_none() && pending.is_some(),
+            "a running arm stays pending"
+        );
+        release.send(()).unwrap();
+        let mut observed = 0;
+        wait_for_capture_wake(&wake, &mut observed, std::time::Duration::from_secs(5));
+        assert_eq!(
+            PendingArm::take(&mut pending, 7)
+                .as_deref()
+                .map(String::as_str),
+            Some("pane"),
+            "the current generation adopts its channel"
+        );
+        assert!(pending.is_none(), "a delivered arm is no longer pending");
+
+        let (release, gate) = std::sync::mpsc::channel::<()>();
+        let mut pending = Some(PendingArm::spawn(
+            "pane".into(),
+            7,
+            wake.clone(),
+            move |name, _| {
+                gate.recv().ok()?;
+                Some(std::sync::Arc::new(name.to_string()))
+            },
+        ));
+        release.send(()).unwrap();
+        wait_for_capture_wake(&wake, &mut observed, std::time::Duration::from_secs(5));
+        assert!(
+            PendingArm::take(&mut pending, 8).is_none(),
+            "a retarget mid-arm drops the stale channel"
+        );
+        assert!(
+            pending.is_none(),
+            "a stale arm no longer blocks the next one"
+        );
     }
 
     #[test]

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -807,9 +807,9 @@ fn authoritative_refresh_is_quiet(chunk_timing: Option<(u64, u64)>) -> bool {
 const VT_REARM_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// How long a selection must rest on a pane before the worker arms a channel
-/// for it. Arming is a chain of tmux forks plus a forwarder spawn that blocks
-/// the worker, so a selection moving through the list must not start one per
-/// row; until it rests, each row costs one `capture-pane` fork.
+/// for it. Arming puts a real `pipe-pane` on the pane, so a selection moving
+/// through the list must not arm and tear one down per row it passes; until
+/// it rests, each row costs one `capture-pane` fork instead.
 #[cfg(unix)]
 const CHANNEL_ARM_SETTLE: std::time::Duration = std::time::Duration::from_millis(250);
 
@@ -830,8 +830,8 @@ fn channel_arm_due(
 
 /// A channel arm running off the worker thread, so its chain of tmux forks
 /// and the forwarder spawn never delay a frame. The result is tagged with the
-/// target generation it was started for; a stale one is dropped, and dropping
-/// the last `Arc` of a channel shuts it down.
+/// target generation it was started for; a stale one goes to the caller's
+/// teardown sink, which runs after the cycle's frame.
 #[cfg(unix)]
 struct PendingArm<T> {
     generation: u64,
@@ -859,15 +859,24 @@ impl<T: Send + Sync + 'static> PendingArm<T> {
     }
 
     /// The channel a finished arm produced for `generation`. `None` while
-    /// the arm is still running, failed, or finished for another generation.
-    fn take(pending: &mut Option<Self>, generation: u64) -> Option<std::sync::Arc<T>> {
+    /// the arm is still running, failed, or finished for another generation;
+    /// a channel armed for another generation is pushed onto `stale`.
+    fn take(
+        pending: &mut Option<Self>,
+        generation: u64,
+        stale: &mut Vec<std::sync::Arc<T>>,
+    ) -> Option<std::sync::Arc<T>> {
         let done = match pending.as_ref()?.result.try_recv() {
             Ok(done) => done,
             Err(std::sync::mpsc::TryRecvError::Empty) => return None,
             Err(std::sync::mpsc::TryRecvError::Disconnected) => None,
         };
-        let current = pending.take().is_some_and(|p| p.generation == generation);
-        done.filter(|_| current)
+        if pending.take().is_some_and(|p| p.generation == generation) {
+            done
+        } else {
+            stale.extend(done);
+            None
+        }
     }
 }
 
@@ -1399,10 +1408,11 @@ impl LiveCaptureWorker {
                 // the old generation for the consumer to drop.
                 let generation_now = generation_cell.load(Ordering::Relaxed);
                 let command_deadline = crate::tmux::TmuxCommandDeadline::new();
+                // Channels detached this cycle, shut down after its frame.
                 #[cfg(unix)]
-                let mut stale_vt = None;
+                let mut stale_vt = Vec::new();
                 #[cfg(unix)]
-                let mut stale_osc52 = None;
+                let mut stale_osc52 = Vec::new();
                 // A retarget resets the dedup so the new generation's first
                 // frame always publishes, even in an ABA switch A -> B -> A
                 // that happens entirely between worker cycles and leaves the
@@ -1427,11 +1437,11 @@ impl LiveCaptureWorker {
                     // dropped on arrival.
                     #[cfg(unix)]
                     {
-                        stale_vt = vt_source.take();
+                        stale_vt.extend(vt_source.take());
                         last_vt_arm = None;
                         arm_after = Some(std::time::Instant::now() + CHANNEL_ARM_SETTLE);
                         next_authoritative_capture = None;
-                        stale_osc52 = osc52_source.take();
+                        stale_osc52.extend(osc52_source.take());
                         osc52_seen = 0;
                         last_osc52_arm = None;
                     }
@@ -1442,7 +1452,9 @@ impl LiveCaptureWorker {
                 // Adopt finished arms before the enable checks below so a
                 // setting toggled off meanwhile tears the channel down at once.
                 #[cfg(unix)]
-                if let Some(v) = PendingArm::take(&mut pending_vt_arm, generation_now) {
+                if let Some(v) =
+                    PendingArm::take(&mut pending_vt_arm, generation_now, &mut stale_vt)
+                {
                     // Event-driven echo: the channel pokes our nudge condvar
                     // on every grid change, so the wait below ends the moment
                     // output lands instead of after a poll interval.
@@ -1452,7 +1464,9 @@ impl LiveCaptureWorker {
                     vt_source = Some(v);
                 }
                 #[cfg(unix)]
-                if let Some(source) = PendingArm::take(&mut pending_osc52_arm, generation_now) {
+                if let Some(source) =
+                    PendingArm::take(&mut pending_osc52_arm, generation_now, &mut stale_osc52)
+                {
                     osc52_seen = source.clipboard_sequence();
                     osc52_source = Some(source);
                 }
@@ -1733,6 +1747,7 @@ impl LiveCaptureWorker {
                                     pending_since = None;
                                     if let Some(seen) = retarget_seen.take() {
                                         tracing::debug!(
+                                            target: "tui.live_send",
                                             pane = %name,
                                             elapsed_ms = seen.elapsed().as_millis() as u64,
                                             "preview: first frame after retarget"
@@ -1760,8 +1775,12 @@ impl LiveCaptureWorker {
                 }
                 #[cfg(unix)]
                 {
-                    shutdown_vt_source(&mut stale_vt, &command_deadline);
-                    shutdown_osc52_source(&mut stale_osc52, &command_deadline);
+                    for channel in stale_vt.drain(..) {
+                        shutdown_vt_source(&mut Some(channel), &command_deadline);
+                    }
+                    for channel in stale_osc52.drain(..) {
+                        shutdown_osc52_source(&mut Some(channel), &command_deadline);
+                    }
                 }
                 // Nothing deferred this cycle means no frame is being held, so
                 // clear the debounce hold and let the next repaint's latency cap
@@ -1805,14 +1824,23 @@ impl LiveCaptureWorker {
                     None => ms,
                 };
                 // Start the settled arm on time rather than after a full idle
-                // interval.
+                // interval, while no channel of either kind is held or pending.
                 #[cfg(unix)]
-                let ms = match arm_after.filter(|_| vt_source.is_none() && pending_vt_arm.is_none())
-                {
-                    Some(t) if t > std::time::Instant::now() => ms
-                        .min((t - std::time::Instant::now()).as_millis() as u64)
-                        .max(1),
-                    _ => ms,
+                let ms = match arm_after.filter(|_| {
+                    vt_source.is_none()
+                        && pending_vt_arm.is_none()
+                        && osc52_source.is_none()
+                        && pending_osc52_arm.is_none()
+                }) {
+                    Some(t) => {
+                        let remaining = t.saturating_duration_since(std::time::Instant::now());
+                        if remaining.is_zero() {
+                            ms
+                        } else {
+                            ms.min(remaining.as_millis() as u64).max(1)
+                        }
+                    }
+                    None => ms,
                 };
                 let _ = wait_for_capture_wake(
                     &nudge_thread,
@@ -3609,21 +3637,23 @@ mod tests {
                 Some(std::sync::Arc::new(name.to_string()))
             },
         ));
+        let mut stale = Vec::new();
         assert!(
-            PendingArm::take(&mut pending, 7).is_none() && pending.is_some(),
+            PendingArm::take(&mut pending, 7, &mut stale).is_none() && pending.is_some(),
             "a running arm stays pending"
         );
         release.send(()).unwrap();
         let mut observed = 0;
         wait_for_capture_wake(&wake, &mut observed, std::time::Duration::from_secs(5));
         assert_eq!(
-            PendingArm::take(&mut pending, 7)
+            PendingArm::take(&mut pending, 7, &mut stale)
                 .as_deref()
                 .map(String::as_str),
             Some("pane"),
             "the current generation adopts its channel"
         );
         assert!(pending.is_none(), "a delivered arm is no longer pending");
+        assert!(stale.is_empty());
 
         let (release, gate) = std::sync::mpsc::channel::<()>();
         let mut pending = Some(PendingArm::spawn(
@@ -3638,8 +3668,13 @@ mod tests {
         release.send(()).unwrap();
         wait_for_capture_wake(&wake, &mut observed, std::time::Duration::from_secs(5));
         assert!(
-            PendingArm::take(&mut pending, 8).is_none(),
-            "a retarget mid-arm drops the stale channel"
+            PendingArm::take(&mut pending, 8, &mut stale).is_none(),
+            "a retarget mid-arm never adopts the stale channel"
+        );
+        assert_eq!(
+            stale.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            ["pane"],
+            "the stale channel goes to the teardown sink"
         );
         assert!(
             pending.is_none(),

--- a/src/tui/home/preview.rs
+++ b/src/tui/home/preview.rs
@@ -217,6 +217,12 @@ impl PreviewCache {
     /// the session, target, generation, and dimensions the content belongs to.
     /// Returns the captured line count so the caller can clamp scroll. Written
     /// only by `apply_worker_capture`; there is no synchronous capture source.
+    /// Whether no frame has landed yet for the displayed session `id`, so
+    /// the render paints nothing rather than a hint about an unknown pane.
+    pub(in crate::tui) fn is_pending_for(&self, id: &str) -> bool {
+        self.session_id.as_deref() != Some(id)
+    }
+
     pub(in crate::tui) fn store_capture(
         &mut self,
         content: String,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2883,7 +2883,10 @@ impl HomeView {
                                 frame,
                                 inner,
                                 inst,
-                                CachedPreview::from_text(self.preview_cache.parsed_text.as_ref()),
+                                CachedPreview::new(
+                                    self.preview_cache.parsed_text.as_ref(),
+                                    self.preview_cache.session_id.as_deref() != Some(id.as_str()),
+                                ),
                                 self.preview_scroll_offset,
                                 theme,
                                 self.idle_decay_window,
@@ -2977,14 +2980,14 @@ impl HomeView {
                         // every frame, and the preview capture above is already
                         // worker-driven, so a per-name `has-session` here would
                         // be the only fork left in a steady-state frame.
-                        let (terminal_running, preview_text) =
+                        let (terminal_running, cache) =
                             match terminal_mode {
                                 TerminalMode::Container => {
                                     let name = crate::tmux::ContainerTerminalSession::
                                     resolve_name_for_display(&inst.id, &inst.title);
                                     (
                                         crate::tmux::session_exists_for_display(&name),
-                                        self.container_terminal_preview_cache.parsed_text.as_ref(),
+                                        &self.container_terminal_preview_cache,
                                     )
                                 }
                                 TerminalMode::Host => {
@@ -2995,7 +2998,7 @@ impl HomeView {
                                         );
                                     (
                                         crate::tmux::session_exists_for_display(&name),
-                                        self.terminal_preview_cache.parsed_text.as_ref(),
+                                        &self.terminal_preview_cache,
                                     )
                                 }
                             };
@@ -3005,7 +3008,10 @@ impl HomeView {
                             inner,
                             inst,
                             terminal_running,
-                            CachedPreview::from_text(preview_text),
+                            CachedPreview::new(
+                                cache.parsed_text.as_ref(),
+                                cache.session_id.as_deref() != Some(id.as_str()),
+                            ),
                             self.preview_scroll_offset,
                             theme,
                             compact,
@@ -3073,7 +3079,10 @@ impl HomeView {
                             inner,
                             inst,
                             tool_running,
-                            CachedPreview::from_text(self.tool_preview_cache.parsed_text.as_ref()),
+                            CachedPreview::new(
+                                self.tool_preview_cache.parsed_text.as_ref(),
+                                self.tool_preview_cache.session_id.as_deref() != Some(id.as_str()),
+                            ),
                             self.preview_scroll_offset,
                             theme,
                             compact,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2885,7 +2885,7 @@ impl HomeView {
                                 inst,
                                 CachedPreview::new(
                                     self.preview_cache.parsed_text.as_ref(),
-                                    self.preview_cache.session_id.as_deref() != Some(id.as_str()),
+                                    self.preview_cache.is_pending_for(id),
                                 ),
                                 self.preview_scroll_offset,
                                 theme,
@@ -3010,7 +3010,7 @@ impl HomeView {
                             terminal_running,
                             CachedPreview::new(
                                 cache.parsed_text.as_ref(),
-                                cache.session_id.as_deref() != Some(id.as_str()),
+                                cache.is_pending_for(&id),
                             ),
                             self.preview_scroll_offset,
                             theme,
@@ -3081,7 +3081,7 @@ impl HomeView {
                             tool_running,
                             CachedPreview::new(
                                 self.tool_preview_cache.parsed_text.as_ref(),
-                                self.tool_preview_cache.session_id.as_deref() != Some(id.as_str()),
+                                self.tool_preview_cache.is_pending_for(&id),
                             ),
                             self.preview_scroll_offset,
                             theme,


### PR DESCRIPTION
## Description

Since #3537, selecting a session showed "No output available" until the capture worker had torn down the old VT channel, probed the pane count, and armed a new one: a chain of tmux forks plus a forwarder spawn, up to 500 ms when the forwarder never connects. Every row passed during list navigation paid the same chain.

The worker now publishes one `capture-pane` frame first. Arming waits until the selection has rested 250 ms and runs off the worker thread; the result carries the target generation, so a retarget mid-arm drops it and the channel's `Drop` tears it down. The old channel, and any arm result that arrives for a previous target, is shut down after that frame. Until a frame lands for the displayed session, the preview body paints blank instead of the hint.

Retarget to first frame in the debug TUI on macOS: 60 to 120 ms for settled and rapid moves alike, with the VT channel armed about 400 ms after a settled click. The unit harness, where the forwarder can never connect, went from 740 to 990 ms down to about 75 ms.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is the ordering of worker cycles, which an e2e test can only observe as timing. Unit tests cover the arm gate and the generation-tagged arm result instead.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5.1 via Claude Code

**Any Additional AI Details you'd like to share:** analysis, implementation, and measurements by the model, directed and reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR was drafted by Claude Fable 5.1 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose and code are Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jFAkn2Gj44LsfyZZ7Cuz1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improves TUI preview retargeting by publishing the first capture frame before channel setup.
- Delays channel setup until the pane selection remains unchanged for 250 ms.
- Handles outdated targets safely and cleans up old channels without blocking frame delivery.
- Shows a blank preview while the displayed session is still waiting for its first frame.
- Applies the behavior to both channel types.
- Adds tests for settling, stale results, generation tracking, and preview hints.

## Benefits

- Reduces retarget-to-first-frame latency.
- Reduces failed-forwarder test timing from about 740–990 ms to about 75 ms.
- Prevents misleading “No output available” messages during pending capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->