### PR TITLE
fix(serve): clear rotated tokens on the configured grace period

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,10 @@ serve = ["web"]
 
 [dev-dependencies]
 serial_test = "4.0"
+# Test-only tokio clock control (`start_paused`), so the token-rotation
+# loop's grace deadline can be asserted without sleeping through it. The
+# lib build and release binaries never see `test-util`.
+tokio = { version = "1.52", features = ["test-util"] }
 # Test-only tracing capture (#2756, I4): asserts the equal-timestamp guard's
 # drop branch logged. Its target `session.store` is rejected by the default
 # `agent_of_empires=trace` env filter, so `no-env-filter` is required; the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,8 +228,8 @@ serve = ["web"]
 [dev-dependencies]
 serial_test = "4.0"
 # Test-only tokio clock control (`start_paused`), so the token-rotation
-# loop's grace deadline can be asserted without sleeping through it. The
-# lib build and release binaries never see `test-util`.
+# loop's grace deadline can be asserted without sleeping through it.
+# `cargo build` and released binaries never enable `test-util`.
 tokio = { version = "1.52", features = ["test-util"] }
 # Test-only tracing capture (#2756, I4): asserts the equal-timestamp guard's
 # drop branch logged. Its target `session.store` is rejected by the default

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -905,7 +905,6 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             state.shutdown.clone(),
             rot_base_url,
             local_port,
-            token_grace,
         ));
     } else if test_token_lifetime_override().is_some() && auth_token.is_some() {
         // Debug-build test path: live Playwright specs set
@@ -1039,19 +1038,19 @@ pub(super) fn maybe_open_browser(url: &str) {
 /// subscriptions bound only to its hash.
 ///
 /// Runs here rather than in `TokenManager::spawn_rotation_task` so rotation can
-/// also refresh `serve.url` and prune the push store. `grace` must be the same
-/// duration the manager validates against; otherwise the previous token's state
-/// and its subscriptions outlive the window it is accepted in.
+/// also refresh `serve.url` and prune the push store. Both deadlines come from
+/// the manager, so the previous token's state and its subscriptions cannot
+/// outlive the window `validate` accepts it in.
 async fn remote_rotation_loop(
     token_manager: Arc<TokenManager>,
     push: Option<Arc<PushState>>,
     shutdown: CancellationToken,
     base_url: Option<String>,
     local_port: u16,
-    grace: Duration,
 ) {
     loop {
         let lifetime = token_manager.lifetime_secs().await;
+        let grace = token_manager.grace().await;
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(lifetime)) => {}
             _ = shutdown.cancelled() => break,
@@ -1115,7 +1114,9 @@ async fn remote_rotation_loop(
             if valid_hashes.is_empty() {
                 valid_hashes.push([0u8; 32]);
             }
-            let _ = push.store.retain_owners(&valid_hashes).await;
+            if let Err(e) = push.store.retain_owners(&valid_hashes).await {
+                tracing::warn!(target: "http.middleware", error = %e, "push: retain_owners failed");
+            }
         }
     }
 }
@@ -1196,7 +1197,6 @@ mod tests {
             shutdown.clone(),
             None,
             8080,
-            grace,
         ));
 
         // Mid-grace: the rotated-out token is still accepted, and its

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -894,97 +894,19 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     login_manager.spawn_cleanup_task(state.shutdown.clone());
 
     if remote {
-        // Inline the rotation loop here rather than calling
-        // token_manager.spawn_rotation_task() so we can also invalidate
-        // push subscriptions whose owner hash is no longer valid after
-        // rotation. Behavior otherwise matches the original: wait one
-        // lifetime, rotate, wait 300s grace, clear previous.
-        let rot_state = state.clone();
-        let rot_shutdown = state.shutdown.clone();
         // The tunnel URL is stable across the daemon's lifetime (Tailscale
         // and named CF tunnels are stable; quick CF rotates only on
         // restart, which is outside this task's scope). Capture once so
         // the rotation task can rebuild `serve.url` with the new token.
         let rot_base_url: Option<String> = tunnel_handle.as_ref().map(|h| h.url.clone());
-        tokio::spawn(async move {
-            loop {
-                let lifetime = rot_state.token_manager.lifetime_secs().await;
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(lifetime)) => {}
-                    _ = rot_shutdown.cancelled() => break,
-                }
-
-                // Capture the hashes of the current and (about-to-be)
-                // previous tokens BEFORE rotating, so we know which
-                // owner-hashes are still valid in the store.
-                let pre_rotate_current = rot_state.token_manager.current_token().await;
-                rot_state.token_manager.rotate().await;
-                let post_rotate_current = rot_state.token_manager.current_token().await;
-
-                // Refresh `serve.url` so the TUI display and the QR-code
-                // URL stay in sync with the rotated token. Without this
-                // the TUI keeps showing `?token=<old>`, which is invalid
-                // 5 minutes after rotation (end of grace period).
-                if let (Some(base_url), Some(token)) =
-                    (rot_base_url.as_ref(), post_rotate_current.as_ref())
-                {
-                    if let Ok(app_dir) = crate::session::get_app_dir() {
-                        let contents = remote_serve_url_contents(base_url, local_port, Some(token));
-                        write_secret_file(&app_dir.join("serve.url"), &contents).await;
-                    }
-                }
-
-                if let Some(push) = rot_state.push.as_ref() {
-                    let mut valid_hashes: Vec<[u8; 32]> = Vec::new();
-                    if let Some(t) = &post_rotate_current {
-                        valid_hashes.push(push::sha256_token(t));
-                    }
-                    if let Some(t) = &pre_rotate_current {
-                        // The old token remains in the grace period (5m)
-                        // so devices that haven't yet picked up the new
-                        // token should keep receiving pushes.
-                        valid_hashes.push(push::sha256_token(t));
-                    }
-                    // In no-auth mode the token is None and we use a
-                    // zero hash; preserve that so zero-hash subs survive.
-                    if valid_hashes.is_empty() {
-                        valid_hashes.push([0u8; 32]);
-                    }
-                    match push.store.retain_owners(&valid_hashes).await {
-                        Ok(0) => {}
-                        Ok(n) => tracing::info!(target: "http.middleware",
-                            removed = n,
-                            "push: dropped subscriptions whose owner-hash is no longer valid after rotation"
-                        ),
-                        Err(e) => {
-                            tracing::warn!(target: "http.middleware", error = %e, "push: retain_owners failed")
-                        }
-                    }
-                }
-
-                // After grace period, the previous token becomes invalid.
-                // Clear it AND drop any subscriptions that were bound
-                // only to the old hash (retain_owners with only the new).
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(300)) => {}
-                    _ = rot_shutdown.cancelled() => break,
-                }
-                // Clear previous token inside TokenManager. Reuse its
-                // internal state access via a tiny helper on the manager.
-                rot_state.token_manager.clear_previous().await;
-
-                if let Some(push) = rot_state.push.as_ref() {
-                    let mut valid_hashes: Vec<[u8; 32]> = Vec::new();
-                    if let Some(t) = rot_state.token_manager.current_token().await {
-                        valid_hashes.push(push::sha256_token(&t));
-                    }
-                    if valid_hashes.is_empty() {
-                        valid_hashes.push([0u8; 32]);
-                    }
-                    let _ = push.store.retain_owners(&valid_hashes).await;
-                }
-            }
-        });
+        tokio::spawn(remote_rotation_loop(
+            state.token_manager.clone(),
+            state.push.clone(),
+            state.shutdown.clone(),
+            rot_base_url,
+            local_port,
+            token_grace,
+        ));
     } else if test_token_lifetime_override().is_some() && auth_token.is_some() {
         // Debug-build test path: live Playwright specs set
         // AOE_TEST_TOKEN_LIFETIME_SECS (and optionally AOE_TEST_TOKEN_GRACE_SECS)
@@ -1112,6 +1034,92 @@ pub(super) fn maybe_open_browser(url: &str) {
     }
 }
 
+/// The `--remote` token rotation loop: wait one lifetime, rotate, then wait out
+/// the grace window before clearing the previous token and dropping the push
+/// subscriptions bound only to its hash.
+///
+/// Runs here rather than in `TokenManager::spawn_rotation_task` so rotation can
+/// also refresh `serve.url` and prune the push store. `grace` must be the same
+/// duration the manager validates against; otherwise the previous token's state
+/// and its subscriptions outlive the window it is accepted in.
+async fn remote_rotation_loop(
+    token_manager: Arc<TokenManager>,
+    push: Option<Arc<PushState>>,
+    shutdown: CancellationToken,
+    base_url: Option<String>,
+    local_port: u16,
+    grace: Duration,
+) {
+    loop {
+        let lifetime = token_manager.lifetime_secs().await;
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(lifetime)) => {}
+            _ = shutdown.cancelled() => break,
+        }
+
+        // Capture the hashes of the current and (about-to-be) previous tokens
+        // BEFORE rotating, so we know which owner-hashes are still valid in
+        // the store.
+        let pre_rotate_current = token_manager.current_token().await;
+        token_manager.rotate().await;
+        let post_rotate_current = token_manager.current_token().await;
+
+        // Refresh `serve.url` so the TUI display and the QR-code URL stay in
+        // sync with the rotated token. Without this the TUI keeps showing
+        // `?token=<old>`, which stops working once the grace window closes.
+        if let (Some(base_url), Some(token)) = (base_url.as_ref(), post_rotate_current.as_ref()) {
+            if let Ok(app_dir) = crate::session::get_app_dir() {
+                let contents = remote_serve_url_contents(base_url, local_port, Some(token));
+                write_secret_file(&app_dir.join("serve.url"), &contents).await;
+            }
+        }
+
+        if let Some(push) = push.as_ref() {
+            let mut valid_hashes: Vec<[u8; 32]> = Vec::new();
+            if let Some(t) = &post_rotate_current {
+                valid_hashes.push(push::sha256_token(t));
+            }
+            if let Some(t) = &pre_rotate_current {
+                // The old token is still inside the grace window, so devices
+                // that have not picked up the new one keep receiving pushes.
+                valid_hashes.push(push::sha256_token(t));
+            }
+            // In no-auth mode the token is None and we use a zero hash;
+            // preserve that so zero-hash subs survive.
+            if valid_hashes.is_empty() {
+                valid_hashes.push([0u8; 32]);
+            }
+            match push.store.retain_owners(&valid_hashes).await {
+                Ok(0) => {}
+                Ok(n) => tracing::info!(target: "http.middleware",
+                    removed = n,
+                    "push: dropped subscriptions whose owner-hash is no longer valid after rotation"
+                ),
+                Err(e) => {
+                    tracing::warn!(target: "http.middleware", error = %e, "push: retain_owners failed")
+                }
+            }
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep(grace) => {}
+            _ = shutdown.cancelled() => break,
+        }
+        token_manager.clear_previous().await;
+
+        if let Some(push) = push.as_ref() {
+            let mut valid_hashes: Vec<[u8; 32]> = Vec::new();
+            if let Some(t) = token_manager.current_token().await {
+                valid_hashes.push(push::sha256_token(&t));
+            }
+            if valid_hashes.is_empty() {
+                valid_hashes.push([0u8; 32]);
+            }
+            let _ = push.store.retain_owners(&valid_hashes).await;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1150,5 +1158,62 @@ mod tests {
         );
         // Neither configured is the security-relevant fully-open mode.
         assert_eq!(resolve_auth_mode(&no_token, &no_passphrase).await, "none");
+    }
+
+    /// The post-rotation cleanup must run on the configured grace period, not
+    /// a hardcoded default, so a token stops being accepted and stops owning
+    /// push subscriptions at the same moment.
+    #[tokio::test(start_paused = true)]
+    async fn rotation_cleanup_honors_the_configured_grace() {
+        let lifetime = Duration::from_secs(60);
+        let grace = Duration::from_secs(7);
+        let manager = Arc::new(TokenManager::with_grace(
+            Some("old_token".to_string()),
+            lifetime,
+            grace,
+        ));
+
+        let dir = tempfile::tempdir().unwrap();
+        let push = Arc::new(PushState::init(dir.path()).unwrap());
+        push.store
+            .upsert(push::Subscription {
+                endpoint: "https://push.example.test/old".to_string(),
+                p256dh: "pk".into(),
+                auth: "auth".into(),
+                owner_token_hash: push::sha256_token("old_token"),
+                user_agent: "UA".into(),
+                created_at: chrono::Utc::now(),
+                generation: 0,
+                origin: "https://aoe.example.test".into(),
+            })
+            .await
+            .unwrap();
+
+        let shutdown = CancellationToken::new();
+        tokio::spawn(remote_rotation_loop(
+            manager.clone(),
+            Some(push.clone()),
+            shutdown.clone(),
+            None,
+            8080,
+            grace,
+        ));
+
+        // Mid-grace: the rotated-out token is still accepted, and its
+        // subscription still belongs to a valid owner.
+        tokio::time::sleep(lifetime + grace / 2).await;
+        assert!(manager.validate("old_token").await.0);
+        assert!(manager.holds_previous().await);
+        assert_eq!(push.store.snapshot().await.len(), 1);
+
+        // Past the configured grace: validation and cleanup agree. With the
+        // hardcoded 300s sleep the token was rejected here while its state and
+        // subscription lingered.
+        tokio::time::sleep(grace).await;
+        assert!(!manager.validate("old_token").await.0);
+        assert!(!manager.holds_previous().await);
+        assert!(push.store.snapshot().await.is_empty());
+
+        shutdown.cancel();
     }
 }

--- a/src/server/token.rs
+++ b/src/server/token.rs
@@ -79,12 +79,18 @@ impl TokenManager {
         self.state.read().await.lifetime.as_secs()
     }
 
-    /// Clear the previous token after the grace period has expired.
-    /// Used by the rotation task after the 5-minute grace window.
+    /// Clear the previous token once its grace window has closed.
     pub async fn clear_previous(&self) {
         let mut state = self.state.write().await;
         state.previous = None;
         state.grace_expires = None;
+    }
+
+    /// Whether a rotated-out token is still held, so the rotation loop's
+    /// cleanup deadline can be asserted.
+    #[cfg(test)]
+    pub(super) async fn holds_previous(&self) -> bool {
+        self.state.read().await.previous.is_some()
     }
 
     /// Rotate: generate new token, move current to previous with grace period.

--- a/src/server/token.rs
+++ b/src/server/token.rs
@@ -79,6 +79,12 @@ impl TokenManager {
         self.state.read().await.lifetime.as_secs()
     }
 
+    /// How long a rotated-out token stays valid. The rotation loop reads it
+    /// here so its cleanup deadline cannot drift from what `validate` accepts.
+    pub(super) async fn grace(&self) -> Duration {
+        self.state.read().await.grace
+    }
+
     /// Clear the previous token once its grace window has closed.
     pub async fn clear_previous(&self) {
         let mut state = self.state.write().await;


### PR DESCRIPTION
## Description

When the daemon runs with `--remote`, it hands out an access token and swaps it for a fresh one on a schedule. The old token keeps working for a short "grace" period afterwards, so a phone or browser that has not noticed the swap yet is not locked out mid-session. The length of that grace period is configurable, and tests set it very short so they do not have to wait five minutes. The problem: only the "is this token still accepted?" check honoured the configured length. The follow-up cleanup, which forgets the old token and drops the push-notification registrations that belonged to it, always waited a flat five minutes. So with a short grace period the old token was already being refused while its leftover state and its push registrations sat around until the five minutes were up. Now both use the same configured duration, so the token stops being accepted and stops owning anything at the same moment.

Concretely: the `--remote` rotation loop slept a hardcoded `Duration::from_secs(300)` before `clear_previous()` and the second `retain_owners()` prune, while validation used the resolved `token_grace` (`AOE_TEST_TOKEN_GRACE_SECS` or `DEFAULT_TOKEN_GRACE`). The loop was inlined in `start_server`, so its deadline could not be asserted; it is extracted as `remote_rotation_loop(...)`, which now reads the grace from the `TokenManager` alongside the lifetime so the two deadlines cannot drift apart again. Behavior is otherwise unchanged. `TokenManager::spawn_rotation_task` (the non-remote debug path) already used the configured grace and is untouched.

Default behavior does not change: `DEFAULT_TOKEN_GRACE` is 300s.

Fixes #3662

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (no UI changes)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: a rotation cycle is a timing behavior of the daemon's background loop; a paused-clock unit test (`rotation_cleanup_honors_the_configured_grace` in `src/server/startup.rs`) drives the real loop and asserts the deadline deterministically, which an e2e test cannot do without sleeping through it. The test fails on the pre-fix code.

`tokio`'s `test-util` feature is added as a dev-dependency for `start_paused`; the lib build and release binaries never enable it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Implemented and tested by an agent; the regression test was verified to fail against the hardcoded 300s sleep and pass with the fix.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSWd61McFWtJ89f3VUKBDx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Token cleanup now uses the configured grace period instead of a fixed five-minute delay.
- Remote token rotation was moved into a separate loop for clearer behavior and testing.
- Previous tokens and related push subscriptions now expire at the same time as token validation.
- Added a regression test with a paused clock.
- Added Tokio test utilities as a development dependency.

## Benefits

This keeps token validation and cleanup consistent, including when deployments override the default grace period. Non-remote rotation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->