### PR TITLE
fix(tui): reject preview drag start below rendered content

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1450,8 +1450,14 @@ impl App {
                                     self.home.handle_diff_click(mouse.column, mouse.row);
                                     self.draw(terminal)?;
                                     None
+                                } else if self.home.clear_preview_selection() {
+                                    // A click on no surface at all still
+                                    // dismisses a finalized highlight, and
+                                    // nothing below repaints for a bare
+                                    // Down(Left), so draw the clear here.
+                                    self.draw(terminal)?;
+                                    None
                                 } else {
-                                    let _ = self.home.clear_preview_selection();
                                     None
                                 }
                             } else {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -716,8 +716,9 @@ impl HomeView {
         }
         // Seed the selection in content coords so it survives a scroll
         // and can span more than one page. `contains` also requires the
-        // pane to hold real scrollback, so a drag over an empty / not-yet
-        // -captured pane is a no-op rather than a phantom selection.
+        // cell to sit on a painted content row, so a drag over an empty
+        // pane or the blank area below short content is a no-op rather
+        // than a phantom selection.
         let view = self.preview_text_view;
         if view.contains(col, row) {
             let cell = view.screen_to_content(col, row);

--- a/src/tui/home/preview.rs
+++ b/src/tui/home/preview.rs
@@ -21,12 +21,19 @@ pub(in crate::tui) struct PreviewTextView {
 
 impl PreviewTextView {
     /// True when `(col, row)` lands on a row/col that maps to real
-    /// content. Used to gate drag-select start.
+    /// content. Used to gate drag-select start. Rows in the pane below
+    /// the last painted line are rejected: `screen_to_content` clamps
+    /// them onto the last line, so accepting one would anchor a
+    /// selection on text the user never clicked.
     pub(in crate::tui) fn contains(self, col: u16, row: u16) -> bool {
-        self.total_lines > 0
-            && self
-                .pane
-                .contains(ratatui::layout::Position::from((col, row)))
+        if !self
+            .pane
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            return false;
+        }
+        let painted_rows = self.total_lines.saturating_sub(self.first_line);
+        usize::from(row - self.pane.y) < painted_rows
     }
 
     /// Absolute parsed-text index of the line painted on screen row

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -15898,6 +15898,52 @@ mod preview_drag_select {
 
     #[test]
     #[serial]
+    fn drag_start_below_painted_content_is_noop() {
+        // Pane rows past the last painted line show no text, and
+        // `screen_to_content` would clamp them onto the last line, so a
+        // press there must not anchor a selection.
+        let mut env = create_test_env_empty();
+        let pane = Rect::new(40, 0, 60, 20);
+        // (first_line, total_lines, row, starts a selection)
+        let cases = [
+            (0, 3, 2, true),
+            (0, 3, 3, false),
+            (0, 3, 10, false),
+            // Scrolled into history: 5 lines painted from the top row.
+            (100, 105, 4, true),
+            (100, 105, 5, false),
+        ];
+        for (first_line, total_lines, row, accepted) in cases {
+            env.view.preview_selection = None;
+            env.view.drag_state = None;
+            stage_pane(&mut env, pane, first_line, total_lines);
+            let label = format!("first_line={first_line} total={total_lines} row={row}");
+            assert_eq!(env.view.handle_drag_start(50, row), accepted, "{label}");
+            assert_eq!(env.view.preview_selection.is_some(), accepted, "{label}");
+            assert_eq!(
+                matches!(env.view.drag_state, Some(DragKind::PreviewSelect)),
+                accepted,
+                "{label}"
+            );
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn drag_move_below_painted_content_clamps_to_last_line() {
+        // Only the start is gated: a drag already in flight that leaves
+        // the painted rows keeps extending to the last content line.
+        let mut env = create_test_env_empty();
+        stage_pane(&mut env, Rect::new(40, 0, 60, 20), 0, 3);
+        assert!(env.view.handle_drag_start(40, 0));
+        assert!(env.view.handle_drag_move(45, 15));
+        let sel = env.view.preview_selection.expect("selection installed");
+        assert_eq!(to_abs(3, sel.anchor), (0, 0));
+        assert_eq!(to_abs(3, sel.extent), (5, 2));
+    }
+
+    #[test]
+    #[serial]
     fn drag_start_inside_live_mode_installs_selection() {
         let mut env = create_test_env_empty();
         stage_pane(&mut env, Rect::new(40, 0, 60, 20), 0, 100);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -15909,7 +15909,13 @@ mod preview_drag_select {
             (0, 3, 2, true),
             (0, 3, 3, false),
             (0, 3, 10, false),
-            // Scrolled into history: 5 lines painted from the top row.
+            // Scrolled into history: the window is full, so every pane
+            // row is painted and the gate rejects nothing.
+            (85, 105, 0, true),
+            (85, 105, 19, true),
+            // A partly-painted window is geometry `compute_scroll` and
+            // `TranscriptGeometry` both clamp away; the gate stays right
+            // without leaning on that.
             (100, 105, 4, true),
             (100, 105, 5, false),
         ];


### PR DESCRIPTION
## Description

Clicking in the empty space below short preview output used to start a text
selection anyway, and that selection silently latched onto the last line of the
actual content. So if a session had printed three lines into a twenty-row pane
and you pressed the mouse down somewhere in the blank area underneath, aoe
behaved as though you had clicked on the third line and began dragging from
there. Now a press in that blank area does nothing, and selection only starts on
a row that is really showing text. Dragging itself is unchanged: once a
selection is under way, moving the cursor past the end of the content still
extends it to the last line, the way it always did.

`PreviewTextView::contains` accepted any cell inside the pane rect whenever
`total_lines > 0`; `screen_to_content` then clamped the row to
`total_lines - 1`. Hit-testing now also requires the pane-relative row to fall
within the painted rows (`total_lines - first_line`), which covers both the
terminal preview (`compute_scroll`) and the structured transcript
(`TranscriptGeometry`), since both guarantee `first_line + height <= total_lines`
when the content overflows and `first_line == 0` when it does not. `contains` has
a single caller, `handle_drag_start`, so drag moves and auto-scroll keep their
existing clamping.

Second commit fixes a repaint gap the first one exposes. A rejected press falls
through to the app loop's catch-all click branch, which dismissed a finalized
highlight without drawing; nothing downstream repaints for a bare `Down(Left)`,
so the highlight stayed painted until an unrelated wake-up. That branch now
draws when the clear changed something.

Fixes #3660

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Interaction-only change with no visual difference to capture: the fix is that a
press below the content no longer paints a highlight. The two unit tests assert
that directly.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the change is pure coordinate math on the drag-start hit test, which unit tests in `src/tui/home/tests.rs` cover directly (short content at first_line 0 and scrolled into history, plus the drag-move clamp). A full-binary test would need synthetic mouse input for no extra signal.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Fix and tests drafted by the agent, reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nn6GHG48PAbRQ81L5YWB4E


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevented preview drag selection from starting in blank space below rendered content.
- Preserved clamping when an active drag moves outside the preview.
- Redraws the TUI when a rejected click clears a finalized highlight.
- Added tests for short content, scrolled views, drag clamping, and highlight clearing.

## Benefits

Users can select only visible content, and cleared highlights no longer remain on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->