### PR TITLE
fix(plugin): check session ownership before prompt disposition

### DIFF
--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -557,23 +557,23 @@ async fn sessions_turn_send(
 
     let result = async {
         deps.policy.admit_turn(&plugin_id)?;
+        let caller = SessionCaller::Plugin {
+            plugin_id: plugin_id.clone(),
+        };
         // Same per-session submission authority the HTTP surfaces and the
         // queue drain take, and the same disposition decided under it, so a
         // plugin turn cannot land between the drain's idle check and its send
-        // (#3621, #3649). An unknown session is refused here rather than by
-        // `send_turn`, so a plugin probing distinct nonexistent ids cannot
-        // grow the lock registry within its turn quota.
-        let Some((_submission, dispatch)) = deps
+        // (#3621, #3649). Existence and ownership are settled here rather
+        // than by `send_turn`: a plugin probing distinct nonexistent ids
+        // cannot grow the lock registry within its turn quota (#3651), and a
+        // foreign session is refused before its disposition is computed, so
+        // it cannot answer `agent_busy` for a session the caller may not see
+        // (#3685).
+        let (_submission, dispatch) = deps
             .session_service
-            .begin_prompt_submission(&req.session_id, false)
+            .begin_prompt_submission(&caller, &req.session_id, false)
             .await
-        else {
-            return Err(DispatchError::with_kind(
-                codes::INVALID_PARAMS,
-                "session_not_found",
-                "session not found",
-            ));
-        };
+            .map_err(|e| map_send_error(e.into()))?;
         // A cold worker is not a refusal on this path: `send_turn` resumes it
         // and waits, which is how a scheduler wakes a session it created. The
         // turn gates are, because a second prompt at a busy non-steerable
@@ -589,16 +589,7 @@ async fn sessions_turn_send(
             }
         }
         deps.session_service
-            .send_turn(
-                &SessionCaller::Plugin {
-                    plugin_id: plugin_id.clone(),
-                },
-                &req.session_id,
-                &req.text,
-                &[],
-                false,
-                None,
-            )
+            .send_turn(&caller, &req.session_id, &req.text, &[], false, None)
             .await
             .map_err(map_send_error)
     }
@@ -666,18 +657,30 @@ mod tests {
     }
 
     fn test_deps(prior: Vec<Instance>) -> (Arc<SessionRpcDeps>, tempfile::TempDir) {
+        let (deps, _state, dir) = test_deps_with_state(prior);
+        (deps, dir)
+    }
+
+    /// [`test_deps`] keeping the app state, for a test that has to publish
+    /// events through the real sink to move a session's control fold.
+    fn test_deps_with_state(
+        prior: Vec<Instance>,
+    ) -> (
+        Arc<SessionRpcDeps>,
+        Arc<crate::server::AppState>,
+        tempfile::TempDir,
+    ) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let session_service = crate::server::test_support::build_test_app_state(prior)
-            .session_service
-            .clone();
+        let state = crate::server::test_support::build_test_app_state(prior);
         let policy =
             Arc::new(AutomationPolicy::open(&dir.path().join("plugin_events.db")).expect("policy"));
         (
             Arc::new(SessionRpcDeps {
-                session_service,
+                session_service: state.session_service.clone(),
                 policy,
                 profile: "test".to_string(),
             }),
+            state,
             dir,
         )
     }
@@ -936,6 +939,109 @@ mod tests {
             Vec::<&'static str>::new(),
             "nothing may reach the agent behind the running turn"
         );
+    }
+
+    /// #3685: ownership is immutable and decided before any live state is
+    /// folded, so a session another plugin owns answers `not_owner` whatever
+    /// it is doing. Settling the disposition first leaked coarse live state
+    /// for a foreign session, and answered a retryable `agent_busy` for a
+    /// permanently unauthorized call.
+    #[tokio::test]
+    async fn turn_send_refuses_a_foreign_session_in_every_control_state() {
+        use crate::acp::state::Event;
+        use crate::acp::supervisor::BroadcastSink;
+
+        let mut foreign = Instance::new("other-owned", "/tmp/aoe-3685-plugin");
+        foreign.id = "sess-3685".to_string();
+        foreign.view = crate::session::View::Structured;
+        foreign.agent_name = Some("claude".to_string());
+        foreign.created_by_plugin = Some("other-plugin".to_string());
+        let (deps, state, _dir) = test_deps_with_state(vec![foreign]);
+        // A live worker: without one every dispatch parks on `WorkerDown`,
+        // which this path forwards rather than refusing, so the leak the test
+        // is about would never be reachable.
+        deps.session_service
+            .acp_supervisor
+            .test_insert_worker("sess-3685")
+            .await;
+        let sink = crate::acp::supervisor::ChannelSink {
+            tx: state.acp_events_tx.clone(),
+            event_store: Arc::clone(&state.acp_event_store),
+            control_cache: Arc::clone(&state.acp_control_cache),
+        };
+        let ctx = ctx_with(&["session.prompt"]);
+
+        let mut seq = 0;
+        let mut record = |event: Event| {
+            seq += 1;
+            assert!(
+                sink.publish_persisted("sess-3685", seq, &event),
+                "publish must reach the event store"
+            );
+        };
+        let prompt = || Event::UserPromptSent {
+            text: "the owner's turn".into(),
+            attachments: Vec::new(),
+            prompt_id: None,
+        };
+        // Each state named by the disposition it would have leaked.
+        for (label, events, expected) in [
+            ("idle", vec![], crate::acp::dispatch::PromptDispatch::Sent),
+            (
+                "busy",
+                vec![prompt()],
+                crate::acp::dispatch::PromptDispatch::Queued {
+                    reason: crate::acp::dispatch::QueueReason::TurnActive,
+                },
+            ),
+            (
+                "cancelling",
+                vec![Event::CancelRequested {
+                    escalates_at: chrono::Utc::now(),
+                }],
+                crate::acp::dispatch::PromptDispatch::Queued {
+                    reason: crate::acp::dispatch::QueueReason::Cancelling,
+                },
+            ),
+            (
+                "compacting",
+                vec![
+                    Event::Stopped {
+                        reason: "cancelled".into(),
+                    },
+                    prompt(),
+                    Event::ConversationCompactionStarted,
+                ],
+                crate::acp::dispatch::PromptDispatch::Queued {
+                    reason: crate::acp::dispatch::QueueReason::Compacting,
+                },
+            ),
+        ] {
+            for event in events {
+                record(event);
+            }
+            assert_eq!(
+                crate::acp::dispatch::decide(
+                    &deps.session_service.fold_control_state("sess-3685").await,
+                    crate::acp::dispatch::WorkerLiveness {
+                        running: true,
+                        idle_dormant: false,
+                    },
+                ),
+                expected,
+                "{label}: the session is not in the state this row exercises"
+            );
+            let err = dispatch(
+                &deps,
+                &ctx,
+                "sessions.turn.send",
+                &serde_json::json!({ "session_id": "sess-3685", "text": "hi" }),
+            )
+            .await
+            .expect_err("a foreign session must be refused");
+            assert_eq!(kind(&err), "not_owner", "{label}");
+            assert_eq!(err.code, codes::FORBIDDEN, "{label}");
+        }
     }
 
     /// `prompt_submission` auto-vivifies a per-session lock-registry entry

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1360,9 +1360,9 @@ pub async fn acp_prompt(
     // back `agent_busy` after its queue row was already retired (#3621).
     // `woke_idle_dormant` is passed rather than re-read: the wake above
     // already cleared the marker, so the instance now says "awake".
-    let Some((_submission, dispatch)) = state
+    let Ok((_submission, dispatch)) = state
         .session_service
-        .begin_prompt_submission(&id, woke_idle_dormant)
+        .begin_prompt_submission(&SessionCaller::User, &id, woke_idle_dormant)
         .await
     else {
         return (StatusCode::NOT_FOUND, "session not found").into_response();
@@ -1518,9 +1518,9 @@ pub async fn acp_prompt_diff_comments(
     // This opens a turn (`UserDiffCommentsPrompt` folds to `turn_active`) just
     // as an ordinary prompt does, so it takes the same submission authority
     // and settles the same disposition under it (#3621, #3649).
-    let Some((_submission, dispatch)) = state
+    let Ok((_submission, dispatch)) = state
         .session_service
-        .begin_prompt_submission(&id, woke_idle_dormant)
+        .begin_prompt_submission(&SessionCaller::User, &id, woke_idle_dormant)
         .await
     else {
         return (StatusCode::NOT_FOUND, "session not found").into_response();

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -208,6 +208,26 @@ pub(crate) enum SessionCaller {
     Plugin { plugin_id: String },
 }
 
+/// Why a caller may not open a turn on a session. Settled before any live
+/// state is read, so an unauthorized caller learns nothing about what the
+/// session is currently doing (#3685).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TurnAdmissionError {
+    /// No session with this id.
+    SessionNotFound,
+    /// A plugin caller targeted a session it did not create.
+    NotOwner,
+}
+
+impl From<TurnAdmissionError> for SendTurnError {
+    fn from(e: TurnAdmissionError) -> Self {
+        match e {
+            TurnAdmissionError::SessionNotFound => Self::SessionNotFound,
+            TurnAdmissionError::NotOwner => Self::NotOwner,
+        }
+    }
+}
+
 /// Typed outcome of [`SessionService::send_turn`], split by whether the
 /// failure happened before or after the prompt was published into the event
 /// stream, so callers can map each stage faithfully (the HTTP handler keeps
@@ -1389,8 +1409,8 @@ impl SessionService {
         lock.lock_owned().await
     }
 
-    /// [`Self::prompt_submission`] for a caller that has not yet proved the
-    /// session exists. `None` means "do not act", and no registry entry is
+    /// [`Self::prompt_submission`] for a caller that has not yet proved it may
+    /// act on the session. `Err` means "do not act", and no registry entry is
     /// left behind for an id that was never admitted: the registry
     /// auto-vivifies per id it is asked for and nothing else prunes it, so an
     /// authenticated client probing random ids would otherwise grow it for the
@@ -1401,45 +1421,87 @@ impl SessionService {
     /// teardown and removes the session row before dropping its lock, so both
     /// a waiter parked on that lock and one that vivified a fresh entry after
     /// `forget_prompt_lock` observe the removal and decline.
+    async fn admit_prompt_submission(
+        &self,
+        caller: &SessionCaller,
+        id: &str,
+    ) -> Result<tokio::sync::OwnedMutexGuard<()>, TurnAdmissionError> {
+        self.admits_turn(caller, id).await?;
+        let guard = self.prompt_submission(id).await;
+        if let Err(e) = self.admits_turn(caller, id).await {
+            drop(guard);
+            // Only for a vanished session: the registry entry is the live
+            // session's mutual exclusion, and dropping it while another
+            // caller holds the guard would hand the next waiter a different
+            // mutex.
+            if matches!(e, TurnAdmissionError::SessionNotFound) {
+                self.forget_prompt_lock(id).await;
+            }
+            return Err(e);
+        }
+        Ok(guard)
+    }
+
+    /// May `caller` open a turn on `id`? Existence plus, for a plugin, the
+    /// immutable ownership gate: a plugin may act only on a session it
+    /// created. Decided before any live state is folded, so a foreign session
+    /// answers `not_owner` whatever it is currently doing (#3685).
+    async fn admits_turn(
+        &self,
+        caller: &SessionCaller,
+        id: &str,
+    ) -> Result<(), TurnAdmissionError> {
+        let instances = self.instances.read().await;
+        let Some(inst) = instances.iter().find(|i| i.id == id) else {
+            return Err(TurnAdmissionError::SessionNotFound);
+        };
+        match caller {
+            SessionCaller::User => Ok(()),
+            SessionCaller::Plugin { plugin_id } => {
+                if inst.created_by_plugin.as_deref() == Some(plugin_id.as_str()) {
+                    Ok(())
+                } else {
+                    Err(TurnAdmissionError::NotOwner)
+                }
+            }
+        }
+    }
+
+    /// [`Self::admit_prompt_submission`] for a user surface, which only ever
+    /// fails on a session that no longer exists.
     pub(crate) async fn prompt_submission_for_session(
         &self,
         id: &str,
     ) -> Option<tokio::sync::OwnedMutexGuard<()>> {
-        if !self.session_exists(id).await {
-            return None;
-        }
-        let guard = self.prompt_submission(id).await;
-        if !self.session_exists(id).await {
-            drop(guard);
-            self.forget_prompt_lock(id).await;
-            return None;
-        }
-        Some(guard)
+        self.admit_prompt_submission(&SessionCaller::User, id)
+            .await
+            .ok()
     }
 
     /// Claim the session's submission authority and settle the prompt's
     /// disposition under it, so every turn-starting surface decides and
     /// dispatches as one step instead of dispatching unconditionally after
-    /// the wait (#3649). `None` for a session that no longer exists.
+    /// the wait (#3649). Admission is decided first, so the disposition is
+    /// only ever computed for a caller entitled to see it.
     pub(crate) async fn begin_prompt_submission(
         &self,
+        caller: &SessionCaller,
         id: &str,
         idle_dormant: bool,
-    ) -> Option<(
-        tokio::sync::OwnedMutexGuard<()>,
-        crate::acp::dispatch::PromptDispatch,
-    )> {
-        let guard = self.prompt_submission_for_session(id).await?;
+    ) -> Result<
+        (
+            tokio::sync::OwnedMutexGuard<()>,
+            crate::acp::dispatch::PromptDispatch,
+        ),
+        TurnAdmissionError,
+    > {
+        let guard = self.admit_prompt_submission(caller, id).await?;
         let liveness = crate::acp::dispatch::WorkerLiveness {
             running: self.acp_supervisor.is_running(id).await,
             idle_dormant,
         };
         let dispatch = crate::acp::dispatch::decide(&self.fold_control_state(id).await, liveness);
-        Some((guard, dispatch))
-    }
-
-    async fn session_exists(&self, id: &str) -> bool {
-        self.instances.read().await.iter().any(|i| i.id == id)
+        Ok((guard, dispatch))
     }
 
     /// Drop a deleted session's submission lock, mirroring the `instance_locks`

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -1430,10 +1430,8 @@ impl SessionService {
         let guard = self.prompt_submission(id).await;
         if let Err(e) = self.admits_turn(caller, id).await {
             drop(guard);
-            // Only for a vanished session: the registry entry is the live
-            // session's mutual exclusion, and dropping it while another
-            // caller holds the guard would hand the next waiter a different
-            // mutex.
+            // Only for a vanished session: forgetting a live one's entry
+            // would hand the next waiter a different mutex.
             if matches!(e, TurnAdmissionError::SessionNotFound) {
                 self.forget_prompt_lock(id).await;
             }


### PR DESCRIPTION
## Description

Plugins can only send prompts to sessions they created. That rule was still
enforced, but too late: before refusing, the daemon already worked out what it
would have done with the prompt, and told the plugin. So a plugin that guessed
or learned another session's id got one of two different answers depending on
what that session happened to be doing at that moment. If the session was in
the middle of a turn, being cancelled, or compacting its context, the plugin was
told "the agent is busy, try again later". If it was free, the plugin was told
"you don't own this session". Either way the call was refused, but the choice of
refusal quietly reported live state about somebody else's session, and the busy
answer invited a retry for something that will never be permitted.

Now the ownership check happens first, before any of that state is looked at, so
a session the plugin does not own always answers the same way: not the owner.
Nothing changes for a plugin acting on its own sessions, and nothing changes for
the dashboard or the TUI.

The plugin RPC settled the prompt's disposition under the submission guard and
returned `agent_busy` before `send_turn` performed the ownership check
(regression from #3673). Admission moved into `begin_prompt_submission`: under
the same guard, it rechecks existence and the immutable
`created_by_plugin == caller` gate before folding control state, and returns a
typed `TurnAdmissionError` the plugin surface maps to the existing
`session_not_found` / `not_owner` kinds. `send_turn` keeps its own check, which
still covers the queue drain and the pending-initial-turn path. HTTP surfaces
pass `SessionCaller::User` and are unaffected. The `#3651` property (no
lock-registry entry for an id that was never admitted) holds: a foreign id is
refused before the guard is claimed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (no UI changes)

## Test Coverage Analysis

`turn_send_refuses_a_foreign_session_in_every_control_state` drives one
plugin-owned session through idle, busy, cancelling, and compacting, asserts the
dispatch each state would have produced, and asserts the RPC answers `not_owner`
in all four. It fails on the busy row without the fix (`agent_busy`).

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**
Implemented and tested by Claude Opus 5 under @njbrake's direction, then
reviewed by a separate fresh-context agent before this PR left draft.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ENb6EDniyBjRtvnUDXwFN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Check plugin session ownership before evaluating prompt state.
- Return `session_not_found` or `not_owner` consistently.
- Preserve ownership checks for queued and pending turns.
- Update ACP callers for the new admission result.
- Add regression coverage for foreign sessions in all control states.

## Benefits

- Prevents unauthorized callers from learning session state.
- Avoids retryable errors for permanently unauthorized requests.
- Keeps HTTP, dashboard, and TUI behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->