### PR TITLE
fix(tmux): refresh @aoe_title when a session is renamed

### DIFF
--- a/docs/guides/tmux-status-bar.md
+++ b/docs/guides/tmux-status-bar.md
@@ -135,7 +135,10 @@ set -g status-right "#{@aoe_title} #{@aoe_branch} #{@aoe_sandbox} | %H:%M"
 
 ### Status bar shows old info
 
-The tmux user options are set when the session starts. If you rename a session in aoe, the status bar will show the old name until you restart the session.
+Renaming a session refreshes `@aoe_title` on its agent pane straight away. The
+paired terminal and container panes keep the old title, and `@aoe_branch` keeps
+the old branch after a tied worktree branch rename, until those sessions are
+restarted.
 
 ### Branch not showing
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -581,8 +581,8 @@ pub(crate) fn rekey_session(id: &str, old_title: &str, new_title: &str) -> anyho
     Ok(renamed)
 }
 
-/// The rename half of [`rekey_session`], split out so the title refresh runs
-/// once for every path that reports the pane moved.
+/// The rename half of [`rekey_session`]: resolves the live session for `id`
+/// and moves it to the name derived from `new_title`.
 fn rekey_session_name(id: &str, old_title: &str, new_title: &str) -> anyhow::Result<bool> {
     // Name resolution is cache-backed. Force an authoritative scan first so a
     // process-local snapshot from before another writer's rename cannot point

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -573,6 +573,17 @@ fn resolved_agent_existence(
 /// per-session title and lifecycle locks through this call; rekeying before
 /// commit can strand the pane when persistence fails.
 pub(crate) fn rekey_session(id: &str, old_title: &str, new_title: &str) -> anyhow::Result<bool> {
+    let renamed = rekey_session_name(id, old_title, new_title)?;
+    if renamed {
+        // Every `Ok(true)` path leaves the session under the new derived name.
+        status_bar::refresh_session_title(&Session::generate_name(id, new_title), new_title);
+    }
+    Ok(renamed)
+}
+
+/// The rename half of [`rekey_session`], split out so the title refresh runs
+/// once for every path that reports the pane moved.
+fn rekey_session_name(id: &str, old_title: &str, new_title: &str) -> anyhow::Result<bool> {
     // Name resolution is cache-backed. Force an authoritative scan first so a
     // process-local snapshot from before another writer's rename cannot point
     // this mutation at the old title-derived name.
@@ -3450,6 +3461,45 @@ mod tests {
         assert!(rekey_session(ID, "Fix login bug", "Final rename").unwrap());
         assert!(Session::from_name(&final_name).exists());
         drop((start_guard, peer_guard, final_guard));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn rekey_session_refreshes_the_status_bar_title() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let start_name = Session::generate_name(ID, "Britons");
+        let final_name = Session::generate_name(ID, "Fix detach hint");
+        let start_guard = TmuxTestSession::from_name(start_name.clone());
+        let final_guard = TmuxTestSession::from_name(final_name.clone());
+        let created = tmux_command()
+            .args(["new-session", "-d", "-s", start_guard.name(), "sleep 60"])
+            .output()
+            .expect("tmux new-session");
+        assert!(created.status.success());
+        // Seed the option the way `apply_status_bar` does at session start.
+        let seeded = tmux_command()
+            .args(["set-option", "-t", &start_name, "@aoe_title", "Britons"])
+            .output()
+            .expect("tmux set-option @aoe_title");
+        assert!(seeded.status.success());
+        refresh_session_cache();
+
+        assert!(rekey_session(ID, "Britons", "Fix detach hint").unwrap());
+
+        // `status-right` renders `#{@aoe_title}`, so a stale value keeps the
+        // pre-rename title on the bar until the session is restarted.
+        let shown = tmux_command()
+            .args(["show-options", "-t", &final_name, "-v", "@aoe_title"])
+            .output()
+            .expect("tmux show-options @aoe_title");
+        assert_eq!(
+            String::from_utf8_lossy(&shown.stdout).trim(),
+            "Fix detach hint"
+        );
+        drop((start_guard, final_guard));
     }
 
     #[test]

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -101,9 +101,12 @@ fn set_session_option_unset(session_name: &str, option: &str) -> Result<()> {
 }
 
 fn set_session_option(session_name: &str, option: &str, value: &str) -> Result<()> {
-    let output = crate::tmux::tmux_command()
-        .args(["set-option", "-t", session_name, option, value])
-        .output()?;
+    // Deadline-bounded like every other tmux call aoe makes: `rekey_session`
+    // reaches this from a rename the TUI and the HTTP handler both wait on, so
+    // a wedged server must not hold the rename open.
+    let mut command = crate::tmux::tmux_command();
+    command.args(["set-option", "-t", session_name, option, value]);
+    let output = crate::tmux::run_tmux_command_with_timeout(&mut command)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -114,6 +114,18 @@ fn set_session_option(session_name: &str, option: &str, value: &str) -> Result<(
     Ok(())
 }
 
+/// Refresh the title the status bar and `aoe tmux-status` read for a session.
+///
+/// A rename moves the session name but leaves `@aoe_title` holding the
+/// pre-rename title, and nothing re-applies the status bar to a session that
+/// is already live. Written outside the `StatusBar` setting gate on purpose:
+/// `@aoe_*` are aoe's own user options rather than tmux built-ins, so they
+/// never override a user's config, and `aoe tmux-status` serves them to users
+/// painting their own bar.
+pub(crate) fn refresh_session_title(session_name: &str, title: &str) {
+    let _ = set_session_option(session_name, "@aoe_title", title);
+}
+
 /// Apply mouse support option to a tmux session.
 /// When enabled, scrolling with the mouse wheel enters copy mode.
 pub fn apply_mouse_option(session_name: &str, enabled: bool) -> Result<()> {


### PR DESCRIPTION
## Description

`status-right` renders `#{@aoe_title}` and `aoe tmux-status` reads the same option, but `rekey_session` only moved the tmux session name. None of the `apply_all_tmux_options` call sites run on the rename path, and `attach_session` re-applies options only when it decides to restart, so a renamed session kept painting its pre-rename title until it was restarted. `smart_rename` defaults to on, which makes that the common case rather than an edge one.

The visible symptom is a bar disagreeing with itself: `status-left` shows the new session name while `status-right` still shows the old title.

Found while reviewing #3727, which fixed the neighbouring `status-left-length` staleness on the same code path.

The refresh is written outside the `StatusBar` setting gate on purpose: `@aoe_*` are aoe's own user options rather than tmux built-ins, so they never override a user's config, and `aoe tmux-status` serves them to users painting their own bar. `apply_all_tmux_options`'s unset branch already leaves `@aoe_*` alone for the same reason.

`rekey_session` is split into a thin wrapper plus `rekey_session_name` so the refresh runs once for every path that reports the pane moved, instead of being duplicated across five `Ok(true)` returns. The extracted body is byte-identical to the previous one.

### Known remaining gaps, not fixed here

Both are pre-existing and neither is a regression from this change:

- Paired terminal and container panes carry their own `@aoe_title` (`"<title> (terminal)"`), applied only when the session is newly created (`terminal.rs:59-62`, `terminal.rs:170-181`). They are not renamed by `rekey_session` and resolve by id suffix, so their bars still show the old title. Refreshing them needs paired-session naming context that `rekey_session` does not have.
- `@aoe_branch` goes stale the same way after a tied worktree branch rename. `blocks_worktree_edit` (`status.rs:89-98`) excludes `Idle`, so `aoe session rename --rename-branch` on an Idle session renames the branch under a live pane and then calls `rekey_session`, leaving the old branch on the bar.

Tool sessions are not affected: `apply_all_tmux_options` runs on every tool attach (`app.rs:3899-3911`), so they self-heal.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: covered by a cheaper tmux-backed unit regression test, `rekey_session_refreshes_the_status_bar_title`, which asserts the option value directly against a real tmux server. Verified it fails without the fix (reads back `Britons` instead of `Fix detach hint`) and passes with it.

Local: `cargo fmt --check`, `cargo clippy --lib`, and `cargo test --lib tmux::` (440 passed) are clean. The full suite was not run locally because the sandbox filesystem ran out of space.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**

The bug was spotted by Claude while reviewing #3727, and the fix and test were written by Claude under @njbrake's direction. The PR was then reviewed by a second, independent Claude agent, which caught the stale troubleshooting entry in `docs/guides/tmux-status-bar.md` and an incorrect claim in an earlier draft of this description about `@aoe_branch`.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS79LCJdFJ5KHaxR1ir4AM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refreshes `@aoe_title` after a tmux session rename.
- Prevents stalled tmux commands from blocking the rename flow.
- Adds a regression test for the updated status-bar title.
- Updates documentation for remaining stale-title cases.

This keeps `status-right` and `aoe tmux-status` current without restarting the session. Formatting, clippy, and tmux library tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->