### PR TITLE
perf(build): cut dev-profile debug info to shrink target dirs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,14 @@ installed app's namespace and port 8080. `AOE_TMUX_SOCKET` overrides the socket.
 
 For web commands and tests, read `web/AGENTS.md`.
 
+Stay on one feature set per worktree. Each distinct combination of features is a
+separate build hash, so cargo keeps a full extra copy of the crate in `target/`
+for every one you run: plain `cargo test` and `cargo test --features web` cost
+roughly twice the disk of either alone. Pick the narrowest set that covers your
+change rather than running several to be thorough. `--all-targets` links every
+test, bench and example separately; keep it for a pre-push check, not routine
+iteration.
+
 ## Code rules
 
 - Let `cargo fmt` and `cargo clippy` decide style; fix warnings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ Stay on one feature set per worktree. Each distinct combination of features is a
 separate build hash, so cargo keeps a full extra copy of the crate in `target/`
 for every one you run: plain `cargo test` and `cargo test --features web` cost
 roughly twice the disk of either alone. Pick the narrowest set that covers your
-change rather than running several to be thorough. `--all-targets` links every
-test, bench and example separately; keep it for a pre-push check, not routine
+change rather than running several to be thorough. `--all-targets` links all
+twenty-odd test binaries separately; keep it for a pre-push check, not routine
 iteration.
 
 ## Code rules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,24 @@ tower = { version = "0.5", features = ["util"] }
 # `cargo test --no-default-features`, making that CI job meaningless.
 agent-of-empires = { path = ".", default-features = false, features = ["test-support"] }
 
+[profile.dev]
+# Full DWARF is the cargo default for `dev` and dominates `target/`: a single
+# sandbox here carries a 5.8 GB target dir, 5.4 GB of it in `debug/deps`, with
+# the four largest artifacts (two `libagent_of_empires` rlibs and two test
+# binaries) accounting for 3.4 GB on their own. `line-tables-only` keeps the
+# filename and line number in panics and backtraces, which is what CI logs and
+# agent sandboxes actually read; it drops variable and function-parameter info,
+# so stepping through a local debugger loses value inspection. Use
+# `RUSTFLAGS="-Cdebuginfo=2"` or a scratch `[profile.dev]` override when you
+# need a full debugging session.
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+# Dependencies only (567 crates in Cargo.lock); workspace members are unaffected
+# by this table. Nobody steps through tokio internals, and their debug info is
+# pure weight in every target dir.
+debug = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,21 +252,16 @@ tower = { version = "0.5", features = ["util"] }
 agent-of-empires = { path = ".", default-features = false, features = ["test-support"] }
 
 [profile.dev]
-# Full DWARF is the cargo default for `dev` and dominates `target/`: a single
-# sandbox here carries a 5.8 GB target dir, 5.4 GB of it in `debug/deps`, with
-# the four largest artifacts (two `libagent_of_empires` rlibs and two test
-# binaries) accounting for 3.4 GB on their own. `line-tables-only` keeps the
-# filename and line number in panics and backtraces, which is what CI logs and
-# agent sandboxes actually read; it drops variable and function-parameter info,
-# so stepping through a local debugger loses value inspection. Use
-# `RUSTFLAGS="-Cdebuginfo=2"` or a scratch `[profile.dev]` override when you
-# need a full debugging session.
+# Full DWARF is cargo's `dev` default and it dominates `target/`: this table and
+# the one below take a `cargo build --lib --bins` here from 5.6 GB to 3.8 GB.
+# Line tables keep the file and line number in panics and backtraces; the cost
+# is local-variable inspection under a debugger. docs/development.md documents
+# the tradeoff and how to opt back into full debug info.
 debug = "line-tables-only"
 
 [profile.dev.package."*"]
-# Dependencies only (567 crates in Cargo.lock); workspace members are unaffected
-# by this table. Nobody steps through tokio internals, and their debug info is
-# pure weight in every target dir.
+# Dependencies only; the `"*"` glob never matches a workspace member. Nobody
+# reads DWARF for tokio internals, so it is pure weight in every target dir.
 debug = false
 
 [profile.release]

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,11 @@ cargo clippy
 The binary is `target/{profile}/aoe`. Web commands and test selection are in
 `web/AGENTS.md`.
 
+Debug builds carry line tables only, and dependencies carry no debug info, to
+keep `target/` small across worktrees. Panics and backtraces still name the file
+and line in this crate; a debugger has no local-variable values. Rebuild with
+`RUSTFLAGS="-Cdebuginfo=2"` for a full debugging session.
+
 ## Run and inspect logs
 
 ```sh


### PR DESCRIPTION
## Description

Debug builds keep far more on disk than they need to. Cargo's default for the `dev` profile is full debug information, and that information is the bulk of what ends up in `target/`. On this machine a single agent sandbox carries a 5.8 GB target directory, 5.4 GB of it under `debug/deps`, where two copies of the `agent_of_empires` library and two test binaries take up 3.4 GB between them. Running twenty of those sandboxes at once fills a 160 GB disk.

This lowers debug information for the workspace to line tables only, which still gives you the file and line number in panics and backtraces, and turns it off entirely for the 567 dependency crates. Local debugging changes: you keep backtraces, you lose variable and parameter inspection when stepping through code. `RUSTFLAGS="-Cdebuginfo=2"` restores it when you need a real debugger session.

It also adds a note to `AGENTS.md` about staying on one feature set per worktree, since every distinct combination of features is a separate build hash and cargo keeps a full extra copy of the crate for each one.

**Measured.** `origin/main` and this branch, each built with `cargo build --lib --bins` into a separate `CARGO_TARGET_DIR`, default features, macOS:

| | main | this PR | delta |
|---|---|---|---|
| target total | 5.56 GB | 3.79 GB | -1.77 GB (-32%) |
| `debug/deps` | 3.35 GB | 2.02 GB | -40% |
| `libagent_of_empires-*.rlib` | 904.6 MB | 531.9 MB | -41% |
| `libtokio-*.rlib` | 25.6 MB | 14.8 MB | -42% |

`debug/incremental` is untouched at 0.89 GB and is now 23% of what remains. Setting `incremental = false` would take this to roughly 2.9 GB, but that slows the edit-rebuild loop, so it is a separate change with its own tradeoff rather than part of this one.

One cost worth flagging: adding profile tables changes the `rust-cache` key, so every Rust CI leg pays one cold build on the first run after merge.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording <!-- N/A: no UI change -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Skipped a test, because: build profile settings and a docs paragraph; no runtime behaviour changes, and cargo does not expose profile resolution to a test

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**
The artifact breakdown came from inspecting a live sandbox's target directory. The reasoning and the decision to open this are njbrake's.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Reduced Rust development build size by keeping line information for the project and removing debug information from dependencies.
- Added guidance on feature-set consistency to avoid unnecessary duplicate builds.
- Documented the debugging trade-off and how to restore full debug information with `RUSTFLAGS="-Cdebuginfo=2"`.

## Benefits

- Reduced `target/` size by approximately 32%.
- Preserved useful file and line information in panics and backtraces.
- Developers can restore full debugger support when needed.

## Follow-up

- The profile change invalidates `rust-cache` keys, so the first Rust CI build after merging will be cold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->