### PR TITLE
fix(serve): arm the shutdown deadline before reaping plugin workers

### DIFF
--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -79,8 +79,13 @@ async fn run_shutdown_sequence<R, F>(
     F: FnOnce() + Send + 'static,
 {
     shutdown.cancel();
+    // Build the timer here, not inside the task: `sleep` fixes its deadline
+    // from the clock at construction, so constructing it in the task would
+    // restart the window at the task's first poll, which the reap's own
+    // synchronous work can delay.
+    let deadline = tokio::time::sleep(grace);
     tokio::spawn(async move {
-        tokio::time::sleep(grace).await;
+        deadline.await;
         tracing::warn!(
             target: "shutdown",
             grace_secs = grace.as_secs(),
@@ -1287,6 +1292,38 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+        assert!(forced.load(Ordering::SeqCst));
+    }
+
+    /// The grace window must run from the cancel, not from whenever the
+    /// watchdog task first gets polled. On this single-threaded runtime a
+    /// reap that works synchronously before yielding holds the only worker,
+    /// so a deadline built inside the task would not start until the reap
+    /// released it, stretching the window past `GRACE`.
+    #[tokio::test]
+    async fn shutdown_deadline_runs_from_the_cancel_not_the_watchdog_poll() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        const GRACE: Duration = Duration::from_millis(100);
+
+        let shutdown = CancellationToken::new();
+        let forced = Arc::new(AtomicBool::new(false));
+        let flag = forced.clone();
+        run_shutdown_sequence(
+            &shutdown,
+            GRACE,
+            async { std::thread::sleep(GRACE * 2) },
+            move || flag.store(true, Ordering::SeqCst),
+        )
+        .await;
+        assert!(
+            !forced.load(Ordering::SeqCst),
+            "the reap blocked the worker"
+        );
+
+        // One short park is all the watchdog needs once its deadline has
+        // already passed, and far less than another full window.
+        tokio::time::sleep(Duration::from_millis(1)).await;
         assert!(forced.load(Ordering::SeqCst));
     }
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -5,6 +5,7 @@ use crate::file_watch::FileWatchService;
 use crate::server::push::{PushState, STATUS_CHANNEL_CAPACITY};
 use crate::server::rate_limit::RateLimiter;
 use anyhow::Context;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -54,6 +55,41 @@ pub(super) fn remote_serve_url_contents(
     let remote_url = with_token(remote_base_url);
     let loopback_url = with_token(&format!("http://127.0.0.1:{local_port}"));
     format!("{remote_url}\nlocalhost\t{loopback_url}\n")
+}
+
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Post-signal shutdown: cancel the shared token, arm the force-exit
+/// deadline, then reap plugin workers.
+///
+/// The deadline is armed before `reap` is awaited so a plugin worker that
+/// never terminates cannot keep the daemon alive indefinitely.
+///
+/// A forced exit skips the post-`axum::serve` cleanup (acp detach, tunnel
+/// SIGTERM of cloudflared, removal of serve.passphrase). The PID file is
+/// swept by `daemon_pid`'s stale-PID check on the next start, but a leftover
+/// cloudflared subprocess and residual passphrase file may survive it. The
+/// common path returns from `axum::serve` normally and runs the full cleanup.
+async fn run_shutdown_sequence<R, F>(
+    shutdown: &CancellationToken,
+    grace: Duration,
+    reap: R,
+    force_exit: F,
+) where
+    R: Future<Output = ()>,
+    F: FnOnce() + Send + 'static,
+{
+    shutdown.cancel();
+    tokio::spawn(async move {
+        tokio::time::sleep(grace).await;
+        tracing::warn!(
+            target: "shutdown",
+            grace_secs = grace.as_secs(),
+            "graceful shutdown exceeded grace window, forcing exit"
+        );
+        force_exit();
+    });
+    reap.await;
 }
 
 /// Raise the soft `RLIMIT_NOFILE` so the server can sustain many WS
@@ -924,9 +960,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     //      terminal) wake from their `select!` and close cleanly,
     //      letting `axum::serve` return promptly instead of blocking
     //      on the open WebSockets the browser hasn't disconnected.
-    //   2. Spawns a 5s deadline as the safety net: if any handler
-    //      somehow ignores the cancel, the process force-exits so
-    //      `Ctrl-C` and `aoe serve --stop` never hang. See #1198.
+    //   2. Arms a 5s force-exit deadline, then reaps plugin workers:
+    //      if any handler or worker ignores the cancel, the process
+    //      force-exits so `Ctrl-C` and `aoe serve --stop` never hang.
+    //      See #1198.
     //
     // Note: this future is awaited by `with_graceful_shutdown`, which
     // signals axum to stop accepting new connections once the future
@@ -935,7 +972,6 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // of just the post-signal drain, which is wrong (the server would
     // exit after 5s of normal uptime). The deadline lives inside the
     // signal handler so the clock only starts after the signal fires.
-    const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
     let shutdown_state = state.clone();
     let shutdown_signal = async move {
         #[cfg(unix)]
@@ -960,28 +996,18 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             let _ = tokio::signal::ctrl_c().await;
             tracing::info!(target: "serve.shutdown", "received ctrl-c, shutting down");
         }
-        shutdown_state.shutdown.cancel();
-        // Reap plugin workers before the force-exit deadline so no worker tree
-        // is left behind when the daemon stops.
-        if let Some(host) = shutdown_state.plugin_host.clone() {
-            host.shutdown().await;
-        }
-        tokio::spawn(async {
-            tokio::time::sleep(SHUTDOWN_GRACE).await;
-            tracing::warn!(
-                target: "shutdown",
-                grace_secs = SHUTDOWN_GRACE.as_secs(),
-                "graceful shutdown exceeded grace window, forcing exit"
-            );
-            // Force-exit skips the post-`axum::serve` cleanup block below
-            // (acp detach, tunnel SIGTERM of cloudflared, removal of
-            // serve.passphrase). The PID file is swept by `daemon_pid`'s
-            // stale-PID check on the next start, but a leftover cloudflared
-            // subprocess and residual passphrase file may survive a forced
-            // exit. The common path (handlers honor cancel) returns from
-            // `axum::serve` normally and runs the full cleanup.
-            std::process::exit(0);
-        });
+        let plugin_host = shutdown_state.plugin_host.clone();
+        run_shutdown_sequence(
+            &shutdown_state.shutdown,
+            SHUTDOWN_GRACE,
+            async move {
+                if let Some(host) = plugin_host {
+                    host.shutdown().await;
+                }
+            },
+            || std::process::exit(0),
+        )
+        .await;
     };
 
     axum::serve(
@@ -1215,5 +1241,43 @@ mod tests {
         assert!(push.store.snapshot().await.is_empty());
 
         shutdown.cancel();
+    }
+
+    #[tokio::test]
+    async fn shutdown_sequence_force_exits_when_plugin_reap_never_finishes() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        const GRACE: Duration = Duration::from_millis(50);
+
+        // A reap that completes lets the sequence return without forcing an exit.
+        let quick_shutdown = CancellationToken::new();
+        let quick_forced = Arc::new(AtomicBool::new(false));
+        let flag = quick_forced.clone();
+        run_shutdown_sequence(&quick_shutdown, GRACE, std::future::ready(()), move || {
+            flag.store(true, Ordering::SeqCst)
+        })
+        .await;
+        assert!(quick_shutdown.is_cancelled());
+        assert!(!quick_forced.load(Ordering::SeqCst));
+
+        // A reap that never finishes must still arm the deadline and force the exit.
+        let shutdown = CancellationToken::new();
+        let forced = Arc::new(AtomicBool::new(false));
+        let flag = forced.clone();
+        let sequence = tokio::spawn({
+            let shutdown = shutdown.clone();
+            async move {
+                run_shutdown_sequence(&shutdown, GRACE, std::future::pending::<()>(), move || {
+                    flag.store(true, Ordering::SeqCst)
+                })
+                .await;
+            }
+        });
+
+        shutdown.cancelled().await;
+        tokio::time::sleep(GRACE * 4).await;
+        assert!(forced.load(Ordering::SeqCst));
+        assert!(!sequence.is_finished());
+        sequence.abort();
     }
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -60,14 +60,15 @@ pub(super) fn remote_serve_url_contents(
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 
 /// Post-signal shutdown: cancel the shared token, arm the force-exit
-/// deadline, then reap plugin workers.
+/// deadline, then reap plugin workers within four fifths of the window,
+/// leaving the rest for the caller's own cleanup.
 ///
-/// The deadline is armed before `reap` is awaited, and the reap gets only
-/// part of the window, so a plugin worker that never terminates can neither
-/// keep the daemon alive nor starve the post-`axum::serve` cleanup (acp
-/// detach, tunnel SIGTERM of cloudflared, removal of serve.passphrase) of
-/// its chance to run. A forced exit skips that cleanup entirely; the PID
-/// file is swept by `daemon_pid`'s stale-PID check on the next start.
+/// A worker that never terminates therefore cannot keep the daemon alive.
+/// It is not free: a reap cut short can leave a worker group SIGTERMed
+/// without the SIGKILL escalation, and a forced exit skips the
+/// post-`axum::serve` cleanup entirely (acp detach, tunnel SIGTERM of
+/// cloudflared, removal of serve.passphrase). The PID file is swept by
+/// `daemon_pid`'s stale-PID check on the next start.
 async fn run_shutdown_sequence<R, F>(
     shutdown: &CancellationToken,
     grace: Duration,
@@ -87,10 +88,7 @@ async fn run_shutdown_sequence<R, F>(
         );
         force_exit();
     });
-    if tokio::time::timeout(grace.mul_f32(0.8), reap)
-        .await
-        .is_err()
-    {
+    if tokio::time::timeout(grace * 4 / 5, reap).await.is_err() {
         tracing::warn!(
             target: "shutdown",
             "plugin worker reap did not finish in time, continuing shutdown"

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -62,14 +62,12 @@ const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// Post-signal shutdown: cancel the shared token, arm the force-exit
 /// deadline, then reap plugin workers.
 ///
-/// The deadline is armed before `reap` is awaited so a plugin worker that
-/// never terminates cannot keep the daemon alive indefinitely.
-///
-/// A forced exit skips the post-`axum::serve` cleanup (acp detach, tunnel
-/// SIGTERM of cloudflared, removal of serve.passphrase). The PID file is
-/// swept by `daemon_pid`'s stale-PID check on the next start, but a leftover
-/// cloudflared subprocess and residual passphrase file may survive it. The
-/// common path returns from `axum::serve` normally and runs the full cleanup.
+/// The deadline is armed before `reap` is awaited, and the reap gets only
+/// part of the window, so a plugin worker that never terminates can neither
+/// keep the daemon alive nor starve the post-`axum::serve` cleanup (acp
+/// detach, tunnel SIGTERM of cloudflared, removal of serve.passphrase) of
+/// its chance to run. A forced exit skips that cleanup entirely; the PID
+/// file is swept by `daemon_pid`'s stale-PID check on the next start.
 async fn run_shutdown_sequence<R, F>(
     shutdown: &CancellationToken,
     grace: Duration,
@@ -89,7 +87,15 @@ async fn run_shutdown_sequence<R, F>(
         );
         force_exit();
     });
-    reap.await;
+    if tokio::time::timeout(grace.mul_f32(0.8), reap)
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            target: "shutdown",
+            "plugin worker reap did not finish in time, continuing shutdown"
+        );
+    }
 }
 
 /// Raise the soft `RLIMIT_NOFILE` so the server can sustain many WS
@@ -960,10 +966,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     //      terminal) wake from their `select!` and close cleanly,
     //      letting `axum::serve` return promptly instead of blocking
     //      on the open WebSockets the browser hasn't disconnected.
-    //   2. Arms a 5s force-exit deadline, then reaps plugin workers:
-    //      if any handler or worker ignores the cancel, the process
-    //      force-exits so `Ctrl-C` and `aoe serve --stop` never hang.
-    //      See #1198.
+    //   2. Arms a 5s force-exit deadline, then reaps plugin workers
+    //      within part of that window: if any handler or worker ignores
+    //      the cancel, the process still force-exits, so `Ctrl-C` and
+    //      terminal hangups never hang. See #1198.
     //
     // Note: this future is awaited by `with_graceful_shutdown`, which
     // signals axum to stop accepting new connections once the future
@@ -1244,40 +1250,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shutdown_sequence_force_exits_when_plugin_reap_never_finishes() {
+    async fn shutdown_sequence_bounds_a_plugin_reap_that_never_finishes() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        const GRACE: Duration = Duration::from_millis(50);
+        const GRACE: Duration = Duration::from_millis(100);
 
-        // A reap that completes lets the sequence return without forcing an exit.
-        let quick_shutdown = CancellationToken::new();
-        let quick_forced = Arc::new(AtomicBool::new(false));
-        let flag = quick_forced.clone();
-        run_shutdown_sequence(&quick_shutdown, GRACE, std::future::ready(()), move || {
-            flag.store(true, Ordering::SeqCst)
-        })
+        // Arming the deadline first must not skip the plugin teardown.
+        let shutdown = CancellationToken::new();
+        let reaped = Arc::new(AtomicBool::new(false));
+        let flag = reaped.clone();
+        run_shutdown_sequence(
+            &shutdown,
+            GRACE,
+            async move { flag.store(true, Ordering::SeqCst) },
+            || {},
+        )
         .await;
-        assert!(quick_shutdown.is_cancelled());
-        assert!(!quick_forced.load(Ordering::SeqCst));
+        assert!(shutdown.is_cancelled());
+        assert!(reaped.load(Ordering::SeqCst));
 
-        // A reap that never finishes must still arm the deadline and force the exit.
+        // A reap that never finishes is bounded, so the caller still reaches
+        // its own cleanup, and the deadline still forces the exit.
         let shutdown = CancellationToken::new();
         let forced = Arc::new(AtomicBool::new(false));
         let flag = forced.clone();
-        let sequence = tokio::spawn({
-            let shutdown = shutdown.clone();
-            async move {
-                run_shutdown_sequence(&shutdown, GRACE, std::future::pending::<()>(), move || {
-                    flag.store(true, Ordering::SeqCst)
-                })
-                .await;
-            }
-        });
+        tokio::time::timeout(
+            GRACE * 10,
+            run_shutdown_sequence(&shutdown, GRACE, std::future::pending::<()>(), move || {
+                flag.store(true, Ordering::SeqCst)
+            }),
+        )
+        .await
+        .expect("a hung reap must not block the shutdown sequence");
 
-        shutdown.cancelled().await;
-        tokio::time::sleep(GRACE * 4).await;
+        for _ in 0..200 {
+            if forced.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
         assert!(forced.load(Ordering::SeqCst));
-        assert!(!sequence.is_finished());
-        sequence.abort();
     }
 }


### PR DESCRIPTION
## Description

When you stop the background daemon (Ctrl-C, a closed terminal, or `aoe serve --stop`), it tries to shut plugin workers down cleanly before exiting. There is also a five second safety timer that force-exits the process if anything refuses to stop. The timer was only started *after* the plugin cleanup finished, so if a plugin worker never stopped, the cleanup waited forever and the timer was never started: Ctrl-C appeared to hang, and `aoe serve --stop` fell back to killing the daemon outright two seconds later, before any of its own cleanup ran. Now the timer starts first and the plugin cleanup gets a bounded slice of that window, so the daemon always goes away within five seconds and still gets a chance to run its remaining cleanup on the way out. A healthy plugin is reaped normally, well inside its slice.

The post-signal sequence (cancel the shared shutdown token, arm the force-exit deadline, reap plugin workers under a timeout) moved into `run_shutdown_sequence`, which takes the reap future and the force-exit action so it can be exercised without a live daemon.

Fixes #3661

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: an e2e test would need a plugin worker that ignores SIGTERM plus a real five second wall clock wait. The unit test in `src/server/startup.rs` drives the same sequence with a short injected grace, covering the hung reap, the bounded return, and the normal teardown.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Implementation and regression test written by the agent from the issue report, then reviewed locally.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147tgKJjCQ9RLbN1EC2ta65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Moved shutdown handling into a reusable sequence.
- Started the five-second force-exit deadline immediately after shutdown cancellation.
- Bounded plugin-worker reaping within the shutdown window.
- Preserved normal cleanup and the existing forced-exit warning.
- Added tests for successful reaping, stalled reaping, cancellation, and deadline timing.

This prevents the daemon from hanging when a plugin worker does not stop while preserving normal shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->