### PR TITLE
fix(sandbox): quote container terminal workdir, harden shell resolution

### DIFF
--- a/docs/guides/web/terminal.md
+++ b/docs/guides/web/terminal.md
@@ -25,7 +25,7 @@ Copy relies on the browser Clipboard API, which only works in a secure context: 
 
 Each session can open a **paired terminal**: a host (or, for sandboxed sessions, in-container) shell rooted at the session's working directory. On desktop it shares the split with the agent terminal; on mobile it is one of the right-panel picker's views. It stays alive in the background when you switch away, preserving scrollback and focus.
 
-For sandboxed sessions, the **Container** tab launches the container user's login shell, resolved inside the container (passwd entry, then `$SHELL`, then bash, sh), so your prompt, aliases, and oh-my-zsh setup load like the Host tab.
+For sandboxed sessions, the **Container** tab launches the container user's login shell, resolved inside the container (passwd entry, then `$SHELL`, then bash, sh). Candidates must be regular executable files and either have a recognized shell name or be listed in `/etc/shells`. Minimal images without `getent` read `/etc/passwd` directly.
 
 ## Reconnect
 

--- a/docs/guides/web/terminal.md
+++ b/docs/guides/web/terminal.md
@@ -25,7 +25,7 @@ Copy relies on the browser Clipboard API, which only works in a secure context: 
 
 Each session can open a **paired terminal**: a host (or, for sandboxed sessions, in-container) shell rooted at the session's working directory. On desktop it shares the split with the agent terminal; on mobile it is one of the right-panel picker's views. It stays alive in the background when you switch away, preserving scrollback and focus.
 
-For sandboxed sessions, the **Container** tab launches the container user's login shell, resolved inside the container (passwd entry, then `$SHELL`, then bash, sh). Candidates must be regular executable files and either have a recognized shell name or be listed in `/etc/shells`. Minimal images without `getent` read `/etc/passwd` directly.
+For sandboxed sessions, the **Container** tab launches the container user's preferred shell, resolved inside the container (passwd entry, then `$SHELL`, then bash, sh). Candidates must be regular executable files and either have a recognized shell name or be listed exactly in `/etc/shells`. Known-compatible shells run in login mode; other authorized shells run plain. Minimal images without `getent` read `/etc/passwd` directly.
 
 ## Reconnect
 

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -381,7 +381,7 @@ impl ContainerRuntime {
             }
             RuntimeKind::AppleContainer => {
                 // Apple Container has a very limited initial PATH, so we wrap
-                // the command in `sh -c` to get a proper shell environment.
+                // the command in `/bin/sh -c` to get a proper shell environment.
                 // Single-quote with escaped embedded quotes to avoid issues
                 // with double-quote metacharacters ($, `, \, !) in the command.
                 let escaped = cmd.replace('\'', "'\\''");
@@ -394,13 +394,13 @@ impl ContainerRuntime {
                         "-it",
                         opt_str,
                         name,
-                        "sh",
+                        "/bin/sh",
                         "-c",
                         &cmd_str,
                     ]
                     .join(" ")
                 } else {
-                    ["container", "exec", "-it", name, "sh", "-c", &cmd_str].join(" ")
+                    ["container", "exec", "-it", name, "/bin/sh", "-c", &cmd_str].join(" ")
                 }
             }
         }
@@ -427,7 +427,7 @@ impl ContainerRuntime {
                 // is `$0`; the command starts at `$1`.
                 let mut argv = self.base.build_exec_argv(name, workdir, &[]);
                 argv.extend([
-                    "sh".to_string(),
+                    "/bin/sh".to_string(),
                     "-c".to_string(),
                     "exec \"$@\"".to_string(),
                     "sh".to_string(),
@@ -723,6 +723,19 @@ mod tests {
         assert_eq!(cmd, "podman exec -it aoe-sandbox-test1234 claude");
     }
 
+    #[test]
+    fn apple_container_exec_command_uses_absolute_shell() {
+        let cmd = ContainerRuntime::apple_container().exec_command(
+            "aoe-sandbox-test1234",
+            None,
+            "printf ok",
+        );
+        assert_eq!(
+            cmd,
+            "container exec -it aoe-sandbox-test1234 /bin/sh -c 'printf ok'"
+        );
+    }
+
     /// A title one-shot argv: the agent, its flags, and a prompt full of shell
     /// metacharacters as ONE element.
     fn oneshot_argv() -> Vec<String> {
@@ -782,7 +795,7 @@ mod tests {
                 "-w",
                 "/workspace",
                 "aoe-sandbox-test1234",
-                "sh",
+                "/bin/sh",
                 "-c",
                 "exec \"$@\"",
                 "sh",
@@ -791,6 +804,20 @@ mod tests {
         // The shell program is a fixed literal and the command follows it as
         // separate elements, so the prompt is never shell-parsed.
         assert_eq!(&argv[9..], &oneshot_argv()[..]);
+
+        let executable = ContainerRuntime::apple_container().build_exec_argv(
+            "aoe-sandbox-test1234",
+            "",
+            &["/bin/printf".to_string(), "PATH_INDEPENDENT".to_string()],
+        );
+        let output = std::process::Command::new(&executable[3])
+            .args(&executable[4..])
+            .env_clear()
+            .env("PATH", "/definitely-missing")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"PATH_INDEPENDENT");
     }
 
     #[test]

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -244,18 +244,7 @@ pub(crate) fn shell_escape(val: &str) -> String {
 /// Unlike [`shell_escape`], literal CR and LF bytes remain inside the quoted
 /// word. Use this only when writing a script, not a single-line command.
 pub(crate) fn shell_escape_script_word(value: &str) -> String {
-    let quote_count = value.bytes().filter(|byte| *byte == b'\'').count();
-    let mut escaped = String::with_capacity(value.len() + 2 + quote_count * 3);
-    escaped.push('\'');
-    let mut rest = value;
-    while let Some(index) = rest.find('\'') {
-        escaped.push_str(&rest[..index]);
-        escaped.push_str("'\\''");
-        rest = &rest[index + 1..];
-    }
-    escaped.push_str(rest);
-    escaped.push('\'');
-    escaped
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// Resolve a session's sandbox environment entries to concrete `(KEY, VALUE)`

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -165,7 +165,27 @@ const NON_POSIX_SHELLS: &[&str] = &["fish", "nu", "nushell", "pwsh", "powershell
 /// Shells we can safely launch with a `-l` login flag. Others (nushell,
 /// PowerShell) are launched plain; they still source their own interactive
 /// config, and `-l` would either error or mean something different there.
-const LOGIN_FLAG_SHELLS: &[&str] = &["bash", "zsh", "sh", "ksh", "dash", "fish", "csh", "tcsh"];
+const LOGIN_FLAG_SHELLS: &[&str] = &[
+    "bash", "zsh", "sh", "ash", "ksh", "mksh", "dash", "fish", "csh", "tcsh",
+];
+
+/// The `LOGIN_FLAG_SHELLS` basenames as one POSIX `case` pattern
+/// (`bash|zsh|...`), for embedding in a generated shell script.
+pub(crate) fn login_flag_shell_case_pattern() -> String {
+    LOGIN_FLAG_SHELLS.join("|")
+}
+
+/// Every shell basename this codebase recognizes, as one POSIX `case` pattern,
+/// whether or not `-l` applies to it.
+pub(crate) fn known_shell_case_pattern() -> String {
+    let mut names: Vec<&str> = Vec::with_capacity(LOGIN_FLAG_SHELLS.len() + NON_POSIX_SHELLS.len());
+    for name in LOGIN_FLAG_SHELLS.iter().chain(NON_POSIX_SHELLS) {
+        if !names.contains(name) {
+            names.push(name);
+        }
+    }
+    names.join("|")
+}
 
 /// Build the tmux pane command that launches `shell` as a login+interactive
 /// shell, so it sources the user's profile and rc files (`~/.zprofile`,

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -219,6 +219,25 @@ pub(crate) fn shell_escape(val: &str) -> String {
     format!("'{}'", escaped)
 }
 
+/// Quote one POSIX script word without changing its bytes.
+///
+/// Unlike [`shell_escape`], literal CR and LF bytes remain inside the quoted
+/// word. Use this only when writing a script, not a single-line command.
+pub(crate) fn shell_escape_script_word(value: &str) -> String {
+    let quote_count = value.bytes().filter(|byte| *byte == b'\'').count();
+    let mut escaped = String::with_capacity(value.len() + 2 + quote_count * 3);
+    escaped.push('\'');
+    let mut rest = value;
+    while let Some(index) = rest.find('\'') {
+        escaped.push_str(&rest[..index]);
+        escaped.push_str("'\\''");
+        rest = &rest[index + 1..];
+    }
+    escaped.push_str(rest);
+    escaped.push('\'');
+    escaped
+}
+
 /// Resolve a session's sandbox environment entries to concrete `(KEY, VALUE)`
 /// pairs on the host, for feeding into a host-side hook's process environment
 /// (so a `before_start` hook can read a per-session `$TEST_VAR`).

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -18,6 +18,7 @@ use crate::containers::{self, DockerContainer};
 use crate::session::config::container_config;
 use crate::session::environment::{
     build_docker_env_args_with_managed_codex_home, resolved_sandbox_environment, shell_escape,
+    shell_escape_script_word,
 };
 use crate::session::poller::SessionPoller;
 use crate::tmux;

--- a/src/session/instance/terminal.rs
+++ b/src/session/instance/terminal.rs
@@ -7,19 +7,101 @@ use super::*;
 /// Resolves the container user's login shell at spawn time, inside the container,
 /// and execs it as a login shell so profile/rc files load (parity with the Host
 /// terminal tab, which launches the user's default shell as a login shell).
-/// Resolution order: the passwd entry (the authoritative login shell, what
-/// `chsh` writes and what `login(1)` reads into `$SHELL`), then the container's
-/// `$SHELL`, then bash, sh. Passwd comes first because `docker exec` never goes
-/// through `login(1)`, so `$SHELL` is usually unset or a generic image default
-/// rather than the user's configured shell. Each candidate is run through
-/// `command -v` so an unset, stale, or non-executable value falls through to the
-/// next instead of killing the pane.
+/// Resolution order: the passwd entry, `$SHELL`, bash, then sh. Each candidate
+/// is resolved and validated inside the container as a regular executable login
+/// shell. Passwd is read directly when `getent` is unavailable.
 ///
-/// The single-quoted body is evaluated by the container's `sh`, not the host
+/// The single-quoted body is evaluated by the container's `/bin/sh`, not the host
 /// shell tmux uses to spawn the session, so the embedded `$()` runs in the
 /// container. The host does not propagate its own `$SHELL` into the container,
 /// so this reads the container's value, not the host's.
-const CONTAINER_TERMINAL_AUTODETECT_CMD: &str = r#"sh -c 'exec "$(command -v "$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f7)" 2>/dev/null || command -v "$SHELL" 2>/dev/null || command -v bash || command -v sh)" -l'"#;
+const CONTAINER_TERMINAL_AUTODETECT_CMD: &str = r#"/bin/sh -c '
+lookup_shell() {
+    wanted_uid=$1
+    while IFS=: read -r _ _ entry_uid _ _ _ candidate; do
+        if [ "$entry_uid" = "$wanted_uid" ]; then
+            printf "%s\n" "$candidate"
+            return
+        fi
+    done
+}
+
+resolve_shell() {
+    candidate=$1
+    case "$candidate" in
+        ""|-*) return 1 ;;
+    esac
+
+    case "$candidate" in
+        */*) resolved=$candidate ;;
+        *) resolved=$(command -v "$candidate" 2>/dev/null) || return 1 ;;
+    esac
+    case "$resolved" in
+        /*) ;;
+        */*)
+            directory=${resolved%/*}
+            filename=${resolved##*/}
+            directory=$(CDPATH= cd "$directory" 2>/dev/null && pwd -P) || return 1
+            resolved=$directory/$filename
+            ;;
+        *) return 1 ;;
+    esac
+    [ -f "$resolved" ] && [ -x "$resolved" ] || return 1
+
+    case "${resolved##*/}" in
+        sh|ash|bash|dash|zsh|fish|ksh|mksh|csh|tcsh|nu|nushell|pwsh|powershell)
+            printf "%s\n" "$resolved"
+            return
+            ;;
+    esac
+
+    if [ -r /etc/shells ]; then
+        while IFS= read -r allowed; do
+            case "$allowed" in
+                ""|\#*) continue ;;
+            esac
+            if [ "$resolved" = "$allowed" ] || [ "$resolved" -ef "$allowed" ]; then
+                printf "%s\n" "$resolved"
+                return
+            fi
+        done < /etc/shells
+    fi
+    return 1
+}
+
+uid=$(id -u 2>/dev/null || true)
+if [ -z "$uid" ] && [ -r /proc/self/status ]; then
+    while read -r key _ effective _; do
+        if [ "$key" = "Uid:" ]; then
+            uid=$effective
+            break
+        fi
+    done < /proc/self/status
+fi
+
+passwd_shell=
+if [ -n "$uid" ]; then
+    if command -v getent >/dev/null 2>&1; then
+        passwd_shell=$(getent passwd "$uid" 2>/dev/null | lookup_shell "$uid")
+    fi
+    if [ -z "$passwd_shell" ] && [ -r /etc/passwd ]; then
+        passwd_shell=$(lookup_shell "$uid" < /etc/passwd)
+    fi
+fi
+
+shell=$(resolve_shell "$passwd_shell" || resolve_shell "${SHELL-}" || resolve_shell bash || resolve_shell /bin/sh) || {
+    printf "%s\n" "No usable login shell found in container" >&2
+    exit 127
+}
+export SHELL=$shell
+case "${shell##*/}" in
+    sh|ash|bash|dash|zsh|fish|ksh|mksh|csh|tcsh) exec "$shell" -l ;;
+    *) exec "$shell" ;;
+esac
+'"#;
+fn container_terminal_exec_options(workdir: &str, env_args: &str) -> String {
+    format!("-w {} {}", shell_escape(workdir), env_args)
+}
 
 impl Instance {
     pub fn terminal_tmux_session(&self) -> Result<tmux::TerminalSession> {
@@ -160,7 +242,10 @@ impl Instance {
         let container_workdir = self.container_workdir();
 
         let cmd = container.exec_command(
-            Some(&format!("-w {} {}", container_workdir, env_part)),
+            Some(&container_terminal_exec_options(
+                &container_workdir,
+                &env_part,
+            )),
             CONTAINER_TERMINAL_AUTODETECT_CMD,
         );
 
@@ -214,25 +299,129 @@ impl Instance {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::{Command, Stdio};
+
+    fn write_executable(path: &std::path::Path, contents: &str) {
+        std::fs::write(path, contents).unwrap();
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
 
     #[test]
-    fn container_terminal_autodetect_cmd_resolves_login_shell() {
-        let cmd = CONTAINER_TERMINAL_AUTODETECT_CMD;
-        // Resolution order: passwd entry first (authoritative, since docker exec
-        // skips login(1) and so $SHELL is usually unset), then $SHELL, then
-        // bash, sh. Each candidate is guarded by `command -v` so an unset, stale,
-        // or non-executable value falls through rather than killing the pane.
-        assert!(cmd.contains("getent passwd"));
-        assert!(cmd.contains(r#"command -v "$SHELL""#));
-        assert!(cmd.contains("command -v bash"));
-        assert!(cmd.contains("command -v sh"));
-        // Passwd is resolved ahead of $SHELL.
-        assert!(cmd.find("getent passwd").unwrap() < cmd.find(r#"command -v "$SHELL""#).unwrap());
-        // Login shell so profile/rc files load, matching the Host terminal tab.
-        assert!(cmd.contains("-l"));
-        // Single-quoted body: the embedded command substitution is evaluated by
-        // the container's sh, not the host shell tmux spawns the session with.
-        assert!(cmd.starts_with("sh -c '"));
+    fn container_terminal_resolver_executes_only_usable_shells() {
+        for invalid_kind in ["non_executable", "directory", "non_shell"] {
+            let temp = tempfile::tempdir().unwrap();
+            write_executable(
+                &temp.path().join("getent"),
+                r#"#!/bin/sh
+printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
+"#,
+            );
+            write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
+
+            let candidate = temp.path().join(invalid_kind);
+            match invalid_kind {
+                "non_executable" => std::fs::write(&candidate, "not executable").unwrap(),
+                "directory" => std::fs::create_dir(&candidate).unwrap(),
+                "non_shell" => write_executable(&candidate, "#!/bin/sh\necho WRONG_CANDIDATE\n"),
+                _ => unreachable!(),
+            }
+
+            let mut child = Command::new("/bin/sh")
+                .args(["-c", CONTAINER_TERMINAL_AUTODETECT_CMD])
+                .env("HOME", temp.path())
+                .env("PATH", format!("{}:/usr/bin:/bin", temp.path().display()))
+                .env("PASSWD_SHELL", &candidate)
+                .env("SHELL", "/bin/sh")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(b"echo RESOLVED_SHELL\nexit\n")
+                .unwrap();
+            let output = child.wait_with_output().unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+
+            assert!(
+                output.status.success(),
+                "resolver failed for {invalid_kind}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                stdout.contains("RESOLVED_SHELL"),
+                "resolver executed {invalid_kind} instead of a shell: stdout={stdout}, stderr={}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(!stdout.contains("WRONG_CANDIDATE"));
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let shell = temp.path().join("fish");
+        write_executable(
+            &shell,
+            r#"#!/bin/sh
+printf 'CUSTOM_SHELL %s %s\n' "$1" "$SHELL"
+"#,
+        );
+        write_executable(
+            &temp.path().join("getent"),
+            r#"#!/bin/sh
+printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
+"#,
+        );
+        write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
+        let output = Command::new("/bin/sh")
+            .args(["-c", CONTAINER_TERMINAL_AUTODETECT_CMD])
+            .env("PATH", format!("{}:/usr/bin:/bin", temp.path().display()))
+            .env("PASSWD_SHELL", &shell)
+            .env_remove("SHELL")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(stdout.contains(&format!("CUSTOM_SHELL -l {}", shell.display())));
+    }
+    #[test]
+    fn container_terminal_workdir_stays_one_runtime_argument() {
+        let temp = tempfile::tempdir().unwrap();
+        write_executable(
+            &temp.path().join("docker"),
+            r#"#!/bin/sh
+printf '%s\n' "$@" > "$ARGS_FILE"
+"#,
+        );
+        let args_file = temp.path().join("args");
+        let workdir = "/workspace/project;printf HOST_WORKDIR_INJECTION";
+        let options = container_terminal_exec_options(workdir, "");
+        let command = crate::containers::ContainerRuntime::docker().exec_command(
+            "test-container",
+            Some(&options),
+            "true",
+        );
+
+        let status = Command::new("/bin/sh")
+            .args(["-c", &command])
+            .env("PATH", temp.path())
+            .env("ARGS_FILE", &args_file)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        assert_eq!(
+            std::fs::read_to_string(args_file).unwrap(),
+            "exec\n-it\n-w\n/workspace/project;printf HOST_WORKDIR_INJECTION\ntest-container\ntrue\n"
+        );
     }
 
     #[test]

--- a/src/session/instance/terminal.rs
+++ b/src/session/instance/terminal.rs
@@ -15,6 +15,10 @@ use super::*;
 /// uses to spawn the session, so the embedded `$()` runs in the container. The
 /// host does not propagate its own `$SHELL` into the container, so this reads the
 /// container's value, not the host's.
+///
+/// `@KNOWN_SHELLS@` and `@LOGIN_FLAG_SHELLS@` are substituted from
+/// [`crate::session::environment`] so the container tab recognizes the same
+/// shells, and makes the same login-mode call, as the host tab.
 const CONTAINER_TERMINAL_AUTODETECT_SCRIPT: &str = r#"passwd_file=$1
 shells_file=$2
 
@@ -51,7 +55,7 @@ resolve_shell() {
     [ -f "$resolved" ] && [ -x "$resolved" ] || return 1
 
     case "${resolved##*/}" in
-        sh|ash|bash|dash|zsh|fish|ksh|mksh|csh|tcsh|nu|nushell|pwsh|powershell)
+        @KNOWN_SHELLS@)
             printf "%s\n" "$resolved"
             return
             ;;
@@ -97,15 +101,24 @@ shell=$(resolve_shell "$passwd_shell" || resolve_shell "${SHELL-}" || resolve_sh
 }
 export SHELL=$shell
 case "${shell##*/}" in
-    sh|ash|bash|dash|zsh|fish|ksh|mksh|csh|tcsh) exec "$shell" -l ;;
+    @LOGIN_FLAG_SHELLS@) exec "$shell" -l ;;
     *) exec "$shell" ;;
 esac
 "#;
 
 fn container_terminal_autodetect_command(passwd_file: &str, shells_file: &str) -> String {
+    let script = CONTAINER_TERMINAL_AUTODETECT_SCRIPT
+        .replace(
+            "@KNOWN_SHELLS@",
+            &crate::session::environment::known_shell_case_pattern(),
+        )
+        .replace(
+            "@LOGIN_FLAG_SHELLS@",
+            &crate::session::environment::login_flag_shell_case_pattern(),
+        );
     format!(
         "/bin/sh -c {} aoe-container-terminal {} {}",
-        shell_escape_script_word(CONTAINER_TERMINAL_AUTODETECT_SCRIPT),
+        shell_escape_script_word(&script),
         shell_escape_script_word(passwd_file),
         shell_escape_script_word(shells_file)
     )

--- a/src/session/instance/terminal.rs
+++ b/src/session/instance/terminal.rs
@@ -20,7 +20,7 @@ shells_file=$2
 
 lookup_shell() {
     wanted_uid=$1
-    while IFS=: read -r _ _ entry_uid _ _ _ candidate; do
+    while IFS=: read -r _ _ entry_uid _ _ _ candidate || [ -n "$candidate" ]; do
         if [ "$entry_uid" = "$wanted_uid" ]; then
             printf "%s\n" "$candidate"
             return
@@ -58,7 +58,7 @@ resolve_shell() {
     esac
 
     if [ -r "$shells_file" ]; then
-        while IFS= read -r allowed; do
+        while IFS= read -r allowed || [ -n "$allowed" ]; do
             case "$allowed" in
                 ""|\#*) continue ;;
             esac
@@ -102,14 +102,17 @@ case "${shell##*/}" in
 esac
 "#;
 
-fn container_terminal_autodetect_command() -> String {
-    // Preserve script newlines; shell_escape sanitizes them in external values.
-    let script = CONTAINER_TERMINAL_AUTODETECT_SCRIPT.replace('\'', "'\\''");
-    format!("/bin/sh -c '{script}' aoe-container-terminal /etc/passwd /etc/shells")
+fn container_terminal_autodetect_command(passwd_file: &str, shells_file: &str) -> String {
+    format!(
+        "/bin/sh -c {} aoe-container-terminal {} {}",
+        shell_escape_script_word(CONTAINER_TERMINAL_AUTODETECT_SCRIPT),
+        shell_escape_script_word(passwd_file),
+        shell_escape_script_word(shells_file)
+    )
 }
 
 fn container_terminal_exec_options(workdir: &str, env_args: &str) -> String {
-    format!("-w {} {}", shell_escape(workdir), env_args)
+    format!("-w {} {}", shell_escape_script_word(workdir), env_args)
 }
 
 impl Instance {
@@ -250,7 +253,7 @@ impl Instance {
         // Get workspace path inside container (handles bare repo worktrees correctly)
         let container_workdir = self.container_workdir();
 
-        let resolver_command = container_terminal_autodetect_command();
+        let resolver_command = container_terminal_autodetect_command("/etc/passwd", "/etc/shells");
         let cmd = container.exec_command(
             Some(&container_terminal_exec_options(
                 &container_workdir,
@@ -340,7 +343,8 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
                 _ => unreachable!(),
             }
 
-            let resolver_command = container_terminal_autodetect_command();
+            let resolver_command =
+                container_terminal_autodetect_command("/etc/passwd", "/etc/shells");
             let mut child = Command::new("/bin/sh")
                 .arg("-c")
                 .arg(&resolver_command)
@@ -390,7 +394,7 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
 "#,
         );
         write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
-        let resolver_command = container_terminal_autodetect_command();
+        let resolver_command = container_terminal_autodetect_command("/etc/passwd", "/etc/shells");
         let output = Command::new("/bin/sh")
             .arg("-c")
             .arg(&resolver_command)
@@ -408,82 +412,152 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
         assert!(stdout.contains(&format!("CUSTOM_SHELL -l {}", shell.display())));
     }
     #[test]
-    fn container_terminal_resolver_uses_passwd_without_getent() {
-        let temp = tempfile::tempdir().unwrap();
-        write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
+    fn container_terminal_resolver_reads_passwd_without_getent() {
+        for (case, passwd_ending, shells_ending) in [
+            ("terminated", "\n", "\n"),
+            ("unterminated_passwd", "", "\n"),
+            ("unterminated_shells", "\n", ""),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
 
-        let passwd_shell = temp.path().join("custom-authorized-shell");
-        write_executable(
-            &passwd_shell,
-            "#!/bin/sh\nprintf 'PASSWD argc=%s arg1=%s shell=%s\\n' \"$#\" \"${1-}\" \"$SHELL\"\n",
-        );
+            let passwd_shell = temp.path().join("custom-authorized-shell");
+            write_executable(
+                &passwd_shell,
+                "#!/bin/sh\nprintf 'PASSWD argc=%s arg1=%s shell=%s\\n' \"$#\" \"${1-}\" \"$SHELL\"\n",
+            );
+            let fallback_shell = temp.path().join("bash");
+            write_executable(&fallback_shell, "#!/bin/sh\nprintf 'WRONG_FALLBACK\\n'\n");
+
+            let passwd_file = temp.path().join("passwd");
+            std::fs::write(
+                &passwd_file,
+                format!(
+                    "test:x:2999:2999::/tmp:{}{passwd_ending}",
+                    passwd_shell.display()
+                ),
+            )
+            .unwrap();
+            let shells_file = temp.path().join("shells");
+            std::fs::write(
+                &shells_file,
+                format!("{}{shells_ending}", passwd_shell.display()),
+            )
+            .unwrap();
+
+            let resolver_command = container_terminal_autodetect_command(
+                passwd_file.to_str().unwrap(),
+                shells_file.to_str().unwrap(),
+            );
+            let output = Command::new("/bin/sh")
+                .args(["-c", &resolver_command])
+                .env_clear()
+                .env("HOME", temp.path())
+                .env("PATH", temp.path())
+                .env("SHELL", &fallback_shell)
+                .output()
+                .unwrap();
+
+            assert!(
+                output.status.success(),
+                "{case}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(output.stderr.is_empty(), "{case}");
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout),
+                format!("PASSWD argc=0 arg1= shell={}\n", passwd_shell.display()),
+                "{case}"
+            );
+        }
+    }
+
+    #[test]
+    fn container_terminal_command_preserves_runtime_boundaries() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime_driver = r#"#!/bin/sh
+[ "$1" = exec ] || exit 90
+shift
+[ "$1" = -it ] || exit 91
+shift
+[ "$1" = -w ] || exit 92
+printf '%s' "$2" > "$ARGS_FILE"
+shift 2
+if [ "${1-}" = --env-file ]; then
+    [ "$2" = /dev/fd/9 ] || exit 93
+    shift 2
+fi
+[ "$1" = test-container ] || exit 94
+shift
+exec /usr/bin/env -i PATH="$TARGET_PATH" SHELL="$FALLBACK_SHELL" "$@"
+"#;
+        for binary in ["docker", "podman", "container"] {
+            write_executable(&temp.path().join(binary), runtime_driver);
+        }
+        write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
         let fallback_shell = temp.path().join("bash");
         write_executable(&fallback_shell, "#!/bin/sh\nprintf 'WRONG_FALLBACK\\n'\n");
 
-        let passwd_file = temp.path().join("passwd");
+        let fixtures = temp.path().join("fixtures'quoted");
+        std::fs::create_dir(&fixtures).unwrap();
+        let passwd_shell = fixtures.join("custom-authorized-shell");
+        write_executable(
+            &passwd_shell,
+            "#!/bin/sh\nprintf 'RUNTIME argc=%s shell=%s\\n' \"$#\" \"$SHELL\"\n",
+        );
+        let passwd_file = fixtures.join("passwd");
         std::fs::write(
             &passwd_file,
             format!("test:x:2999:2999::/tmp:{}\n", passwd_shell.display()),
         )
         .unwrap();
-        let shells_file = temp.path().join("shells");
+        let shells_file = fixtures.join("shells");
         std::fs::write(&shells_file, format!("{}\n", passwd_shell.display())).unwrap();
-
-        let output = Command::new("/bin/sh")
-            .args([
-                "-c",
-                CONTAINER_TERMINAL_AUTODETECT_SCRIPT,
-                "aoe-container-terminal",
-            ])
-            .arg(&passwd_file)
-            .arg(&shells_file)
-            .env_clear()
-            .env("HOME", temp.path())
-            .env("PATH", temp.path())
-            .env("SHELL", &fallback_shell)
-            .output()
-            .unwrap();
-
-        assert!(
-            output.status.success(),
-            "{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        assert!(output.stderr.is_empty());
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout),
-            format!("PASSWD argc=0 arg1= shell={}\n", passwd_shell.display())
-        );
-    }
-    #[test]
-    fn container_terminal_workdir_stays_one_runtime_argument() {
-        let temp = tempfile::tempdir().unwrap();
-        write_executable(
-            &temp.path().join("docker"),
-            r#"#!/bin/sh
-printf '%s\n' "$@" > "$ARGS_FILE"
-"#,
-        );
-        let args_file = temp.path().join("args");
-        let workdir = "/workspace/project;printf HOST_WORKDIR_INJECTION";
-        let options = container_terminal_exec_options(workdir, "");
-        let command = crate::containers::ContainerRuntime::docker().exec_command(
-            "test-container",
-            Some(&options),
-            "true",
+        let resolver_command = container_terminal_autodetect_command(
+            passwd_file.to_str().unwrap(),
+            shells_file.to_str().unwrap(),
         );
 
-        let status = Command::new("/bin/sh")
-            .args(["-c", &command])
-            .env("PATH", temp.path())
-            .env("ARGS_FILE", &args_file)
-            .status()
-            .unwrap();
-        assert!(status.success());
-        assert_eq!(
-            std::fs::read_to_string(args_file).unwrap(),
-            "exec\n-it\n-w\n/workspace/project;printf HOST_WORKDIR_INJECTION\ntest-container\ntrue\n"
+        let injection_marker = temp.path().join("injected");
+        let workdir = format!(
+            "/workspace/project\nline\rcarriage' ; printf PWNED > {}; #",
+            injection_marker.display()
         );
+        let options = container_terminal_exec_options(&workdir, "--env-file /dev/fd/9 ");
+
+        for (binary, runtime) in [
+            ("docker", crate::containers::ContainerRuntime::docker()),
+            ("podman", crate::containers::ContainerRuntime::podman()),
+            (
+                "container",
+                crate::containers::ContainerRuntime::apple_container(),
+            ),
+        ] {
+            let args_file = temp.path().join(format!("args-{binary}"));
+            let command = runtime.exec_command("test-container", Some(&options), &resolver_command);
+            let output = Command::new("/bin/sh")
+                .args(["-c", &command])
+                .env_clear()
+                .env("PATH", temp.path())
+                .env("ARGS_FILE", &args_file)
+                .env("TARGET_PATH", temp.path())
+                .env("FALLBACK_SHELL", &fallback_shell)
+                .output()
+                .unwrap();
+
+            assert!(
+                output.status.success(),
+                "{binary}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(std::fs::read(&args_file).unwrap(), workdir.as_bytes());
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout),
+                format!("RUNTIME argc=0 shell={}\n", passwd_shell.display()),
+                "{binary}"
+            );
+        }
+        assert!(!injection_marker.exists());
     }
 
     #[test]

--- a/src/session/instance/terminal.rs
+++ b/src/session/instance/terminal.rs
@@ -4,18 +4,20 @@ use super::*;
 
 /// Command run inside the sandbox container for the web Container terminal tab.
 ///
-/// Resolves the container user's login shell at spawn time, inside the container,
-/// and execs it as a login shell so profile/rc files load (parity with the Host
-/// terminal tab, which launches the user's default shell as a login shell).
+/// Resolves the container user's preferred shell at spawn time, inside the
+/// container. Known-compatible shells run in login mode so profile/rc files
+/// load; other authorized shells run plain.
 /// Resolution order: the passwd entry, `$SHELL`, bash, then sh. Each candidate
-/// is resolved and validated inside the container as a regular executable login
-/// shell. Passwd is read directly when `getent` is unavailable.
+/// is resolved and validated inside the container as a regular executable
+/// authorized shell. Passwd is read directly when `getent` is unavailable.
 ///
-/// The single-quoted body is evaluated by the container's `/bin/sh`, not the host
-/// shell tmux uses to spawn the session, so the embedded `$()` runs in the
-/// container. The host does not propagate its own `$SHELL` into the container,
-/// so this reads the container's value, not the host's.
-const CONTAINER_TERMINAL_AUTODETECT_CMD: &str = r#"/bin/sh -c '
+/// The script is evaluated by the container's `/bin/sh`, not the host shell tmux
+/// uses to spawn the session, so the embedded `$()` runs in the container. The
+/// host does not propagate its own `$SHELL` into the container, so this reads the
+/// container's value, not the host's.
+const CONTAINER_TERMINAL_AUTODETECT_SCRIPT: &str = r#"passwd_file=$1
+shells_file=$2
+
 lookup_shell() {
     wanted_uid=$1
     while IFS=: read -r _ _ entry_uid _ _ _ candidate; do
@@ -55,16 +57,16 @@ resolve_shell() {
             ;;
     esac
 
-    if [ -r /etc/shells ]; then
+    if [ -r "$shells_file" ]; then
         while IFS= read -r allowed; do
             case "$allowed" in
                 ""|\#*) continue ;;
             esac
-            if [ "$resolved" = "$allowed" ] || [ "$resolved" -ef "$allowed" ]; then
+            if [ "$resolved" = "$allowed" ]; then
                 printf "%s\n" "$resolved"
                 return
             fi
-        done < /etc/shells
+        done < "$shells_file"
     fi
     return 1
 }
@@ -84,13 +86,13 @@ if [ -n "$uid" ]; then
     if command -v getent >/dev/null 2>&1; then
         passwd_shell=$(getent passwd "$uid" 2>/dev/null | lookup_shell "$uid")
     fi
-    if [ -z "$passwd_shell" ] && [ -r /etc/passwd ]; then
-        passwd_shell=$(lookup_shell "$uid" < /etc/passwd)
+    if [ -z "$passwd_shell" ] && [ -r "$passwd_file" ]; then
+        passwd_shell=$(lookup_shell "$uid" < "$passwd_file")
     fi
 fi
 
 shell=$(resolve_shell "$passwd_shell" || resolve_shell "${SHELL-}" || resolve_shell bash || resolve_shell /bin/sh) || {
-    printf "%s\n" "No usable login shell found in container" >&2
+    printf "%s\n" "No usable shell found in container" >&2
     exit 127
 }
 export SHELL=$shell
@@ -98,7 +100,14 @@ case "${shell##*/}" in
     sh|ash|bash|dash|zsh|fish|ksh|mksh|csh|tcsh) exec "$shell" -l ;;
     *) exec "$shell" ;;
 esac
-'"#;
+"#;
+
+fn container_terminal_autodetect_command() -> String {
+    // Preserve script newlines; shell_escape sanitizes them in external values.
+    let script = CONTAINER_TERMINAL_AUTODETECT_SCRIPT.replace('\'', "'\\''");
+    format!("/bin/sh -c '{script}' aoe-container-terminal /etc/passwd /etc/shells")
+}
+
 fn container_terminal_exec_options(workdir: &str, env_args: &str) -> String {
     format!("-w {} {}", shell_escape(workdir), env_args)
 }
@@ -241,12 +250,13 @@ impl Instance {
         // Get workspace path inside container (handles bare repo worktrees correctly)
         let container_workdir = self.container_workdir();
 
+        let resolver_command = container_terminal_autodetect_command();
         let cmd = container.exec_command(
             Some(&container_terminal_exec_options(
                 &container_workdir,
                 &env_part,
             )),
-            CONTAINER_TERMINAL_AUTODETECT_CMD,
+            &resolver_command,
         );
 
         // Values ride the protected env-file, never the host shell or runtime
@@ -330,8 +340,10 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
                 _ => unreachable!(),
             }
 
+            let resolver_command = container_terminal_autodetect_command();
             let mut child = Command::new("/bin/sh")
-                .args(["-c", CONTAINER_TERMINAL_AUTODETECT_CMD])
+                .arg("-c")
+                .arg(&resolver_command)
                 .env("HOME", temp.path())
                 .env("PATH", format!("{}:/usr/bin:/bin", temp.path().display()))
                 .env("PASSWD_SHELL", &candidate)
@@ -378,8 +390,10 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
 "#,
         );
         write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
+        let resolver_command = container_terminal_autodetect_command();
         let output = Command::new("/bin/sh")
-            .args(["-c", CONTAINER_TERMINAL_AUTODETECT_CMD])
+            .arg("-c")
+            .arg(&resolver_command)
             .env("PATH", format!("{}:/usr/bin:/bin", temp.path().display()))
             .env("PASSWD_SHELL", &shell)
             .env_remove("SHELL")
@@ -392,6 +406,54 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
             String::from_utf8_lossy(&output.stderr)
         );
         assert!(stdout.contains(&format!("CUSTOM_SHELL -l {}", shell.display())));
+    }
+    #[test]
+    fn container_terminal_resolver_uses_passwd_without_getent() {
+        let temp = tempfile::tempdir().unwrap();
+        write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
+
+        let passwd_shell = temp.path().join("custom-authorized-shell");
+        write_executable(
+            &passwd_shell,
+            "#!/bin/sh\nprintf 'PASSWD argc=%s arg1=%s shell=%s\\n' \"$#\" \"${1-}\" \"$SHELL\"\n",
+        );
+        let fallback_shell = temp.path().join("bash");
+        write_executable(&fallback_shell, "#!/bin/sh\nprintf 'WRONG_FALLBACK\\n'\n");
+
+        let passwd_file = temp.path().join("passwd");
+        std::fs::write(
+            &passwd_file,
+            format!("test:x:2999:2999::/tmp:{}\n", passwd_shell.display()),
+        )
+        .unwrap();
+        let shells_file = temp.path().join("shells");
+        std::fs::write(&shells_file, format!("{}\n", passwd_shell.display())).unwrap();
+
+        let output = Command::new("/bin/sh")
+            .args([
+                "-c",
+                CONTAINER_TERMINAL_AUTODETECT_SCRIPT,
+                "aoe-container-terminal",
+            ])
+            .arg(&passwd_file)
+            .arg(&shells_file)
+            .env_clear()
+            .env("HOME", temp.path())
+            .env("PATH", temp.path())
+            .env("SHELL", &fallback_shell)
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.stderr.is_empty());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!("PASSWD argc=0 arg1= shell={}\n", passwd_shell.display())
+        );
     }
     #[test]
     fn container_terminal_workdir_stays_one_runtime_argument() {

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -17,6 +17,7 @@ use super::{
 };
 use crate::cli::truncate_id;
 use crate::process;
+use crate::session::environment::shell_escape_script_word;
 use crate::session::Status;
 use crate::util::now_ms;
 
@@ -2368,7 +2369,7 @@ impl EphemeralEnvFile {
             }
             match mutation {
                 PaneEnvMutation::Set { key, value } => {
-                    writeln!(file, "export {}={}", key, script_shell_escape(value))?;
+                    writeln!(file, "export {}={}", key, shell_escape_script_word(value))?;
                 }
                 PaneEnvMutation::Unset { key } => writeln!(file, "unset {}", key)?,
             }
@@ -2396,18 +2397,18 @@ impl EphemeralEnvFile {
                 file,
                 "exec {}<{} || exit 1",
                 crate::session::environment::CONTAINER_EXEC_ENV_FD,
-                script_shell_escape(&container_env_path.to_string_lossy())
+                shell_escape_script_word(&container_env_path.to_string_lossy())
             )?;
             writeln!(
                 file,
                 "rm -f -- {}",
-                script_shell_escape(&container_env_path.to_string_lossy())
+                shell_escape_script_word(&container_env_path.to_string_lossy())
             )?;
         }
         writeln!(
             file,
             "rm -f -- {}",
-            script_shell_escape(&path.to_string_lossy())
+            shell_escape_script_word(&path.to_string_lossy())
         )?;
         writeln!(file, "{launch}")?;
         file.flush()?;
@@ -2453,13 +2454,6 @@ impl Drop for EphemeralEnvFile {
             let _ = std::fs::remove_file(path);
         }
     }
-}
-
-/// Quote one POSIX script word without changing its bytes. Unlike the
-/// single-line command formatter, literal CR and LF bytes are valid inside
-/// single quotes here and must survive environment transport.
-fn script_shell_escape(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// Whether `text` should get a trailing space appended before being typed
@@ -4954,8 +4948,8 @@ mod tests {
         .unwrap();
         let command = format!(
             "printf '%s' \"$MULTILINE_SECRET\" > {}; printf '%s' \"${{AOE_TEST_STALE+x}}\" > {}",
-            script_shell_escape(&output.to_string_lossy()),
-            script_shell_escape(&stale_output.to_string_lossy())
+            shell_escape_script_word(&output.to_string_lossy()),
+            shell_escape_script_word(&stale_output.to_string_lossy())
         );
         let wrapper = file.wrap_command(Some(&command)).unwrap();
         let status = std::process::Command::new("sh")
@@ -4995,9 +4989,9 @@ mod tests {
         let command = format!(
             "printf '%s\\n%s' \"$PATH\" \"${{DOCKER_HOST-unset}}\" > {}; \
              cat {} > {}",
-            script_shell_escape(&host_output.to_string_lossy()),
+            shell_escape_script_word(&host_output.to_string_lossy()),
             crate::session::environment::CONTAINER_EXEC_ENV_PATH,
-            script_shell_escape(&payload_output.to_string_lossy()),
+            shell_escape_script_word(&payload_output.to_string_lossy()),
         );
         let wrapper = file.wrap_command(Some(&command)).unwrap();
         let script = std::fs::read_to_string(&script_path).unwrap();


### PR DESCRIPTION
## Description
<!-- Describe your changes and the problem they solve -->

Harden sandboxed paired-terminal startup at both trust boundaries:

- resolve the container user's passwd shell without requiring `getent`
- reject non-regular, non-executable, and non-shell candidates before falling back
- invoke login mode only for shells known to support `-l`
- use absolute `/bin/sh` for the resolver and Apple Container wrappers
- preserve the exact container workdir as one host-side runtime argument
- document the resolution and validation behavior

Real Docker and Podman runtime matrices cover passwd-first fish/zsh selection, stale or missing `SHELL`, missing `getent`, invalid passwd candidates, missing users, minimal Alpine and BusyBox images, and hostile workdir values. Deterministic Rust tests execute emitted Docker, Podman, and Apple Container commands; cover unterminated passwd and `/etc/shells` records; and preserve LF, CR, apostrophes, and shell metacharacters in workdirs without execution.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo clippy -- -D warnings` (commit hook)
- `cargo test container_terminal_ --lib -- --nocapture`
- local `cargo test` ran 6,613 library tests: 6,609 passed and 2 ignored. The unrelated `session::storage::tests::profile_move_crash_before_publication_source_wins` failed in the full run but passed in isolation; the real-tmux test `tmux::env::tests::test_batch_output_frames_records_against_a_real_tmux` retains its audited baseline failure.
- on final head `9f52675d4a66d315e27dabc46aac9019c073be66`, formatting, Clippy, all six container-terminal tests, the migrated multiline quoting test, and both Apple wrapper tests pass; GitHub checks were still running at the final nonblocking snapshot, with no completed failure

No visual UI behavior changed, so there is no screenshot or recording.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the changed behavior is container-runtime shell selection and host command construction; deterministic Rust behavioral tests and real Docker/Podman matrices cover it without duplicating the contract in browser plumbing.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenAI Codex, GPT-5.6

**Any Additional AI Details you'd like to share:**

An AI agent performed the forensic audit, implemented the fix, exercised Docker and Podman runtime matrices, added behavioral regression coverage, and ran the repository validation gates. A human should independently review the shell resolver and command-boundary changes.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved paired-terminal startup in containers.
- Resolves and validates the container user’s shell without requiring `getent`.
- Falls back to safe shell options when candidates are missing or invalid.
- Uses login mode only for compatible shells.
- Preserves container workdir argument boundaries.
- Uses absolute `/bin/sh` for Apple Container commands.
- Shares shell-escaping logic between terminal and tmux code.
- Updated documentation and added coverage for Docker, Podman, and Apple Container.

## Benefits

- Improves startup reliability across container runtimes.
- Supports minimal images and missing users.
- Prevents hostile workdirs from altering generated commands.
- Keeps shell behavior consistent across host and container terminals.

Formatting, Clippy, and container-terminal tests pass. One unrelated real-tmux test fails on the audited `main` baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->