### PR TITLE
fix(hooks): read sandbox trust files through one O_NOFOLLOW descriptor

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -885,7 +885,8 @@ impl SymlinkPolicy {
     /// The content to merge into, or `None` when there is none. Under `Never`
     /// anything that is not a regular file reads as absent: following a planted
     /// link would pull an arbitrary host file into a config the container
-    /// reads.
+    /// reads. The type check and the read share one `O_NOFOLLOW` descriptor,
+    /// so a link swapped in after the check cannot be the thing read.
     fn read(self, path: &Path) -> Result<Option<String>> {
         match self {
             Self::Follow => match std::fs::read_to_string(path) {
@@ -893,11 +894,23 @@ impl SymlinkPolicy {
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
                 Err(e) => Err(e).with_context(|| format!("reading {}", path.display())),
             },
-            Self::Never => Ok(std::fs::symlink_metadata(path)
-                .is_ok_and(|m| m.is_file())
-                .then(|| std::fs::read_to_string(path).ok())
-                .flatten()),
+            Self::Never => {
+                let (dir, name) = Self::split_in_bind(path)?;
+                crate::session::read_file_no_follow(dir, Path::new(name))
+            }
         }
+    }
+
+    /// The bind root is the directory AoE owns; the file sits directly in it,
+    /// so the whole path below the root is that one name.
+    fn split_in_bind(path: &Path) -> Result<(&Path, &std::ffi::OsStr)> {
+        let dir = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("{} has no parent", path.display()))?;
+        let name = path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("{} has no file name", path.display()))?;
+        Ok((dir, name))
     }
 
     fn write(self, path: &Path, content: &[u8]) -> Result<()> {
@@ -908,15 +921,8 @@ impl SymlinkPolicy {
                 }
                 crate::session::atomic_write(path, content)
             }
-            // The bind root is the directory AoE owns; the file sits directly
-            // in it, so the whole path below the root is that one name.
             Self::Never => {
-                let dir = path
-                    .parent()
-                    .ok_or_else(|| anyhow::anyhow!("{} has no parent", path.display()))?;
-                let name = path
-                    .file_name()
-                    .ok_or_else(|| anyhow::anyhow!("{} has no file name", path.display()))?;
+                let (dir, name) = Self::split_in_bind(path)?;
                 crate::session::replace_file_no_follow(dir, Path::new(name), content)
             }
         }
@@ -3412,8 +3418,11 @@ trust_level = "trusted"
             Value::Bool(true)
         );
 
+        // Valid JSON, so the only thing keeping it out of the merged config is
+        // the read refusing to follow the link.
         let outside = tmp.path().join("host-secret");
-        std::fs::write(&outside, "untouched").unwrap();
+        let host_json = r#"{"projects":{"/host/secret":{"hasTrustDialogAccepted":true}}}"#;
+        std::fs::write(&outside, host_json).unwrap();
         let bind = tmp.path().join("bind");
         std::fs::create_dir(&bind).unwrap();
         let planted = bind.join(".claude.json");
@@ -3423,7 +3432,7 @@ trust_level = "trusted"
 
         assert_eq!(
             std::fs::read_to_string(&outside).unwrap(),
-            "untouched",
+            host_json,
             "the planted link must not carry the write out of the bind"
         );
         assert!(!std::fs::symlink_metadata(&planted)
@@ -3440,6 +3449,10 @@ trust_level = "trusted"
         // The link's target is not merged in either: it never reaches a config
         // the container can read.
         assert_eq!(written.as_object().unwrap().len(), 1);
+        assert!(
+            written["projects"].get("/host/secret").is_none(),
+            "the host file behind the link must not be republished into the bind"
+        );
 
         // The lock sidecar is part of the path the container can plant on, so
         // a link there fails the write closed rather than locking a host file.
@@ -3449,7 +3462,7 @@ trust_level = "trusted"
             trust_claude_project(&locked, "/workspace/wt", SymlinkPolicy::Never).is_err(),
             "a planted lock link must fail the write, not follow it"
         );
-        assert_eq!(std::fs::read_to_string(&outside).unwrap(), "untouched");
+        assert_eq!(std::fs::read_to_string(&outside).unwrap(), host_json);
     }
 
     #[test]

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -2311,6 +2311,47 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    /// The extension read must go through the anchored walk, not a stat of the
+    /// pathname followed by a second open of it. With `agent/extensions`
+    /// swapped for a link to a directory that already holds the current
+    /// extension, the check-then-open shape stats the host copy through the
+    /// link, finds it equal, and reports success without ever looking inside
+    /// the bind; the walk refuses the linked component instead, and the write
+    /// behind it fails closed.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn install_pi_sandbox_extension_refuses_a_linked_parent() {
+        let (_guard, _base, _tmp) = crate::hooks::test_support::BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+
+        let root = pi_sandbox_dir().expect("a Pi sandbox dir");
+        let outside = temp_home.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(
+            outside.join("aoe-session-id.js"),
+            crate::session::instance::PI_SESSION_EXTENSION,
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("agent")).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("agent").join("extensions")).unwrap();
+
+        assert!(
+            install_pi_sandbox_extension().is_err(),
+            "a linked parent must fail the install, not read the host copy through it"
+        );
+        let outside_entries: Vec<_> = std::fs::read_dir(&outside)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            outside_entries.len(),
+            1,
+            "nothing may be written through the link: {outside_entries:?}"
+        );
+    }
+
     #[test]
     fn sanitize_network_defaults_to_none() {
         assert_eq!(sanitize_network(None), None);

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -979,12 +979,9 @@ pub(crate) fn install_pi_sandbox_extension() -> Result<()> {
         .join("aoe-session-id.js");
     let source = crate::session::instance::PI_SESSION_EXTENSION;
     // The bind is writable from the container, so the current content counts
-    // only when it is a regular file, and the write below follows no link.
-    let path = root.join(&rel);
-    let current = std::fs::symlink_metadata(&path)
-        .is_ok_and(|m| m.is_file())
-        .then(|| std::fs::read_to_string(&path).ok())
-        .flatten();
+    // only when it is a regular file reached without following a link, and the
+    // write below follows none either.
+    let current = crate::session::read_file_no_follow(&root, &rel)?;
     if current.as_deref() != Some(source) {
         crate::session::replace_file_no_follow(&root, &rel, source.as_bytes())?;
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -136,8 +136,8 @@ pub use projects::{Project, ProjectScope};
 pub use recovery::HookTimeoutScope;
 pub use scope::SessionScope;
 pub(crate) use storage::{
-    acquire_session_title_lock, atomic_write, replace_file_no_follow, resolve_symlink_chain,
-    GroupMovePlan, StorageFlock,
+    acquire_session_title_lock, atomic_write, read_file_no_follow, replace_file_no_follow,
+    resolve_symlink_chain, GroupMovePlan, StorageFlock,
 };
 pub use storage::{
     load_recent_projects, load_workspace_ordering, recent_project_entry_for, record_recent_project,

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -269,7 +269,6 @@ pub(crate) fn replace_file_no_follow(root: &Path, rel: &Path, content: &[u8]) ->
 /// Split `rel` into the directories to walk and the final name, rejecting
 /// anything but plain relative components so no `..` or absolute segment can
 /// leave the anchor. `what` names the caller for the error.
-#[cfg(unix)]
 fn split_no_follow_rel<'a>(
     rel: &'a Path,
     what: &str,
@@ -301,16 +300,16 @@ fn split_no_follow_rel<'a>(
 /// leaves a window a process sharing the bind wins by swapping the file for a
 /// symlink, which pulls a host file into the config AoE merges and republishes
 /// into the container. Here every component is opened `O_NOFOLLOW` from the
-/// previous descriptor, and the regular-file check and the bytes both come
-/// from that one descriptor, so there is no pathname to re-resolve.
+/// previous descriptor, and the decisive regular-file check and the bytes both
+/// come from that one descriptor, so there is no pathname to re-resolve.
 ///
 /// `None` when the entry is missing, is not a regular file (a planted link
 /// included), or cannot be read: callers merge into what they read, so absent
 /// is the fail-closed answer.
 #[cfg(unix)]
 pub(crate) fn read_file_no_follow(root: &Path, rel: &Path) -> Result<Option<String>> {
-    use nix::fcntl::{open, openat, OFlag};
-    use nix::sys::stat::Mode;
+    use nix::fcntl::{open, openat, AtFlags, OFlag};
+    use nix::sys::stat::{fstat, fstatat, Mode};
     use std::io::Read;
 
     let (dirs, file_name) = split_no_follow_rel(rel, "read_file_no_follow")?;
@@ -326,14 +325,31 @@ pub(crate) fn read_file_no_follow(root: &Path, rel: &Path) -> Result<Option<Stri
         dir = next;
     }
 
-    // `O_NONBLOCK` so a fifo or device planted at the name cannot park the
-    // open until a peer shows up; the fstat below rejects it either way.
+    let regular = |mode| mode & libc::S_IFMT == libc::S_IFREG;
+
+    // Stat the name on the descriptor first. Opening is not free of side
+    // effects on every file type a container can plant: a character device
+    // arms on open, and `O_NONBLOCK` only covers a fifo parking the open until
+    // a peer shows up. This stat is not what makes the read safe, so do not
+    // read it as the check-then-open shape this function exists to replace:
+    // the open still decides, and the identity check below pins the descriptor
+    // to the entry stat'd here, so a swap in between yields nothing.
+    let Ok(before) = fstatat(&dir, file_name, AtFlags::AT_SYMLINK_NOFOLLOW) else {
+        return Ok(None);
+    };
+    if !regular(before.st_mode) {
+        return Ok(None);
+    }
+
     let flags = OFlag::O_RDONLY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK;
     let Ok(fd) = openat(&dir, file_name, flags, Mode::empty()) else {
         return Ok(None);
     };
     let mut file = fs::File::from(fd);
-    if !file.metadata().is_ok_and(|metadata| metadata.is_file()) {
+    let Ok(after) = fstat(&file) else {
+        return Ok(None);
+    };
+    if !regular(after.st_mode) || after.st_dev != before.st_dev || after.st_ino != before.st_ino {
         return Ok(None);
     }
     let mut content = String::new();
@@ -346,9 +362,11 @@ pub(crate) fn read_file_no_follow(root: &Path, rel: &Path) -> Result<Option<Stri
 static NO_FOLLOW_TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Windows keeps the check-then-open the unix arm closes; the sandbox this
-/// guards against is Linux and macOS only. Kept so the module compiles.
+/// guards against is Linux and macOS only. Kept so the module compiles. `rel`
+/// is still validated, so the two arms agree on what a caller may ask for.
 #[cfg(not(unix))]
 pub(crate) fn read_file_no_follow(root: &Path, rel: &Path) -> Result<Option<String>> {
+    split_no_follow_rel(rel, "read_file_no_follow")?;
     let path = root.join(rel);
     Ok(fs::symlink_metadata(&path)
         .is_ok_and(|metadata| metadata.is_file())

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -209,23 +209,7 @@ pub(crate) fn replace_file_no_follow(root: &Path, rel: &Path, content: &[u8]) ->
     use nix::unistd::{unlinkat, UnlinkatFlags};
     use std::os::fd::OwnedFd;
 
-    let mut dirs = Vec::new();
-    let mut file_name = None;
-    let mut components = rel.components().peekable();
-    while let Some(component) = components.next() {
-        let std::path::Component::Normal(name) = component else {
-            return Err(anyhow!(
-                "replace_file_no_follow needs a plain relative path, got {}",
-                rel.display()
-            ));
-        };
-        if components.peek().is_some() {
-            dirs.push(name);
-        } else {
-            file_name = Some(name);
-        }
-    }
-    let file_name = file_name.ok_or_else(|| anyhow!("replace_file_no_follow needs a file name"))?;
+    let (dirs, file_name) = split_no_follow_rel(rel, "replace_file_no_follow")?;
 
     let dir_flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC;
     // The anchor is created the ordinary way; anything that could plant a
@@ -282,10 +266,95 @@ pub(crate) fn replace_file_no_follow(root: &Path, rel: &Path, content: &[u8]) ->
     written.with_context(|| format!("writing {} under {}", rel.display(), root.display()))
 }
 
+/// Split `rel` into the directories to walk and the final name, rejecting
+/// anything but plain relative components so no `..` or absolute segment can
+/// leave the anchor. `what` names the caller for the error.
+#[cfg(unix)]
+fn split_no_follow_rel<'a>(
+    rel: &'a Path,
+    what: &str,
+) -> Result<(Vec<&'a std::ffi::OsStr>, &'a std::ffi::OsStr)> {
+    let mut dirs = Vec::new();
+    let mut file_name = None;
+    let mut components = rel.components().peekable();
+    while let Some(component) = components.next() {
+        let std::path::Component::Normal(name) = component else {
+            return Err(anyhow!(
+                "{what} needs a plain relative path, got {}",
+                rel.display()
+            ));
+        };
+        if components.peek().is_some() {
+            dirs.push(name);
+        } else {
+            file_name = Some(name);
+        }
+    }
+    let file_name = file_name.ok_or_else(|| anyhow!("{what} needs a file name"))?;
+    Ok((dirs, file_name))
+}
+
+/// Read `root`/`rel` as UTF-8 without ever traversing a symlink below `root`.
+///
+/// The read half of [`replace_file_no_follow`]'s contract, for the same
+/// bind-mounted files. Validating the pathname and then reopening it to read
+/// leaves a window a process sharing the bind wins by swapping the file for a
+/// symlink, which pulls a host file into the config AoE merges and republishes
+/// into the container. Here every component is opened `O_NOFOLLOW` from the
+/// previous descriptor, and the regular-file check and the bytes both come
+/// from that one descriptor, so there is no pathname to re-resolve.
+///
+/// `None` when the entry is missing, is not a regular file (a planted link
+/// included), or cannot be read: callers merge into what they read, so absent
+/// is the fail-closed answer.
+#[cfg(unix)]
+pub(crate) fn read_file_no_follow(root: &Path, rel: &Path) -> Result<Option<String>> {
+    use nix::fcntl::{open, openat, OFlag};
+    use nix::sys::stat::Mode;
+    use std::io::Read;
+
+    let (dirs, file_name) = split_no_follow_rel(rel, "read_file_no_follow")?;
+
+    let dir_flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC;
+    let Ok(mut dir) = open(root, dir_flags, Mode::empty()) else {
+        return Ok(None);
+    };
+    for name in dirs {
+        let Ok(next) = openat(&dir, name, dir_flags | OFlag::O_NOFOLLOW, Mode::empty()) else {
+            return Ok(None);
+        };
+        dir = next;
+    }
+
+    // `O_NONBLOCK` so a fifo or device planted at the name cannot park the
+    // open until a peer shows up; the fstat below rejects it either way.
+    let flags = OFlag::O_RDONLY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK;
+    let Ok(fd) = openat(&dir, file_name, flags, Mode::empty()) else {
+        return Ok(None);
+    };
+    let mut file = fs::File::from(fd);
+    if !file.metadata().is_ok_and(|metadata| metadata.is_file()) {
+        return Ok(None);
+    }
+    let mut content = String::new();
+    Ok(file.read_to_string(&mut content).ok().map(|_| content))
+}
+
 /// Serial for the per-attempt temp name in [`replace_file_no_follow`], so two
 /// writers in one process cannot pick the same one inside a clock tick.
 #[cfg(unix)]
 static NO_FOLLOW_TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Windows keeps the check-then-open the unix arm closes; the sandbox this
+/// guards against is Linux and macOS only. Kept so the module compiles.
+#[cfg(not(unix))]
+pub(crate) fn read_file_no_follow(root: &Path, rel: &Path) -> Result<Option<String>> {
+    let path = root.join(rel);
+    Ok(fs::symlink_metadata(&path)
+        .is_ok_and(|metadata| metadata.is_file())
+        .then(|| fs::read_to_string(&path).ok())
+        .flatten())
+}
 
 /// Windows has no `O_NOFOLLOW` walk here; the sandbox this guards against is
 /// Linux and macOS only. Kept so the module compiles.
@@ -2825,6 +2894,76 @@ mod tests {
             .filter(|name| name != "extension.js")
             .collect();
         assert!(leftovers.is_empty(), "stray temp files: {leftovers:?}");
+    }
+
+    /// The read half of the same contract: whatever a container plants at the
+    /// name, the bytes AoE merges come from a regular file it opened
+    /// `O_NOFOLLOW` below the bind root, or from nothing at all. The
+    /// substitution the fix closes is a swap between the type check and the
+    /// open, so the check runs on the descriptor the read uses and there is no
+    /// second resolution of the pathname to redirect.
+    #[cfg(unix)]
+    #[test]
+    fn read_file_no_follow_reads_only_regular_files_below_root() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("bind");
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(root.join("agent")).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        let secret = outside.join("host-secret");
+        fs::write(&secret, "host-only").unwrap();
+
+        let rel = Path::new("agent/config.json");
+        assert_eq!(read_file_no_follow(&root, rel).unwrap(), None, "missing");
+        assert_eq!(
+            read_file_no_follow(&tmp.path().join("no-such-bind"), rel).unwrap(),
+            None,
+            "missing root"
+        );
+
+        fs::write(root.join(rel), "inside").unwrap();
+        assert_eq!(
+            read_file_no_follow(&root, rel).unwrap().as_deref(),
+            Some("inside")
+        );
+
+        // A link planted at the name reads as absent, not as its target.
+        fs::remove_file(root.join(rel)).unwrap();
+        std::os::unix::fs::symlink(&secret, root.join(rel)).unwrap();
+        assert_eq!(
+            read_file_no_follow(&root, rel).unwrap(),
+            None,
+            "planted link"
+        );
+
+        // So does anything else that is not a regular file. The fifo also
+        // pins that the open does not park waiting for a writer.
+        fs::remove_file(root.join(rel)).unwrap();
+        nix::unistd::mkfifo(
+            &root.join(rel),
+            nix::sys::stat::Mode::from_bits_truncate(0o600),
+        )
+        .unwrap();
+        assert_eq!(read_file_no_follow(&root, rel).unwrap(), None, "fifo");
+        fs::remove_file(root.join(rel)).unwrap();
+        fs::create_dir(root.join(rel)).unwrap();
+        assert_eq!(read_file_no_follow(&root, rel).unwrap(), None, "directory");
+
+        // A parent swapped for a link fails the walk rather than resolving
+        // out of the bind, even though the entry it points at is a plain file.
+        fs::write(outside.join("config.json"), "host-only").unwrap();
+        fs::remove_dir_all(root.join("agent")).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("agent")).unwrap();
+        assert_eq!(
+            read_file_no_follow(&root, rel).unwrap(),
+            None,
+            "linked parent"
+        );
+
+        assert!(
+            read_file_no_follow(&root, Path::new("../outside/host-secret")).is_err(),
+            "a path that leaves the anchor is rejected"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Description

When AoE pre-trusts a project folder for an agent, it writes a small config file into a directory that is bind-mounted into the sandbox container, and it merges into whatever that file already holds. Before this change it checked the file's type by name, then opened the name a second time to actually read it. A process inside the container shares that directory, so it could swap the real file for a shortcut to a file on the host in the gap between those two steps; AoE would then read the host file and copy its contents back into the config the container gets to read.

The read now works the way the matching write already did: it opens the file once through the directory AoE owns, refusing to follow any shortcut, and both the type check and the bytes come from that single open file handle. There is no second lookup left for anything to redirect. Anything that is not an ordinary file, and any error while opening or reading, is treated as "no existing content", exactly as before. Reads of the user's own config on the host still follow symlinks, so a config symlinked into a dotfiles repo keeps working.

The same check-then-open sat in front of the Pi session-id extension, on the other directory a container can write to. It reads through the same anchored walk now. Its path is several folders deep, so there a container could also swap one of the parent folders for a shortcut, which made AoE look outside the sandbox and then silently skip installing the extension.

Follow-up to #3599, which hardened the write and the lock sidecar on this path but left the read.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by Rust unit tests instead, at the level the fix lives:

- `session::storage::tests::read_file_no_follow_reads_only_regular_files_below_root` pins the fail-closed cases: a link planted at the name, a fifo (which also pins that the open cannot park waiting for a writer), a directory, a missing entry, a missing root, and a path that tries to leave the anchor. The linked-parent case is the deterministic stand-in for the swap: `symlink_metadata` resolves an intermediate link, so the old check-then-open code reads the host file there and fails this assertion, while the descriptor walk refuses it.
- `hooks::tests::test_trust_claude_project_follows_a_dotfile_link_and_replaces_a_planted_one` now plants a link to a *valid JSON* host file and asserts its key never reaches the config written into the bind. That case passes on the pre-fix code too, since `symlink_metadata` does not follow the final component; it pins the merge behavior, not the fix.
- `container_config::tests` already installs the Pi extension, which exercises the second call site.

A test of the timing window itself is not included: it needs the swap to land between two pathname resolutions, and the fix removes the second resolution, so there is nothing left to synchronise against. A hammering loop would be nondeterministic in this repo's terms. The linked-parent case is the deterministic discriminator that stands in for it, at the level where the walk lives.

Checks run: `cargo fmt`, `cargo clippy --all-targets`, `cargo test`. No `--features web`: nothing here touches the dashboard or the structured view.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Implemented and tested by the agent, then reviewed in a fresh-context agent before this PR left draft.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3641

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Yr5iYmwvqXnz1tMpYixhn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Hardened sandbox trust-file reads against symlink and directory substitution.
- Reused the same validated file handle for validation and reading.
- Applied the safe-read logic to Pi session-extension files.
- Reused path-splitting helpers for read and write operations.
- Added regression tests for symlinks, non-regular files, path swaps, and escaping paths.
- Preserved symlink-following behavior for host-managed configuration files.

## Benefits

These changes prevent sandbox reads from accessing or modifying files outside the sandbox. Invalid or unsafe file types now fail closed.

## Technical details

`read_file_no_follow` uses anchored descriptors and `O_NOFOLLOW`. It verifies that the opened file remains the expected regular file before reading. Formatting, Clippy, and Rust tests were run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->