### PR TITLE
fix(session): never surface archived rows as Waiting/pending-permission

### DIFF
--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -34,13 +34,14 @@ mod v023_clear_structured_container_error;
 mod v024_backfill_detect_as;
 mod v025_reenable_confirm_delete;
 mod v026_repoint_acp_default_agent;
+mod v027_clear_archived_live_status;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 26;
+const CURRENT_VERSION: u32 = 27;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -179,6 +180,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 26,
         name: "repoint_acp_default_agent",
         run: v026_repoint_acp_default_agent::run,
+    },
+    Migration {
+        version: 27,
+        name: "clear_archived_live_status",
+        run: v027_clear_archived_live_status::run,
     },
 ];
 

--- a/src/migrations/v027_clear_archived_live_status.rs
+++ b/src/migrations/v027_clear_archived_live_status.rs
@@ -1,0 +1,175 @@
+//! Migration v027: settle the live-interaction status frozen onto archived
+//! sessions by builds shipped before `archive()` learned to degrade it.
+//!
+//! Archiving tears down the session's tmux (#1868), and the status poller
+//! deliberately never touches archived rows (#2206) — so whatever status the
+//! row happened to hold at archive time is persisted verbatim and never
+//! revisited. A session archived while `Waiting` (agent blocked on a
+//! permission prompt) therefore kept rendering as a pending-permission row
+//! in the TUI, `aoe ps`, and the web dashboard indefinitely, with no pane
+//! and no process behind it, and no CLI verb able to clear it
+//! (`session stop` refuses: the session is not running).
+//!
+//! This one-shot migration walks every sessions.json and settles any
+//! archived row still persisted at a live-interaction status
+//! (`running`/`waiting`/`starting`) to `idle` — the same resting state v016
+//! chose for archived rows. `archive()` and the poller's archived
+//! short-circuit now degrade in-process, so this cleans up only the rows
+//! older builds left behind.
+//!
+//! ## Failure policy
+//!
+//! Per `AGENTS.md > Data Migrations`, a returned `Err` aborts boot. A
+//! sessions.json that fails to parse is logged and skipped (a corrupt file
+//! must not block boot or spam every launch). Only `get_app_dir` and
+//! directory-read failures propagate.
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir)
+}
+
+pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
+    let profiles_dir = app_dir.join("profiles");
+    if profiles_dir.exists() {
+        for entry in fs::read_dir(&profiles_dir)? {
+            let entry = entry?;
+            if entry.path().is_dir() {
+                clear_archived_live_status(&entry.path().join("sessions.json"))?;
+            }
+        }
+    }
+    // Legacy top-level sessions.json (pre-profiles layout).
+    clear_archived_live_status(&app_dir.join("sessions.json"))?;
+    Ok(())
+}
+
+/// Settle any archived session still persisted at a live-interaction status
+/// (`running`/`waiting`/`starting`) to `idle`. Leaves non-archived rows and
+/// archived rows in any other status untouched.
+fn clear_archived_live_status(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(path)?;
+    let mut value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!("v027: failed to parse {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
+
+    let mut healed = 0usize;
+    if let Some(array) = value.as_array_mut() {
+        for instance in array.iter_mut() {
+            if let Some(obj) = instance.as_object_mut() {
+                let archived = obj.get("archived_at").is_some_and(|v| !v.is_null());
+                let live = matches!(
+                    obj.get("status").and_then(|v| v.as_str()),
+                    Some("running" | "waiting" | "starting")
+                );
+                if archived && live {
+                    obj.insert(
+                        "status".to_string(),
+                        serde_json::Value::String("idle".to_string()),
+                    );
+                    healed += 1;
+                }
+            }
+        }
+    }
+
+    if healed > 0 {
+        crate::session::atomic_write(path, serde_json::to_string_pretty(&value)?.as_bytes())?;
+        info!(
+            "v027: settled frozen live status on {healed} archived session(s) in {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settles_only_archived_live_status_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(
+            &path,
+            r#"[
+                {"id":"a","status":"waiting","archived_at":"2026-07-13T22:17:21Z"},
+                {"id":"b","status":"running","archived_at":"2026-07-13T22:17:21Z"},
+                {"id":"c","status":"starting","archived_at":"2026-07-13T22:17:21Z"},
+                {"id":"d","status":"waiting"},
+                {"id":"e","status":"idle","archived_at":"2026-07-13T22:17:21Z"},
+                {"id":"f","status":"stopped","archived_at":"2026-07-13T22:17:21Z"},
+                {"id":"g","status":"error","archived_at":"2026-07-13T22:17:21Z"},
+                {"id":"h","status":"waiting","archived_at":null}
+            ]"#,
+        )
+        .unwrap();
+
+        clear_archived_live_status(&path).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let arr = v.as_array().unwrap();
+        // archived + live-interaction status -> idle (the bug footprint)
+        assert_eq!(arr[0]["status"], "idle");
+        assert_eq!(arr[1]["status"], "idle");
+        assert_eq!(arr[2]["status"], "idle");
+        // non-archived waiting -> untouched (a real permission prompt)
+        assert_eq!(arr[3]["status"], "waiting");
+        // archived resting/terminal statuses -> untouched
+        assert_eq!(arr[4]["status"], "idle");
+        assert_eq!(arr[5]["status"], "stopped");
+        assert_eq!(arr[6]["status"], "error");
+        // explicit null archived_at counts as non-archived -> untouched
+        assert_eq!(arr[7]["status"], "waiting");
+    }
+
+    #[test]
+    fn missing_file_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        clear_archived_live_status(&dir.path().join("does-not-exist.json")).unwrap();
+    }
+
+    #[test]
+    fn unparseable_file_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(&path, "not json").unwrap();
+        clear_archived_live_status(&path).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "not json");
+    }
+
+    #[test]
+    fn walks_profile_dirs_and_legacy_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("profiles").join("p1");
+        fs::create_dir_all(&profile).unwrap();
+        let row = r#"[{"id":"a","status":"waiting","archived_at":"2026-07-13T22:17:21Z"}]"#;
+        fs::write(profile.join("sessions.json"), row).unwrap();
+        fs::write(dir.path().join("sessions.json"), row).unwrap();
+
+        run_in(dir.path()).unwrap();
+
+        for p in [
+            profile.join("sessions.json"),
+            dir.path().join("sessions.json"),
+        ] {
+            let v: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap();
+            assert_eq!(v[0]["status"], "idle", "{}", p.display());
+        }
+    }
+}

--- a/src/session/instance/flags.rs
+++ b/src/session/instance/flags.rs
@@ -91,11 +91,32 @@ impl Instance {
     /// the user just sunk produces contradictory state, and the web
     /// sidebar's tier comparator already assumes the server enforces a
     /// single active triage state (see `sidebarSort.ts` in #1581).
+    ///
+    /// Archiving tears down the session's tmux (#1868), so a live-interaction
+    /// status (Running/Waiting/Starting) cannot be true of an archived row.
+    /// Left in place, a frozen `Waiting` keeps rendering as a
+    /// pending-permission row forever — the status poller deliberately never
+    /// touches archived rows (#2206), so nothing else can clear it. Degrade
+    /// those statuses to Idle here, matching where v016 settles archived rows.
     pub fn archive(&mut self) {
         self.archived_at = Some(Utc::now());
         self.favorited_at = None;
         self.snoozed_until = None;
         self.pinned_at = None;
+        self.settle_archived_status();
+    }
+
+    /// Idle is the resting state an archived row can truthfully claim; see
+    /// `archive`. Shared with the status poller's archived short-circuit so a
+    /// row frozen by an older build (or merged in from a peer) heals in
+    /// memory without waiting for the one-shot v027 migration.
+    pub(crate) fn settle_archived_status(&mut self) {
+        if matches!(
+            self.status,
+            Status::Running | Status::Waiting | Status::Starting
+        ) {
+            self.status = Status::Idle;
+        }
     }
 
     pub fn unarchive(&mut self) {
@@ -801,5 +822,34 @@ mod tests {
         inst.status = Status::Idle;
         inst.idle_entered_at = None;
         assert!(!inst.has_recent_activity(window));
+    }
+    #[test]
+    fn archive_settles_live_interaction_status_to_idle() {
+        for status in [Status::Running, Status::Waiting, Status::Starting] {
+            let mut inst = Instance::new("test", "/tmp/test");
+            inst.status = status;
+            inst.archive();
+            assert!(inst.is_archived());
+            assert_eq!(
+                inst.status,
+                Status::Idle,
+                "{status:?} cannot be true of a row whose tmux archive tore down"
+            );
+        }
+    }
+
+    #[test]
+    fn archive_leaves_resting_statuses_alone() {
+        for status in [
+            Status::Idle,
+            Status::Stopped,
+            Status::Error,
+            Status::Unknown,
+        ] {
+            let mut inst = Instance::new("test", "/tmp/test");
+            inst.status = status;
+            inst.archive();
+            assert_eq!(inst.status, status, "{status:?} should survive archive");
+        }
     }
 }

--- a/src/session/instance/status_update.rs
+++ b/src/session/instance/status_update.rs
@@ -147,7 +147,15 @@ impl Instance {
         // re-probes a row whose tmux is gone by design; this keeps
         // archive/unarchive status-preserving. Rows already persisted as Error
         // by a pre-fix build are cleaned up once by the v016 migration.
+        //
+        // Status-preserving stops at live-interaction statuses: with the tmux
+        // gone by design, a persisted Running/Waiting/Starting is a lie, and a
+        // frozen Waiting renders as a pending-permission row forever. Settle
+        // those to Idle (same resting state v016/v027 choose) before
+        // returning, so a row archived by an older build heals on the next
+        // poll instead of only at the one-shot migration.
         if self.is_archived() {
+            self.settle_archived_status();
             return;
         }
 
@@ -616,6 +624,34 @@ mod tests {
         );
         // No capture recorded yet: nothing to date the stamp against.
         assert!(!skip_capture(Some(100), Some(100), None, false, false));
+    }
+
+    #[test]
+    fn archived_row_with_frozen_live_status_settles_to_idle_on_poll() {
+        // A row archived by a build that predates archive()'s status degrade
+        // arrives here still claiming Waiting. The archived short-circuit
+        // must settle it rather than preserve the lie (a pending-permission
+        // row with no pane behind it), and must not probe tmux to do so.
+        for status in [Status::Running, Status::Waiting, Status::Starting] {
+            let mut inst = Instance::new("test", "/tmp/test");
+            inst.status = status;
+            inst.archived_at = Some(Utc::now());
+            inst.update_status_with_metadata(None, None);
+            assert_eq!(inst.status, Status::Idle, "{status:?} must settle");
+        }
+        // Resting statuses on an archived row stay put.
+        for status in [
+            Status::Idle,
+            Status::Stopped,
+            Status::Error,
+            Status::Unknown,
+        ] {
+            let mut inst = Instance::new("test", "/tmp/test");
+            inst.status = status;
+            inst.archived_at = Some(Utc::now());
+            inst.update_status_with_metadata(None, None);
+            assert_eq!(inst.status, status, "{status:?} should survive the poll");
+        }
     }
 
     #[test]
@@ -1094,25 +1130,28 @@ mod tests {
         // concurrent archives through merge_user_action_diff's touched arm.
         //
         // Archiving short-circuits update_status_with_metadata_inner before
-        // it touches `status` (see the `is_archived()` guard), which lets
-        // this test fully control the "detected" status for two
-        // independent calls without a real tmux session.
+        // it probes tmux (see the `is_archived()` guard), which lets this
+        // test fully control the "detected" status for two independent calls
+        // without a real tmux session. The lever must be a resting status:
+        // the guard now settles live-interaction statuses
+        // (Running/Waiting/Starting) to Idle, so Unknown stands in as the
+        // preserved non-idle state.
         let mut inst = Instance::new("test", "/tmp/test");
         inst.archive();
         inst.live_status_baseline = Some(Status::Idle);
-        inst.status = Status::Running;
+        inst.status = Status::Unknown;
         let user_touch = Some(Utc::now() - chrono::Duration::hours(2));
         inst.last_accessed_at = user_touch;
 
         inst.update_status_with_metadata(None, None);
         assert_eq!(
             inst.status,
-            Status::Running,
-            "archived guard preserves status"
+            Status::Unknown,
+            "archived guard preserves resting status"
         );
         assert_eq!(inst.idle_entered_at, None, "non-idle transition clears it");
         assert_eq!(inst.last_accessed_at, user_touch);
-        assert_eq!(inst.live_status_baseline, Some(Status::Running));
+        assert_eq!(inst.live_status_baseline, Some(Status::Unknown));
 
         inst.status = Status::Idle;
         inst.update_status_with_metadata(None, None);


### PR DESCRIPTION
## Problem

A session archived while `Waiting` (agent blocked on a permission prompt) keeps rendering as a pending-permission row in the TUI, `aoe ps`, and the web dashboard **forever** — with no pane and no process behind it, and no way to clear it (`session stop` refuses: the session is not running).

Root cause is the interaction of two deliberate behaviors:
- #1868 tears down the session's tmux on archive.
- #2206 stops the status poller from touching archived rows (so it can't spuriously flip them to Error).

Together they mean whatever status the row held at archive time is persisted verbatim and never revisited. For `Waiting` that persisted snapshot is a lie the UI keeps telling: we found rows frozen this way for 7+ weeks.

## Fix

Three layers, mirroring how v016 handled the archived-`Error` freeze left by builds between #1868 and #2206:

1. **`archive()` settles live-interaction statuses** (`Running`/`Waiting`/`Starting`) to `Idle` at archive time, so new archives can never freeze one in. Resting statuses (`Idle`/`Stopped`/`Error`/`Unknown`) still survive archive, keeping #2206's status-preserving intent where the status can actually still be true.
2. **The poller's archived short-circuit self-heals**: the same settle runs before the early return, so a row archived by an older build (or merged in from a peer) heals on the next poll instead of only at boot.
3. **Migration v027** walks every sessions.json once and settles archived rows still persisted at `running`/`waiting`/`starting` to `idle` — same shape, failure policy, and tests as v016.

The #3465 regression test used the archived guard's status-preservation as its lever to fake transitions without tmux; it now levers on `Unknown`, which the guard still preserves.

## Testing

- New unit tests: archive-time settle (live statuses settle, resting statuses survive), poller self-heal on archived rows, v027 row selection (archived+live only; non-archived `waiting`, archived resting statuses, and `archived_at: null` all untouched), profile-dir + legacy-root walk, missing/unparseable file tolerance.
- `cargo test --lib`: instance + migration suites green (364 tests in the touched areas).
- Verified live on a daemon carrying 174 sessions with 4 frozen-Waiting archived rows: after upgrade+restart, all 4 read `Idle` with `archived_at` and titles intact, `/api/sessions` has zero `Waiting` rows, `aoe ps` shows zero waiting rows, schema advanced 26→27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q31GUgXtJh6368NdrPFsUF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Archived sessions with live statuses now settle to `Idle` instead of remaining visible as `Waiting` or pending-permission rows.
- The fix applies during archiving, status polling, and migration of existing `sessions.json` data.
- Migration v027 handles profile and legacy session files while skipping missing or invalid files safely.
- Resting statuses remain unchanged.
- Tests cover archiving, recovery, migration paths, and invalid data.

This keeps the TUI, `aoe ps`, and web dashboard consistent and removes stale archived sessions from active-session views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->