### PR TITLE
feat(agents): add openzoo (Claude Code paid per call over x402, no API key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Nothing. Sessions are tmux sessions running in the background. Open and close `a
 
 ### Which AI tools are supported?
 
-Run `aoe agents` for the current list and availability on your machine.
+Run `aoe agents` for the current list and availability on your machine. If you want Claude Code without an API key or account, the [openzoo](https://www.agent-of-empires.com/guides/openzoo/) agent runs the same CLI paid per call over x402.
 
 ### Can I use AoE over SSH?
 

--- a/docs/guides/openzoo.md
+++ b/docs/guides/openzoo.md
@@ -1,0 +1,56 @@
+# openzoo (Claude Code, paid per call)
+
+[openzoo](https://github.com/staccDOTsol/openzoo) is a local
+[x402](https://www.x402.org/) pay-per-call proxy for Claude Code. `openzoo
+claude` launches the real Claude Code CLI with `ANTHROPIC_BASE_URL` pointed at
+the proxy (`http://localhost:8402/v1`) and forwards every argument untouched to
+`claude`. No API key, no Anthropic account, no signup wall: every turn is paid
+on chain from a local burner wallet in `~/.openzoo`.
+
+AoE lists it as its own agent, `openzoo`, because the launch and the billing
+differ from `claude`; everything else is Claude Code.
+
+## Install
+
+```sh
+npm install -g openzoo
+aoe agents   # openzoo shows as installed
+```
+
+Fund the burner wallet as described in the openzoo README. `openzoo` starts
+the proxy itself when nothing is listening on its port, so there is no
+separate daemon to keep alive.
+
+## What AoE does with it
+
+Because the pane is the real Claude Code CLI, AoE reuses its Claude support
+wholesale:
+
+- **Launch**: `openzoo claude`, with `--dangerously-skip-permissions` (YOLO),
+  `--append-system-prompt`, and every other flag placed after the `claude`
+  subcommand so Claude Code, not the proxy CLI, parses them. A custom command
+  override is used verbatim.
+- **Status**: the Claude pane detector plus the same
+  `~/.claude/settings.json` hooks (`CLAUDE_CONFIG_DIR` honoured), so running /
+  waiting / idle / error land the instant Claude Code reports them.
+- **Resume and fork**: `--session-id` / `--resume` / `--fork-session` exactly
+  as for `claude`, with the session ID captured from the same hook sidecar and
+  the same `~/.claude/projects` transcripts. See
+  [Session Resume](./session-resume.md) and [Forking Sessions](./session-fork.md).
+- **Quick permission response**: the sidebar `a` / `A` / deny keys send the
+  same `1` / `2` / `3` Claude Code expects.
+- **Smart rename**: one-shot `openzoo claude -p` titles, paid like any other
+  turn.
+
+## Limitations
+
+- **Host only.** The wallet lives in `~/.openzoo` on your machine and the
+  sandbox image does not ship openzoo, so the new-session dialog disables
+  Docker sandboxing (and, as for every host-only agent, the worktree field)
+  for it. Run `claude` in a sandbox if you need isolation.
+- **No structured view.** openzoo has no ACP adapter of its own; it runs in
+  the terminal view. Structured-view features (including the web "Import from
+  Claude" flow) stay on the built-in `claude` agent.
+- **Same settings file as `claude`.** Installing or removing AoE's hooks for
+  one of the two updates the shared `~/.claude/settings.json`; the hook
+  commands are identical, so nothing conflicts.

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -179,6 +179,8 @@ AOE provides two official sandbox images:
 | Image | Description |
 |-------|-------------|
 | `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Kiro CLI, Qwen Code, Kimi Code, Prime Agent, git, ripgrep, fzf |
+
+[openzoo](./openzoo.md) is host-only (its wallet lives in `~/.openzoo` on the host) and is not in the image; the new-session dialog disables sandboxing for it.
 | `ghcr.io/agent-of-empires/aoe-dev-sandbox:latest` | Extended image with additional dev tools |
 
 ### Dev Sandbox Tools

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -179,9 +179,9 @@ AOE provides two official sandbox images:
 | Image | Description |
 |-------|-------------|
 | `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Kiro CLI, Qwen Code, Kimi Code, Prime Agent, git, ripgrep, fzf |
-
-[openzoo](./openzoo.md) is host-only (its wallet lives in `~/.openzoo` on the host) and is not in the image; the new-session dialog disables sandboxing for it.
 | `ghcr.io/agent-of-empires/aoe-dev-sandbox:latest` | Extended image with additional dev tools |
+
+[openzoo](./openzoo.md) is host-only (its wallet lives in `~/.openzoo` on the host) and is not in either image; the new-session dialog disables sandboxing for it.
 
 ### Dev Sandbox Tools
 

--- a/docs/guides/session-fork.md
+++ b/docs/guides/session-fork.md
@@ -47,7 +47,7 @@ Forking only reads the parent's conversation. The parent session and its transcr
 
 Forking needs an agent that can branch a conversation:
 
-- **Terminal sessions**: claude, codex, and opencode.
+- **Terminal sessions**: claude, [openzoo](./openzoo.md) (the same Claude Code CLI), codex, and opencode.
 - **Structured (ACP) sessions**: the Claude adapter (`claude-agent-acp`).
 
 Resume-only agents (such as gemini, vibe, and copilot) and agents without resume enabled in AoE (such as cursor, droid, kiro, and qwen) cannot fork. For those, the Fork option is hidden or refused.

--- a/docs/guides/session-resume.md
+++ b/docs/guides/session-resume.md
@@ -1,6 +1,6 @@
 # Session Resume (Claude)
 
-Claude Code sessions launched through AoE resume their prior conversation automatically after a reboot, an `aoe` upgrade, or a `kill-server`. No need to hunt through `/resume` to find the right session.
+Claude Code sessions launched through AoE resume their prior conversation automatically after a reboot, an `aoe` upgrade, or a `kill-server`. No need to hunt through `/resume` to find the right session. This covers the `claude` agent and [openzoo](./openzoo.md), which runs the same Claude Code CLI.
 
 This is automatic and on by default. Runtime conversation changes (via `/clear`, `--fork-session`, `--continue`, or starting fresh in the pane) are picked up too, in both host and sandboxed (Docker) modes.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Running several AI coding agents in parallel across tasks or branches means jugg
 
 ## Supported Agents
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, Qwen Code, Kimi Code, and Prime Agent. AoE auto-detects which are installed.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, Qwen Code, Kimi Code, Prime Agent, and [openzoo](guides/openzoo.md) (Claude Code paid per call over x402, no API key). AoE auto-detects which are installed.
 
 Agents carry a lifecycle state in AoE's registry. When an upstream vendor
 deprecates a CLI, AoE keeps supporting it but marks it everywhere it appears

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1368,6 +1368,66 @@ pub const AGENTS: &[AgentDef] = &[
         permission_response: None,
         lifecycle: AgentLifecycle::Active,
     },
+    AgentDef {
+        // openzoo (npm `openzoo`, https://github.com/staccDOTsol/openzoo) is a
+        // local x402 pay-per-call proxy. `openzoo claude [args...]` launches
+        // the REAL Claude Code CLI with ANTHROPIC_BASE_URL pointed at the
+        // proxy (http://localhost:8402/v1) and forwards every argument
+        // untouched to `claude`, so the pane IS Claude Code: same status
+        // shapes, same ~/.claude/settings.json hooks, same
+        // --resume/--session-id/--fork-session, same `-p` one-shot, same
+        // permission-prompt keys. What earns it its own entry is that no API
+        // key, account, or signup is needed: every turn is paid on chain from
+        // a local burner wallet. Sites that key Claude's session plumbing on
+        // the tool name go through `runs_claude_code` so this entry inherits
+        // them.
+        //
+        // Appended at the END of AGENTS on purpose: settings_index_from_name
+        // persists 1-based array positions, so inserting next to claude would
+        // silently remap every user's saved default agent.
+        name: "openzoo",
+        oneshot_flag: Some("-p"),
+        binary: "openzoo",
+        // Claude Code's flags belong to the `claude` subcommand; the bare
+        // `openzoo` binary is the proxy's own CLI.
+        launch_subcommand: Some("claude"),
+        aliases: &[],
+        detection: DetectionMethod::Which("openzoo"),
+        yolo: Some(YoloMode::CliFlag("--dangerously-skip-permissions")),
+        instruction_flag: Some("--append-system-prompt {}"),
+        set_default_command: false,
+        detect_status: status_detection::detect_claude_status,
+        // host_only: the burner wallet lives in ~/.openzoo on the host and the
+        // sandbox image does not ship openzoo, so there is no container env,
+        // no config mount, and no Dockerfile install.
+        container_env: &[],
+        // The spawned claude reads the same settings file, so the generic
+        // Claude hook install (status + session-id capture) covers it.
+        hook_config: Some(AgentHookConfig {
+            settings_rel_path: ".claude/settings.json",
+            config_dir_env_var: Some("CLAUDE_CONFIG_DIR"),
+            events: CLAUDE_HOOK_EVENTS,
+            format: HookFormat::JsonSettings,
+        }),
+        sidecar_hooks: None,
+        resume_strategy: ResumeStrategy::FlagPair {
+            existing: "--resume",
+            new_session: "--session-id",
+        },
+        fork_strategy: ForkStrategy::ClaudeFork,
+        host_only: true,
+        // Same paste-burst suppression as claude (see its entry): the Enter
+        // must land after Claude Code's 100ms paste-completion window.
+        send_keys_enter_delay_ms: 150,
+        ready_marker: None,
+        install_hint: "npm install -g openzoo",
+        permission_response: Some(PermissionResponse {
+            allow: &[KeyToken::Literal("1")],
+            allow_always: Some(&[KeyToken::Literal("2")]),
+            deny: &[KeyToken::Literal("3")],
+        }),
+        lifecycle: AgentLifecycle::Active,
+    },
 ];
 
 /// Look up an agent by canonical name.
@@ -1427,7 +1487,7 @@ impl AgentDef {
     /// ignored rather than mis-injected (fail-closed).
     pub fn oneshot_model_flag(&self) -> Option<&'static str> {
         match self.name {
-            "claude" | "copilot" | "omp" | "prime-agent" => Some("--model"),
+            "claude" | "openzoo" | "copilot" | "omp" | "prime-agent" => Some("--model"),
             "codex" | "gemini" | "opencode" | "kimi" => Some("-m"),
             _ => None,
         }
@@ -1821,6 +1881,19 @@ pub fn install_hint(name: &str) -> Option<&'static str> {
     get_agent(name).map(|a| a.install_hint)
 }
 
+/// True for agents whose pane is the real Claude Code CLI: `claude` itself and
+/// wrappers such as `openzoo` (`openzoo claude ...` execs `claude` with a
+/// different API base URL). They share Claude's transcript store
+/// (`~/.claude/projects/*.jsonl`), its hook session-id sidecar, its
+/// `--resume`/`--session-id`/`--fork-session` flags, its boolean `-p` one-shot
+/// and its startup banner, so every site that keys that plumbing on the tool
+/// name goes through here rather than `tool == "claude"`. Deliberately not
+/// used where the behaviour belongs to the `claude` registry entry itself
+/// (ACP adapter lookup, sandbox config mounts, the web session import).
+pub fn runs_claude_code(tool: &str) -> bool {
+    matches!(tool, "claude" | "openzoo")
+}
+
 /// Convert a tool name to a 1-based settings index (0 = Auto).
 pub fn settings_index_from_name(name: Option<&str>) -> usize {
     match name {
@@ -1948,7 +2021,7 @@ mod tests {
         // flag to emit it.
         for agent in AGENTS {
             let expected = match agent.name {
-                "claude" | "copilot" | "omp" | "prime-agent" => Some("--model"),
+                "claude" | "openzoo" | "copilot" | "omp" | "prime-agent" => Some("--model"),
                 "codex" | "gemini" | "opencode" | "kimi" => Some("-m"),
                 _ => None,
             };
@@ -2019,10 +2092,11 @@ mod tests {
                 );
             }
             // Semi-independent oracle (not a copy of the impl's name list):
-            // `-p` is value-binding except for claude, omp, and prime-agent,
-            // where it is the boolean `--print` flag.
+            // `-p` is value-binding except for claude (and openzoo, which
+            // execs claude), omp, and prime-agent, where it is the boolean
+            // `--print` flag.
             if agent.oneshot_flag == Some("-p")
-                && !matches!(agent.name, "claude" | "omp" | "prime-agent")
+                && !matches!(agent.name, "claude" | "openzoo" | "omp" | "prime-agent")
             {
                 assert!(
                     agent.oneshot_flag_binds_prompt(),
@@ -2081,6 +2155,7 @@ mod tests {
         assert_eq!(get_agent("kimi").unwrap().binary, "kimi");
         assert_eq!(get_agent("omp").unwrap().binary, "omp");
         assert_eq!(get_agent("prime-agent").unwrap().binary, "prime-agent");
+        assert_eq!(get_agent("openzoo").unwrap().binary, "openzoo");
     }
 
     #[test]
@@ -2369,7 +2444,8 @@ mod tests {
                 "antigravity",
                 "kimi",
                 "omp",
-                "prime-agent"
+                "prime-agent",
+                "openzoo"
             ]
         );
     }
@@ -2407,6 +2483,14 @@ mod tests {
             resolve_tool_name("prime-agent --mode acp"),
             Some("prime-agent")
         );
+        assert_eq!(resolve_tool_name("openzoo"), Some("openzoo"));
+        // Longest token wins: the default launch command `openzoo claude`
+        // contains claude's name, but "openzoo" is the longer match.
+        assert_eq!(resolve_tool_name("openzoo claude"), Some("openzoo"));
+        assert_eq!(
+            resolve_tool_name("openzoo claude --dangerously-skip-permissions"),
+            Some("openzoo")
+        );
         assert_eq!(resolve_tool_name("unknown-tool"), None);
     }
 
@@ -2427,6 +2511,7 @@ mod tests {
         assert_eq!(settings_index_from_name(Some("kimi")), 15);
         assert_eq!(settings_index_from_name(Some("omp")), 16);
         assert_eq!(settings_index_from_name(Some("prime-agent")), 17);
+        assert_eq!(settings_index_from_name(Some("openzoo")), 18);
 
         assert_eq!(name_from_settings_index(0), None);
         assert_eq!(name_from_settings_index(1), Some("claude"));
@@ -2443,6 +2528,7 @@ mod tests {
         assert_eq!(name_from_settings_index(15), Some("kimi"));
         assert_eq!(name_from_settings_index(16), Some("omp"));
         assert_eq!(name_from_settings_index(17), Some("prime-agent"));
+        assert_eq!(name_from_settings_index(18), Some("openzoo"));
         assert_eq!(name_from_settings_index(99), None);
     }
 
@@ -2476,14 +2562,50 @@ mod tests {
     }
 
     #[test]
-    fn test_only_kiro_uses_launch_subcommand() {
-        // Lock the surface: today only kiro needs a launch subcommand. A new
-        // agent that needs one must update this test deliberately.
+    fn test_openzoo_launches_via_claude_subcommand() {
+        // openzoo wraps Claude Code behind its `claude` subcommand, which is
+        // where claude's own flags (--dangerously-skip-permissions, --resume,
+        // -p) parse; the bare binary is the proxy's CLI.
+        let openzoo = get_agent("openzoo").unwrap();
+        assert_eq!(openzoo.launch_subcommand, Some("claude"));
+        assert_eq!(openzoo.launch_base_command(), "openzoo claude");
+    }
+
+    #[test]
+    fn test_runs_claude_code() {
+        assert!(runs_claude_code("claude"));
+        assert!(runs_claude_code("openzoo"));
+        assert!(!runs_claude_code("codex"));
+        assert!(!runs_claude_code("claude-code"));
+        assert!(!runs_claude_code(""));
+        // Drift guard: the set is exactly the registry agents that carry
+        // Claude's shape (ClaudeFork + hooks in Claude's own settings file).
+        // A new Claude wrapper must join both, and nothing else may.
         for agent in AGENTS {
-            let expected = if agent.name == "kiro" {
-                Some("chat")
-            } else {
-                None
+            let claude_shaped = matches!(agent.fork_strategy, ForkStrategy::ClaudeFork)
+                && agent
+                    .hook_config
+                    .as_ref()
+                    .is_some_and(|h| h.settings_rel_path == ".claude/settings.json");
+            assert_eq!(
+                runs_claude_code(agent.name),
+                claude_shaped,
+                "agent '{}' drifted from runs_claude_code",
+                agent.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_launch_subcommand_registry() {
+        // Lock the surface: today only kiro (`kiro-cli chat`) and openzoo
+        // (`openzoo claude`) need a launch subcommand. A new agent that needs
+        // one must update this test deliberately.
+        for agent in AGENTS {
+            let expected = match agent.name {
+                "kiro" => Some("chat"),
+                "openzoo" => Some("claude"),
+                _ => None,
             };
             assert_eq!(
                 agent.launch_subcommand, expected,
@@ -2617,6 +2739,8 @@ mod tests {
         // `[Pasted text]` sits unsubmitted). The Enter must arrive after that
         // 100ms window expires, so claude needs a delay > 100ms.
         assert!(send_keys_enter_delay("claude") > 100);
+        // openzoo's pane is the same Claude Code binary, so the same window.
+        assert!(send_keys_enter_delay("openzoo") > 100);
         // Other agents have no paste-burst suppression and should not delay
         assert_eq!(send_keys_enter_delay("opencode"), 0);
         assert_eq!(send_keys_enter_delay("hermes"), 0);
@@ -2644,6 +2768,7 @@ mod tests {
             Some("npm install -g @anthropic-ai/claude-code")
         );
         assert_eq!(install_hint("codex"), Some("npm install -g @openai/codex"));
+        assert_eq!(install_hint("openzoo"), Some("npm install -g openzoo"));
         // Pi is distributed via npm, not pip (issue #818).
         assert_eq!(
             install_hint("pi"),
@@ -2698,6 +2823,7 @@ mod tests {
             ("gemini", HookFormat::JsonSettings),
             ("cursor", HookFormat::JsonSettings),
             ("qwen", HookFormat::JsonSettings),
+            ("openzoo", HookFormat::JsonSettings),
         ];
         for (name, fmt) in expected {
             let agent = get_agent(name).unwrap_or_else(|| panic!("missing agent {name}"));
@@ -2755,11 +2881,16 @@ mod tests {
 
     #[test]
     fn test_fork_strategy_is_set_for_fork_capable_agents() {
-        // Only claude, codex, and opencode can fork; every other agent is
-        // Unsupported. Iterating the full AGENTS slice makes a new agent with a
-        // stray fork_strategy fail loudly here.
+        // Only claude (and openzoo, which execs claude), codex, and opencode
+        // can fork; every other agent is Unsupported. Iterating the full
+        // AGENTS slice makes a new agent with a stray fork_strategy fail
+        // loudly here.
         assert!(matches!(
             get_agent("claude").unwrap().fork_strategy,
+            ForkStrategy::ClaudeFork
+        ));
+        assert!(matches!(
+            get_agent("openzoo").unwrap().fork_strategy,
             ForkStrategy::ClaudeFork
         ));
         assert!(matches!(
@@ -2778,7 +2909,7 @@ mod tests {
             ForkStrategy::Unsupported
         ));
         for agent in AGENTS {
-            let fork_capable = matches!(agent.name, "claude" | "codex" | "opencode");
+            let fork_capable = matches!(agent.name, "claude" | "openzoo" | "codex" | "opencode");
             assert_eq!(
                 matches!(agent.fork_strategy, ForkStrategy::Unsupported),
                 !fork_capable,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1459,8 +1459,9 @@ pub fn trust_host_project(
     match agent_name {
         // Without a config dir the trust record lives at `~/.claude.json`,
         // beside `~/.claude/` rather than inside it; an override replaces the
-        // whole directory, so it takes the file with it.
-        "claude" => trust_claude_project(
+        // whole directory, so it takes the file with it. openzoo execs the
+        // same claude binary, which reads the same record.
+        "claude" | "openzoo" => trust_claude_project(
             &declared()
                 .or_else(|| from_env("CLAUDE_CONFIG_DIR"))
                 .map(|dir| dir.join(".claude.json"))

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -507,7 +507,7 @@ impl SessionResponse {
             .iter()
             .map(|s| s.to_string())
             .collect(),
-            claude_fullscreen: claude_fullscreen && inst.tool == "claude",
+            claude_fullscreen: claude_fullscreen && crate::agents::runs_claude_code(&inst.tool),
             // A session converted by `attach_project` (#3103) has a real
             // `workspace_info`, so this lists both repos with no special case:
             // the structured view's repo-relative path rendering, the diff-repo

--- a/src/session/instance/hooks.rs
+++ b/src/session/instance/hooks.rs
@@ -667,5 +667,11 @@ mod tests {
             status_hook_env_prefix("work", "abc123", crate::agents::get_agent("kimi")),
             "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
+        // openzoo shares claude's hook_config, so its spawned claude gets the
+        // instance id its status/session-id hooks need.
+        assert_eq!(
+            status_hook_env_prefix("work", "abc123", crate::agents::get_agent("openzoo")),
+            "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
+        );
     }
 }

--- a/src/session/instance/launch_command.rs
+++ b/src/session/instance/launch_command.rs
@@ -1150,6 +1150,53 @@ mod tests {
     }
 
     #[test]
+    fn test_build_host_command_openzoo_uses_claude_subcommand() {
+        // openzoo must launch via `openzoo claude` so the wrapped Claude Code
+        // CLI receives claude-scoped flags; bare `openzoo` is the proxy CLI.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "openzoo".to_string();
+        let (cmd, _, _) = inst
+            .build_host_command(crate::agents::get_agent("openzoo"))
+            .unwrap();
+        assert!(cmd.unwrap().contains("openzoo claude"));
+    }
+
+    #[test]
+    fn test_build_host_command_openzoo_yolo_and_resume_after_claude() {
+        // Both the YOLO flag and the session-id/resume pair must follow the
+        // `claude` subcommand, not precede it, so claude (not openzoo) parses
+        // them.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "openzoo".to_string();
+        inst.yolo_mode = true;
+        inst.agent_session_id = Some("11111111-2222-4333-8444-555555555555".to_string());
+        let (cmd, _, _) = inst
+            .build_host_command(crate::agents::get_agent("openzoo"))
+            .unwrap();
+        let cmd_str = cmd.unwrap();
+        let sub_pos = cmd_str
+            .find("openzoo claude")
+            .expect("claude subcommand present");
+        let yolo_pos = cmd_str
+            .find("--dangerously-skip-permissions")
+            .expect("yolo flag present");
+        let resume_pos = cmd_str
+            .find("--resume 11111111-2222-4333-8444-555555555555")
+            .or_else(|| cmd_str.find("--session-id 11111111-2222-4333-8444-555555555555"))
+            .expect("resume or session-id flag present");
+        assert!(
+            yolo_pos > sub_pos,
+            "--dangerously-skip-permissions must come after `openzoo claude` \
+             (subcommand at {sub_pos}, flag at {yolo_pos})"
+        );
+        assert!(
+            resume_pos > sub_pos,
+            "session flags must come after `openzoo claude` \
+             (subcommand at {sub_pos}, flag at {resume_pos})"
+        );
+    }
+
+    #[test]
     fn test_build_host_command_custom_override_skips_subcommand() {
         // A user command override is passed through verbatim; AoE must not
         // inject a launch subcommand into it (the user is in full control).

--- a/src/session/instance/polling.rs
+++ b/src/session/instance/polling.rs
@@ -95,7 +95,7 @@ impl Instance {
         }
 
         let poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static> = match tool {
-            "claude" => {
+            _ if crate::agents::runs_claude_code(tool) => {
                 if self.is_sandboxed() {
                     let container_name = match self.sandbox_info.as_ref() {
                         Some(s) => s.container_name.clone(),

--- a/src/session/instance/reconcile.rs
+++ b/src/session/instance/reconcile.rs
@@ -74,11 +74,11 @@ impl Instance {
     /// the daemon crashes before the next poll tick persists it: without
     /// this step, the next launch's wipe destroys the fresh sid.
     ///
-    /// Claude-only (sole sidecar tool); `Default` intent only (`Use(X)`
-    /// and `Cleared` override); excluded sids skipped (cascade re-poison
-    /// guard).
+    /// Claude Code panes only (the sole sidecar tool; see
+    /// `runs_claude_code`); `Default` intent only (`Use(X)` and `Cleared`
+    /// override); excluded sids skipped (cascade re-poison guard).
     pub(super) fn reconcile_sidecar_into_disk(&mut self) {
-        if self.tool != "claude" {
+        if !crate::agents::runs_claude_code(&self.tool) {
             return;
         }
         if !matches!(self.resume_intent, ResumeIntent::Default) {

--- a/src/session/instance/retroactive_capture.rs
+++ b/src/session/instance/retroactive_capture.rs
@@ -12,7 +12,7 @@ impl Instance {
             &self.id,
             &self.project_path,
             &self.tool,
-            self.tool == "claude"
+            crate::agents::runs_claude_code(&self.tool)
                 || (matches!(self.tool.as_str(), "codex" | "kimi") && !self.is_sandboxed()),
             &self.effective_profile(),
             &self.retroactive_capture_excludes,
@@ -34,7 +34,7 @@ impl Instance {
 
     pub(crate) fn try_retroactive_capture(&self) -> Option<String> {
         let result: Option<String> = match self.tool.as_str() {
-            "claude" => {
+            tool if crate::agents::runs_claude_code(tool) => {
                 // Claude additionally extends the common live and parked-id
                 // exclusion with stopped, archived, or pane-less peer sids so
                 // the mtime fallback skips peers whose jsonl outlived their

--- a/src/session/instance/session_id.rs
+++ b/src/session/instance/session_id.rs
@@ -102,7 +102,7 @@ impl Instance {
             // the conversation under the same id (see
             // `resume_flag_arm_is_existing`). Host-only: a sandboxed transcript
             // lives inside the container, which may not be up at acquire time.
-            if self.tool == "claude"
+            if crate::agents::runs_claude_code(&self.tool)
                 && !self.is_sandboxed()
                 && crate::session::capture::claude_host_transcript_confirmed_absent(
                     &self.project_path,
@@ -156,7 +156,7 @@ impl Instance {
         mint_fresh_id: &dyn Fn(&str) -> Option<String>,
     ) -> Option<String> {
         match self.tool.as_str() {
-            "claude" => Some(generate_session_uuid()),
+            tool if crate::agents::runs_claude_code(tool) => Some(generate_session_uuid()),
             "opencode" | "pi" => mint_fresh_id(&self.project_path),
             _ => None,
         }
@@ -352,7 +352,7 @@ impl Instance {
             }
             return override_if_distinct(self.agent_session_id.as_deref(), authoritative);
         }
-        if self.tool == "claude" {
+        if crate::agents::runs_claude_code(&self.tool) {
             if let Some(authoritative) = crate::hooks::read_hook_session_id(&self.id) {
                 if self.retroactive_capture_excludes.contains(&authoritative) {
                     return None;

--- a/src/session/instance/start.rs
+++ b/src/session/instance/start.rs
@@ -201,7 +201,7 @@ impl Instance {
             "agent launch command prepared"
         );
 
-        if self.tool == "claude" {
+        if crate::agents::runs_claude_code(&self.tool) {
             let _ = crate::hooks::unlink_session_id_via_guard(&self.id);
         }
 

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -444,7 +444,15 @@ pub fn load_native_mcp_servers_checked(agent_key: &str, home: &Path) -> Result<N
         return Ok(NativeRead::empty());
     };
     match config {
-        NativeMcpConfig::StandardJson(rel) => read_standard_json(&home.join(rel)),
+        // Claude-family CLIs (including the openzoo launcher) relocate
+        // `.claude.json` to `$CLAUDE_CONFIG_DIR` when that is set; read the same
+        // file the launched process will, not unconditionally the one in home.
+        NativeMcpConfig::StandardJson(rel) => {
+            let base = std::env::var_os("CLAUDE_CONFIG_DIR")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| home.to_path_buf());
+            read_standard_json(&base.join(rel))
+        }
         NativeMcpConfig::GeminiJson(rel) => read_gemini_json(&home.join(rel)),
         NativeMcpConfig::CodexToml(rel) => read_codex_toml(&home.join(rel)),
     }

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -400,7 +400,7 @@ enum NativeMcpConfig {
 /// an agent AoE has no native reader for (those contribute no native servers).
 fn native_config_for(agent_key: &str) -> Option<NativeMcpConfig> {
     match agent_key {
-        "claude" | "claude-code" => Some(NativeMcpConfig::StandardJson(".claude.json")),
+        "claude" | "claude-code" | "openzoo" => Some(NativeMcpConfig::StandardJson(".claude.json")),
         "gemini" => Some(NativeMcpConfig::GeminiJson(".gemini/settings.json")),
         "codex" => Some(NativeMcpConfig::CodexToml(".codex/config.toml")),
         _ => None,

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -796,9 +796,10 @@ fn capture_terminal_context(tmux: &crate::tmux::Session, tool: &str) -> Option<S
 /// substantive, so it can never make the capture worse. The `INSTRUCTION` prose
 /// is the backstop for banners this misses or for other agents.
 fn strip_agent_banner(text: &str, tool: &str) -> String {
-    // Only Claude Code has a verified banner shape to key on. Other agents rely
-    // on the instruction prose; add a case here per agent as needed.
-    if !tool.eq_ignore_ascii_case("claude") {
+    // Only Claude Code (and wrappers that exec it, see `runs_claude_code`) has
+    // a verified banner shape to key on. Other agents rely on the instruction
+    // prose; add a case here per agent as needed.
+    if !crate::agents::runs_claude_code(&tool.to_ascii_lowercase()) {
         return text.to_string();
     }
     // Gate loosely: the startup box names the tool ("Claude Code v2.1.216" in

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -132,6 +132,13 @@ const PAGES = [
       "Fork a session to start a second agent from its context, then diverge onto a different task, leaving the original untouched.",
   },
   {
+    source: "docs/guides/openzoo.md",
+    dest: "guides/openzoo.md",
+    title: "openzoo (Claude Code, paid per call)",
+    description:
+      "Run Claude Code through the openzoo x402 proxy: no API key or account, every turn paid on chain from a local wallet.",
+  },
+  {
     source: "docs/guides/multi-repo-workspaces.md",
     dest: "guides/multi-repo-workspaces.md",
     title: "Multi-Repo Workspaces",
@@ -372,6 +379,7 @@ const URL_MAP = {
   "docs/guides/agent-override.md": "/guides/agent-override/",
   "docs/guides/session-resume.md": "/guides/session-resume/",
   "docs/guides/session-fork.md": "/guides/session-fork/",
+  "docs/guides/openzoo.md": "/guides/openzoo/",
   "docs/guides/multi-repo-workspaces.md": "/guides/multi-repo-workspaces/",
   "docs/guides/scratch-sessions.md": "/guides/scratch-sessions/",
   "docs/guides/live-mode.md": "/guides/live-mode/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -38,6 +38,7 @@ export const docsNav: NavSection[] = [
       { title: "MCP Servers", href: "/guides/mcp-servers/", description: "Forward configured MCP servers to structured-view agents." },
       { title: "Session Resume (Claude)", href: "/guides/session-resume/", description: "Resume a previous Claude Code conversation in a session." },
       { title: "Forking Sessions", href: "/guides/session-fork/", description: "Branch a session's conversation into a new, independent session." },
+      { title: "openzoo (Claude Code, paid per call)", href: "/guides/openzoo/", description: "Run Claude Code with no API key through the openzoo x402 proxy." },
       { title: "Shell Completions", href: "/guides/shell-completions/", description: "Install and refresh tab-completion for the aoe CLI." },
       { title: "Sound Effects", href: "/docs/sounds/", description: "Play sounds when agents need input or finish work." },
       { title: "Push Notifications", href: "/docs/push-notifications/", description: "Get notified when a session needs your attention." },


### PR DESCRIPTION
## Description

Adds **openzoo** to the agent registry: Claude Code launched through a local pay-per-call proxy, so a session needs no API key and no account.

`openzoo claude [args…]` (npm `openzoo`, https://github.com/staccDOTsol/openzoo) spawns the real Claude Code CLI with `ANTHROPIC_BASE_URL` pointed at a local x402 proxy and forwards every flag untouched. From AoE's point of view it *is* Claude Code — same pane, same `~/.claude/settings.json` hooks, same `--resume` / `--session-id` / `--fork-session`, same `--dangerously-skip-permissions`, same `-p`, same permission-prompt keys — which is why the entry is a thin Claude clone:

- `binary: "openzoo"`, `launch_subcommand: Some("claude")` (the kiro `kiro-cli chat` mechanism), detection `which openzoo`, install hint `npm install -g openzoo`.
- `hook_config`, `resume_strategy`, `fork_strategy`, `yolo`, `permission_response`, `send_keys_enter_delay_ms` identical to `claude`, because the spawned process is `claude`.
- `host_only: true`: the burner wallet lives in `~/.openzoo` on the host and the sandbox image does not ship openzoo. No Dockerfile / container-mount changes.
- Appended at the **end** of `AGENTS` so persisted `settings_index` values for existing agents do not shift.
- Session plumbing that was gated on `tool == "claude"` (session-id minting, hook sidecar read, `~/.claude/projects` polling, folder trust, banner strip, fullscreen flag) now goes through a new `agents::runs_claude_code(tool)` (`claude | openzoo`). Without it `resume_strategy` would be dead for openzoo: nothing would ever mint `--session-id` or capture one. ACP adapter lookup, sandbox mounts and the web "Import from Claude" flow deliberately stay `claude`-only.

Why a separate entry rather than `agent_command_override`: an override re-points the user's *own* Claude account sessions; this is a different way to pay for the same CLI, and users want both side by side in the picker. It also composes with the existing `custom_agents` + `agent_detect_as = "claude"` route, which is what `openzoo aoe` writes today for older AoE builds.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the change is one registry entry exercised by the `src/agents.rs` unit tests (resolve `"openzoo claude"` → `openzoo`, default launch command `openzoo claude`, yolo/resume flags land after the subcommand, install-hint lookup, settings-index roundtrip); an e2e run would need a funded x402 wallet on the CI host. Verified live locally: `aoe add --tool openzoo <repo> -l` boots Claude Code with the openzoo banner and `aoe ps` tracks it through the Claude hooks.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Fable 5.1)

**Any Additional AI Details you'd like to share:** The registry entry, tests and docs were drafted with Claude Code and reviewed by the author; the live AoE session check was run on a real machine. Author: @STACCoverflow

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `openzoo` as a host-only agent for Claude Code through an x402 pay-per-call proxy.
- Reused Claude Code support for hooks, sessions, resume, fork, permissions, polling, and smart rename.
- Added MCP configuration support through `CLAUDE_CONFIG_DIR`.
- Added installation, usage, sandbox, session, and agent documentation.
- Updated website navigation and documentation sync configuration.
- Added registry, launch, hook, and session tests.

## Benefits

Users can run Claude Code without a direct API key or account. Existing Claude Code workflows remain available through `openzoo`.

## Follow-up

End-to-end testing still requires a funded x402 wallet. Further testing can cover live proxy use and wallet-related failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->