### PR TITLE
fix(status): decide an unwitnessed idle from a single observation

### DIFF
--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -610,7 +610,7 @@ fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
             &inst.id,
             &crate::tmux::Session::generate_name(&inst.id, &inst.title),
         );
-        inst.update_status_with_metadata(meta.get(&name), Some(&name));
+        inst.update_status_once(meta.get(&name), Some(&name));
         let agent = if inst.tool.is_empty() {
             meta.get(&name)
                 .and_then(|m| m.pane_current_command.clone())

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1556,7 +1556,7 @@ async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
     // Refresh status from tmux so the output reflects current state
     // rather than the stale persisted value.
     crate::tmux::refresh_session_cache();
-    inst.update_status();
+    inst.update_status_once(None, None);
     let contended = crate::session::Instance::contended_capture_cwds(&instances);
     inst.self_heal_session_id(profile, &contended);
 
@@ -1851,10 +1851,15 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
             // Persisted status can lag the live tmux pane; recompute only when
             // the request will mutate the checkout. A cwd/branch-stable title
             // no-op must remain valid for an active session.
+            //
+            // Deliberately the holding entry point rather than
+            // `update_status_once`: a held proposal leaves the row on Running,
+            // so an ambiguous frame refuses the edit instead of moving a
+            // worktree out from under a live agent.
             let mut live = inst.clone();
             live.source_profile = profile.to_string();
             crate::tmux::refresh_session_cache();
-            live.update_status();
+            live.update_status_with_metadata(None, None);
             let container_holds = !live.status.blocks_worktree_edit()
                 && moves_worktree
                 && crate::session::worktree_edit::ensure_sandbox_container_released(
@@ -2206,10 +2211,11 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     }
     // Persisted status can lag the real tmux pane, and moving the worktree of
     // a still-running session is unsafe. Recompute from live tmux state before
-    // enforcing the guard.
+    // enforcing the guard. The holding entry point, for the reason
+    // `rename_session` gives: an ambiguous frame must refuse the move.
     let mut live = inst.clone();
     crate::tmux::refresh_session_cache();
-    live.update_status();
+    live.update_status_with_metadata(None, None);
     // A sandbox container keeps the worktree dir mounted even while the agent
     // is Idle, so the move would fail. The gate drops a merely-stopped
     // container to free the mount and only reports held for a live one, which

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -72,7 +72,7 @@ pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
 
     let contended = crate::session::Instance::contended_capture_cwds(&instances);
     for inst in &mut instances {
-        inst.update_status();
+        inst.update_status_once(None, None);
         inst.self_heal_session_id(profile, &contended);
     }
 

--- a/src/session/instance/status_update.rs
+++ b/src/session/instance/status_update.rs
@@ -60,13 +60,62 @@ impl Instance {
     /// field itself; this method's job is the guard shape (baseline vs. newly
     /// detected). Every call re-seeds the baseline at exit, so the next call
     /// compares against a value this method itself wrote.
+    ///
+    /// A `Running -> Idle` no rule read off live chrome is held for the next
+    /// call to agree with it. A caller that will not call again wants
+    /// [`Self::update_status_once`].
     pub fn update_status_with_metadata(
         &mut self,
         metadata: Option<&tmux::PaneMetadata>,
         resolved_name: Option<&str>,
     ) {
+        self.poll_status(metadata, resolved_name, false);
+    }
+
+    /// Update status for a caller that observes this session exactly once.
+    ///
+    /// `confirm_detection` (private, so a code span rather than an intra-doc
+    /// link) holds a `Running -> Idle` no rule read off the agent's own chrome
+    /// until a second poll agrees with it. A caller that observes once and
+    /// exits never makes that second observation, so the hold publishes
+    /// nothing and the row's last persisted status stands. With no TUI or
+    /// daemon polling to converge that row, `aoe send` followed by `aoe ps`
+    /// read `Running` for the life of the session (#3712). One observation is
+    /// all this caller gets, so its proposal decides.
+    pub fn update_status_once(
+        &mut self,
+        metadata: Option<&tmux::PaneMetadata>,
+        resolved_name: Option<&str>,
+    ) {
+        self.poll_status(metadata, resolved_name, true);
+    }
+
+    /// The body both entry points share. `single_poll` says no further
+    /// observation is coming, which is what decides a held proposal.
+    fn poll_status(
+        &mut self,
+        metadata: Option<&tmux::PaneMetadata>,
+        resolved_name: Option<&str>,
+        single_poll: bool,
+    ) {
+        if single_poll {
+            // This observation decides, so only this observation may propose:
+            // a proposal carried in from an earlier poll was made against a
+            // screen this call never read, and the publish below would take it
+            // even on a path that returned before reaching the pane.
+            self.detection.pending = None;
+        }
         let baseline = self.live_status_baseline;
         self.update_status_with_metadata_inner(metadata, resolved_name);
+        if single_poll {
+            if let Some(pending) = self.detection.pending.take() {
+                // Only a plain Idle is ever held, so there is no error
+                // explanation to keep or derive; the confirmed arm of
+                // `update_status_from_manifest` clears it for the same reason.
+                self.status = pending;
+                self.last_error = None;
+            }
+        }
         if let Some(prev) = baseline {
             if prev != self.status {
                 self.log_status_transition(prev);
@@ -562,10 +611,6 @@ impl Instance {
                 None
             }
         }
-    }
-
-    pub fn update_status(&mut self) {
-        self.update_status_with_metadata(None, None);
     }
 }
 
@@ -1305,7 +1350,7 @@ Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
         // then pin it). Refresh from live tmux now that the pane is painted so
         // the single authoritative read sees a true existence result.
         crate::tmux::refresh_session_cache();
-        inst.update_status();
+        inst.update_status_with_metadata(None, None);
 
         std::fs::remove_file(&pane_file).ok();
         crate::hooks::cleanup_hook_status_dir(&inst.id);
@@ -1581,5 +1626,102 @@ Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
             Status::Idle,
             "the confirming poll must publish the idle the final frame showed"
         );
+    }
+
+    /// #3712: `aoe ps`, `aoe status` and the worktree-edit guards observe a
+    /// session once and exit, so the confirming poll an unwitnessed
+    /// `Running -> Idle` waits for never arrives. The hold published nothing
+    /// and the row's last persisted status stood, so every parked session
+    /// read `Running` for the life of the session.
+    ///
+    /// One pane, two readers: the repeating poller holds its proposal for the
+    /// poll it will make, and the single-observation reader publishes the same
+    /// proposal now.
+    #[test]
+    #[serial_test::serial]
+    fn a_single_observation_publishes_an_unwitnessed_idle() {
+        if !tmux_available() {
+            eprintln!("skipping: tmux not available");
+            return;
+        }
+
+        let mut polled = Instance::new("aoe_test_3712_polled", "/tmp");
+        // Guard, not a constant assertion: the manifest path is only reached
+        // for a tool that has one.
+        assert_eq!(polled.tool, "claude");
+
+        // A parked Claude prompt carrying half-typed text. `ready_prompt`
+        // wants an empty box and `completed_turn` wants a completion line in
+        // the status slot, so the idle here is the one `live_prompt_box`
+        // guesses at rather than reads off live chrome: unwitnessed, and so
+        // held.
+        let pane = "earlier output\n\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n\u{276f} half typed prompt\n\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n  \u{23f5}\u{23f5} auto mode on (shift+tab to cycle)\n";
+        let pane_file = std::env::temp_dir().join(format!("aoe_test_3712_{}.txt", polled.id));
+        std::fs::write(&pane_file, pane).expect("write pane fixture");
+
+        let session_name = tmux::Session::generate_name(&polled.id, &polled.title);
+        let _guard = KillTmuxOnDrop(session_name.clone());
+        let quoted = format!("'{}'", pane_file.to_string_lossy().replace('\'', r#"'\''"#));
+        let created = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "120",
+                "-y",
+                "40",
+                &format!("cat {quoted}; sleep 300"),
+            ])
+            .output()
+            .expect("spawn tmux");
+        assert!(
+            created.status.success(),
+            "tmux new-session failed: {}",
+            String::from_utf8_lossy(&created.stderr)
+        );
+
+        let mut painted = false;
+        for _ in 0..100 {
+            let cap = crate::tmux::tmux_command()
+                .args(["capture-pane", "-p", "-t", &session_name])
+                .output();
+            if let Ok(out) = cap {
+                if String::from_utf8_lossy(&out.stdout).contains("half typed prompt") {
+                    painted = true;
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        std::fs::remove_file(&pane_file).ok();
+        assert!(painted, "parked prompt never painted into the tmux pane");
+
+        let cache = crate::tmux::SessionCacheGuard::capture();
+        cache.force_present(&[session_name.as_str()]);
+        let metadata = agent_pane_metadata("claude", None);
+
+        // Both rows come off disk on `Running`, which is what the CLI reads.
+        polled.status = Status::Running;
+        polled.update_status_with_metadata(Some(&metadata), Some(&session_name));
+        assert_eq!(
+            polled.status,
+            Status::Running,
+            "a repeating poller holds an unwitnessed Idle for the poll that agrees"
+        );
+        assert_eq!(polled.detection.pending, Some(Status::Idle));
+
+        // A one-shot reader starts from a bare disk load: no proposal on
+        // record, and none it can ever meet.
+        let mut once = Instance::new("aoe_test_3712_once", "/tmp");
+        once.status = Status::Running;
+        once.update_status_once(Some(&metadata), Some(&session_name));
+        assert_eq!(
+            once.status,
+            Status::Idle,
+            "one observation is all this caller gets, so its proposal decides (#3712)"
+        );
+        assert_eq!(once.detection.pending, None);
     }
 }


### PR DESCRIPTION
## Description

`aoe ps` and `aoe status` were reporting sessions as busy when the agent was
sitting at an empty prompt doing nothing. This PR makes them report what the
screen actually shows.

Why it happened: to stop sessions flickering between busy and idle, the status
code learned to be cautious about one specific change. When it decides a
session went from working to idle *without* seeing direct proof on screen, it
waits and looks a second time before believing it. The dashboard and the
background daemon look repeatedly, so their second look always comes. But
`aoe ps` looks once and exits. Its second look never happens, so it never
believed the session had gone idle and printed the last status that had been
saved to disk instead, which for a session that had been working was "running".
Now a command that only gets one look trusts that look.

### Detail

#3600 made a `Running -> Idle` that no rule read off the agent's own live
chrome wait for a second agreeing poll: a mid-redraw frame is otherwise
indistinguishable from a finished turn. `DetectionState` is runtime-only
(`#[serde(skip)]`), so every consumer has to carry the proposal to the poll
that confirms it, which #3672 made the repeating pollers do (the TUI projects
it through `StatusUpdate`, the daemon seeds it per tick).

`aoe ps`, `aoe status` and `aoe session info` observe once and exit. Their
proposal has no next poll to meet, so `confirm_detection` returned `None`,
`status` was left at the disk value, and the CLI printed it.

`update_status_with_metadata` keeps the hold for a caller that will observe
again; the new `update_status_once` publishes the proposal. Cadence is stated
at the call site rather than assumed.

The two worktree-edit guards (`rename_session`, `set_worktree_name`) keep the
hold deliberately, and say so. A held proposal leaves the row on `Running`, and
`confirm_detection` only engages when the row is already `Running`, so the hold
can never mask a busy session: an ambiguous frame refuses the edit rather than
letting `git worktree move` run under a live agent. A false refusal there is
recoverable; a false permit is not.

### Reproduced and verified live

Real `claude` 2.1.258 in tmux, parked at its prompt with half-typed text (an
unwitnessed idle: `ready_prompt` wants an empty box, `completed_turn` wants a
completion line in the status slot, so `live_prompt_box` guesses), disk row on
`running`:

```
before:  aoe ps -> running     (every invocation, indefinitely)
after:   aoe ps -> idle
         aoe status --json -> {"idle":1,"running":0,...}
```

`aoe session capture --json` read `idle` throughout, on both trees: it calls
`detect_with_rules` directly and never reaches the hold. That gap between the
two commands is the signature of this bug.

### The deterministic case

`aoe session send` writes `Status::Running` straight to disk
(src/cli/send.rs:99). For a user with no TUI and no `aoe serve`, nothing ever
converges that row, so `aoe send` followed by `aoe ps` reports `running` for
the life of the session. No mid-redraw frame or timing needed.

### Scope

`Refs`, not `Fixes`. This is a real bug that produces the reported symptom, but
it is not demonstrably all of what #3712 saw: for `aoe ps` to be wrong the
persisted row must say `Running`, and a healthy daemon converges in two ticks
(checked here against a live `aoe serve`). The reporter had a daemon and
restarted it twice, so if their dashboard was wrong too there is a second
cause. Asked them to compare `aoe ps` against `aoe session capture --json` on
one session at the same moment; the `session.status_change` line in `debug.log`
records the deciding `rule=` if both agree on `running`.

Separately, `aoe session add-project` gates on `inst.status` straight off
`storage.load()` with no live poll at all (src/cli/session.rs:2425). Same
symptom, different cause, predates #3600; worth its own issue rather than
bundling.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is one poll of the detection path,
  not a CLI surface. `a_single_observation_publishes_an_unwitnessed_idle` drives
  a real tmux pane through both entry points and is red on the pre-fix tree; an
  e2e run of `aoe ps` would need a live agent painting an unwitnessed-idle
  screen to assert anything the unit test does not.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**
Root cause found by reading the #3600 / #3672 detection path, then reproduced
against a live `claude` pane and the built binary before any code changed.

- [x] I am an AI Agent filling out this form (check box if true)

Refs #3712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvJadEgmtKj3VPrgMJjHVn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed session status reporting for `aoe ps`, `aoe status`, and `aoe session info`.
- Added `update_status_once` for single-observation callers.
- Preserved confirmation behavior for repeating pollers and worktree edits.
- Updated status and session commands to use the correct update path.
- Added regression coverage for immediate status publication.

## Benefits

Users now see idle sessions without waiting for a second observation. Existing safeguards remain in place for repeated polling and worktree changes.

## Technical details

The shared polling logic now separates one-shot updates from repeating updates. The legacy `update_status` method was removed, and callers now use either `update_status_once` or `update_status_with_metadata`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
