### PR TITLE
fix(ci): key the PR-template escape hatches on the head branch

### DIFF
--- a/.github/workflows/nix-npm-hash.yml
+++ b/.github/workflows/nix-npm-hash.yml
@@ -129,7 +129,9 @@ jobs:
               --label automated | tail -n1)
             PR_NUMBER="${PR_URL##*/}"
           else
-            gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
+            # Re-assert the label; pr-template-check.yml's close-stale job
+            # keys this PR's exemption on it.
+            gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md --add-label automated
           fi
 
           # Fails loudly if "Allow auto-merge" is disabled at repo level.

--- a/.github/workflows/nix-npm-hash.yml
+++ b/.github/workflows/nix-npm-hash.yml
@@ -88,8 +88,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # PR body must contain `## Checklist` + "I understand the code
-          # I am submitting" to satisfy pr-template-check.yml.
+          # pr-template-check.yml exempts this PR on the head branch plus
+          # the `<!-- nix-npm-hash: -->` marker and `## Checklist` below.
           {
             echo "<!-- nix-npm-hash: ${NEW_HASH} -->"
             echo

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -2,7 +2,7 @@ name: PR Template Check
 
 on:
   # Use pull_request_target to have write access for PRs from forks
-  # This is safe because we only read the PR body from the event payload
+  # This is safe because we only read PR metadata from the event payload
   # and don't checkout or execute any code from the fork
   pull_request_target:
     types: [opened, edited]
@@ -16,8 +16,7 @@ jobs:
     # triggered the event; on an `edited` event fired by a maintainer or
     # another bot the actor is the editor, so a github.actor guard would let
     # the check run against Dependabot's templateless body. Matches the
-    # close-stale job and the nix-npm-hash escape hatch, which both key on
-    # pull_request.user.login.
+    # close-stale job, which keys on the same field.
     if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
@@ -54,18 +53,18 @@ jobs:
             // branch in the base repo needs push access, so a fork cannot
             // opt out of enforcement by pasting a marker into its body.
             const head = context.payload.pull_request.head;
-            const isInternalBranch =
+            const isInternalRepo =
               head?.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`;
             const headRef = head?.ref || '';
 
             const isNixNpmHashBotPr =
-              isInternalBranch &&
+              isInternalRepo &&
               headRef === 'chore/nix-npm-hash-update' &&
               body.includes('<!-- nix-npm-hash:') &&
               body.includes('## Checklist');
 
             const isReleaseStagingBotPr =
-              isInternalBranch &&
+              isInternalRepo &&
               headRef.startsWith('release-staging/v') &&
               body.includes('<!-- release-version:');
 

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -43,27 +43,30 @@ jobs:
               body.includes('## Test Coverage Analysis') &&
               body.includes('## AI Usage');
 
-            // Escape hatch for trusted internal automation: the
-            // nix-npm-hash bot (`.github/workflows/nix-npm-hash.yml`)
-            // emits a body with only `## Checklist` plus a
-            // `<!-- nix-npm-hash: -->` marker. Gate this on actor
-            // login = github-actions[bot] so a human PR cannot opt
-            // out of template enforcement by dropping the marker
-            // into its body.
-            const actor = context.payload.pull_request.user?.login;
+            // Escape hatches for trusted internal automation, whose body
+            // is not the contributor template: the nix-npm-hash bot
+            // (`.github/workflows/nix-npm-hash.yml`) and the weekly
+            // release-staging PR (`.github/workflows/open-release-pr.yml`).
+            //
+            // Both open their PR with `secrets.RELEASE_TOKEN`, so the
+            // author is the token owner, not github-actions[bot]. Key on
+            // the head branch, as `tag-release-pr.yml` does: creating a
+            // branch in the base repo needs push access, so a fork cannot
+            // opt out of enforcement by pasting a marker into its body.
+            const head = context.payload.pull_request.head;
+            const isInternalBranch =
+              head?.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            const headRef = head?.ref || '';
+
             const isNixNpmHashBotPr =
-              actor === 'github-actions[bot]' &&
+              isInternalBranch &&
+              headRef === 'chore/nix-npm-hash-update' &&
               body.includes('<!-- nix-npm-hash:') &&
               body.includes('## Checklist');
 
-            // Escape hatch for the weekly release-staging PR
-            // (`.github/workflows/open-release-pr.yml`), whose body is a
-            // version bump plus changelog, not the contributor template.
-            // It carries a `<!-- release-version: -->` marker; gate on
-            // actor login = github-actions[bot] so a human PR cannot opt
-            // out by pasting the marker into its body.
             const isReleaseStagingBotPr =
-              actor === 'github-actions[bot]' &&
+              isInternalBranch &&
+              headRef.startsWith('release-staging/v') &&
               body.includes('<!-- release-version:');
 
             const hasChecklist =
@@ -182,12 +185,20 @@ jobs:
                 continue;
               }
 
-              // Skip the weekly release-staging PR; its body is exempt
-              // from the template check above, so it should never be
-              // closed for missing it.
-              if (pr.user?.login === 'github-actions[bot]' &&
-                  (pr.body || '').includes('<!-- release-version:')) {
+              // Skip the automation PRs the check above exempts. This
+              // listing returns issue payloads, which carry no head
+              // branch, so key on the label the opening workflow applies;
+              // only a maintainer can set one.
+              const prBody = pr.body || '';
+              const prLabels = (pr.labels || []).map(l => l.name);
+              if (prLabels.includes('release-staging') &&
+                  prBody.includes('<!-- release-version:')) {
                 console.log(`Skipping release-staging PR #${pr.number}`);
+                continue;
+              }
+              if (prLabels.includes('automated') &&
+                  prBody.includes('<!-- nix-npm-hash:')) {
+                console.log(`Skipping nix-npm-hash PR #${pr.number}`);
                 continue;
               }
 


### PR DESCRIPTION
## Description

`open-release-pr.yml` and `nix-npm-hash.yml` both create their PR with `secrets.RELEASE_TOKEN`, so the author is the token owner, never `github-actions[bot]`. Both escape hatches in `pr-template-check.yml` gated on that bot login, so neither has ever fired.

Two consequences. `check-template` fails on every release PR at `opened`, then flips green on a later `edited` event only because `missing-template` is already set and the script returns before `setFailed`; that label on #3697 and #3698 is this bug, not a real template miss. More seriously, `close-stale` does not skip those PRs, so a release or hash-bump PR left open across a 24h boundary gets auto-closed with a "create a new PR using the template" comment. It has not fired yet purely by timing: #2859 (v1.13.0) was labeled 13.7h when the midnight run checked it.

`check-template` now keys on the head branch plus the body marker, matching the gate `tag-release-pr.yml` already applies. Creating a branch in the base repo needs push access, so a fork cannot claim one by pasting a marker. `close-stale` reads issue payloads that carry no head branch, so it keys on the `release-staging` / `automated` label plus the marker.

## PR Type

- [x] Bug Fix
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A, no UI change)

Workflow-only change, so no Rust or web code is touched. Verified by extracting both inline scripts and replaying them against simulated payloads with stubbed `github` / `context` / `core`:

- release-staging and nix-npm-hash PRs on internal branches are exempt; a normal PR with the full template is exempt; a stripped template is still flagged.
- Fork PRs that paste either marker **and** name their branch `release-staging/v9.9.9` or `chore/nix-npm-hash-update` are still flagged, so the hatch is not forgeable.
- A release PR authored by `github-actions[bot]` stays exempt, so the fix survives a switch back to `GITHUB_TOKEN`.
- `close-stale` on the current script closes only the genuine stale contributor PR. On `main` the same input also closes the release and hash-bump PRs.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Found while reviewing the v1.15.2 release PR. The root cause and the fix were worked out in discussion with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated CI exemptions for release and Nix/NPM hash-bump pull requests.
- Trusted automation now uses internal branches, labels, and body markers instead of author identity.
- Refreshed hash-bump pull requests retain the `automated` label.
- Fork branches cannot use these exemptions.
- Updated workflow comments to match the new checks.

## Benefits

- Prevents valid automated pull requests from failing template checks.
- Prevents stale automation pull requests from being closed incorrectly.
- Keeps the existing `github-actions[bot]` exemption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->