### PR TITLE
fix(sandbox): stop rejecting the container user's custom shell

### DIFF
--- a/docs/guides/web/terminal.md
+++ b/docs/guides/web/terminal.md
@@ -25,7 +25,7 @@ Copy relies on the browser Clipboard API, which only works in a secure context: 
 
 Each session can open a **paired terminal**: a host (or, for sandboxed sessions, in-container) shell rooted at the session's working directory. On desktop it shares the split with the agent terminal; on mobile it is one of the right-panel picker's views. It stays alive in the background when you switch away, preserving scrollback and focus.
 
-For sandboxed sessions, the **Container** tab launches the container user's preferred shell, resolved inside the container (passwd entry, then `$SHELL`, then bash, sh). Candidates must be regular executable files and either have a recognized shell name or be listed exactly in `/etc/shells`. Known-compatible shells run in login mode; other authorized shells run plain. Minimal images without `getent` read `/etc/passwd` directly.
+For sandboxed sessions, the **Container** tab launches the container user's preferred shell, resolved inside the container (passwd entry, then `$SHELL`, then bash, sh). A candidate must be a regular executable file; `nologin` and `false` entries fall through to the next candidate instead of killing the pane. Shells known to accept `-l` run in login mode, so your prompt, aliases, and oh-my-zsh setup load like the Host tab; any other shell runs plain. Minimal images without `getent` read `/etc/passwd` directly.
 
 ## Reconnect
 

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -175,18 +175,6 @@ pub(crate) fn login_flag_shell_case_pattern() -> String {
     LOGIN_FLAG_SHELLS.join("|")
 }
 
-/// Every shell basename this codebase recognizes, as one POSIX `case` pattern,
-/// whether or not `-l` applies to it.
-pub(crate) fn known_shell_case_pattern() -> String {
-    let mut names: Vec<&str> = Vec::with_capacity(LOGIN_FLAG_SHELLS.len() + NON_POSIX_SHELLS.len());
-    for name in LOGIN_FLAG_SHELLS.iter().chain(NON_POSIX_SHELLS) {
-        if !names.contains(name) {
-            names.push(name);
-        }
-    }
-    names.join("|")
-}
-
 /// Build the tmux pane command that launches `shell` as a login+interactive
 /// shell, so it sources the user's profile and rc files (`~/.zprofile`,
 /// `~/.zshrc`, oh-my-zsh, Homebrew/nvm PATH setup) exactly as a native

--- a/src/session/instance/terminal.rs
+++ b/src/session/instance/terminal.rs
@@ -5,22 +5,28 @@ use super::*;
 /// Command run inside the sandbox container for the web Container terminal tab.
 ///
 /// Resolves the container user's preferred shell at spawn time, inside the
-/// container. Known-compatible shells run in login mode so profile/rc files
-/// load; other authorized shells run plain.
+/// container. Shells known to accept `-l` run in login mode so profile/rc
+/// files load; anything else runs plain.
 /// Resolution order: the passwd entry, `$SHELL`, bash, then sh. Each candidate
-/// is resolved and validated inside the container as a regular executable
-/// authorized shell. Passwd is read directly when `getent` is unavailable.
+/// must resolve to a regular executable file that is not a deliberately
+/// non-interactive account shell. Passwd is read directly when `getent` is
+/// unavailable.
+///
+/// Everything the script consults (passwd, `$SHELL`, `PATH`, the binaries) is
+/// container-controlled, so this validation is not a trust boundary: it keeps a
+/// broken or minimal image from killing the pane, nothing more. The one real
+/// boundary is that no container-side value reaches the host command line,
+/// which holds because the script and its argument are compile-time literals.
 ///
 /// The script is evaluated by the container's `/bin/sh`, not the host shell tmux
 /// uses to spawn the session, so the embedded `$()` runs in the container. The
 /// host does not propagate its own `$SHELL` into the container, so this reads the
 /// container's value, not the host's.
 ///
-/// `@KNOWN_SHELLS@` and `@LOGIN_FLAG_SHELLS@` are substituted from
-/// [`crate::session::environment`] so the container tab recognizes the same
-/// shells, and makes the same login-mode call, as the host tab.
+/// `@LOGIN_FLAG_SHELLS@` is substituted with
+/// [`crate::session::environment::login_flag_shell_case_pattern`] so the
+/// container tab makes the same login-mode call as the host tab.
 const CONTAINER_TERMINAL_AUTODETECT_SCRIPT: &str = r#"passwd_file=$1
-shells_file=$2
 
 lookup_shell() {
     wanted_uid=$1
@@ -54,25 +60,13 @@ resolve_shell() {
     esac
     [ -f "$resolved" ] && [ -x "$resolved" ] || return 1
 
+    # Accounts deliberately given a non-interactive shell. Exec'ing one kills
+    # the pane on open, so fall through to a real shell instead.
     case "${resolved##*/}" in
-        @KNOWN_SHELLS@)
-            printf "%s\n" "$resolved"
-            return
-            ;;
+        nologin|false|true) return 1 ;;
     esac
 
-    if [ -r "$shells_file" ]; then
-        while IFS= read -r allowed || [ -n "$allowed" ]; do
-            case "$allowed" in
-                ""|\#*) continue ;;
-            esac
-            if [ "$resolved" = "$allowed" ]; then
-                printf "%s\n" "$resolved"
-                return
-            fi
-        done < "$shells_file"
-    fi
-    return 1
+    printf "%s\n" "$resolved"
 }
 
 uid=$(id -u 2>/dev/null || true)
@@ -106,21 +100,15 @@ case "${shell##*/}" in
 esac
 "#;
 
-fn container_terminal_autodetect_command(passwd_file: &str, shells_file: &str) -> String {
-    let script = CONTAINER_TERMINAL_AUTODETECT_SCRIPT
-        .replace(
-            "@KNOWN_SHELLS@",
-            &crate::session::environment::known_shell_case_pattern(),
-        )
-        .replace(
-            "@LOGIN_FLAG_SHELLS@",
-            &crate::session::environment::login_flag_shell_case_pattern(),
-        );
+fn container_terminal_autodetect_command(passwd_file: &str) -> String {
+    let script = CONTAINER_TERMINAL_AUTODETECT_SCRIPT.replace(
+        "@LOGIN_FLAG_SHELLS@",
+        &crate::session::environment::login_flag_shell_case_pattern(),
+    );
     format!(
-        "/bin/sh -c {} aoe-container-terminal {} {}",
+        "/bin/sh -c {} aoe-container-terminal {}",
         shell_escape_script_word(&script),
-        shell_escape_script_word(passwd_file),
-        shell_escape_script_word(shells_file)
+        shell_escape_script_word(passwd_file)
     )
 }
 
@@ -266,7 +254,7 @@ impl Instance {
         // Get workspace path inside container (handles bare repo worktrees correctly)
         let container_workdir = self.container_workdir();
 
-        let resolver_command = container_terminal_autodetect_command("/etc/passwd", "/etc/shells");
+        let resolver_command = container_terminal_autodetect_command("/etc/passwd");
         let cmd = container.exec_command(
             Some(&container_terminal_exec_options(
                 &container_workdir,
@@ -338,7 +326,7 @@ mod tests {
 
     #[test]
     fn container_terminal_resolver_executes_only_usable_shells() {
-        for invalid_kind in ["non_executable", "directory", "non_shell"] {
+        for invalid_kind in ["non_executable", "directory", "nologin"] {
             let temp = tempfile::tempdir().unwrap();
             write_executable(
                 &temp.path().join("getent"),
@@ -352,12 +340,11 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
             match invalid_kind {
                 "non_executable" => std::fs::write(&candidate, "not executable").unwrap(),
                 "directory" => std::fs::create_dir(&candidate).unwrap(),
-                "non_shell" => write_executable(&candidate, "#!/bin/sh\necho WRONG_CANDIDATE\n"),
+                "nologin" => write_executable(&candidate, "#!/bin/sh\necho WRONG_CANDIDATE\n"),
                 _ => unreachable!(),
             }
 
-            let resolver_command =
-                container_terminal_autodetect_command("/etc/passwd", "/etc/shells");
+            let resolver_command = container_terminal_autodetect_command("/etc/passwd");
             let mut child = Command::new("/bin/sh")
                 .arg("-c")
                 .arg(&resolver_command)
@@ -407,7 +394,7 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
 "#,
         );
         write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
-        let resolver_command = container_terminal_autodetect_command("/etc/passwd", "/etc/shells");
+        let resolver_command = container_terminal_autodetect_command("/etc/passwd");
         let output = Command::new("/bin/sh")
             .arg("-c")
             .arg(&resolver_command)
@@ -423,14 +410,49 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
             String::from_utf8_lossy(&output.stderr)
         );
         assert!(stdout.contains(&format!("CUSTOM_SHELL -l {}", shell.display())));
+
+        // A shell the login-flag list does not know is still the user's shell:
+        // run it, just without `-l`, rather than falling back to bash.
+        let temp = tempfile::tempdir().unwrap();
+        let shell = temp.path().join("elvish");
+        write_executable(
+            &shell,
+            r#"#!/bin/sh
+printf 'CUSTOM_SHELL argc=%s %s\n' "$#" "$SHELL"
+"#,
+        );
+        write_executable(
+            &temp.path().join("bash"),
+            "#!/bin/sh\nprintf WRONG_FALLBACK\n",
+        );
+        write_executable(
+            &temp.path().join("getent"),
+            r#"#!/bin/sh
+printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
+"#,
+        );
+        write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
+        let output = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(container_terminal_autodetect_command("/etc/passwd"))
+            .env("PATH", format!("{}:/usr/bin:/bin", temp.path().display()))
+            .env("PASSWD_SHELL", &shell)
+            .env_remove("SHELL")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!("CUSTOM_SHELL argc=0 {}\n", shell.display())
+        );
     }
     #[test]
     fn container_terminal_resolver_reads_passwd_without_getent() {
-        for (case, passwd_ending, shells_ending) in [
-            ("terminated", "\n", "\n"),
-            ("unterminated_passwd", "", "\n"),
-            ("unterminated_shells", "\n", ""),
-        ] {
+        for (case, passwd_ending) in [("terminated", "\n"), ("unterminated_passwd", "")] {
             let temp = tempfile::tempdir().unwrap();
             write_executable(&temp.path().join("id"), "#!/bin/sh\nprintf 2999\n");
 
@@ -451,17 +473,9 @@ printf 'test:x:2999:2999::/tmp:%s\n' "$PASSWD_SHELL"
                 ),
             )
             .unwrap();
-            let shells_file = temp.path().join("shells");
-            std::fs::write(
-                &shells_file,
-                format!("{}{shells_ending}", passwd_shell.display()),
-            )
-            .unwrap();
 
-            let resolver_command = container_terminal_autodetect_command(
-                passwd_file.to_str().unwrap(),
-                shells_file.to_str().unwrap(),
-            );
+            let resolver_command =
+                container_terminal_autodetect_command(passwd_file.to_str().unwrap());
             let output = Command::new("/bin/sh")
                 .args(["-c", &resolver_command])
                 .env_clear()
@@ -524,12 +538,7 @@ exec /usr/bin/env -i PATH="$TARGET_PATH" SHELL="$FALLBACK_SHELL" "$@"
             format!("test:x:2999:2999::/tmp:{}\n", passwd_shell.display()),
         )
         .unwrap();
-        let shells_file = fixtures.join("shells");
-        std::fs::write(&shells_file, format!("{}\n", passwd_shell.display())).unwrap();
-        let resolver_command = container_terminal_autodetect_command(
-            passwd_file.to_str().unwrap(),
-            shells_file.to_str().unwrap(),
-        );
+        let resolver_command = container_terminal_autodetect_command(passwd_file.to_str().unwrap());
 
         let injection_marker = temp.path().join("injected");
         let workdir = format!(


### PR DESCRIPTION
## Description

Follow-up to #3732. Authorizing a shell by basename or by an exact `/etc/shells` line dropped legitimate shells: an image built with `useradd -s /usr/bin/elvish` sets the passwd field without adding an `/etc/shells` entry, so the Container tab silently fell back to bash with no diagnostic.

The check was not a security control. passwd, `/etc/shells`, `$SHELL`, `PATH` and the binaries are all container-controlled, and the resolver runs inside the container as that user, so the list authorized nothing it did not also own.

Kept the part that earned its place: `nologin`, `false` and `true` fall through instead of exec'ing and killing the pane. Anything else that is a regular executable file runs, with `-l` only when the login-flag list knows it. That leaves the `/etc/shells` read unreachable, so it and `known_shell_case_pattern` are gone.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by the existing container-terminal unit tests, which execute the rendered resolver script: an unrecognized shell name now runs plain instead of falling back, and `nologin` still falls through. Verified separately under dash, bash and busybox ash.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**

Found while reviewing #3732. @jerome-benoit, this reverses the authorization half of your hardening, so I would like your read on it before it lands. The workdir quoting and the executable-file validation from #3732 are untouched.

- [x] I am an AI Agent filling out this form (check box if true)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K96RTjPyevC9Yrxf7b5rWW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Custom shells in `/etc/passwd` can now run when they are executable regular files.
- The `/etc/shells` requirement and related shell-list logic were removed.
- Login mode applies only to shells that support the `-l` option.
- `nologin`, `false`, and `true` still fall back to the next shell candidate.
- Tests and terminal documentation were updated to cover the new behavior.

This improves compatibility with container-specific shells while preserving safe fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->