### PR TITLE
chore: release v1.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Agent of Empires will be documented in this file.
 
 The format follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [1.15.3](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.15.3) - 2026-09-02
+
+
+
+### Bug Fixes
+
+- **ci:** Key the PR-template escape hatches on the head branch in [#3700](https://github.com/agent-of-empires/agent-of-empires/pull/3700) by [@njbrake](https://github.com/njbrake) ([`fc792b2`](https://github.com/agent-of-empires/agent-of-empires/commit/fc792b2c857910d525688f4885ec966a9908c3cf))
+- **ci:** Constrain the Nix hash PR lookup to the base repository in [#3706](https://github.com/agent-of-empires/agent-of-empires/pull/3706) by [@njbrake](https://github.com/njbrake) ([`03c4fba`](https://github.com/agent-of-empires/agent-of-empires/commit/03c4fba9cd804ddb027f7e1af578b13798d48436))
+- **status:** Decide an unwitnessed idle from a single observation in [#3717](https://github.com/agent-of-empires/agent-of-empires/pull/3717) by [@njbrake](https://github.com/njbrake) ([`6038459`](https://github.com/agent-of-empires/agent-of-empires/commit/6038459d8ddd60e3efc4927dee6579b84603d5e1))
+
+
+### Features
+
+- **tui:** Pre-size every open session's pane to its preview rect in [#3709](https://github.com/agent-of-empires/agent-of-empires/pull/3709) by [@njbrake](https://github.com/njbrake) ([`b00049e`](https://github.com/agent-of-empires/agent-of-empires/commit/b00049e22daaf2e921bf94a92be6d77e3ce34360))
+
+
+**Full Changelog**: https://github.com/agent-of-empires/agent-of-empires/compare/v1.15.2...v1.15.3
 ## [1.15.2](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.15.2) - 2026-09-02
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agent-of-empires"
-version = "1.15.2"
+version = "1.15.3"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask", "aoe-settings-derive", "aoe-plugin-api"]
 
 [package]
 name = "agent-of-empires"
-version = "1.15.2"
+version = "1.15.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Agent of Empires Contributors"]


### PR DESCRIPTION
<!-- release-version: 1.15.3 -->

Automated weekly release-staging PR (#1140).

**Current:** `v1.15.2`  
**Proposed:** `v1.15.3` (bump: `patch`)

If you want a different semver bump, edit `Cargo.toml` + `Cargo.lock` on this branch, push the change, and the merge tagger will use whatever version is in `Cargo.toml` at merge time. The `<!-- release-version: ... -->` marker above is cross-checked by the tagger and must match.

## Changes since v1.15.2

- fix(status): decide an unwitnessed idle from a single observation (#3717) (`6038459d`, Nathan Brake, 2026-09-02)
- feat(tui): pre-size every open session's pane to its preview rect (#3709) (`b00049e2`, Nathan Brake, 2026-09-02)
- fix(ci): constrain the Nix hash PR lookup to the base repository (#3706) (`03c4fba9`, Nathan Brake, 2026-09-02)
- fix(ci): key the PR-template escape hatches on the head branch (#3700) (`fc792b2c`, Nathan Brake, 2026-09-02)
- refactor(server): make the daemon core, gate only the web bundle behind `web` (#3632) (`15be9fdf`, Nathan Brake, 2026-09-02)

## Maintainer checklist

- [ ] Version bump is appropriate for the change set
- [ ] No breaking changes hidden under `refactor:` / `chore:`
- [ ] CI is green
- [ ] Ready to ship — merge this PR to publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Prepares the `v1.15.3` patch release.

- Improves idle status decisions from a single observation.
- Sizes open-session panes to their preview rectangles.
- Limits Nix hash pull-request searches to the base repository.
- Keys PR-template escape hatches to the head branch.
- Makes the server daemon core available without the `web` feature.
- Updates the changelog and bumps the crate version from `1.15.2` to `1.15.3`.

These changes improve status accuracy, session layout, repository matching, CI behavior, and feature flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->