### PR TITLE
fix(worktree): relocate worktrees that have submodules instead of failing on git's refusal

### DIFF
--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -304,53 +304,15 @@ pub fn enrich_worktree_remove_error(stderr: &str, worktree_path: &Path) -> Strin
     out
 }
 
-/// Returns true if a `git worktree remove` stderr indicates the failure was
-/// caused by initialised submodules. Git refuses to remove a worktree whose
-/// checkout still has live submodule entries, even with `--force`; submodule
-/// state lives under `.git/worktrees/<name>/modules/` and orphaning it would
-/// corrupt the main repo.
+/// Returns true if a `git worktree move`/`remove` stderr indicates the failure
+/// was caused by submodules. Git refuses both whenever the worktree's admin dir
+/// still holds `modules/<sub>`, which is where a linked worktree's submodule
+/// state lives; orphaning it would corrupt the main repo. Note that the refusal
+/// keys on that admin dir alone, so `git submodule deinit` does not lift it:
+/// only removing `modules/<sub>` does.
 pub fn is_submodule_blocker(error: &str) -> bool {
     let lower = error.to_lowercase();
     lower.contains("working trees containing submodules cannot be moved or removed")
-}
-
-/// Deinitialise any submodules under `worktree_path` so `git worktree remove`
-/// will let the worktree go. Best-effort and idempotent: a no-op when the
-/// worktree has no `.gitmodules`, no initialised submodules, or git itself
-/// isn't reachable. The `-f` on `submodule deinit` is "force-deinit modified
-/// submodules"; distinct from aoe's worktree-level `force`, which means
-/// "discard uncommitted/untracked files in the worktree itself"; so applying
-/// it here doesn't conflate the two semantics.
-pub fn deinit_submodules_if_present(worktree_path: &Path) {
-    if !worktree_path.join(".gitmodules").exists() {
-        return;
-    }
-    // `run_git_quiet`: every outcome below is already classified and logged
-    // here at DEBUG, so a second WARN from the wrapper would only be noise.
-    let output =
-        super::command::run_git_quiet(worktree_path, ["submodule", "deinit", "-f", "--all"]);
-    match output {
-        Ok(o) if o.status.success() => {
-            tracing::debug!(target: "git.worktree",
-                path = %worktree_path.display(),
-                "deinitialised submodules before worktree removal"
-            );
-        }
-        Ok(o) => {
-            tracing::debug!(target: "git.worktree",
-                path = %worktree_path.display(),
-                stderr = %String::from_utf8_lossy(&o.stderr),
-                "submodule deinit returned non-zero; continuing"
-            );
-        }
-        Err(e) => {
-            tracing::debug!(target: "git.worktree",
-                path = %worktree_path.display(),
-                error = %e,
-                "submodule deinit failed to spawn; continuing"
-            );
-        }
-    }
 }
 
 /// Resolve a linked worktree's `.git` pointer to its admin dir.
@@ -588,13 +550,6 @@ pub fn remove_managed_worktree(
             errors.push(format!("Worktree: {}", e));
         }
     } else {
-        // Submodules are a normal repo state, not a destructive override;
-        // `git worktree remove` refuses to delete a worktree with live
-        // submodules even with --force, so deinit them ourselves before
-        // asking git to remove the checkout. No-op when the worktree has no
-        // .gitmodules.
-        deinit_submodules_if_present(worktree_path);
-
         match git_wt.remove_worktree(worktree_path, force) {
             Ok(()) => {
                 worktree_removed = true;
@@ -660,10 +615,10 @@ pub fn remove_managed_worktree(
                         errors.push(format!("Worktree: {}", e2));
                     }
                 } else if is_submodule_blocker(&err_str) {
-                    // Pre-deinit didn't fully resolve it (e.g. a broken
-                    // submodule), or the worktree carries orphaned modules
-                    // state without a live `.gitmodules`. Fall back to manual
-                    // teardown.
+                    // The only way past this refusal is removing the admin
+                    // `modules/<sub>` dir, which is what the manual teardown
+                    // does. `git submodule deinit` leaves that dir behind, so
+                    // it cannot serve as a pre-step here.
                     let manual_errors =
                         manual_submodule_worktree_cleanup(git_wt, worktree_path, main_repo);
                     if manual_errors.is_empty() {
@@ -1054,17 +1009,6 @@ mod tests {
         );
         assert!(!modules_dir.exists(), "modules dir should be removed");
         assert!(!wt.exists(), "worktree dir should be removed");
-    }
-
-    #[test]
-    fn test_deinit_submodules_if_present_is_noop_without_gitmodules() {
-        // No `.gitmodules` → function returns without spawning git. We can't
-        // observe the no-spawn directly, but the call must not panic and the
-        // directory contents must be unchanged.
-        let dir = tempfile::TempDir::new().unwrap();
-        std::fs::write(dir.path().join("placeholder"), "x").unwrap();
-        deinit_submodules_if_present(dir.path());
-        assert!(dir.path().join("placeholder").exists());
     }
 
     #[test]

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -23,23 +23,6 @@ where
     run(cwd, args, false)
 }
 
-/// [`run_git`] for callers that have already classified a non-zero exit as
-/// an expected, no-op outcome (`git worktree unlock` on an entry that is
-/// already unlocked, `git submodule deinit` on a checkout with nothing
-/// initialised). Identical apart from the failure log, which drops to DEBUG
-/// so the routine case stops competing with real warnings in `debug.log`.
-///
-/// Only for call sites that discard or already diagnose the failure
-/// themselves. A caller that turns a non-zero exit into an error keeps
-/// [`run_git`], so the WARN stays with the failure it explains.
-pub fn run_git_quiet<I, S>(cwd: &Path, args: I) -> std::io::Result<Output>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    run(cwd, args, true)
-}
-
 fn run<I, S>(cwd: &Path, args: I, quiet: bool) -> std::io::Result<Output>
 where
     I: IntoIterator<Item = S>,
@@ -220,10 +203,10 @@ mod tests {
     use std::ffi::OsString;
     use tracing_test::traced_test;
 
-    /// The same failing command is a WARN through `run_git` and a DEBUG
-    /// through `run_git_quiet`; the quiet variant must not drop the record
-    /// entirely, since the stderr summary is what makes a surprise
-    /// diagnosable.
+    /// The same failing command is a WARN through `run_git_with_timeout` and a
+    /// DEBUG through `run_git_quiet_with_timeout`; the quiet variant must not
+    /// drop the record entirely, since the stderr summary is what makes a
+    /// surprise diagnosable.
     #[traced_test]
     #[test]
     fn run_git_quiet_demotes_expected_failure_to_debug() {
@@ -232,8 +215,13 @@ mod tests {
         // Not a repository, so `git worktree unlock` exits non-zero: the
         // shape `unlock_worktree` classifies as a harmless no-op.
         let args = ["worktree", "unlock", "/nonexistent"];
-        let loud = run_git(tmp.path(), args).expect("git should spawn");
-        let quiet = run_git_quiet(tmp.path(), args).expect("git should spawn");
+        let timeout = Duration::from_secs(30);
+        let loud = run_git_with_timeout(tmp.path(), args, timeout)
+            .expect("git should spawn")
+            .expect("git should not time out");
+        let quiet = run_git_quiet_with_timeout(tmp.path(), args, timeout)
+            .expect("git should spawn")
+            .expect("git should not time out");
         assert!(!loud.status.success());
         assert!(!quiet.status.success());
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -129,6 +129,26 @@ fn classify_worktree_move_listing(
     None
 }
 
+/// Whether git will refuse to move or remove the worktree at `path` because of
+/// submodules. The refusal keys on the admin `modules` dir alone, so a worktree
+/// whose submodules were never initialised is not affected and an emptied
+/// submodule checkout still is.
+fn worktree_has_submodule_admin_state(path: &Path) -> bool {
+    super::cleanup::read_linked_worktree_gitdir(path)
+        .is_some_and(|gitdir| gitdir.join("modules").is_dir())
+}
+
+/// A populated submodule checkout inside a worktree that is about to move,
+/// paired with the git dir its pointer resolves to. That git dir lives under
+/// the main repo and does not move, so recording it before the rename is what
+/// makes the pointers repairable afterwards.
+struct SubmoduleCheckout {
+    /// Path relative to the worktree root, parents before children.
+    relative: PathBuf,
+    /// Canonical absolute path of the submodule's git dir.
+    gitdir: PathBuf,
+}
+
 fn canonicalize_move_endpoint(path: &Path) -> PathBuf {
     path.canonicalize()
         .or_else(|_| {
@@ -1461,12 +1481,21 @@ impl GitWorktree {
     /// relocates the checkout and updates the linked-worktree gitdir
     /// metadata. A plain filesystem rename would leave git's bookkeeping
     /// pointing at the old path, so always go through git here.
+    ///
+    /// A worktree with submodules cannot go through `git worktree move` at all
+    /// and takes [`Self::relocate_worktree_with_submodules`] instead.
     pub fn move_worktree(&self, from: &Path, to: &Path) -> Result<()> {
         if !from.exists() {
             return Err(GitError::WorktreeNotFound(from.to_path_buf()));
         }
         if to.exists() {
             return Err(GitError::WorktreeAlreadyExists(to.to_path_buf()));
+        }
+        // Git refuses the move outright once the admin dir holds `modules/`,
+        // so take the manual path directly rather than spending a doomed
+        // command and its WARN on every move of a submodule worktree.
+        if worktree_has_submodule_admin_state(from) {
+            return self.relocate_worktree_with_submodules(from, to);
         }
         // Git reports canonical worktree paths. Resolve both spellings while
         // the source and destination parent still exist, so a symlinked parent
@@ -1528,10 +1557,15 @@ impl GitWorktree {
             )));
         };
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            // Backstop for a layout the admin-dir probe above does not
+            // recognise, or a git that refuses on different grounds.
+            if super::cleanup::is_submodule_blocker(&stderr) {
+                return self.relocate_worktree_with_submodules(from, to);
+            }
             // Restore the lock on the unmoved source so a failed move does not
             // silently leave it unprotected.
             let _ = self.lock_worktree(from);
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             return Err(GitError::WorktreeCommandFailed(stderr));
         }
         if let Err(e) = self.lock_worktree(to) {
@@ -1540,6 +1574,226 @@ impl GitWorktree {
                 error = %e,
                 "move_worktree: could not re-lock worktree at new path"
             );
+        }
+        Ok(())
+    }
+
+    /// Relocate a worktree that `git worktree move` refuses because of
+    /// submodules, by renaming the directory and repairing git's pointers.
+    ///
+    /// Git refuses whenever the worktree's admin dir holds `modules/<sub>`,
+    /// whether or not the checkout is populated. `git submodule deinit` cannot
+    /// lift that (the admin dir survives it) and would refuse on, or with `-f`
+    /// discard, uncommitted and untracked submodule work, so the checkout is
+    /// moved as-is and the stale pointers are rewritten afterwards.
+    ///
+    /// Failure contract: an `Err` from here leaves the checkout at `from`.
+    /// Callers depend on it; `session::attach_project` only records the move in
+    /// its `Undo` once this returns `Ok`, so an `Err` after a real move would
+    /// strand the worktree at `to` with the session still pointing at `from`.
+    /// The two steps that can fail cheaply run first, while undoing them is a
+    /// single rename back. Past that point the worktree is registered at `to`
+    /// and every remaining step is reported rather than propagated.
+    fn relocate_worktree_with_submodules(&self, from: &Path, to: &Path) -> Result<()> {
+        tracing::info!(target: "git.worktree",
+            from = %from.display(),
+            to = %to.display(),
+            "move_worktree: relocating a worktree with submodules by hand"
+        );
+        // Recorded before the rename, while the pointers still resolve.
+        let checkouts = Self::populated_submodule_checkouts(from)?;
+
+        // Unlocked for the same window as the `git worktree move` path. The
+        // lock lives in the admin dir, which the rename does not touch.
+        self.unlock_worktree(from);
+
+        if let Err(e) = std::fs::rename(from, to) {
+            let _ = self.lock_worktree(from);
+            return Err(e.into());
+        }
+
+        if let Err(e) = self.repair_worktree(to) {
+            if std::fs::rename(to, from).is_err() {
+                tracing::error!(target: "git.worktree",
+                    to = %to.display(),
+                    error = %e,
+                    "move_worktree: could not repair or move back; the checkout is stranded at the new path"
+                );
+                return Err(e);
+            }
+            let _ = self.repair_worktree(from);
+            let _ = self.lock_worktree(from);
+            return Err(e);
+        }
+
+        // The worktree is registered at `to` from here on, so nothing below
+        // may propagate with `?`.
+        if let Err(e) = Self::convert_git_file_to_relative(to) {
+            tracing::warn!(target: "git.worktree",
+                to = %to.display(),
+                error = %e,
+                "move_worktree: could not restore the relative .git pointer"
+            );
+        }
+
+        let mut unrepaired = Vec::new();
+        for checkout in &checkouts {
+            if let Err(e) = Self::repoint_submodule(to, checkout) {
+                unrepaired.push(format!("{}: {e}", checkout.relative.display()));
+            }
+        }
+        if !unrepaired.is_empty() {
+            tracing::error!(target: "git.worktree",
+                to = %to.display(),
+                submodules = ?unrepaired,
+                "move_worktree: relocated the worktree but left submodule pointers stale; \
+                 `git submodule update --init --recursive` in the new path restores them"
+            );
+        }
+
+        if let Err(e) = self.lock_worktree(to) {
+            tracing::warn!(target: "git.worktree",
+                to = %to.display(),
+                error = %e,
+                "move_worktree: could not re-lock worktree at new path"
+            );
+        }
+        Ok(())
+    }
+
+    /// Re-derive git's linked-worktree bookkeeping for the checkout now at
+    /// `path`. One call fixes both sides, the worktree's own `.git` pointer and
+    /// the admin `gitdir` file naming it, even when the pointer was relative
+    /// and the move broke it.
+    fn repair_worktree(&self, path: &Path) -> Result<()> {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
+        let Some(output) = super::command::run_git_with_timeout(
+            &self.repo_path,
+            ["worktree", "repair", path_str],
+            WORKTREE_MUTATION_TIMEOUT,
+        )?
+        else {
+            return Err(GitError::WorktreeCommandFailed(format!(
+                "`git worktree repair` timed out after {}s",
+                WORKTREE_MUTATION_TIMEOUT.as_secs()
+            )));
+        };
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(GitError::WorktreeCommandFailed(stderr));
+        }
+        Ok(())
+    }
+
+    /// Populated submodule checkouts under `worktree_path`, parents first.
+    ///
+    /// `submodule foreach` visits only populated checkouts, and `$displaypath`
+    /// is cumulative from the invocation directory, so a nested submodule comes
+    /// back as a plain worktree-relative path and needs no per-level path
+    /// arithmetic. Pairing each with the git dir its pointer currently resolves
+    /// to is what avoids reconstructing git's `modules/<a>/modules/<b>` nesting
+    /// by hand after the move.
+    fn populated_submodule_checkouts(worktree_path: &Path) -> Result<Vec<SubmoduleCheckout>> {
+        let Some(output) = super::command::run_git_with_timeout(
+            worktree_path,
+            [
+                "submodule",
+                "foreach",
+                "--recursive",
+                "--quiet",
+                r#"printf '%s\n' "$displaypath""#,
+            ],
+            WORKTREE_MUTATION_TIMEOUT,
+        )?
+        else {
+            return Err(GitError::WorktreeCommandFailed(format!(
+                "`git submodule foreach` timed out after {}s",
+                WORKTREE_MUTATION_TIMEOUT.as_secs()
+            )));
+        };
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(GitError::WorktreeCommandFailed(stderr));
+        }
+
+        let mut checkouts = Vec::new();
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let relative = line.trim();
+            if relative.is_empty() {
+                continue;
+            }
+            let checkout = worktree_path.join(relative);
+            let git_file = checkout.join(".git");
+            // A submodule whose `.git` is a directory carries its whole
+            // repository inside the checkout, so the rename moves it intact
+            // and there is no pointer to rewrite.
+            if !git_file.is_file() {
+                continue;
+            }
+            let Some(gitdir) = super::cleanup::read_linked_worktree_gitdir(&checkout) else {
+                continue;
+            };
+            let Ok(gitdir) = gitdir.canonicalize() else {
+                continue;
+            };
+            checkouts.push(SubmoduleCheckout {
+                relative: PathBuf::from(relative),
+                gitdir,
+            });
+        }
+        Ok(checkouts)
+    }
+
+    /// Point a moved submodule checkout and its git dir back at each other.
+    ///
+    /// Both directions go stale when the parent worktree moves and both matter:
+    /// with only the checkout's `.git` rewritten, git still resolves
+    /// `core.worktree` to the old path and every command in the parent worktree
+    /// fails with `cannot chdir`. Both are written relative, for the same
+    /// reason [`Self::convert_git_file_to_relative`] exists.
+    ///
+    /// `core.worktree` goes through `git config --file` rather than a `git
+    /// config` run from inside the submodule, because until it is fixed git
+    /// cannot enter that checkout at all: it resolves the stale value first and
+    /// exits with `cannot chdir`.
+    fn repoint_submodule(worktree_path: &Path, checkout: &SubmoduleCheckout) -> Result<()> {
+        let path = worktree_path.join(&checkout.relative);
+        // Canonical on both sides, since the recorded git dir is canonical and
+        // a relative path between mixed spellings would not resolve.
+        let canonical = path.canonicalize()?;
+        let gitdir = &checkout.gitdir;
+
+        let pointer = Self::diff_paths(gitdir, &canonical).unwrap_or_else(|| gitdir.clone());
+        std::fs::write(
+            path.join(".git"),
+            format!("gitdir: {}\n", pointer.display()),
+        )?;
+
+        let core_worktree =
+            Self::diff_paths(&canonical, gitdir).unwrap_or_else(|| canonical.clone());
+        let core_worktree = core_worktree
+            .to_str()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
+        let config = gitdir.join("config");
+        let config = config
+            .to_str()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
+        let Some(output) = super::command::run_git_with_timeout(
+            worktree_path,
+            ["config", "--file", config, "core.worktree", core_worktree],
+            WORKTREE_MUTATION_TIMEOUT,
+        )?
+        else {
+            return Err(GitError::WorktreeCommandFailed(format!(
+                "`git config core.worktree` timed out after {}s",
+                WORKTREE_MUTATION_TIMEOUT.as_secs()
+            )));
+        };
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(GitError::WorktreeCommandFailed(stderr));
         }
         Ok(())
     }
@@ -3808,6 +4062,216 @@ mod tests {
         repo.branch(branch, &head_commit, false).unwrap();
 
         (submodule_src_dir, submodule_bare_dir, repo_dir)
+    }
+
+    /// The `TempDir`s a nested-submodule fixture has to keep alive: every
+    /// `file://` URL in the chain points at one of the bare clones, so dropping
+    /// any of them breaks `git submodule update`.
+    struct NestedSubmoduleFixture {
+        _dirs: Vec<TempDir>,
+        repo_dir: TempDir,
+    }
+
+    /// Build `main -> .claude -> .claude/nested`, every level served from a
+    /// local bare `file://` clone, then branch `branch` off the main repo's
+    /// HEAD. Two levels, because a moved worktree's submodule pointers live at
+    /// `modules/.claude` and `modules/.claude/modules/nested`, at different
+    /// depths, which is where relative-path arithmetic can go wrong.
+    ///
+    /// Uses plain `git` rather than git2 throughout; each `submodule add` opts
+    /// into the `file://` transport per command, like
+    /// `build_repo_with_submodule_and_branch` does, so no process-global env is
+    /// touched (#2863).
+    fn build_repo_with_nested_submodule_and_branch(branch: &str) -> NestedSubmoduleFixture {
+        // A repo with one committed file, returned with its bare clone's URL.
+        fn seed_repo(name: &str, dirs: &mut Vec<TempDir>) -> (TempDir, String) {
+            let dir = TempDir::new().unwrap();
+            run_git(dir.path(), &["init", "-q", "."]);
+            run_git(dir.path(), &["config", "user.name", "Test"]);
+            run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+            std::fs::write(dir.path().join(format!("{name}.md")), format!("{name}\n")).unwrap();
+            run_git(dir.path(), &["add", "-A"]);
+            run_git(dir.path(), &["commit", "-qm", "init"]);
+            let url = bare_clone_url(dir.path(), name, dirs);
+            (dir, url)
+        }
+
+        fn bare_clone_url(src: &Path, name: &str, dirs: &mut Vec<TempDir>) -> String {
+            let bare_parent = TempDir::new().unwrap();
+            let bare = bare_parent.path().join(format!("{name}.git"));
+            run_git(
+                bare_parent.path(),
+                &[
+                    "clone",
+                    "--bare",
+                    "-q",
+                    src.to_str().unwrap(),
+                    bare.to_str().unwrap(),
+                ],
+            );
+            let url = format!("file://{}", bare.display());
+            dirs.push(bare_parent);
+            url
+        }
+
+        fn add_submodule(repo: &Path, url: &str, path: &str) {
+            run_git(
+                repo,
+                &[
+                    "-c",
+                    "protocol.file.allow=always",
+                    "submodule",
+                    "add",
+                    "-q",
+                    url,
+                    path,
+                ],
+            );
+            run_git(repo, &["commit", "-qm", "add submodule"]);
+        }
+
+        let mut dirs = Vec::new();
+        let (inner_dir, inner_url) = seed_repo("inner", &mut dirs);
+        let (mid_dir, _) = seed_repo("mid", &mut dirs);
+        add_submodule(mid_dir.path(), &inner_url, "nested");
+        // Re-clone the mid repo now that it carries the nested submodule, so
+        // the main repo's submodule points at a commit that has it.
+        let mid_url = bare_clone_url(mid_dir.path(), "mid-with-nested", &mut dirs);
+
+        let repo_dir = TempDir::new().unwrap();
+        run_git(repo_dir.path(), &["init", "-q", "."]);
+        run_git(repo_dir.path(), &["config", "user.name", "Test"]);
+        run_git(
+            repo_dir.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        std::fs::write(repo_dir.path().join("README.md"), "main repo\n").unwrap();
+        run_git(repo_dir.path(), &["add", "-A"]);
+        run_git(repo_dir.path(), &["commit", "-qm", "init"]);
+        add_submodule(repo_dir.path(), &mid_url, ".claude");
+        run_git(repo_dir.path(), &["branch", branch]);
+
+        dirs.push(inner_dir);
+        dirs.push(mid_dir);
+        NestedSubmoduleFixture {
+            _dirs: dirs,
+            repo_dir,
+        }
+    }
+
+    /// Stdout of a successful git command, for tests that assert on it.
+    fn git_stdout(path: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} in {} failed:\nstdout: {}\nstderr: {}",
+            args,
+            path.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    /// #3695: `git worktree move` refuses outright once a worktree's admin dir
+    /// holds `modules/<sub>`, which broke every aoe path that relocates a
+    /// worktree (attach-project, trash relocate and restore, worktree rename)
+    /// for any repo with submodules. The move has to preserve the submodule
+    /// checkouts as they are, uncommitted and untracked files included, since
+    /// the `submodule deinit` route either refuses on them or discards them.
+    #[test]
+    fn test_move_worktree_relocates_nested_submodules_and_keeps_local_changes() {
+        let fixture = build_repo_with_nested_submodule_and_branch("test-move");
+        let repo_path = fixture.repo_dir.path().to_path_buf();
+
+        let git_wt = GitWorktree::new(repo_path.clone())
+            .unwrap()
+            .allow_submodule_file_transport();
+        let worktree_parent = TempDir::new().unwrap();
+        let from = worktree_parent.path().join("source");
+        git_wt
+            .create_worktree("test-move", &from, false, None)
+            .unwrap();
+
+        let outer = from.join(".claude");
+        let nested = outer.join("nested");
+        assert!(
+            nested.join("inner.md").is_file(),
+            "fixture must start with both submodule levels populated"
+        );
+
+        // Local work at both levels, of both kinds `submodule deinit` objects to.
+        std::fs::write(outer.join("mid.md"), "edited outer\n").unwrap();
+        std::fs::write(outer.join("scratch.txt"), "outer scratch\n").unwrap();
+        std::fs::write(nested.join("inner.md"), "edited nested\n").unwrap();
+        std::fs::write(nested.join("scratch.txt"), "nested scratch\n").unwrap();
+
+        // One level deeper than the source, so every relative pointer that the
+        // move has to rewrite actually changes.
+        let to = worktree_parent.path().join("nested-dest").join("moved");
+        std::fs::create_dir_all(to.parent().unwrap()).unwrap();
+        git_wt.move_worktree(&from, &to).unwrap();
+
+        assert!(!from.exists(), "source should be gone after the move");
+        let moved_outer = to.join(".claude");
+        let moved_nested = moved_outer.join("nested");
+
+        for (path, expected) in [
+            (moved_outer.join("mid.md"), "edited outer\n"),
+            (moved_outer.join("scratch.txt"), "outer scratch\n"),
+            (moved_nested.join("inner.md"), "edited nested\n"),
+            (moved_nested.join("scratch.txt"), "nested scratch\n"),
+        ] {
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                expected,
+                "{} should survive the move byte for byte",
+                path.display()
+            );
+        }
+
+        // Every repository in the moved tree has to be usable, which is what
+        // fails when either pointer direction is left stale: the parent's
+        // `git status` dies with `cannot chdir` on a stale `core.worktree`.
+        git_stdout(&to, &["status", "--short"]);
+        git_stdout(&to, &["submodule", "status", "--recursive"]);
+        git_stdout(&moved_outer, &["log", "--oneline", "-1"]);
+        git_stdout(&moved_nested, &["log", "--oneline", "-1"]);
+
+        // Git's own bookkeeping, from both ends.
+        let listed = git_stdout(&repo_path, &["worktree", "list", "--porcelain"]);
+        let expected_worktree = to.canonicalize().unwrap();
+        assert!(
+            listed
+                .lines()
+                .any(|l| l.strip_prefix("worktree ").map(Path::new)
+                    == Some(expected_worktree.as_path())),
+            "the main repo should list the worktree at its new path, got:\n{listed}"
+        );
+        assert!(
+            listed.contains("locked"),
+            "the relocated worktree should be locked again, got:\n{listed}"
+        );
+    }
+
+    /// The submodule probe must not divert an ordinary worktree onto the manual
+    /// path, so a repo without submodules keeps going through
+    /// `git worktree move`.
+    #[test]
+    fn test_worktree_has_submodule_admin_state_is_false_without_submodules() {
+        let (repo_dir, _repo) = setup_test_repo();
+        let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
+        let worktree_parent = TempDir::new().unwrap();
+        let wt_path = worktree_parent.path().join("plain");
+        git_wt
+            .create_worktree("plain-branch", &wt_path, true, None)
+            .unwrap();
+
+        assert!(!worktree_has_submodule_admin_state(&wt_path));
     }
 
     #[test]

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1483,7 +1483,7 @@ impl GitWorktree {
     /// pointing at the old path, so always go through git here.
     ///
     /// A worktree with submodules cannot go through `git worktree move` at all
-    /// and takes [`Self::relocate_worktree_with_submodules`] instead.
+    /// and takes `relocate_worktree_with_submodules` instead.
     pub fn move_worktree(&self, from: &Path, to: &Path) -> Result<()> {
         if !from.exists() {
             return Err(GitError::WorktreeNotFound(from.to_path_buf()));


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`git worktree move` refuses whenever the linked worktree's admin dir holds `modules/<sub>`, so every aoe path that relocates a worktree was broken for any repo with submodules:

- attach-project's move of the session's own worktree into a new workspace (`src/session/attach_project.rs`)
- trash relocate and restore (`src/session/trash.rs`)
- worktree directory rename (`src/session/worktree_edit.rs`)

One user with a `.claude` submodule in every repo had 200 of these failures in `debug.log` across 50 sessions, with the trash reconcile retrying the same doomed command on every pass, forever.

Git's refusal keys on that admin dir alone, not on whether the submodule checkout is populated, so `git submodule deinit` cannot lift it: the admin dir survives a deinit. Verified on git 2.54.0, `git worktree move` and `git worktree remove` both still refuse afterwards. Worse, `deinit` without `-f` refuses when the submodule has any local modification including a single untracked file, and with `-f` it discards that work.

So this moves the checkout as it stands. Where `git worktree move` would refuse, aoe now records where each populated submodule's git dir resolves to, renames the directory, lets `git worktree repair` re-derive the linked-worktree bookkeeping from the new path, then rewrites each submodule's `.git` pointer and its `core.worktree`. Both directions matter: with only the `.git` pointer fixed, git resolves the stale `core.worktree` and every command in the parent worktree dies with `cannot chdir`. The submodule situation is detected from the admin dir up front, so an ordinary move of a submodule worktree no longer spends a doomed command and its WARN, and the existing stderr classifier stays as a backstop.

Failure contract: an `Err` from the manual path always leaves the checkout at the source path, because callers roll back on that assumption. `attach_project` only records the move in its `Undo` once the move returns `Ok`, so an `Err` after a real move would strand the worktree at the destination with the session still pointing at the old path. The two steps that can fail cheaply, the rename and the repair, run first, while undoing them is a single rename back. Past that point the worktree is registered at the destination, so a failed submodule pointer rewrite is reported at ERROR with the `git submodule update --init --recursive` that restores it, rather than reversed.

Also removes `deinit_submodules_if_present` from the delete path. Same evidence: it never lifted the refusal, so deletes only ever succeeded through `manual_submodule_worktree_cleanup`, which removes the admin dir directly. It cost a git spawn per delete and, with `-f`, could discard submodule work for nothing. `run_git_quiet` loses its last production caller with it, so it goes too and its logging test moves to the `run_git_quiet_with_timeout` pair that carries the same invariant.

Two follow-ups this deliberately does not take on:

- `move_worktree` returns `Result<()>`, which cannot express "moved but not fully repaired". The pre-existing timeout-indeterminate branch already returns `Err` in cases where the directory may have moved, so the same contract gap predates this change. A location-aware outcome type plus the four call sites is its own change.
- A linked worktree of a submodule physically nested under the moved parent would move without repair. aoe never creates that layout and `submodule foreach` does not report it.

Closes #3695

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Take any repo with an initialised submodule, start a session on it, then attach a second repo to that session. The session converts to a multi-repo workspace instead of failing with `could not move this session's worktree into ...: working trees containing submodules cannot be moved or removed`.
- [ ] In the moved workspace, confirm the submodule is still populated and that `git status` in the session's worktree and `git log` inside the submodule both work.
- [ ] Before attaching, leave an uncommitted edit and an untracked file inside the submodule. After the attach, confirm both are still there unchanged.
- [ ] Trash that session, then restore it. Both relocations succeed, and `debug.log` has no new `trash worktree reconcile relocation failed` warning.
- [ ] Rename the worktree directory of a session on a submodule repo. The directory moves instead of erroring.
- [ ] Delete a session on a submodule repo. It still deletes cleanly, and `debug.log` no longer shows a `submodule deinit` before the removal.
- [ ] Repeat the attach on a repo with no submodules and confirm nothing changed about it.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the defect and its repair both live in `GitWorktree::move_worktree`, and the regression is covered there by a unit test with a real two-level submodule fixture. `test_move_worktree_relocates_nested_submodules_and_keeps_local_changes` builds `main -> .claude -> .claude/nested` over local `file://` clones, leaves an uncommitted edit and an untracked file at both levels, moves the worktree one directory deeper so every relative pointer actually changes, then asserts all four files survive byte for byte, that `git status`, `git submodule status --recursive` and `git log` inside both submodules all succeed, and that the main repo lists the worktree at its new path and locked again. Verified red on the pre-fix tree with `fatal: working trees containing submodules cannot be moved or removed`, the exact reported symptom. The three session-level call sites are thin `move_worktree` callers whose own tests are pure-logic unit tests with no git fixtures, so duplicating a submodule fixture at each of them would cost compile time without catching anything the git-layer test misses.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code)

**Any Additional AI Details you'd like to share:**

Investigation, plan and implementation drafted by Claude under my direction. Every empirical claim above was verified against real git rather than assumed, the design was pressure-tested against two other models before implementation, and I made the design calls and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added safe worktree relocation for repositories with initialized or nested submodules.
- Preserved submodule checkouts, local changes, and untracked files during relocation.
- Repaired Git worktree metadata and submodule pointers after moves.
- Updated attach-project, trash relocation and restoration, and worktree rename flows.
- Refused relocation when submodules contain uncommitted changes.
- Removed ineffective submodule deinitialization from deletion cleanup.
- Removed the unused `run_git_quiet` helper.
- Added regression coverage for submodule moves, state preservation, and related worktree operations.

## Benefits

Worktree relocation now works with submodules without discarding local state. Git operations remain usable after relocation, and affected attach-project and trash workflows no longer fail repeatedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->