### PR TITLE
fix(acp): reject out-of-range ACP wakeup delays without panicking

### DIFF
--- a/src/acp/acp_client/raw_input.rs
+++ b/src/acp/acp_client/raw_input.rs
@@ -145,24 +145,19 @@ mod tests {
         }
     }
 
+    // The JSON-number path is covered end to end by
+    // `map_tool_call_update_emits_wakeup_when_title_and_raw_input_land_in_update`;
+    // only the numeric-string fallback is unique to this layer.
     #[test]
-    fn wakeup_from_raw_schedules_valid_delay() {
+    fn wakeup_from_raw_schedules_delay_given_as_string() {
         let before = chrono::Utc::now();
-        let raw = serde_json::json!({ "delaySeconds": 600, "reason": "watching CI" });
-        match wakeup_event_from_raw(&raw) {
-            Some(Event::WakeupScheduled { at, reason }) => {
-                assert_eq!(reason.as_deref(), Some("watching CI"));
-                assert!((at - before).num_seconds() >= 600);
-                assert!((at - before).num_seconds() < 660);
+        match wakeup_event_from_raw(&serde_json::json!({ "delaySeconds": "600" })) {
+            Some(Event::WakeupScheduled { at, .. }) => {
+                let delta = (at - before).num_seconds();
+                assert!((600..660).contains(&delta), "expected ~600s, got {delta}s");
             }
             other => panic!("expected WakeupScheduled, got {other:?}"),
         }
-        // A numeric string is accepted the same way.
-        let raw = serde_json::json!({ "delaySeconds": "600" });
-        assert!(matches!(
-            wakeup_event_from_raw(&raw),
-            Some(Event::WakeupScheduled { .. })
-        ));
     }
 
     #[test]

--- a/src/acp/acp_client/raw_input.rs
+++ b/src/acp/acp_client/raw_input.rs
@@ -8,8 +8,9 @@ use tracing::{debug, info, warn};
 /// raw_input. Reads `delaySeconds` (number, falls back to numeric
 /// string) and the optional `reason`; computes the absolute wake
 /// timestamp from `Utc::now()`. Returns `None` if `delaySeconds` is
-/// missing or non-finite, better to skip the event than publish a
-/// wakeup at epoch zero. See #1091.
+/// missing, non-finite, or so large the wake time is unrepresentable,
+/// better to skip the event than publish a wakeup at epoch zero or
+/// panic on overflow. See #1091.
 pub(super) fn wakeup_event_from_raw(raw_input: &serde_json::Value) -> Option<Event> {
     let Some(delay_value) = raw_input.get("delaySeconds") else {
         debug!(
@@ -38,7 +39,15 @@ pub(super) fn wakeup_event_from_raw(raw_input: &serde_json::Value) -> Option<Eve
         return None;
     }
     let delay_ms = (delay_secs * 1000.0).clamp(0.0, i64::MAX as f64) as i64;
-    let at = chrono::Utc::now() + chrono::Duration::milliseconds(delay_ms);
+    let Some(at) = chrono::Utc::now().checked_add_signed(chrono::Duration::milliseconds(delay_ms))
+    else {
+        warn!(
+            target: "acp.protocol.wakeup",
+            delay_secs,
+            "ScheduleWakeup `delaySeconds` overflows the representable wake time; refusing to emit"
+        );
+        return None;
+    };
     let reason = raw_input
         .get("reason")
         .and_then(|v| v.as_str())
@@ -116,6 +125,45 @@ pub(super) fn background_agent_launched_from_value(v: &serde_json::Value) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wakeup_from_raw_rejects_unusable_delays() {
+        let cases = [
+            ("missing", serde_json::json!({})),
+            ("non-numeric", serde_json::json!({ "delaySeconds": "soon" })),
+            ("negative", serde_json::json!({ "delaySeconds": -1.0 })),
+            // JSON has no infinity literal, so it arrives as a numeric string.
+            ("non-finite", serde_json::json!({ "delaySeconds": "inf" })),
+            // Finite, but past the range chrono can add to `now`.
+            ("overflowing", serde_json::json!({ "delaySeconds": 1e18 })),
+        ];
+        for (label, raw) in cases {
+            assert!(
+                wakeup_event_from_raw(&raw).is_none(),
+                "{label} delaySeconds must not emit WakeupScheduled"
+            );
+        }
+    }
+
+    #[test]
+    fn wakeup_from_raw_schedules_valid_delay() {
+        let before = chrono::Utc::now();
+        let raw = serde_json::json!({ "delaySeconds": 600, "reason": "watching CI" });
+        match wakeup_event_from_raw(&raw) {
+            Some(Event::WakeupScheduled { at, reason }) => {
+                assert_eq!(reason.as_deref(), Some("watching CI"));
+                assert!((at - before).num_seconds() >= 600);
+                assert!((at - before).num_seconds() < 660);
+            }
+            other => panic!("expected WakeupScheduled, got {other:?}"),
+        }
+        // A numeric string is accepted the same way.
+        let raw = serde_json::json!({ "delaySeconds": "600" });
+        assert!(matches!(
+            wakeup_event_from_raw(&raw),
+            Some(Event::WakeupScheduled { .. })
+        ));
+    }
 
     #[test]
     fn background_agent_launched_parsed_from_agent_meta() {


### PR DESCRIPTION
## Description

When an agent asked Agent of Empires to schedule a wake-up, the app took the requested delay and added it to the current time to work out when to wake up. If the delay was an absurdly large number, that sum landed further into the future than the app's clock type can represent, and the calculation crashed. The crash took down the connection to that agent, so a single bad number from a misbehaving agent could knock a session offline.

The delay is now added with an arithmetic operation that reports failure instead of crashing. If the resulting wake time cannot be represented, the wake-up is simply not scheduled and a warning is logged, which is what already happened for a missing, non-numeric, negative, or infinite delay. Valid delays behave exactly as before.

`wakeup_event_from_raw` clamped `delaySeconds * 1000` to `i64::MAX` and then
did `Utc::now() + Duration::milliseconds(..)`. Chrono's `+` panics on
`DateTime` overflow, so a finite delay such as `1e18` panicked
(`` `DateTime + TimeDelta` overflowed ``) and terminated the ACP connection
task. Replaced with `checked_add_signed`, returning `None` on overflow.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by unit tests in `src/acp/acp_client/raw_input.rs`:
`wakeup_from_raw_rejects_unusable_delays` (table over missing, non-numeric,
negative, non-finite, and overflowing delays; the overflowing case panics
without this change) and `wakeup_from_raw_schedules_valid_delay` (numeric and
numeric-string delays still schedule).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Fix drafted and tested by Claude Opus 5 in back-and-forth with @njbrake, then reviewed in a separate fresh-context agent pass before this PR left draft.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCZrCGGb9nzGY7LFzmyxac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents ACP wake-up scheduling from panicking on delays outside Chrono’s supported time range.
- Keeps existing handling for valid, missing, negative, non-numeric, and non-finite delays.
- Adds unit tests for overflow, invalid values, and valid numeric-string delays.

## Benefits

Malformed ACP wake-up delays now fail safely without terminating the connection task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->