### PR TITLE
chore: release v1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to Agent of Empires will be documented in this file.
 
 The format follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [1.15.2](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.15.2) - 2026-09-02
+
+
+
+### Bug Fixes
+
+- Persist TUI group deletion in [#3565](https://github.com/agent-of-empires/agent-of-empires/pull/3565) by [@jerome-benoit](https://github.com/jerome-benoit) ([`4008b29`](https://github.com/agent-of-empires/agent-of-empires/commit/4008b29da3979760e9559b8a6b7733a2ceafd169))
+- **session:** Stop sessions opening on an agent folder-trust prompt in [#3589](https://github.com/agent-of-empires/agent-of-empires/pull/3589) by [@njbrake](https://github.com/njbrake) ([`0bcdffb`](https://github.com/agent-of-empires/agent-of-empires/commit/0bcdffb2547fefd94b70b0f0cec066777f79f94e))
+- **tmux:** Require a selected option before reading an approval prompt in [#3563](https://github.com/agent-of-empires/agent-of-empires/pull/3563) by [@blueagledev](https://github.com/blueagledev) ([`ed16ca6`](https://github.com/agent-of-empires/agent-of-empires/commit/ed16ca684c77ea01189eb9fe734c6fa0fedc9e3c))
+- **acp:** Gate the debug-only handshake-failure import in [#3597](https://github.com/agent-of-empires/agent-of-empires/pull/3597) by [@njbrake](https://github.com/njbrake) ([`2827780`](https://github.com/agent-of-empires/agent-of-empires/commit/28277809adc3d0c575946d84b2d2d0a51c3aa4e2))
+- Recover from half-closed runner relay in [#3578](https://github.com/agent-of-empires/agent-of-empires/pull/3578) by [@aaiyer](https://github.com/aaiyer) ([`9dc2420`](https://github.com/agent-of-empires/agent-of-empires/commit/9dc2420ece3d3cd7b204bc48adb16450d1cade97))
+- **session:** Make Pi's conversation authoritative instead of guessed in [#3579](https://github.com/agent-of-empires/agent-of-empires/pull/3579) by [@njbrake](https://github.com/njbrake) ([`c050d6f`](https://github.com/agent-of-empires/agent-of-empires/commit/c050d6f308617a9fe36840724457acda9ef38dbd))
+- Capture compressed Codex rollouts in [#3580](https://github.com/agent-of-empires/agent-of-empires/pull/3580) by [@mikemikimike](https://github.com/mikemikimike) ([`6dd64b1`](https://github.com/agent-of-empires/agent-of-empires/commit/6dd64b1bb96272975b5071dda748888b7c852431))
+- **acp:** Default the structured-view agent to claude-code in [#3583](https://github.com/agent-of-empires/agent-of-empires/pull/3583) by [@njbrake](https://github.com/njbrake) ([`a4001cb`](https://github.com/agent-of-empires/agent-of-empires/commit/a4001cb1e47cb92d1e445a84be7766863994d666))
+- **acp:** Stop the queue drain delivering into a running turn in [#3618](https://github.com/agent-of-empires/agent-of-empires/pull/3618) by [@njbrake](https://github.com/njbrake) ([`1e7c236`](https://github.com/agent-of-empires/agent-of-empires/commit/1e7c236892318a4e293996f5d6a4893abd94af74))
+- **tmux:** Stop a parallel refresh clobbering a forced session cache in [#3598](https://github.com/agent-of-empires/agent-of-empires/pull/3598) by [@njbrake](https://github.com/njbrake) ([`6a4e873`](https://github.com/agent-of-empires/agent-of-empires/commit/6a4e8733c487485514bf2f614e234e580f1d308f))
+- Preserve utf-8 names when stopping sessions in [#3584](https://github.com/agent-of-empires/agent-of-empires/pull/3584) by [@xianjianlf2](https://github.com/xianjianlf2) ([`4f6356f`](https://github.com/agent-of-empires/agent-of-empires/commit/4f6356f729d614761dc4b164408975f6fabfbb76))
+- **tests:** Isolate opencode data paths in the live harness in [#3634](https://github.com/agent-of-empires/agent-of-empires/pull/3634) by [@njbrake](https://github.com/njbrake) ([`37d3f4c`](https://github.com/agent-of-empires/agent-of-empires/commit/37d3f4c18b582d61ec9acf393b7f1e4b099405a2))
+- **tmux:** Close the vt resync snapshot/reader race in [#3636](https://github.com/agent-of-empires/agent-of-empires/pull/3636) by [@njbrake](https://github.com/njbrake) ([`b4ac181`](https://github.com/agent-of-empires/agent-of-empires/commit/b4ac18131cea68bf6ce8f3edeb7c122fbcbb0897))
+- **status:** Restore Vibe's vertical activity text and braille-only spinner in [#3635](https://github.com/agent-of-empires/agent-of-empires/pull/3635) by [@njbrake](https://github.com/njbrake) ([`cbbd951`](https://github.com/agent-of-empires/agent-of-empires/commit/cbbd95198f69fef1495885935307e38bea6072fd))
+- **status:** Apply configured rule precedence and date the activity stamp in [#3633](https://github.com/agent-of-empires/agent-of-empires/pull/3633) by [@njbrake](https://github.com/njbrake) ([`3aaba92`](https://github.com/agent-of-empires/agent-of-empires/commit/3aaba923b2c1495ac370b6128311a4a117c8f1bf))
+- **session:** Seed folder trust in the config dir a custom agent reads in [#3599](https://github.com/agent-of-empires/agent-of-empires/pull/3599) by [@njbrake](https://github.com/njbrake) ([`778ca04`](https://github.com/agent-of-empires/agent-of-empires/commit/778ca045a68d72bb7299f37662ce8d2feefbe799))
+- **tmux:** Frame batched hidden env reads so continuations cannot spoof a key in [#3628](https://github.com/agent-of-empires/agent-of-empires/pull/3628) by [@njbrake](https://github.com/njbrake) ([`22ac1e1`](https://github.com/agent-of-empires/agent-of-empires/commit/22ac1e17aad59c5d816c61c3c6042dfbb99d4923))
+- **acp:** Give prompt submission one per-session authority in [#3639](https://github.com/agent-of-empires/agent-of-empires/pull/3639) by [@njbrake](https://github.com/njbrake) ([`51ee1e8`](https://github.com/agent-of-empires/agent-of-empires/commit/51ee1e81e3411f27077e2303bab8824d429374d0))
+- **tui:** Remove every synchronous tmux command from the paint path in [#3537](https://github.com/agent-of-empires/agent-of-empires/pull/3537) by [@jerome-benoit](https://github.com/jerome-benoit) ([`e8ac1c4`](https://github.com/agent-of-empires/agent-of-empires/commit/e8ac1c4d2859d1bd0617096325c7a3966f898e4a))
+- **status:** Carry detection state across every poll boundary in [#3672](https://github.com/agent-of-empires/agent-of-empires/pull/3672) by [@njbrake](https://github.com/njbrake) ([`e51297c`](https://github.com/agent-of-empires/agent-of-empires/commit/e51297c4e7d9d5dedf0e362525c9bb2dc1263afe))
+- **tmux:** Detect OMP 18.0.10 active turns in [#3586](https://github.com/agent-of-empires/agent-of-empires/pull/3586) by [@jerome-benoit](https://github.com/jerome-benoit) ([`9740549`](https://github.com/agent-of-empires/agent-of-empires/commit/9740549405ab61d0c71546b4ba27910830e0e3c1))
+- **acp:** Complete the per-session prompt-submission barrier in [#3673](https://github.com/agent-of-empires/agent-of-empires/pull/3673) by [@njbrake](https://github.com/njbrake) ([`6ed1e0c`](https://github.com/agent-of-empires/agent-of-empires/commit/6ed1e0c77c19a5b65390c6a7719684a5cecc1b1a))
+- **acp:** Align aoe-agent node, sdk and model contracts in [#3656](https://github.com/agent-of-empires/agent-of-empires/pull/3656) by [@zerone0x](https://github.com/zerone0x) ([`919b711`](https://github.com/agent-of-empires/agent-of-empires/commit/919b711470128c7e38581d98a45457b110cd331a))
+- **agents:** Disable Qwen and Kiro resume without capture in [#3570](https://github.com/agent-of-empires/agent-of-empires/pull/3570) by [@jerome-benoit](https://github.com/jerome-benoit) ([`e82a046`](https://github.com/agent-of-empires/agent-of-empires/commit/e82a0467a73d38ce3242b0bf8c33844ec7372c13))
+- **tui:** Publish a capture-pane frame before arming the VT channel on retarget in [#3690](https://github.com/agent-of-empires/agent-of-empires/pull/3690) by [@njbrake](https://github.com/njbrake) ([`ef3c340`](https://github.com/agent-of-empires/agent-of-empires/commit/ef3c340f14e7409ca55444f9371f80253451e0a0))
+- **worktree:** Relocate worktrees that have submodules instead of failing on git's refusal in [#3696](https://github.com/agent-of-empires/agent-of-empires/pull/3696) by [@Seluj78](https://github.com/Seluj78) ([`a63675c`](https://github.com/agent-of-empires/agent-of-empires/commit/a63675c69988c3531ff67e48ae386c3c46dc1513))
+- **sv:** Rebuild the runtime on a fold change in [#3676](https://github.com/agent-of-empires/agent-of-empires/pull/3676) by [@xande](https://github.com/xande) ([`a6e1d0f`](https://github.com/agent-of-empires/agent-of-empires/commit/a6e1d0f307f3222f8a02591f0f6fe1b99e037835))
+
+
+### Features
+
+- Add prime-agent support in [#3486](https://github.com/agent-of-empires/agent-of-empires/pull/3486) by [@jerome-benoit](https://github.com/jerome-benoit) ([`ecbdf5d`](https://github.com/agent-of-empires/agent-of-empires/commit/ecbdf5d34171e107296522d10294496c442f2ec7))
+
+
+### Performance
+
+- **tui:** Cut idle subprocess churn and render-thread capture forks in [#3612](https://github.com/agent-of-empires/agent-of-empires/pull/3612) by [@njbrake](https://github.com/njbrake) ([`90bc4aa`](https://github.com/agent-of-empires/agent-of-empires/commit/90bc4aa6ef4efa359692c402f4d6c8aeebf4ef99))
+- **tui:** Move trashed-row reconciliation off the first-frame path in [#3615](https://github.com/agent-of-empires/agent-of-empires/pull/3615) by [@njbrake](https://github.com/njbrake) ([`95a9edd`](https://github.com/agent-of-empires/agent-of-empires/commit/95a9eddc4df1e892097a27049aa01f44386f78b3))
+
+
+
+### New Contributors
+
+- [@xande](https://github.com/xande) made their first contribution in [#3676](https://github.com/agent-of-empires/agent-of-empires/pull/3676)
+- [@xianjianlf2](https://github.com/xianjianlf2) made their first contribution in [#3584](https://github.com/agent-of-empires/agent-of-empires/pull/3584)
+- [@mikemikimike](https://github.com/mikemikimike) made their first contribution in [#3580](https://github.com/agent-of-empires/agent-of-empires/pull/3580)
+
+**Full Changelog**: https://github.com/agent-of-empires/agent-of-empires/compare/v1.15.1...v1.15.2
 ## [1.15.1](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.15.1) - 2026-08-28
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agent-of-empires"
-version = "1.15.1"
+version = "1.15.2"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask", "aoe-settings-derive", "aoe-plugin-api"]
 
 [package]
 name = "agent-of-empires"
-version = "1.15.1"
+version = "1.15.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Agent of Empires Contributors"]


### PR DESCRIPTION
<!-- release-version: 1.15.2 -->

Automated weekly release-staging PR (#1140).

**Current:** `v1.15.1`  
**Proposed:** `v1.15.2` (bump: `patch`)

If you want a different semver bump, edit `Cargo.toml` + `Cargo.lock` on this branch, push the change, and the merge tagger will use whatever version is in `Cargo.toml` at merge time. The `<!-- release-version: ... -->` marker above is cross-checked by the tagger and must match.

## Changes since v1.15.1

- fix(sv): rebuild the runtime on a fold change (#3676) (`a6e1d0f3`, Alex Baranov, 2026-09-02)
- fix(worktree): relocate worktrees that have submodules instead of failing on git's refusal (#3696) (`a63675c6`, Jules Lasne, 2026-09-02)
- fix(tui): publish a capture-pane frame before arming the VT channel on retarget (#3690) (`ef3c340f`, Nathan Brake, 2026-09-01)
- fix(agents): disable Qwen and Kiro resume without capture (#3570) (`e82a0467`, Jérôme Benoit, 2026-09-01)
- fix(acp): align aoe-agent node, sdk and model contracts (#3656) (`919b7114`, zerone0x, 2026-09-02)
- test(tmux): drive size-owner resize deadlines by command count (#3684) (`652843b4`, Nathan Brake, 2026-09-01)
- fix(acp): complete the per-session prompt-submission barrier (#3673) (`6ed1e0c7`, Nathan Brake, 2026-09-01)
- fix(tmux): detect OMP 18.0.10 active turns (#3586) (`97405494`, Jérôme Benoit, 2026-09-01)
- fix(status): carry detection state across every poll boundary (#3672) (`e51297c4`, Nathan Brake, 2026-09-01)
- refactor(tmux): drop the orphaned resize_window chain (#3677) (`6ca06950`, Nathan Brake, 2026-09-01)
- fix(tui): remove every synchronous tmux command from the paint path (#3537) (`e8ac1c4d`, Jérôme Benoit, 2026-09-01)
- docs(fork): correct the inline structured-fork capability comment (#3675) (`507db0cb`, Nathan Brake, 2026-09-01)
- docs: correct stale hook, fork, and module-ownership pointers (#3671) (`bb6aad66`, Nathan Brake, 2026-09-01)
- fix(acp): give prompt submission one per-session authority (#3639) (`51ee1e81`, Nathan Brake, 2026-08-31)
- perf(tui): move trashed-row reconciliation off the first-frame path (#3615) (`95a9eddc`, Nathan Brake, 2026-08-31)
- fix(tmux): frame batched hidden env reads so continuations cannot spoof a key (#3628) (`22ac1e17`, Nathan Brake, 2026-08-31)
- fix(session): seed folder trust in the config dir a custom agent reads (#3599) (`778ca045`, Nathan Brake, 2026-08-31)
- fix(status): apply configured rule precedence and date the activity stamp (#3633) (`3aaba923`, Nathan Brake, 2026-08-31)
- fix(status): restore Vibe's vertical activity text and braille-only spinner (#3635) (`cbbd9519`, Nathan Brake, 2026-08-31)
- fix(tmux): close the vt resync snapshot/reader race (#3636) (`b4ac1813`, Nathan Brake, 2026-08-31)
- docs: drop stale aoe-agent fallback claims from ACP comments (#3637) (`89e4d0dd`, Nathan Brake, 2026-08-31)
- fix(tests): isolate opencode data paths in the live harness (#3634) (`37d3f4c1`, Nathan Brake, 2026-08-31)
- fix: preserve utf-8 names when stopping sessions (#3584) (`4f6356f7`, Mark Xian, 2026-09-01)
- fix(tmux): stop a parallel refresh clobbering a forced session cache (#3598) (`6a4e8733`, Nathan Brake, 2026-08-31)
- refactor(tmux): drop the write-only hidden env cache (#3620) (`d90e5531`, Nathan Brake, 2026-08-31)
- fix(acp): stop the queue drain delivering into a running turn (#3618) (`1e7c2368`, Nathan Brake, 2026-08-31)
- refactor(status): decide pane status from a rule table, not a chain (#3600) (`faab441c`, Nathan Brake, 2026-08-31)
- perf(tui): cut idle subprocess churn and render-thread capture forks (#3612) (`90bc4aa6`, Nathan Brake, 2026-08-31)
- chore(deps): bump @assistant-ui/react from 0.15.14 to 0.15.16 in /web (#3607) (`db1db011`, dependabot[bot], 2026-08-31)
- fix(acp): default the structured-view agent to claude-code (#3583) (`a4001cb1`, Nathan Brake, 2026-08-31)
- test(session): re-force the tmux cache before each probe in the resolved-name status test (#3613) (`4cdb37df`, Nathan Brake, 2026-08-31)
- chore(deps-dev): bump jsdom from 29.1.1 to 30.0.1 in /web (#3606) (`a3728a2f`, dependabot[bot], 2026-08-31)
- chore(deps): bump @assistant-ui/react-markdown from 0.14.10 to 0.14.12 in /web (#3605) (`556437b4`, dependabot[bot], 2026-08-31)
- chore(deps): bump @agentclientprotocol/codex-acp (#3610) (`780d8d6e`, dependabot[bot], 2026-08-31)
- chore(deps-dev): bump oxfmt from 0.62.0 to 0.63.0 in /web (#3604) (`5c8f405a`, dependabot[bot], 2026-08-31)
- chore(deps): bump the ai-sdk group (#3608) (`1b09d0ab`, dependabot[bot], 2026-08-31)
- chore(deps): bump taiki-e/install-action (#3602) (`33aadd86`, dependabot[bot], 2026-08-31)
- chore(deps): bump @agentclientprotocol/claude-agent-acp (#3609) (`9113feb6`, dependabot[bot], 2026-08-31)
- chore(deps): bump the web-minor-patch group in /web with 9 updates (#3603) (`8a4336f6`, dependabot[bot], 2026-08-31)
- fix: capture compressed Codex rollouts (#3580) (`6dd64b1b`, mikemikimike, 2026-08-31)
- fix(session): make Pi's conversation authoritative instead of guessed (#3579) (`c050d6f3`, Nathan Brake, 2026-08-30)
- fix: recover from half-closed runner relay (#3578) (`9dc2420e`, Anand Aiyer, 2026-08-31)
- fix(acp): gate the debug-only handshake-failure import (#3597) (`28277809`, Nathan Brake, 2026-08-30)
- chore: make git blame work across the three hotspot splits (#3596) (`560d20c4`, Nathan Brake, 2026-08-30)
- refactor(tui): split home/mod.rs into per-concern modules (#3595) (`d649c3d9`, Nathan Brake, 2026-08-30)
- refactor(server): split server/mod.rs into per-concern modules (#3594) (`8827701d`, Nathan Brake, 2026-08-30)
- refactor(acp): split acp_client.rs into per-concern modules (#3593) (`f197ae07`, Nathan Brake, 2026-08-30)
- fix(tmux): require a selected option before reading an approval prompt (#3563) (`ed16ca68`, blueagle.dev, 2026-08-30)
- fix(session): stop sessions opening on an agent folder-trust prompt (#3589) (`0bcdffb2`, Nathan Brake, 2026-08-30)
- ci: move CodeQL to advanced setup and filter test-only alerts (#3591) (`2525dce2`, Nathan Brake, 2026-08-30)
- fix: persist TUI group deletion (#3565) (`4008b29d`, Jérôme Benoit, 2026-08-30)
- chore: make git blame work across the instance.rs split (#3590) (`c66f9f7d`, Nathan Brake, 2026-08-30)
- refactor(session): split instance.rs into per-concern modules (#3587) (`7f0fb177`, Nathan Brake, 2026-08-30)
- docs: ask changes to prune the comments they touch (#3585) (`0246333d`, Nathan Brake, 2026-08-29)
- docs: reduce repository documentation and comments (#3574) (`1929ce52`, Nathan Brake, 2026-08-28)
- feat: add prime-agent support (#3486) (`ecbdf5d3`, Jérôme Benoit, 2026-08-28)

## Maintainer checklist

- [ ] Version bump is appropriate for the change set
- [ ] No breaking changes hidden under `refactor:` / `chore:`
- [ ] CI is green
- [ ] Ready to ship — merge this PR to publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prepared the `v1.15.2` patch release.
- Added fixes for sessions, ACP agents, tmux integration, TUI rendering, status detection, and worktrees.
- Added Prime Agent support.
- Improved TUI performance.
- Updated tests, documentation, CI, dependencies, and related refactors.
- Updated the package version and changelog.

These changes improve stability, performance, and agent integration. Further enhancement may include continued testing across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->