### PR TITLE
fix(tests): isolate host state the live harness's suffix rule misses

### DIFF
--- a/web/tests/helpers/isolatedEnv.test.ts
+++ b/web/tests/helpers/isolatedEnv.test.ts
@@ -124,6 +124,7 @@ describe("isolateEnv", () => {
         XDG_DATA_HOME: `${HOST}/.local/share`,
         OPENCODE_DB: `${HOST}/.local/share/opencode/opencode.db`,
         CLAUDE_CONFIG_DIR: `${HOST}/.claude`,
+        GIT_EXEC_PATH: `${HOST}/libexec/git-core`,
         AOE_DAEMON_URL: "http://a-real-daemon.internal:8080",
         TMPDIR: `${HOST}/tmp`,
         LANG: "en_US.UTF-8",
@@ -137,6 +138,9 @@ describe("isolateEnv", () => {
     expect(env.XDG_DATA_HOME).toBe(PATHS.xdgData);
     // Not a path, but it would point the harness's own `aoe` calls at it.
     expect(env.AOE_DAEMON_URL).toBeUndefined();
+    // Not inherited as a toolchain path: git resolves the subprograms it runs
+    // from it, and finds them on its own once it is gone.
+    expect(env.GIT_EXEC_PATH).toBeUndefined();
     expect(env.LANG).toBe("en_US.UTF-8");
   });
 

--- a/web/tests/helpers/isolatedEnv.test.ts
+++ b/web/tests/helpers/isolatedEnv.test.ts
@@ -25,14 +25,24 @@ const PATHS: IsolatedPaths = {
 const NON_SUFFIX_HOST_STATE: Record<string, string> = {
   AGENT_OF_EMPIRES_DEBUG: "1",
   AGENT_OF_EMPIRES_PROFILE: "work",
+  AOE_ACP_AGENT_ENV: '[["ANTHROPIC_API_KEY","host-key"]]',
   AOE_ACP_NODE: `${HOST}/.nvm/versions/node/v22.0.0/bin/node`,
+  AOE_CAPTURED_SESSION_ID: "host-captured",
+  AOE_CITYHALL_BUNDLE_TOKEN: "host-bundle-token",
+  AOE_CITYHALL_BUNDLE_URL: "https://host.invalid/bundle",
   AOE_CITYHALL_MODE: "1",
   AOE_DAEMON_TOKEN: "host-token",
   AOE_DAEMON_URL: "http://a-real-daemon.internal:8080",
   AOE_GITHUB_CLONE_BASE: `file://${HOST}/plugins`,
   AOE_INSTANCE_ID: "host-session",
+  AOE_OMP_CAPTURE_META: "host-meta",
+  AOE_OMP_CAPTURE_READY: "1",
+  AOE_OMP_LAUNCH_ID: "host-launch",
+  AOE_OPEN_URL_TO: `${HOST}/opened-urls.txt`,
+  AOE_SERVE_INSTANCE_ID: "host-daemon",
   AOE_SERVE_PASSPHRASE: "host-secret",
   AOE_TELEMETRY_ENDPOINT: "https://host.invalid/v1/telemetry",
+  AOE_TMUX_SOCKET: "/tmp/tmux-1000/aoe.sock",
   AOE_UPDATE_API_BASE: "https://host.invalid/api",
   AOE_UPDATE_BASE_URL: "https://host.invalid",
   GIT_CONFIG_GLOBAL: `${HOST}/.gitconfig`,
@@ -76,6 +86,9 @@ const INHERITED_BY_CONTRACT = new Set([
   "AOE_TERMINAL_TRACE",
   "AOE_TEST_TOKEN_GRACE_SECS",
   "AOE_TEST_TOKEN_LIFETIME_SECS",
+  // A marker `aoe` echoes into a pane to probe a login shell, not a variable
+  // the daemon resolves anything from.
+  "AOE_AGENT_OK",
   // Reaches a real agent binary, never the daemon's own state, and every live
   // spec runs a fake agent shim.
   "CLAUDE_CODE_USE_VERTEX",
@@ -161,6 +174,7 @@ describe("isolateEnv", () => {
     expect(names).toEqual(
       expect.arrayContaining([
         "AOE_ACP_NODE",
+        "AOE_CITYHALL_BUNDLE_URL",
         "AOE_GITHUB_CLONE_BASE",
         "CLAUDE_CONFIG_DIR",
         "OPENCODE_DB",
@@ -186,8 +200,10 @@ describe("isolateEnv", () => {
 
 /**
  * Every environment variable `src/` reads: `env::var` / `env::var_os` calls,
- * clap's `env = "..."` attributes, and any quoted path-shaped name, which
- * catches the ones the daemon forwards to an agent rather than reads itself.
+ * clap's `env = "..."` attributes, any quoted path-shaped name, which catches
+ * the ones the daemon forwards to an agent rather than reads itself, and the
+ * `const NAME: &str = "AOE_..."` declarations the call-site patterns cannot
+ * see, since `env::var(SOME_ENV)` names the constant and not the variable.
  */
 function daemonEnvVars(): string[] {
   const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "src");
@@ -195,6 +211,7 @@ function daemonEnvVars(): string[] {
     /env::var(?:_os)?\(\s*"([A-Z][A-Z0-9_]*)"/g,
     /\benv\s*=\s*"([A-Z][A-Z0-9_]*)"/g,
     /"([A-Z][A-Z0-9_]*_(?:HOME|DIR|DB|PATH|CREDENTIALS))"/g,
+    /const\s+[A-Z0-9_]+\s*:\s*&(?:'static\s+)?str\s*=\s*"([A-Z][A-Z0-9_]*)"/g,
   ];
   const names = new Set<string>();
   for (const file of rustFiles(srcDir)) {

--- a/web/tests/helpers/isolatedEnv.test.ts
+++ b/web/tests/helpers/isolatedEnv.test.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { INHERITED_PATH_VARS, isolateEnv, type IsolatedPaths } from "./isolatedEnv";
+import { HOST_STATE_VARS, INHERITED_PATH_VARS, isolateEnv, pinnedVars, type IsolatedPaths } from "./isolatedEnv";
 
 const HOME = "/tmp/aoe-pw-w0-p0-test";
 const HOST = "/host/dev";
@@ -14,6 +14,91 @@ const PATHS: IsolatedPaths = {
   tmp: join(HOME, "tmp"),
   tmuxTmp: join(HOME, "tmux"),
 };
+
+/**
+ * Host state the daemon reads under a name that carries no path suffix, with
+ * a hostile value for each. Written out here rather than derived from `src/`
+ * or from the implementation's own rule: a scanner keyed on that rule cannot
+ * see a name the rule was never written for, which is how these survived the
+ * first source-driven test (#3657).
+ */
+const NON_SUFFIX_HOST_STATE: Record<string, string> = {
+  AGENT_OF_EMPIRES_DEBUG: "1",
+  AGENT_OF_EMPIRES_PROFILE: "work",
+  AOE_ACP_NODE: `${HOST}/.nvm/versions/node/v22.0.0/bin/node`,
+  AOE_CITYHALL_MODE: "1",
+  AOE_DAEMON_TOKEN: "host-token",
+  AOE_DAEMON_URL: "http://a-real-daemon.internal:8080",
+  AOE_GITHUB_CLONE_BASE: `file://${HOST}/plugins`,
+  AOE_INSTANCE_ID: "host-session",
+  AOE_SERVE_PASSPHRASE: "host-secret",
+  AOE_TELEMETRY_ENDPOINT: "https://host.invalid/v1/telemetry",
+  AOE_UPDATE_API_BASE: "https://host.invalid/api",
+  AOE_UPDATE_BASE_URL: "https://host.invalid",
+  GIT_CONFIG_GLOBAL: `${HOST}/.gitconfig`,
+  GIT_CONFIG_SYSTEM: `${HOST}/etc/gitconfig`,
+  GIT_SSH_COMMAND: `ssh -i ${HOST}/.ssh/id_ed25519`,
+  GIT_WORK_TREE: `${HOST}/repo`,
+  TMUX: "/tmp/tmux-1000/default,4242,0",
+  TMUX_PANE: "%7",
+};
+
+/**
+ * Variables `src/` reads that the daemon inherits on purpose, grouped by why.
+ * A name that is neither here nor neutralized fails the contract test below,
+ * which is the point: classifying a new variable stays a decision someone
+ * makes, instead of one the suffix rule makes for them.
+ */
+const INHERITED_BY_CONTRACT = new Set([
+  ...INHERITED_PATH_VARS,
+  // Timing, tracing, and test switches. Their values are numbers or flags, so
+  // a hostile one can slow a spec down but cannot point the daemon anywhere.
+  "AOE_ACP_RUNNER_SOCKET_TIMEOUT_MS",
+  "AOE_ACP_SIMULATE_ORPHAN_NEXT_PROMPT",
+  "AOE_ACP_TEST_FAIL_FIRST_HANDSHAKES",
+  "AOE_ACP_TRACE",
+  "AOE_ACP_WATCHDOG_POLL_MS",
+  "AOE_E2E_DEBUG",
+  "AOE_ENVGUARD_DUP",
+  "AOE_ENVGUARD_EMPTY",
+  "AOE_ENVGUARD_UNSET",
+  "AOE_ENVGUARD_UNSET_ME",
+  "AOE_FILE_WATCH",
+  "AOE_LOG_LEVEL",
+  "AOE_MOUSE_CAPTURE",
+  "AOE_NO_LNAV_TIP",
+  "AOE_PRIVDROP_TESTS",
+  "AOE_RECOVERY_HOOK_TIMEOUT_MS",
+  "AOE_RESUME_IDLE_GRACE_MS",
+  "AOE_SILENT_ORPHAN_CHECK_INTERVAL_MS",
+  "AOE_SILENT_ORPHAN_FAST_GRACE_MS",
+  "AOE_SILENT_ORPHAN_GRACE_MS",
+  "AOE_TERMINAL_TRACE",
+  "AOE_TEST_TOKEN_GRACE_SECS",
+  "AOE_TEST_TOKEN_LIFETIME_SECS",
+  // Reaches a real agent binary, never the daemon's own state, and every live
+  // spec runs a fake agent shim.
+  "CLAUDE_CODE_USE_VERTEX",
+  // Terminal, desktop, and remote-session hints the daemon forwards into the
+  // sessions it creates.
+  "DISPLAY",
+  "DO_NOT_TRACK",
+  "MOSH_CONNECTION",
+  "NO_COLOR",
+  "SSH_CLIENT",
+  "SSH_CONNECTION",
+  "SSH_TTY",
+  "USER",
+  "WAYLAND_DISPLAY",
+  // Host executables the daemon runs on the user's behalf: `user_shell()`
+  // wraps pane commands in `$SHELL` so rc files load, and the TUI opens
+  // `$EDITOR`. Inherited on purpose, so a spec exercises the same programs
+  // the developer has; `spawnAoeServe` prepends its shim dir to PATH.
+  "EDITOR",
+  "PATH",
+  "SHELL",
+  "VISUAL",
+]);
 
 describe("isolateEnv", () => {
   // #3622: XDG_DATA_HOME and OPENCODE_DB reached the daemon, which reads both
@@ -42,33 +127,82 @@ describe("isolateEnv", () => {
     expect(env.LANG).toBe("en_US.UTF-8");
   });
 
-  // The daemon resolves agent paths from its own env, so every new agent adds
-  // a way for a live spec to reach host state. Drive the assertion off `src/`
-  // rather than off a list here, which would fall behind it.
-  it("drops every path variable src/ reads, whatever the name", () => {
-    const names = daemonPathVars();
-    expect(names).toEqual(expect.arrayContaining(["CLAUDE_CONFIG_DIR", "OPENCODE_DB", "VIBE_HOME", "XDG_DATA_HOME"]));
+  // #3657: the suffix rule missed GIT_CONFIG_*, AOE_ACP_NODE and
+  // AOE_GITHUB_CLONE_BASE, so host git config, a host Node binary, and a host
+  // plugin source still reached `aoe serve`.
+  it("neutralizes host state whose name carries no path suffix", () => {
+    const pinned = pinnedVars(PATHS);
+    const env = isolateEnv({ HOME: HOST, ...NON_SUFFIX_HOST_STATE }, PATHS);
+
+    for (const name of Object.keys(NON_SUFFIX_HOST_STATE)) {
+      expect(env[name], `${name} reached the daemon unchanged`).toBe(pinned[name]);
+    }
+    expect(env.GIT_CONFIG_GLOBAL).toBe(join(HOME, ".gitconfig"));
+    expect(env.GIT_CONFIG_SYSTEM).toBe("/dev/null");
+
+    // Pinned unconditionally: an unset GIT_CONFIG_SYSTEM still leaves the
+    // daemon's git reading /etc/gitconfig.
+    expect(isolateEnv({}, PATHS)).toMatchObject(pinned);
+
+    // Every name dropped by name carries a case above, so the list cannot
+    // grow one that nothing exercises.
+    expect(
+      [...HOST_STATE_VARS].filter((name) => !(name in NON_SUFFIX_HOST_STATE)),
+      "dropped by isolatedEnv.ts with no hostile case here",
+    ).toEqual([]);
+  });
+
+  // The daemon resolves paths, executables, and endpoints from its own env, so
+  // every variable `src/` reads is a way for a live spec to reach host state.
+  // Drive the assertion off `src/` and make each name a decision: neutralized
+  // by `isolateEnv`, or listed in INHERITED_BY_CONTRACT with the reason.
+  it("classifies every environment variable src/ reads", () => {
+    const names = daemonEnvVars();
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "AOE_ACP_NODE",
+        "AOE_GITHUB_CLONE_BASE",
+        "CLAUDE_CONFIG_DIR",
+        "OPENCODE_DB",
+        "VIBE_HOME",
+      ]),
+    );
 
     const hostile: NodeJS.ProcessEnv = {};
     for (const name of names) hostile[name] = `${HOST}/${name.toLowerCase()}`;
     const env = isolateEnv(hostile, PATHS);
+    const survived = names.filter((name) => env[name]?.startsWith(HOST));
 
-    const survived = Object.entries(env)
-      .filter(([, value]) => value?.startsWith(HOST))
-      .map(([name]) => name);
-    expect(survived.sort()).toEqual(names.filter((name) => INHERITED_PATH_VARS.has(name)).sort());
+    expect(
+      survived.filter((name) => !INHERITED_BY_CONTRACT.has(name)),
+      "src/ reads these and the daemon still gets the host value: neutralize them in isolatedEnv.ts, or add them to INHERITED_BY_CONTRACT with the reason they are safe",
+    ).toEqual([]);
+    expect(
+      names.filter((name) => INHERITED_BY_CONTRACT.has(name) && !survived.includes(name)),
+      "the contract says the daemon needs these, but isolateEnv drops them",
+    ).toEqual([]);
   });
 });
 
-/** Every variable naming a path that `src/` mentions, e.g. `KIMI_CODE_HOME`. */
-function daemonPathVars(): string[] {
+/**
+ * Every environment variable `src/` reads: `env::var` / `env::var_os` calls,
+ * clap's `env = "..."` attributes, and any quoted path-shaped name, which
+ * catches the ones the daemon forwards to an agent rather than reads itself.
+ */
+function daemonEnvVars(): string[] {
   const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "src");
+  const patterns = [
+    /env::var(?:_os)?\(\s*"([A-Z][A-Z0-9_]*)"/g,
+    /\benv\s*=\s*"([A-Z][A-Z0-9_]*)"/g,
+    /"([A-Z][A-Z0-9_]*_(?:HOME|DIR|DB|PATH|CREDENTIALS))"/g,
+  ];
   const names = new Set<string>();
   for (const file of rustFiles(srcDir)) {
-    for (const [, name] of readFileSync(file, "utf8").matchAll(
-      /"([A-Z][A-Z0-9_]*_(?:HOME|DIR|DB|PATH|CREDENTIALS))"/g,
-    )) {
-      if (name) names.add(name);
+    const source = readFileSync(file, "utf8");
+    for (const pattern of patterns) {
+      for (const [, name] of source.matchAll(pattern)) {
+        if (name) names.add(name);
+      }
     }
   }
   return [...names].sort();

--- a/web/tests/helpers/isolatedEnv.ts
+++ b/web/tests/helpers/isolatedEnv.ts
@@ -36,8 +36,9 @@ const PATH_VAR = /^[A-Z][A-Z0-9_]*_(HOME|DIR|DB|PATH|CREDENTIALS)$/;
 
 /**
  * Git's whole namespace is host state: config files, work trees, object
- * stores, and the helper commands git shells out to. Most of those names
- * carry no path suffix, so the family is dropped by prefix instead.
+ * stores, and the subprograms git resolves and runs, `GIT_EXEC_PATH`
+ * included. Most of those names carry no path suffix, so the family is
+ * dropped by prefix instead.
  */
 const GIT_VAR = /^GIT_/;
 
@@ -101,7 +102,6 @@ export const INHERITED_PATH_VARS = new Set([
   "CARGO_HOME",
   "DYLD_FALLBACK_LIBRARY_PATH",
   "DYLD_LIBRARY_PATH",
-  "GIT_EXEC_PATH",
   "LD_LIBRARY_PATH",
   "RUSTUP_HOME",
   "SSL_CERT_DIR",

--- a/web/tests/helpers/isolatedEnv.ts
+++ b/web/tests/helpers/isolatedEnv.ts
@@ -7,11 +7,20 @@
 // `src/session/capture.rs`, the opencode readers, the XDG bases). A developer
 // or CI shell exporting one of them points a live spec at real agent state.
 //
-// Listing those names does not hold: `src/` reads more than a dozen and gains
-// one per agent integration, and a missed name leaks silently. So anything
-// shaped like a path override is dropped, and the few the child genuinely
-// needs are named instead. Dropping one of those breaks the run loudly, which
-// is the safe direction to fail in.
+// Listing every such name does not hold on its own: `src/` reads more than a
+// dozen and gains one per agent integration, and a missed name leaks
+// silently. So anything shaped like a path override is dropped, and the few
+// the child genuinely needs are named instead. Dropping one of those breaks
+// the run loudly, which is the safe direction to fail in.
+//
+// The shape rule alone is not enough either: `GIT_CONFIG_GLOBAL`,
+// `AOE_ACP_NODE` and `AGENT_OF_EMPIRES_PROFILE` name host state under no
+// suffix at all (#3657). Those are dropped by name, or pinned where dropping
+// would only fall back to another host location. `isolatedEnv.test.ts` holds
+// the resulting contract and fails on a variable `src/` reads that neither
+// rule covers.
+
+import { join } from "node:path";
 
 /** Directories the harness owns, all inside the temporary test HOME. */
 export interface IsolatedPaths {
@@ -26,12 +35,43 @@ export interface IsolatedPaths {
 const PATH_VAR = /^[A-Z][A-Z0-9_]*_(HOME|DIR|DB|PATH|CREDENTIALS)$/;
 
 /**
- * Not path shaped, but `discovery::discover()` prefers them over the local
- * daemon, so every `aoe` call the harness makes with this env, teardown's
- * `acp stop --all` included, would hit the developer's own daemon and kill
- * its workers.
+ * Git's whole namespace is host state: config files, work trees, object
+ * stores, and the helper commands git shells out to. Most of those names
+ * carry no path suffix, so the family is dropped by prefix instead.
  */
-const DAEMON_TARGET_VARS = new Set(["AOE_DAEMON_TOKEN", "AOE_DAEMON_URL"]);
+const GIT_VAR = /^GIT_/;
+
+/**
+ * Host state the daemon reads under a name neither rule above can see. Each
+ * entry points `aoe serve`, or an `aoe` call the harness makes with this
+ * environment, at host configuration, a host executable, a host repository,
+ * or the host session the test runner was launched from.
+ */
+export const HOST_STATE_VARS = new Set([
+  // Both move the app dir, port, and tmux prefix off the ones `appDirFor`
+  // and `tmuxSocketPath` compute for a spec.
+  "AGENT_OF_EMPIRES_DEBUG",
+  "AGENT_OF_EMPIRES_PROFILE",
+  "AOE_ACP_NODE", // an arbitrary host Node executable for the ACP runner
+  "AOE_CITYHALL_MODE", // serves the daemon as a client of a host CityHall
+  // `discovery::discover()` prefers these over the local daemon, so every
+  // `aoe` call the harness makes with this env, teardown's `acp stop --all`
+  // included, would hit the developer's own daemon and kill its workers.
+  "AOE_DAEMON_TOKEN",
+  "AOE_DAEMON_URL",
+  "AOE_GITHUB_CLONE_BASE", // redirects plugin clones at a host path or tree
+  "AOE_SERVE_PASSPHRASE", // host credential for the daemon's own auth
+  // Host endpoints for the daemon's outbound calls.
+  "AOE_TELEMETRY_ENDPOINT",
+  "AOE_UPDATE_API_BASE",
+  "AOE_UPDATE_BASE_URL",
+  // The session the test runner was launched from: `aoe` resolves "the
+  // current session" from `TMUX_PANE`, and `AOE_INSTANCE_ID` names a host
+  // session directly.
+  "AOE_INSTANCE_ID",
+  "TMUX",
+  "TMUX_PANE",
+]);
 
 /**
  * Path variables the child keeps: toolchain and system locations, never agent
@@ -50,6 +90,21 @@ export const INHERITED_PATH_VARS = new Set([
 ]);
 
 /**
+ * Variables pinned rather than dropped, because dropping them only falls back
+ * to another host location: git reads `/etc/gitconfig` for the system file,
+ * and `$HOME/.gitconfig` for the global one. Pinning the global file inside
+ * the test home keeps a daemon-side `git config --global` write in the tree
+ * the harness deletes. `gitFixture.ts` pins the same pair for the fixture
+ * subprocesses; this covers the daemon's own git calls.
+ */
+export function pinnedVars(paths: IsolatedPaths): Record<string, string> {
+  return {
+    GIT_CONFIG_GLOBAL: join(paths.home, ".gitconfig"),
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+/**
  * Copy of `parentEnv` with every agent path pointed inside the test HOME.
  *
  * The bases the harness owns are redirected; the rest are dropped, which
@@ -59,8 +114,12 @@ export const INHERITED_PATH_VARS = new Set([
 export function isolateEnv(parentEnv: NodeJS.ProcessEnv, paths: IsolatedPaths): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [name, value] of Object.entries(parentEnv)) {
-    if (DAEMON_TARGET_VARS.has(name)) continue;
-    if (PATH_VAR.test(name) && !INHERITED_PATH_VARS.has(name)) continue;
+    if (INHERITED_PATH_VARS.has(name)) {
+      env[name] = value;
+      continue;
+    }
+    if (HOST_STATE_VARS.has(name)) continue;
+    if (PATH_VAR.test(name) || GIT_VAR.test(name)) continue;
     env[name] = value;
   }
   return {
@@ -70,5 +129,6 @@ export function isolateEnv(parentEnv: NodeJS.ProcessEnv, paths: IsolatedPaths): 
     XDG_DATA_HOME: paths.xdgData,
     TMPDIR: paths.tmp,
     TMUX_TMPDIR: paths.tmuxTmp,
+    ...pinnedVars(paths),
   };
 }

--- a/web/tests/helpers/isolatedEnv.ts
+++ b/web/tests/helpers/isolatedEnv.ts
@@ -48,29 +48,48 @@ const GIT_VAR = /^GIT_/;
  * or the host session the test runner was launched from.
  */
 export const HOST_STATE_VARS = new Set([
-  // Both move the app dir, port, and tmux prefix off the ones `appDirFor`
-  // and `tmuxSocketPath` compute for a spec.
+  // Raises the daemon to debug logging whenever `AOE_LOG_LEVEL` is unset
+  // (`LogConfig::from_env`), adding the log I/O `spawnAoeServe` pins at
+  // `info` on purpose.
   "AGENT_OF_EMPIRES_DEBUG",
+  // clap's `--profile`, which moves the profile dir and the config the daemon
+  // resolves its port and `[tmux]` options from.
   "AGENT_OF_EMPIRES_PROFILE",
+  "AOE_ACP_AGENT_ENV", // the daemon -> runner env carrier, decoded into agents
   "AOE_ACP_NODE", // an arbitrary host Node executable for the ACP runner
   "AOE_CITYHALL_MODE", // serves the daemon as a client of a host CityHall
+  // `apply_cityhall_bundle` runs on the boot path: a host URL is fetched and
+  // applied as config, and a first boot that cannot reach it aborts the
+  // daemon outright.
+  "AOE_CITYHALL_BUNDLE_TOKEN",
+  "AOE_CITYHALL_BUNDLE_URL",
   // `discovery::discover()` prefers these over the local daemon, so every
   // `aoe` call the harness makes with this env, teardown's `acp stop --all`
   // included, would hit the developer's own daemon and kill its workers.
   "AOE_DAEMON_TOKEN",
   "AOE_DAEMON_URL",
   "AOE_GITHUB_CLONE_BASE", // redirects plugin clones at a host path or tree
+  "AOE_OPEN_URL_TO", // appends every URL the TUI opens to a host file
+  "AOE_SERVE_INSTANCE_ID", // identifies a host daemon process as this one
   "AOE_SERVE_PASSPHRASE", // host credential for the daemon's own auth
   // Host endpoints for the daemon's outbound calls.
   "AOE_TELEMETRY_ENDPOINT",
   "AOE_UPDATE_API_BASE",
   "AOE_UPDATE_BASE_URL",
   // The session the test runner was launched from: `aoe` resolves "the
-  // current session" from `TMUX_PANE`, and `AOE_INSTANCE_ID` names a host
-  // session directly.
+  // current session" from `TMUX_PANE`, `AOE_INSTANCE_ID` names a host session
+  // directly, and the capture markers `aoe` writes into a pane make the
+  // daemon read a host launch as its own.
+  "AOE_CAPTURED_SESSION_ID",
   "AOE_INSTANCE_ID",
+  "AOE_OMP_CAPTURE_META",
+  "AOE_OMP_CAPTURE_READY",
+  "AOE_OMP_LAUNCH_ID",
   "TMUX",
   "TMUX_PANE",
+  // The host tmux server. `spawnAoeServe` re-pins it at `tmuxSocketPath`
+  // after this filter, so dropping it only removes the host fallback.
+  "AOE_TMUX_SOCKET",
 ]);
 
 /**
@@ -93,8 +112,9 @@ export const INHERITED_PATH_VARS = new Set([
  * Variables pinned rather than dropped, because dropping them only falls back
  * to another host location: git reads `/etc/gitconfig` for the system file,
  * and `$HOME/.gitconfig` for the global one. Pinning the global file inside
- * the test home keeps a daemon-side `git config --global` write in the tree
- * the harness deletes. `gitFixture.ts` pins the same pair for the fixture
+ * the test home keeps a daemon-side `git config --global` write
+ * (`session::cityhall_bundle`) in the tree the harness deletes.
+ * `gitFixture.ts` pins both names at `/dev/null` for the fixture
  * subprocesses; this covers the daemon's own git calls.
  */
 export function pinnedVars(paths: IsolatedPaths): Record<string, string> {


### PR DESCRIPTION
## Description

The live browser tests start a real `aoe serve` and hand it a copy of whatever
environment the developer or CI machine happens to have. To stop the server
from reading the developer's own agent config, the harness threw away any
variable whose name looked like it pointed at a folder, such as anything
ending in `_HOME` or `_DIR`. Several settings that send the server somewhere
on the host do not follow that naming pattern, so they got through: the two
variables that select git's config files, the one that picks which Node
program to run, and the one that decides where plugins are downloaded from.
Anyone who had those set in their shell was still running the tests against
their own machine's setup, which is how tests end up passing or failing for
reasons that have nothing to do with the change under test. This makes the
harness handle those names too, pins git's config files inside the throwaway
test folder, and rewrites the guard test so it checks a written-down list of
what the server is allowed to inherit instead of re-deriving the same
name-pattern the code already uses.

Details:

- `isolateEnv` now drops git's whole `GIT_*` namespace by prefix, drops the
  non-suffix host-state names by name, and pins `GIT_CONFIG_GLOBAL` to
  `$TEST_HOME/.gitconfig` with `GIT_CONFIG_SYSTEM` at `/dev/null` (dropping
  either only falls back to `/etc/gitconfig` or the next host location).
- Classifying the rest of what `src/` reads surfaced the same shape of leak in
  `AGENT_OF_EMPIRES_PROFILE`, `AGENT_OF_EMPIRES_DEBUG`, `AOE_CITYHALL_MODE`,
  `AOE_SERVE_PASSPHRASE`, the update/telemetry endpoints, and
  `TMUX` / `TMUX_PANE` / `AOE_INSTANCE_ID`; all are neutralized here.
- The test states a contract: a hostile case per non-suffix name, plus a scan
  of every variable `src/` reads (`env::var`, clap `env = "..."`, path-shaped
  literals) that fails unless each name is either neutralized or listed as
  deliberately inherited with a reason.

No production code changes; the diff is confined to the live-test harness.

Fixes #3657

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Both new test cases fail against the pre-fix `isolateEnv` and pass after it.
`npm run format:check`, `npm run lint`, `npx tsc -b`, and the Vitest suite were
run locally; `cargo fmt --check` passes and no Rust file is touched (this
sandbox cannot resolve the crates.io index, so `cargo clippy` / `cargo test`
are left to CI).

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BvDTS3r5T5sDUwS9wmbGp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Expanded live-test isolation to cover host variables beyond suffix-based filtering.
- Removed the inherited `GIT_*` environment and pinned Git configuration to the temporary test environment.
- Neutralized host-dependent Node, plugin, profile, debug, telemetry, tmux, and instance settings.
- Strengthened regression tests with explicit inheritance rules, hostile values, and broader source scanning.
- No production code changed.

## Benefits

Live tests are less affected by host configuration, executables, repositories, and external state. This improves reliability and prevents unintended host interaction.

## Technical notes

- Replaced `DAEMON_TARGET_VARS` with `HOST_STATE_VARS`.
- Added `pinnedVars()` for `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM`.
- Dropped `GIT_EXEC_PATH` and isolated path variables consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->