### PR TITLE
fix(ci): constrain the Nix hash PR lookup to the base repository

### DIFF
--- a/.github/scripts/select-internal-pr.py
+++ b/.github/scripts/select-internal-pr.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Pick the one open PR from a base-repo branch, or fail closed.
+
+`gh pr list --head <branch>` matches on the branch name alone; its help states
+that `<owner>:<branch>` is not supported. A fork can open a PR from a branch
+with the same name, and automation that takes `.[0]` from that list can then
+edit, label and `gh pr merge --auto` a contributor's PR instead of its own.
+
+This reads a `gh pr list --json ...` array on stdin and keeps only candidates
+whose head repository is the base repository and whose head and base branches
+are the expected ones. Exactly one match prints its number; no match prints
+nothing (the caller opens the PR); anything else is an error, so an ambiguous
+list stops the workflow before it mutates a PR.
+
+Usage:
+    gh pr list --head "$BRANCH" --state open \\
+      --json number,headRefName,headRepository,baseRefName \\
+      | python3 .github/scripts/select-internal-pr.py \\
+          --repo "$BASE_REPO" --head "$BRANCH" --base main
+
+    python3 .github/scripts/select-internal-pr.py --self-test
+"""
+
+import argparse
+import json
+import sys
+
+
+class SelectionError(Exception):
+    pass
+
+
+def _head_repo(candidate):
+    """`headRepository.nameWithOwner`, or None when the field is absent or null.
+
+    A candidate with no readable head repository can never be proven internal,
+    so it is dropped rather than treated as a match.
+    """
+    repo = candidate.get("headRepository")
+    if not isinstance(repo, dict):
+        return None
+    name = repo.get("nameWithOwner")
+    return name if isinstance(name, str) else None
+
+
+def select(payload, repo, head, base):
+    """Number of the single internal candidate, or None when there is none."""
+    if not isinstance(payload, list):
+        raise SelectionError(f"expected a JSON array of PRs, got {type(payload).__name__}")
+
+    matches = []
+    for candidate in payload:
+        if not isinstance(candidate, dict):
+            raise SelectionError(f"expected PR objects, got {type(candidate).__name__}")
+        # Owner and repository names are case insensitive on GitHub; branch
+        # names are not.
+        if (_head_repo(candidate) or "").casefold() != repo.casefold():
+            continue
+        if candidate.get("headRefName") != head or candidate.get("baseRefName") != base:
+            continue
+        number = candidate.get("number")
+        if not isinstance(number, int) or isinstance(number, bool):
+            raise SelectionError(f"matching PR has no usable number: {candidate!r}")
+        matches.append(number)
+
+    if len(matches) > 1:
+        raise SelectionError(
+            f"{len(matches)} open PRs in {repo} share {head} -> {base} "
+            f"(numbers: {', '.join(str(n) for n in sorted(matches))}); "
+            f"refusing to guess which one the automation owns"
+        )
+    return matches[0] if matches else None
+
+
+def self_test():
+    repo, head, base = "agent-of-empires/agent-of-empires", "chore/nix-npm-hash-update", "main"
+
+    internal = {
+        "number": 100,
+        "headRefName": head,
+        "baseRefName": base,
+        "headRepository": {"nameWithOwner": repo},
+    }
+    # A fork PR from an identically named branch: what `gh pr list --head`
+    # cannot filter out and `.[0]` could otherwise select.
+    fork = {
+        "number": 200,
+        "headRefName": head,
+        "baseRefName": base,
+        "headRepository": {"nameWithOwner": "attacker/agent-of-empires"},
+    }
+
+    cases = [
+        ([], None),
+        ([internal], 100),
+        ([fork], None),
+        ([fork, internal], 100),
+        ([internal, fork], 100),
+        # Casing differences in the repository name are not a fork.
+        ([{**internal, "headRepository": {"nameWithOwner": repo.upper()}}], 100),
+        # Same owner, different repository.
+        ([{**fork, "headRepository": {"nameWithOwner": "agent-of-empires/other"}}], None),
+        # An internal PR targeting another base branch is not this PR.
+        ([{**internal, "baseRefName": "release"}], None),
+        ([{**internal, "headRefName": "chore/nix-npm-hash-update-2"}], None),
+        # A head repository that cannot be read is never assumed internal.
+        ([{**internal, "headRepository": None}], None),
+        ([{k: v for k, v in internal.items() if k != "headRepository"}], None),
+    ]
+    for payload, expected in cases:
+        actual = select(payload, repo, head, base)
+        assert actual == expected, f"{payload!r}: {actual} != {expected}"
+
+    failures = [
+        # Two internal candidates: impossible through the GitHub UI, so treat
+        # it as a broken assumption rather than picking one.
+        [internal, {**internal, "number": 101}],
+        # Malformed payloads must not silently look like "no match".
+        {"number": 100},
+        [None],
+        [{**internal, "number": None}],
+        [{**internal, "number": "100"}],
+    ]
+    for payload in failures:
+        try:
+            select(payload, repo, head, base)
+        except SelectionError:
+            continue
+        raise AssertionError(f"{payload!r} should have failed closed")
+
+    print("OK: internal PR selection picks the base-repo PR and fails closed otherwise.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="base repository as <owner>/<name>")
+    parser.add_argument("--head", help="expected head branch")
+    parser.add_argument("--base", help="expected base branch")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        return 0
+
+    missing = [n for n in ("repo", "head", "base") if not getattr(args, n)]
+    if missing:
+        parser.error(f"missing required argument(s): {', '.join('--' + n for n in missing)}")
+
+    try:
+        payload = json.load(sys.stdin)
+    except ValueError as exc:
+        print(f"::error::could not parse the `gh pr list` output: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        number = select(payload, args.repo, args.head, args.base)
+    except SelectionError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    if number is not None:
+        print(number)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,20 @@ jobs:
           persist-credentials: false
       - run: scripts/verify-shared-target.sh --self-test
 
+  pr-lookup-selftest:
+    name: PR Lookup Self-Test
+    runs-on: ubuntu-latest
+    # Guards the selector nix-npm-hash.yml uses to decide which PR it edits,
+    # labels `automated` and queues for auto-merge. No toolchain: feeds
+    # candidate lists (an internal PR, a fork PR on the same branch name,
+    # both, duplicates) through the selector and asserts it picks the
+    # base-repo PR or fails closed. Runs in seconds.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: python3 .github/scripts/select-internal-pr.py --self-test
+
   nix:
     name: Nix Eval
     runs-on: ubuntu-latest

--- a/.github/workflows/nix-npm-hash.yml
+++ b/.github/workflows/nix-npm-hash.yml
@@ -118,9 +118,12 @@ jobs:
           # from an identically named branch can land in this list. The
           # selector keeps only the base-repo PR and fails closed on an
           # ambiguous set, before anything below edits or auto-merges a PR.
+          # --limit raises the default page of 30 so a crowd of same-named
+          # fork PRs cannot push ours out of the result window.
           PR_NUMBER=$(gh pr list \
             --head "$HEAD_BRANCH" \
             --state open \
+            --limit 100 \
             --json number,headRefName,headRepository,baseRefName \
             | python3 .github/scripts/select-internal-pr.py \
                 --repo "$BASE_REPO" --head "$HEAD_BRANCH" --base main)

--- a/.github/workflows/nix-npm-hash.yml
+++ b/.github/workflows/nix-npm-hash.yml
@@ -85,6 +85,8 @@ jobs:
           OLD_HASH: ${{ steps.hash.outputs.current }}
           NEW_HASH: ${{ steps.hash.outputs.hash }}
           TRIGGER_SHA: ${{ github.sha }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_BRANCH: chore/nix-npm-hash-update
         run: |
           set -euo pipefail
 
@@ -112,18 +114,23 @@ jobs:
             --description "Automated bot PR" \
             --force >/dev/null 2>&1 || true
 
+          # `gh pr list --head` matches the branch name only, so a fork PR
+          # from an identically named branch can land in this list. The
+          # selector keeps only the base-repo PR and fails closed on an
+          # ambiguous set, before anything below edits or auto-merges a PR.
           PR_NUMBER=$(gh pr list \
-            --head chore/nix-npm-hash-update \
+            --head "$HEAD_BRANCH" \
             --state open \
-            --json number \
-            --jq '.[0].number // empty')
+            --json number,headRefName,headRepository,baseRefName \
+            | python3 .github/scripts/select-internal-pr.py \
+                --repo "$BASE_REPO" --head "$HEAD_BRANCH" --base main)
 
           if [ -z "$PR_NUMBER" ]; then
             # Capture URL from gh pr create directly; gh pr list right
             # after creation can miss the new PR due to search-index lag.
             PR_URL=$(gh pr create \
               --base main \
-              --head chore/nix-npm-hash-update \
+              --head "$HEAD_BRANCH" \
               --title "chore: update Nix npmDepsHash for web dependencies" \
               --body-file /tmp/pr-body.md \
               --label automated | tail -n1)


### PR DESCRIPTION
## Description

A robot in our CI recomputes a hash whenever the web dependency lockfile changes, opens a pull request with the new value, and tells GitHub to merge that pull request automatically once the checks go green. To find its own pull request each time, it asked GitHub for "open pull requests coming from the branch named `chore/nix-npm-hash-update`" and took the first answer. That question is answered by branch name alone, and anyone who forks the project can create a branch with that same name. So the robot could have picked up an outsider's pull request by mistake, rewritten its description, stamped it with the trusted `automated` label, and queued it to merge into `main` with no person ever looking at it. This change makes the robot check who the pull request actually comes from before touching it: it now only acts on one that lives in this repository, on the expected branch, aimed at `main`. If it finds more than one such candidate, or gets an answer it cannot make sense of, it stops with an error instead of guessing. Nothing changes for the normal case, and a look-alike pull request from a fork is now simply ignored.

`gh pr list --head <branch>` matches on the branch name alone; its help states that `<owner>:<branch>` is not supported. nix-npm-hash.yml took `.[0]` from that list, so a fork PR opened from a branch named `chore/nix-npm-hash-update` could be selected instead of the bot's own PR and then edited, labeled `automated`, and queued with `gh pr merge --auto`. The active `main` ruleset requires status checks but carries no human-review rule, and #3700 turned the `automated` label into a trust signal that exempts a PR from stale-PR cleanup.

The lookup now requests `headRepository`, `headRefName` and `baseRefName` and pipes the candidates through `.github/scripts/select-internal-pr.py`, which keeps only PRs whose head repository is the base repository and whose head and base branches are the expected ones. One match is used, no match still opens the PR, and anything else exits non-zero so the step aborts under `set -euo pipefail` before `gh pr edit` or `gh pr merge` runs.

One deviation from the issue: zero matches is not a failure. Zero internal candidates is the legitimate "no bot PR exists yet" path that leads to `gh pr create`, and no existing PR is mutated there. Ambiguity (more than one internal candidate) fails loudly.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

`.github/scripts/select-internal-pr.py --self-test` covers the selection table: internal PR only, fork PR on the same branch name only, fork plus internal in both orders, repository-name casing, same owner but a different repository, wrong base branch, wrong head branch, and a null or missing head repository. Five fail-closed cases cover two internal candidates, a non-array payload, a non-object entry, and an unusable PR number. A new `PR Lookup Self-Test` job in ci.yml runs it on every PR, matching the existing `Build Cache Self-Test` pattern. Also verified locally: the real pipe shape end to end, `bash -n` over every `run:` block of the modified workflow, and both workflows parsing as YAML.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any Additional AI Details you'd like to share:**

Written through back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3705


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restricts Nix hash PR selection to the internal repository and expected branches.
- Prevents fork PRs from being edited, labeled, or queued for auto-merge.
- Adds fail-closed handling for malformed or ambiguous results.
- Raises the PR lookup limit to avoid missing the internal PR among many fork matches.
- Adds selector self-tests and runs them in CI.

## Benefits

The workflow now updates only the intended internal PR. Existing labels and body markers remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->