### PR TITLE
fix(tmux): prevent detach hint truncation

### DIFF
--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -2,7 +2,6 @@
 
 use anyhow::Result;
 use ratatui::style::Color;
-use unicode_width::UnicodeWidthStr;
 
 use crate::tui::styles::Theme;
 
@@ -17,11 +16,6 @@ fn color_to_tmux(color: Color) -> String {
         Color::Rgb(r, g, b) => format!("#{:02x}{:02x}{:02x}", r, g, b),
         _ => "default".to_string(),
     }
-}
-
-/// Width needed to show the session name and detach hint.
-fn status_left_width(session_name: &str, prefix: &str) -> usize {
-    format!(" {session_name} │ {prefix} d to detach ").width()
 }
 
 /// Apply aoe-styled status bar configuration to a tmux session.
@@ -81,8 +75,12 @@ pub fn apply_status_bar(
             " #[fg={accent},bold]#S#[fg={fg},nobold] \u{2502} #[fg={hint}]{prefix} d#[fg={hint}] to detach ",
         ),
     )?;
-    let status_left_length = status_left_width(session_name, prefix).to_string();
-    set_session_option(session_name, "status-left-length", &status_left_length)?;
+    // Sized past the longest name aoe generates rather than to this one: `#S`
+    // expands when tmux paints, so a session renamed after this write (smart
+    // rename is on by default) outgrows an exact fit and the hint is cut
+    // again. tmux only trims at this cap and never pads, so over-sizing is
+    // free. See #3445.
+    set_session_option(session_name, "status-left-length", "200")?;
 
     Ok(())
 }
@@ -273,13 +271,6 @@ fn get_session_option(session_name: &str, option: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::tui::styles::{builtin_theme_names, load_theme};
-
-    #[test]
-    fn test_status_left_width_fits_full_detach_hint() {
-        let longest_release_name = "aoe_12345678901234567890_12345678";
-
-        assert_eq!(status_left_width(longest_release_name, "Ctrl+b"), 56);
-    }
 
     #[test]
     fn test_get_status_returns_none_for_non_tmux() {

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use ratatui::style::Color;
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::styles::Theme;
 
@@ -16,6 +17,11 @@ fn color_to_tmux(color: Color) -> String {
         Color::Rgb(r, g, b) => format!("#{:02x}{:02x}{:02x}", r, g, b),
         _ => "default".to_string(),
     }
+}
+
+/// Width needed to show the session name and detach hint.
+fn status_left_width(session_name: &str, prefix: &str) -> usize {
+    format!(" {session_name} │ {prefix} d to detach ").width()
 }
 
 /// Apply aoe-styled status bar configuration to a tmux session.
@@ -75,7 +81,8 @@ pub fn apply_status_bar(
             " #[fg={accent},bold]#S#[fg={fg},nobold] \u{2502} #[fg={hint}]{prefix} d#[fg={hint}] to detach ",
         ),
     )?;
-    set_session_option(session_name, "status-left-length", "50")?;
+    let status_left_length = status_left_width(session_name, prefix).to_string();
+    set_session_option(session_name, "status-left-length", &status_left_length)?;
 
     Ok(())
 }
@@ -266,6 +273,13 @@ fn get_session_option(session_name: &str, option: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::tui::styles::{builtin_theme_names, load_theme};
+
+    #[test]
+    fn test_status_left_width_fits_full_detach_hint() {
+        let longest_release_name = "aoe_12345678901234567890_12345678";
+
+        assert_eq!(status_left_width(longest_release_name, "Ctrl+b"), 56);
+    }
 
     #[test]
     fn test_get_status_returns_none_for_non_tmux() {


### PR DESCRIPTION
## Description

Closes #3445.

Calculate `status-left-length` from the displayed width of the session name and tmux prefix instead of using a fixed value of 50. This prevents maximum-length session names from truncating the detach hint and accounts for Unicode display width.

Tests:
- `cargo fmt --check`
- `cargo clippy`
- `cargo test --lib tmux::status_bar::tests` — 5 passed

The full test suite was attempted locally; 52 tests outside this module failed. One representative background-worker timeout also failed when rerun alone.

Manual UI verification was blocked because the local tmux 3.0a does not support the `-e` option used by current AoE session creation.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the tmux status-bar width calculation is covered by a focused unit regression test

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

OpenAI Codex

**Any Additional AI Details you'd like to share:**

Used for repository navigation, implementation discussion, and test drafting. I reviewed the change and ran the checks locally.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Sets `status-left-length` to `200` to prevent truncation of the tmux detach hint.
- Removes the dynamic Unicode-width calculation, helper, dependency import, and regression test.

## Benefits

The full `Ctrl+b d to detach` hint remains visible for long and Unicode session names.

## Potential enhancement

A fixed limit may be larger than necessary. A dynamic width calculation could reduce unused status-bar space while supporting session names that change over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->