### PR TITLE
fix: complete client context review follow-ups

### DIFF
--- a/src/acp/acp_client/connection.rs
+++ b/src/acp/acp_client/connection.rs
@@ -837,6 +837,7 @@ pub(super) async fn run_connection_task<W, R>(
                     image: prompt_caps.image,
                     audio: prompt_caps.audio,
                     embedded_context: prompt_caps.embedded_context,
+                    load_session: Some(load_session_capable),
                     steering: steering_capable,
                 })
                 .await;

--- a/src/acp/acp_client/connection.rs
+++ b/src/acp/acp_client/connection.rs
@@ -838,6 +838,7 @@ pub(super) async fn run_connection_task<W, R>(
                     audio: prompt_caps.audio,
                     embedded_context: prompt_caps.embedded_context,
                     load_session: Some(load_session_capable),
+                    worker_generation: None,
                     steering: steering_capable,
                 })
                 .await;

--- a/src/acp/acp_client/connection.rs
+++ b/src/acp/acp_client/connection.rs
@@ -838,7 +838,6 @@ pub(super) async fn run_connection_task<W, R>(
                     audio: prompt_caps.audio,
                     embedded_context: prompt_caps.embedded_context,
                     load_session: Some(load_session_capable),
-                    worker_generation: None,
                     steering: steering_capable,
                 })
                 .await;

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -2628,6 +2628,7 @@ mod tests {
                     image: true,
                     audio: false,
                     embedded_context: true,
+                    load_session: None,
                     steering: false,
                 },
             )
@@ -2645,6 +2646,7 @@ mod tests {
                     image: false,
                     audio: false,
                     embedded_context: false,
+                    load_session: None,
                     steering: false,
                 },
             )
@@ -4760,6 +4762,7 @@ mod tests {
                     image: true,
                     audio: false,
                     embedded_context: true,
+                    load_session: None,
                     steering: false,
                 },
             )

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -2629,7 +2629,6 @@ mod tests {
                     audio: false,
                     embedded_context: true,
                     load_session: None,
-                    worker_generation: None,
                     steering: false,
                 },
             )
@@ -2648,7 +2647,6 @@ mod tests {
                     audio: false,
                     embedded_context: false,
                     load_session: None,
-                    worker_generation: None,
                     steering: false,
                 },
             )
@@ -4765,7 +4763,6 @@ mod tests {
                     audio: false,
                     embedded_context: true,
                     load_session: None,
-                    worker_generation: None,
                     steering: false,
                 },
             )

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -2629,6 +2629,7 @@ mod tests {
                     audio: false,
                     embedded_context: true,
                     load_session: None,
+                    worker_generation: None,
                     steering: false,
                 },
             )
@@ -2647,6 +2648,7 @@ mod tests {
                     audio: false,
                     embedded_context: false,
                     load_session: None,
+                    worker_generation: None,
                     steering: false,
                 },
             )
@@ -4763,6 +4765,7 @@ mod tests {
                     audio: false,
                     embedded_context: true,
                     load_session: None,
+                    worker_generation: None,
                     steering: false,
                 },
             )

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -28,6 +28,13 @@ pub struct AcpBroadcastFrame {
     pub session_id: String,
     pub seq: u64,
     pub event: Arc<Event>,
+    /// Which installed worker produced this frame, for in-process
+    /// consumers that must reject a replaced worker's queued frames.
+    /// `None` whenever no live worker authored it: a server-side publish,
+    /// a replay off the event log, or a frame parsed from the wire. The
+    /// field is deliberately absent from both serde impls below, so
+    /// provenance never leaves this process.
+    pub worker_generation: Option<u64>,
 }
 
 impl Serialize for AcpBroadcastFrame {
@@ -60,6 +67,7 @@ impl<'de> Deserialize<'de> for AcpBroadcastFrame {
             session_id: w.session_id,
             seq: w.seq,
             event: Arc::new(w.event),
+            worker_generation: None,
         })
     }
 }
@@ -369,12 +377,17 @@ mod tests {
             session_id: "s-1".into(),
             seq: 42,
             event: Arc::new(Event::ThinkingStarted),
+            worker_generation: Some(7),
         };
         let json = serde_json::to_string(&frame).unwrap();
         let back: AcpBroadcastFrame = serde_json::from_str(&json).unwrap();
         assert_eq!(back.session_id, "s-1");
         assert_eq!(back.seq, 42);
         assert!(matches!(*back.event, Event::ThinkingStarted));
+        // Worker provenance is in-process only: it must not reach the wire,
+        // and a frame parsed back from it carries no generation to trust.
+        assert!(!json.contains("worker_generation"));
+        assert_eq!(back.worker_generation, None);
     }
 
     #[test]

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -1076,6 +1076,10 @@ pub enum Event {
         image: bool,
         audio: bool,
         embedded_context: bool,
+        /// Latest ACP initialize result for session/load. Missing on events
+        /// written before this field existed, which means unknown.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        load_session: Option<bool>,
         /// Whether the agent accepts `_session/steering`, so a prompt
         /// sent mid-turn is injected into the running turn instead of
         /// being parked in the composer's client-side queue. Gated on
@@ -1701,8 +1705,30 @@ mod tests {
             image: false,
             audio: false,
             embedded_context: false,
+            load_session: None,
             steering,
         }
+    }
+
+    #[test]
+    fn prompt_capabilities_accept_legacy_events_without_load_session() {
+        let event: Event = serde_json::from_value(serde_json::json!({
+            "PromptCapabilities": {
+                "image": false,
+                "audio": false,
+                "embedded_context": false,
+                "steering": false
+            }
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            event,
+            Event::PromptCapabilities {
+                load_session: None,
+                ..
+            }
+        ));
     }
 
     // The four turn flags ported from the TUI's AcpTranscript (Tier 1: the

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -1080,10 +1080,6 @@ pub enum Event {
         /// written before this field existed, which means unknown.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         load_session: Option<bool>,
-        /// In-process provenance assigned by the supervisor event pump.
-        /// Never persisted or sent to clients.
-        #[serde(skip)]
-        worker_generation: Option<u64>,
         /// Whether the agent accepts `_session/steering`, so a prompt
         /// sent mid-turn is injected into the running turn instead of
         /// being parked in the composer's client-side queue. Gated on
@@ -1710,7 +1706,6 @@ mod tests {
             audio: false,
             embedded_context: false,
             load_session: None,
-            worker_generation: None,
             steering,
         }
     }

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -1080,6 +1080,10 @@ pub enum Event {
         /// written before this field existed, which means unknown.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         load_session: Option<bool>,
+        /// In-process provenance assigned by the supervisor event pump.
+        /// Never persisted or sent to clients.
+        #[serde(skip)]
+        worker_generation: Option<u64>,
         /// Whether the agent accepts `_session/steering`, so a prompt
         /// sent mid-turn is injected into the running turn instead of
         /// being parked in the composer's client-side queue. Gated on
@@ -1706,6 +1710,7 @@ mod tests {
             audio: false,
             embedded_context: false,
             load_session: None,
+            worker_generation: None,
             steering,
         }
     }

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -21,6 +21,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -304,6 +305,18 @@ struct WorkerHandle {
     restart_history: Vec<Instant>,
     kind: WorkerKind,
 }
+/// Install a respawned client and advance both generation views together.
+fn replace_worker_client(
+    handle: &mut WorkerHandle,
+    client: AcpClient,
+    worker_generation: &mut u64,
+    next_worker_generation: &AtomicU64,
+) {
+    let generation = next_worker_generation.fetch_add(1, Ordering::Relaxed);
+    handle.client = Arc::new(client);
+    handle.generation = generation;
+    *worker_generation = generation;
+}
 
 /// Per-session monotonically-increasing seq counter. Lives at the
 /// supervisor level (not on `WorkerHandle`) so it survives shutdown
@@ -360,7 +373,7 @@ pub struct Supervisor<S: BroadcastSink> {
     registry: Arc<Mutex<AgentRegistry>>,
     workers: Arc<Mutex<HashMap<String, WorkerHandle>>>,
     next_seqs: Arc<SeqMap>,
-    next_worker_generation: std::sync::atomic::AtomicU64,
+    next_worker_generation: Arc<AtomicU64>,
     /// Reservation map: a session_id present here means another task is
     /// mid-resume (spawn OR attach) for it. The `ResumeKind` lets the
     /// capacity check distinguish fresh spawns (which contribute to the
@@ -747,7 +760,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             registry: Arc::new(Mutex::new(AgentRegistry::with_defaults())),
             workers: Arc::new(Mutex::new(HashMap::new())),
             next_seqs: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            next_worker_generation: std::sync::atomic::AtomicU64::new(1),
+            next_worker_generation: Arc::new(AtomicU64::new(1)),
             pending_resumes: Arc::new(std::sync::Mutex::new(HashMap::new())),
             cancelled_resumes: Arc::new(std::sync::Mutex::new(HashSet::new())),
             warmed_up_agents: Arc::new(std::sync::Mutex::new(HashSet::new())),
@@ -2028,10 +2041,12 @@ impl<S: BroadcastSink> Supervisor<S> {
         let workers = Arc::clone(&self.workers);
         let next_seqs = Arc::clone(&self.next_seqs);
         let incompatible_binaries = Arc::clone(&self.incompatible_binaries);
+        let next_worker_generation = Arc::clone(&self.next_worker_generation);
         crate::task_util::spawn_supervised(
             "supervisor.drain",
             crate::task_util::PanicPolicy::Log,
             async move {
+                let mut worker_generation = worker_generation;
                 let mut inbound = initial_inbound;
                 loop {
                     // Tracks whether the connection task ended because the
@@ -2556,7 +2571,12 @@ impl<S: BroadcastSink> Supervisor<S> {
                         let Some(handle) = guard.get_mut(&session_id) else {
                             return;
                         };
-                        handle.client = Arc::new(new_client);
+                        replace_worker_client(
+                            handle,
+                            new_client,
+                            &mut worker_generation,
+                            &next_worker_generation,
+                        );
                     }
 
                     info!(
@@ -3416,6 +3436,22 @@ impl<S: BroadcastSink> Supervisor<S> {
         generation
     }
 
+    /// Replace a fixture's client as the automatic respawn path does.
+    #[cfg(test)]
+    pub(crate) async fn test_respawn_worker(&self, session_id: &str) -> u64 {
+        let (client, _tx) = AcpClient::fake_for_test(AcpSessionId(format!("acp-{session_id}")));
+        let mut workers = self.workers.lock().await;
+        let handle = workers.get_mut(session_id).expect("test worker");
+        let mut generation = handle.generation;
+        replace_worker_client(
+            handle,
+            client,
+            &mut generation,
+            &self.next_worker_generation,
+        );
+        generation
+    }
+
     /// Drop a fake in-memory worker inserted by `test_insert_worker`, freeing
     /// the capacity slot for the next reconciler tick.
     #[cfg(test)]
@@ -3976,6 +4012,22 @@ mod tests {
         fn unresolved_elicitation_nonces(&self, _session_id: &str) -> Vec<Nonce> {
             self.stale_elicitation_nonces.lock().unwrap().clone()
         }
+    }
+    #[tokio::test]
+    async fn respawned_worker_rejects_the_prior_generation() {
+        let sup = Supervisor::new(VecSink::new());
+        let first = sup.test_insert_worker("s-generation").await;
+        let second = sup.test_respawn_worker("s-generation").await;
+
+        assert_ne!(first, second);
+        assert!(
+            !sup.is_current_worker_generation("s-generation", first)
+                .await
+        );
+        assert!(
+            sup.is_current_worker_generation("s-generation", second)
+                .await
+        );
     }
 
     /// #3241: the allowlist gates both resolution branches, and a refusal is

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -216,6 +216,15 @@ pub trait BroadcastSink: Send + Sync + 'static {
         self.publish(session_id, seq, event);
         true
     }
+    /// Publish an event the drain task pumped out of a worker, tagging the
+    /// broadcast frame with the generation of the worker that authored it.
+    /// The drain task is the only publisher with that provenance; every
+    /// other caller goes through `publish` and produces an untagged frame.
+    /// Default drops the tag, which is right for sinks with no broadcast
+    /// channel behind them (test fixtures): nothing downstream can read it.
+    fn publish_from_worker(&self, session_id: &str, seq: u64, event: &Event, _generation: u64) {
+        self.publish(session_id, seq, event);
+    }
     /// Drop all stored events for a session. Used by the import path to clear
     /// any partial replay from a prior failed attempt before re-seeding, run
     /// only after the worker slot is reserved so a duplicate spawn that hits
@@ -2074,14 +2083,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                     // different ACP backend via `/acp/switch-agent`. See
                     // #1281.
                     let mut rate_limited = false;
-                    while let Some(mut event) = inbound.recv().await {
-                        if let Event::PromptCapabilities {
-                            worker_generation: event_generation,
-                            ..
-                        } = &mut event
-                        {
-                            *event_generation = Some(worker_generation);
-                        }
+                    while let Some(event) = inbound.recv().await {
                         if let Event::Stopped { reason } = &event {
                             if reason == "agent_unresponsive"
                                 || reason == "prompt_orphaned"
@@ -2167,7 +2169,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                             _ => {}
                         }
                         let seq = next_seq(&next_seqs, &session_id);
-                        sink.publish(&session_id, seq, &event);
+                        sink.publish_from_worker(&session_id, seq, &event, worker_generation);
                     }
 
                     // Channel closed: the agent's connection task ended.
@@ -3720,6 +3722,10 @@ impl BroadcastSink for ChannelSink {
         let _ = self.publish_persisted(session_id, seq, event);
     }
 
+    fn publish_from_worker(&self, session_id: &str, seq: u64, event: &Event, generation: u64) {
+        self.publish_tagged(session_id, seq, event, Some(generation));
+    }
+
     fn clear_session_events(&self, session_id: &str) {
         self.event_store.delete_session(session_id);
         // The cached fold is a projection of the log we just deleted.
@@ -3727,6 +3733,53 @@ impl BroadcastSink for ChannelSink {
     }
 
     fn publish_persisted(&self, session_id: &str, seq: u64, event: &Event) -> bool {
+        self.publish_tagged(session_id, seq, event, None)
+    }
+
+    fn unresolved_approval_nonces(&self, session_id: &str) -> Vec<Nonce> {
+        self.event_store.unresolved_approval_nonces(session_id)
+    }
+
+    fn unresolved_elicitation_nonces(&self, session_id: &str) -> Vec<Nonce> {
+        self.event_store.unresolved_elicitation_nonces(session_id)
+    }
+
+    fn record_attachment(
+        &self,
+        session_id: &str,
+        seq: u64,
+        blob: &crate::acp::event_store::AttachmentBlob,
+    ) -> bool {
+        match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
+            Ok(tokio::runtime::RuntimeFlavor::MultiThread) => tokio::task::block_in_place(|| {
+                self.event_store.record_attachment(session_id, seq, blob)
+            }),
+            _ => self.event_store.record_attachment(session_id, seq, blob),
+        }
+    }
+
+    fn delete_attachments_for_seq(&self, session_id: &str, seq: u64) {
+        match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
+            Ok(tokio::runtime::RuntimeFlavor::MultiThread) => {
+                tokio::task::block_in_place(|| {
+                    self.event_store.delete_attachments_for_seq(session_id, seq)
+                });
+            }
+            _ => self.event_store.delete_attachments_for_seq(session_id, seq),
+        }
+    }
+}
+
+impl ChannelSink {
+    /// Shared body of every `ChannelSink` publish. `worker_generation` is
+    /// `Some` only on the drain task's path.
+    fn publish_tagged(
+        &self,
+        session_id: &str,
+        seq: u64,
+        event: &Event,
+        worker_generation: Option<u64>,
+    ) -> bool {
         // A rejection the agent attached no reset to inherits the reset of
         // the last rejection recorded for this session, as long as that
         // window has not rolled over yet. The worker's own capture dies with
@@ -3816,42 +3869,10 @@ impl BroadcastSink for ChannelSink {
             session_id: session_id.to_string(),
             seq,
             event: Arc::new(event_ref.clone()),
+            worker_generation,
         };
         let _ = self.tx.send(frame);
         persisted
-    }
-
-    fn unresolved_approval_nonces(&self, session_id: &str) -> Vec<Nonce> {
-        self.event_store.unresolved_approval_nonces(session_id)
-    }
-
-    fn unresolved_elicitation_nonces(&self, session_id: &str) -> Vec<Nonce> {
-        self.event_store.unresolved_elicitation_nonces(session_id)
-    }
-
-    fn record_attachment(
-        &self,
-        session_id: &str,
-        seq: u64,
-        blob: &crate::acp::event_store::AttachmentBlob,
-    ) -> bool {
-        match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
-            Ok(tokio::runtime::RuntimeFlavor::MultiThread) => tokio::task::block_in_place(|| {
-                self.event_store.record_attachment(session_id, seq, blob)
-            }),
-            _ => self.event_store.record_attachment(session_id, seq, blob),
-        }
-    }
-
-    fn delete_attachments_for_seq(&self, session_id: &str, seq: u64) {
-        match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
-            Ok(tokio::runtime::RuntimeFlavor::MultiThread) => {
-                tokio::task::block_in_place(|| {
-                    self.event_store.delete_attachments_for_seq(session_id, seq)
-                });
-            }
-            _ => self.event_store.delete_attachments_for_seq(session_id, seq),
-        }
     }
 }
 

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -295,6 +295,8 @@ struct WorkerHandle {
     /// Background task draining events from the client. Aborted on
     /// shutdown.
     drain_task: JoinHandle<()>,
+    /// Identifies this installed worker across shutdown and replacement.
+    generation: u64,
     /// Restart bookkeeping: timestamps of recent respawns (post-
     /// initial-spawn). Used by the watchdog to enforce
     /// `MAX_RESPAWNS_IN_WINDOW`. Empty on first spawn so the initial
@@ -358,6 +360,7 @@ pub struct Supervisor<S: BroadcastSink> {
     registry: Arc<Mutex<AgentRegistry>>,
     workers: Arc<Mutex<HashMap<String, WorkerHandle>>>,
     next_seqs: Arc<SeqMap>,
+    next_worker_generation: std::sync::atomic::AtomicU64,
     /// Reservation map: a session_id present here means another task is
     /// mid-resume (spawn OR attach) for it. The `ResumeKind` lets the
     /// capacity check distinguish fresh spawns (which contribute to the
@@ -744,6 +747,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             registry: Arc::new(Mutex::new(AgentRegistry::with_defaults())),
             workers: Arc::new(Mutex::new(HashMap::new())),
             next_seqs: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            next_worker_generation: std::sync::atomic::AtomicU64::new(1),
             pending_resumes: Arc::new(std::sync::Mutex::new(HashMap::new())),
             cancelled_resumes: Arc::new(std::sync::Mutex::new(HashSet::new())),
             warmed_up_agents: Arc::new(std::sync::Mutex::new(HashSet::new())),
@@ -1951,11 +1955,15 @@ impl<S: BroadcastSink> Supervisor<S> {
             drop(client);
             return Err(SupervisorError::SpawnCancelled(session_id));
         }
-        let drain_task = self.start_drain_task(session_id.clone(), inbound);
+        let worker_generation = self
+            .next_worker_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let drain_task = self.start_drain_task(session_id.clone(), inbound, worker_generation);
         let client_for_mode = (acp_mode_id.is_some() || yolo_mode).then(|| Arc::clone(&client));
         workers.insert(
             session_id.clone(),
             WorkerHandle {
+                generation: worker_generation,
                 client,
                 drain_task,
                 // Empty: the initial spawn doesn't count toward the
@@ -2014,6 +2022,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         &self,
         session_id: String,
         initial_inbound: mpsc::Receiver<Event>,
+        worker_generation: u64,
     ) -> JoinHandle<()> {
         let sink = Arc::clone(&self.sink);
         let workers = Arc::clone(&self.workers);
@@ -2050,7 +2059,14 @@ impl<S: BroadcastSink> Supervisor<S> {
                     // different ACP backend via `/acp/switch-agent`. See
                     // #1281.
                     let mut rate_limited = false;
-                    while let Some(event) = inbound.recv().await {
+                    while let Some(mut event) = inbound.recv().await {
+                        if let Event::PromptCapabilities {
+                            worker_generation: event_generation,
+                            ..
+                        } = &mut event
+                        {
+                            *event_generation = Some(worker_generation);
+                        }
                         if let Event::Stopped { reason } = &event {
                             if reason == "agent_unresponsive"
                                 || reason == "prompt_orphaned"
@@ -3206,10 +3222,14 @@ impl<S: BroadcastSink> Supervisor<S> {
             drop(client);
             return Err(SupervisorError::SpawnCancelled(session_id));
         }
-        let drain_task = self.start_drain_task(session_id.clone(), inbound);
+        let worker_generation = self
+            .next_worker_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let drain_task = self.start_drain_task(session_id.clone(), inbound, worker_generation);
         workers.insert(
             session_id.clone(),
             WorkerHandle {
+                generation: worker_generation,
                 client,
                 drain_task,
                 restart_history: vec![],
@@ -3330,6 +3350,19 @@ impl<S: BroadcastSink> Supervisor<S> {
         }
         lock_recover(&self.pending_resumes).contains_key(session_id)
     }
+    /// Whether a live event came from the worker currently installed for the
+    /// session. Queued frames from a replaced worker must not mutate runtime state.
+    pub(crate) async fn is_current_worker_generation(
+        &self,
+        session_id: &str,
+        generation: u64,
+    ) -> bool {
+        self.workers
+            .lock()
+            .await
+            .get(session_id)
+            .is_some_and(|worker| worker.generation == generation)
+    }
 
     /// Return the number of running workers (for the doctor + stats).
     pub async fn count(&self) -> usize {
@@ -3342,9 +3375,9 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// `begin_resume` and `is_running`, but no registry entry is written, so
     /// the reconciler's orphan sweep never touches it.
     #[cfg(test)]
-    pub(crate) async fn test_insert_worker(&self, session_id: &str) {
+    pub(crate) async fn test_insert_worker(&self, session_id: &str) -> u64 {
         let (client, _tx) = AcpClient::fake_for_test(AcpSessionId(format!("acp-{session_id}")));
-        self.test_install_worker(session_id, client).await;
+        self.test_install_worker(session_id, client).await
     }
 
     /// Like `test_insert_worker`, but the fake worker's command loop records
@@ -3366,16 +3399,21 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// `test_insert_worker*` fixtures so they differ only in which fake
     /// client they build.
     #[cfg(test)]
-    async fn test_install_worker(&self, session_id: &str, client: AcpClient) {
+    async fn test_install_worker(&self, session_id: &str, client: AcpClient) -> u64 {
+        let generation = self
+            .next_worker_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.workers.lock().await.insert(
             session_id.to_string(),
             WorkerHandle {
                 client: Arc::new(client),
                 drain_task: tokio::spawn(async {}),
+                generation,
                 restart_history: vec![],
                 kind: WorkerKind::Stdio,
             },
         );
+        generation
     }
 
     /// Drop a fake in-memory worker inserted by `test_insert_worker`, freeing
@@ -4491,6 +4529,7 @@ cursor-acp-bridge = "agent acp"
         workers.insert(
             "s-1".into(),
             WorkerHandle {
+                generation: 0,
                 client: Arc::new(client),
                 drain_task: drain,
                 restart_history: vec![Instant::now()],
@@ -4766,6 +4805,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-1".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
@@ -4848,6 +4888,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-stop".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
@@ -4880,6 +4921,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-3401".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(AcpClient::fake_for_test_dead_connection(AcpSessionId(
                         "acp-3401".into(),
                     ))),
@@ -4966,6 +5008,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-reap".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
@@ -5047,6 +5090,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-restart".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
@@ -5116,6 +5160,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-stdio".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
@@ -5182,6 +5227,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-stop".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
@@ -5222,13 +5268,15 @@ cursor-acp-bridge = "agent acp"
         let sup = Supervisor::new(sink.clone());
 
         let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<Event>(16);
-        let drain = sup.start_drain_task("s-rl".into(), inbound_rx);
+        let worker_generation = 1;
+        let drain = sup.start_drain_task("s-rl".into(), inbound_rx, worker_generation);
         {
             let mut workers = sup.workers.lock().await;
             let (client, _client_tx) = AcpClient::fake_for_test(AcpSessionId("s-rl".into()));
             workers.insert(
                 "s-rl".into(),
                 WorkerHandle {
+                    generation: worker_generation,
                     client: Arc::new(client),
                     // Drain task installed above owns the only handle we
                     // care about; this field is just a placeholder so
@@ -5290,6 +5338,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 "s-stdio".into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
@@ -5315,6 +5364,7 @@ cursor-acp-bridge = "agent acp"
         workers.insert(
             session_id.into(),
             WorkerHandle {
+                generation: 0,
                 client: Arc::new(client),
                 drain_task: drain,
                 restart_history: vec![],
@@ -5464,6 +5514,7 @@ cursor-acp-bridge = "agent acp"
             workers.insert(
                 session.into(),
                 WorkerHandle {
+                    generation: 0,
                     client: Arc::new(client),
                     drain_task: tokio::spawn(async {}),
                     restart_history: vec![],
@@ -5782,6 +5833,7 @@ cursor-acp-bridge = "agent acp"
         sup.workers.lock().await.insert(
             "s-reset".into(),
             WorkerHandle {
+                generation: 0,
                 client: Arc::new(client),
                 drain_task: tokio::spawn(async {}),
                 restart_history: vec![],
@@ -5834,6 +5886,7 @@ cursor-acp-bridge = "agent acp"
         sup.workers.lock().await.insert(
             "s-reset-busy".into(),
             WorkerHandle {
+                generation: 0,
                 client: Arc::new(client),
                 drain_task: tokio::spawn(async {}),
                 restart_history: vec![],
@@ -6529,6 +6582,7 @@ cursor-acp-bridge = "agent acp"
         workers.insert(
             "s-1".into(),
             WorkerHandle {
+                generation: 0,
                 client: Arc::new(client),
                 drain_task: drain,
                 restart_history: vec![],

--- a/src/acp/transcript.rs
+++ b/src/acp/transcript.rs
@@ -1771,6 +1771,7 @@ mod tests {
                 image: false,
                 audio: false,
                 embedded_context: false,
+                load_session: None,
                 steering: true,
             },
             prompt("read src/acp"),

--- a/src/acp/transcript.rs
+++ b/src/acp/transcript.rs
@@ -1772,6 +1772,7 @@ mod tests {
                 audio: false,
                 embedded_context: false,
                 load_session: None,
+                worker_generation: None,
                 steering: true,
             },
             prompt("read src/acp"),

--- a/src/acp/transcript.rs
+++ b/src/acp/transcript.rs
@@ -1772,7 +1772,6 @@ mod tests {
                 audio: false,
                 embedded_context: false,
                 load_session: None,
-                worker_generation: None,
                 steering: true,
             },
             prompt("read src/acp"),

--- a/src/server/acp_events.rs
+++ b/src/server/acp_events.rs
@@ -328,7 +328,11 @@ pub(super) async fn acp_event_listener(state: Arc<AppState>) {
         let status_intent = derive_acp_status(frame.event.as_ref());
         let acp_change = derive_acp_session_change(frame.event.as_ref());
         let load_session_capability = match frame.event.as_ref() {
-            crate::acp::state::Event::PromptCapabilities { load_session, .. } => *load_session,
+            crate::acp::state::Event::PromptCapabilities {
+                load_session: Some(capable),
+                worker_generation: Some(generation),
+                ..
+            } => Some((*capable, *generation)),
             _ => None,
         };
         if status_intent.is_none() && acp_change.is_none() && load_session_capability.is_none() {
@@ -345,8 +349,17 @@ pub(super) async fn acp_event_listener(state: Arc<AppState>) {
             if !inst.is_structured() {
                 continue;
             }
-            if let Some(capable) = load_session_capability {
-                inst.acp_load_session_capable = Some(capable);
+            // Check while holding the instance lock: teardown removes the worker
+            // before clearing this field, so either this write happens first and
+            // is cleared, or the stale generation is rejected.
+            if let Some((capable, generation)) = load_session_capability {
+                if state
+                    .acp_supervisor
+                    .is_current_worker_generation(&frame.session_id, generation)
+                    .await
+                {
+                    inst.acp_load_session_capable = Some(capable);
+                }
             }
 
             // Snapshotting around the call is exactly "the transition
@@ -1282,6 +1295,7 @@ mod tests {
         inst.acp_session_id = Some("same-acp-id".to_string());
         let id = inst.id.clone();
         let state = test_support::build_test_app_state(vec![inst]);
+        let first_generation = state.acp_supervisor.test_insert_worker(&id).await;
         let listener = tokio::spawn(acp_event_listener(state.clone()));
 
         for _ in 0..500 {
@@ -1292,7 +1306,7 @@ mod tests {
         }
         assert!(state.acp_events_tx.receiver_count() > 0);
 
-        for (seq, capable) in [(1, true), (2, false)] {
+        let send_capability = |seq, capable, worker_generation| {
             state
                 .acp_events_tx
                 .send(AcpBroadcastFrame {
@@ -1303,35 +1317,116 @@ mod tests {
                         audio: false,
                         embedded_context: false,
                         load_session: Some(capable),
+                        worker_generation: Some(worker_generation),
                         steering: false,
                     }),
                 })
                 .expect("listener is subscribed");
+        };
 
-            for _ in 0..500 {
-                if state
-                    .instances
-                    .read()
-                    .await
-                    .iter()
-                    .find(|inst| inst.id == id)
-                    .is_some_and(|inst| inst.acp_load_session_capable == Some(capable))
-                {
-                    break;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        send_capability(1, true, first_generation);
+        for _ in 0..500 {
+            if state
+                .instances
+                .read()
+                .await
+                .iter()
+                .find(|inst| inst.id == id)
+                .is_some_and(|inst| inst.acp_load_session_capable == Some(true))
+            {
+                break;
             }
-            assert!(
-                state
-                    .instances
-                    .read()
-                    .await
-                    .iter()
-                    .find(|inst| inst.id == id)
-                    .is_some_and(|inst| inst.acp_load_session_capable == Some(capable)),
-                "capability update {capable} was not applied"
-            );
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
         }
+        assert!(
+            state
+                .instances
+                .read()
+                .await
+                .iter()
+                .find(|inst| inst.id == id)
+                .is_some_and(|inst| inst.acp_load_session_capable == Some(true)),
+            "the active worker capability was not applied"
+        );
+
+        state.acp_supervisor.test_remove_worker(&id).await;
+        state
+            .instances
+            .write()
+            .await
+            .iter_mut()
+            .find(|inst| inst.id == id)
+            .expect("instance")
+            .acp_load_session_capable = None;
+        let second_generation = state.acp_supervisor.test_insert_worker(&id).await;
+        assert_ne!(first_generation, second_generation);
+
+        send_capability(2, false, first_generation);
+        state
+            .acp_events_tx
+            .send(AcpBroadcastFrame {
+                session_id: id.clone(),
+                seq: 3,
+                event: Arc::new(crate::acp::Event::AcpSessionAssigned {
+                    acp_session_id: "replacement-acp-id".to_string(),
+                }),
+            })
+            .expect("listener is subscribed");
+        for _ in 0..500 {
+            if state
+                .instances
+                .read()
+                .await
+                .iter()
+                .find(|inst| inst.id == id)
+                .is_some_and(|inst| inst.acp_session_id.as_deref() == Some("replacement-acp-id"))
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        let instance = state
+            .instances
+            .read()
+            .await
+            .iter()
+            .find(|inst| inst.id == id)
+            .cloned()
+            .expect("instance");
+        assert_eq!(
+            instance.acp_session_id.as_deref(),
+            Some("replacement-acp-id"),
+            "the sentinel event behind the stale frame was not applied"
+        );
+        assert_eq!(
+            instance.acp_load_session_capable, None,
+            "a queued event from the replaced worker must be ignored"
+        );
+
+        send_capability(4, false, second_generation);
+        for _ in 0..500 {
+            if state
+                .instances
+                .read()
+                .await
+                .iter()
+                .find(|inst| inst.id == id)
+                .is_some_and(|inst| inst.acp_load_session_capable == Some(false))
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        assert!(
+            state
+                .instances
+                .read()
+                .await
+                .iter()
+                .find(|inst| inst.id == id)
+                .is_some_and(|inst| inst.acp_load_session_capable == Some(false)),
+            "the replacement worker capability was not applied"
+        );
 
         listener.abort();
     }

--- a/src/server/acp_events.rs
+++ b/src/server/acp_events.rs
@@ -327,12 +327,14 @@ pub(super) async fn acp_event_listener(state: Arc<AppState>) {
 
         let status_intent = derive_acp_status(frame.event.as_ref());
         let acp_change = derive_acp_session_change(frame.event.as_ref());
-        let load_session_capability = match frame.event.as_ref() {
-            crate::acp::state::Event::PromptCapabilities {
-                load_session: Some(capable),
-                worker_generation: Some(generation),
-                ..
-            } => Some((*capable, *generation)),
+        let load_session_capability = match (frame.event.as_ref(), frame.worker_generation) {
+            (
+                crate::acp::state::Event::PromptCapabilities {
+                    load_session: Some(capable),
+                    ..
+                },
+                Some(generation),
+            ) => Some((*capable, generation)),
             _ => None,
         };
         if status_intent.is_none() && acp_change.is_none() && load_session_capability.is_none() {
@@ -352,6 +354,11 @@ pub(super) async fn acp_event_listener(state: Arc<AppState>) {
             // Check while holding the instance lock: teardown removes the worker
             // before clearing this field, so either this write happens first and
             // is cleared, or the stale generation is rejected.
+            //
+            // This awaits the supervisor's `workers` mutex with the `instances`
+            // write lock held. That ordering is only safe while `Supervisor`
+            // never reaches for `instances`; give it a path that does and this
+            // becomes a lock cycle.
             if let Some((capable, generation)) = load_session_capability {
                 if state
                     .acp_supervisor
@@ -1317,9 +1324,9 @@ mod tests {
                         audio: false,
                         embedded_context: false,
                         load_session: Some(capable),
-                        worker_generation: Some(worker_generation),
                         steering: false,
                     }),
+                    worker_generation: Some(worker_generation),
                 })
                 .expect("listener is subscribed");
         };
@@ -1370,6 +1377,7 @@ mod tests {
                 event: Arc::new(crate::acp::Event::AcpSessionAssigned {
                     acp_session_id: "replacement-acp-id".to_string(),
                 }),
+                worker_generation: None,
             })
             .expect("listener is subscribed");
         for _ in 0..500 {
@@ -1484,6 +1492,7 @@ mod tests {
                 event: Arc::new(crate::acp::Event::Stopped {
                     reason: "prompt_complete".into(),
                 }),
+                worker_generation: None,
             })
             .expect("listener is subscribed");
 

--- a/src/server/acp_events.rs
+++ b/src/server/acp_events.rs
@@ -327,7 +327,11 @@ pub(super) async fn acp_event_listener(state: Arc<AppState>) {
 
         let status_intent = derive_acp_status(frame.event.as_ref());
         let acp_change = derive_acp_session_change(frame.event.as_ref());
-        if status_intent.is_none() && acp_change.is_none() {
+        let load_session_capability = match frame.event.as_ref() {
+            crate::acp::state::Event::PromptCapabilities { load_session, .. } => *load_session,
+            _ => None,
+        };
+        if status_intent.is_none() && acp_change.is_none() && load_session_capability.is_none() {
             continue;
         }
 
@@ -340,6 +344,9 @@ pub(super) async fn acp_event_listener(state: Arc<AppState>) {
             };
             if !inst.is_structured() {
                 continue;
+            }
+            if let Some(capable) = load_session_capability {
+                inst.acp_load_session_capable = Some(capable);
             }
 
             // Snapshotting around the call is exactly "the transition
@@ -1268,6 +1275,66 @@ mod tests {
         assert!(!row(&terminal_id).unread);
     }
 
+    #[tokio::test]
+    async fn acp_event_listener_tracks_load_session_capability_updates() {
+        let mut inst = Instance::new("acp-session", "/tmp/acp");
+        inst.view = crate::session::View::Structured;
+        inst.acp_session_id = Some("same-acp-id".to_string());
+        let id = inst.id.clone();
+        let state = test_support::build_test_app_state(vec![inst]);
+        let listener = tokio::spawn(acp_event_listener(state.clone()));
+
+        for _ in 0..500 {
+            if state.acp_events_tx.receiver_count() > 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        assert!(state.acp_events_tx.receiver_count() > 0);
+
+        for (seq, capable) in [(1, true), (2, false)] {
+            state
+                .acp_events_tx
+                .send(AcpBroadcastFrame {
+                    session_id: id.clone(),
+                    seq,
+                    event: Arc::new(crate::acp::Event::PromptCapabilities {
+                        image: false,
+                        audio: false,
+                        embedded_context: false,
+                        load_session: Some(capable),
+                        steering: false,
+                    }),
+                })
+                .expect("listener is subscribed");
+
+            for _ in 0..500 {
+                if state
+                    .instances
+                    .read()
+                    .await
+                    .iter()
+                    .find(|inst| inst.id == id)
+                    .is_some_and(|inst| inst.acp_load_session_capable == Some(capable))
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+            assert!(
+                state
+                    .instances
+                    .read()
+                    .await
+                    .iter()
+                    .find(|inst| inst.id == id)
+                    .is_some_and(|inst| inst.acp_load_session_capable == Some(capable)),
+                "capability update {capable} was not applied"
+            );
+        }
+
+        listener.abort();
+    }
     /// End to end over `acp_event_listener` itself, the path that actually
     /// closes #3181. The predicate table and the TUI ownership tests all pass
     /// even if the snapshot is taken *after* `apply_status_intent`, the persist

--- a/src/server/acp_ws.rs
+++ b/src/server/acp_ws.rs
@@ -432,6 +432,7 @@ async fn drain_replay_into_socket(
             session_id: session_id.to_string(),
             seq,
             event: Arc::new(event),
+            worker_generation: None,
         };
         let payload = match serde_json::to_string(&frame) {
             Ok(s) => s,
@@ -1040,7 +1041,6 @@ mod tests {
                 audio: false,
                 embedded_context: false,
                 load_session: None,
-                worker_generation: None,
                 steering: true,
             },
         );
@@ -1270,6 +1270,7 @@ mod tests {
             session_id: "s".into(),
             seq: 1,
             event: Arc::new(crate::acp::Event::ThinkingStarted),
+            worker_generation: None,
         });
         // Sending to a channel with no receivers returns Err, but
         // publish() in this module deliberately discards the result.

--- a/src/server/acp_ws.rs
+++ b/src/server/acp_ws.rs
@@ -1040,6 +1040,7 @@ mod tests {
                 audio: false,
                 embedded_context: false,
                 load_session: None,
+                worker_generation: None,
                 steering: true,
             },
         );

--- a/src/server/acp_ws.rs
+++ b/src/server/acp_ws.rs
@@ -1039,6 +1039,7 @@ mod tests {
                 image: false,
                 audio: false,
                 embedded_context: false,
+                load_session: None,
                 steering: true,
             },
         );

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1053,6 +1053,12 @@ pub async fn switch_acp_agent(
         )
             .into_response();
     }
+    {
+        let mut instances = state.instances.write().await;
+        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+            inst.acp_load_session_capable = None;
+        }
+    }
 
     let cwd = PathBuf::from(&instance.project_path);
     let inst_lock = state.instance_lock(&id).await;
@@ -2113,6 +2119,7 @@ pub async fn acp_enable(
     instance.resume_intent = crate::session::ResumeIntent::Default;
     instance.status = crate::session::Status::Idle;
     instance.lifecycle_generation = lifecycle_generation;
+    instance.acp_load_session_capable = None;
     {
         let mut instances = state.instances.write().await;
         if let Some(slot) = instances.iter_mut().find(|candidate| candidate.id == id) {
@@ -2121,6 +2128,7 @@ pub async fn acp_enable(
                 slot.resume_intent = crate::session::ResumeIntent::Default;
                 slot.status = crate::session::Status::Idle;
                 slot.lifecycle_generation = lifecycle_generation;
+                slot.acp_load_session_capable = None;
             }
         }
     }
@@ -2342,6 +2350,7 @@ pub async fn acp_disable(
         instance.switch_to_terminal_keep_context();
     } else {
         instance.view = crate::session::View::Terminal;
+        instance.acp_load_session_capable = None;
         // Clear the stored ACP session id: the agent's transcript is
         // tied to the structured view-mode lifecycle. If the user re-enables
         // structured view later, the agent should start a fresh session/new

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -2884,6 +2884,7 @@ pub async fn acp_replay(
                 session_id: id.clone(),
                 seq,
                 event: Arc::new(event),
+                worker_generation: None,
             })
             .collect();
         (frames, None)

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -2386,6 +2386,7 @@ pub async fn acp_disable(
         let mut instances = state.instances.write().await;
         if let Some(slot) = instances.iter_mut().find(|i| i.id == id) {
             slot.view = crate::session::View::Terminal;
+            slot.acp_load_session_capable = None;
             slot.acp_session_id = persist_acp_session_id.clone();
             slot.import_pending = persist_import_pending;
             if keep_context {
@@ -3866,6 +3867,7 @@ mod tests {
             inst.id = format!("sess-3650-acp-{which}");
             inst.view = crate::session::View::Structured;
             inst.status = crate::session::Status::Idle;
+            inst.acp_load_session_capable = Some(true);
             let id = inst.id.clone();
             let state = crate::server::test_support::build_test_app_state(vec![inst]);
 
@@ -3887,6 +3889,20 @@ mod tests {
                 .await
                 .unwrap_or_else(|_| panic!("{which} must finish once the submission releases"))
                 .unwrap_or_else(|e| panic!("{which} task must not panic: {e}"));
+            if which == "disable" {
+                assert_eq!(
+                    state
+                        .instances
+                        .read()
+                        .await
+                        .iter()
+                        .find(|inst| inst.id == id)
+                        .expect("instance")
+                        .acp_load_session_capable,
+                    None,
+                    "disabling ACP must clear runtime-only negotiated capabilities"
+                );
+            }
         }
     }
 

--- a/src/server/api/sessions/list.rs
+++ b/src/server/api/sessions/list.rs
@@ -455,6 +455,20 @@ mod context_resume_tests {
             }
         );
 
+        structured.acp_load_session_capable = Some(false);
+        assert_eq!(
+            context_resume_for(&structured),
+            ContextResumeAvailability::Unavailable {
+                reason: ContextResumeUnavailableReason::AgentUnsupported,
+            }
+        );
+
+        structured.acp_load_session_capable = Some(true);
+        assert_eq!(
+            context_resume_for(&structured),
+            ContextResumeAvailability::Available
+        );
+
         structured.fork_pending = Some("opaque-parent".to_string());
         assert_eq!(
             context_resume_for(&structured),

--- a/src/server/api/sessions/model.rs
+++ b/src/server/api/sessions/model.rs
@@ -572,13 +572,19 @@ pub(super) fn context_resume_for(inst: &Instance) -> ContextResumeAvailability {
             ContextResumeAvailability::Unavailable {
                 reason: ContextResumeUnavailableReason::ForkPending,
             }
-        } else if inst.acp_session_id.is_some() {
-            ContextResumeAvailability::Indeterminate {
-                reason: ContextResumeIndeterminateReason::AgentHandshakeRequired,
-            }
-        } else {
+        } else if inst.acp_session_id.is_none() {
             ContextResumeAvailability::Unavailable {
                 reason: ContextResumeUnavailableReason::NoTarget,
+            }
+        } else {
+            match inst.acp_load_session_capable {
+                Some(true) => ContextResumeAvailability::Available,
+                Some(false) => ContextResumeAvailability::Unavailable {
+                    reason: ContextResumeUnavailableReason::AgentUnsupported,
+                },
+                None => ContextResumeAvailability::Indeterminate {
+                    reason: ContextResumeIndeterminateReason::AgentHandshakeRequired,
+                },
             }
         };
     }

--- a/src/server/reload.rs
+++ b/src/server/reload.rs
@@ -71,6 +71,7 @@ pub(super) fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Inst
     fresh.session_id_poller = prior.session_id_poller;
     fresh.session_id_poller_retry_after = prior.session_id_poller_retry_after;
     fresh.retroactive_capture_excludes = prior.retroactive_capture_excludes;
+    fresh.acp_load_session_capable = prior.acp_load_session_capable;
     fresh
 }
 
@@ -900,5 +901,16 @@ mod tests {
 
         let merged = merge_runtime_fields(prior, fresh);
         assert_eq!(merged.last_error, None);
+    }
+
+    #[test]
+    fn merge_runtime_fields_preserves_acp_load_session_capability() {
+        let mut prior = Instance::new("seed", "/tmp/seed");
+        prior.acp_load_session_capable = Some(true);
+
+        let fresh = Instance::new("seed", "/tmp/seed");
+        let merged = merge_runtime_fields(prior, fresh);
+
+        assert_eq!(merged.acp_load_session_capable, Some(true));
     }
 }

--- a/src/server/structured_repair.rs
+++ b/src/server/structured_repair.rs
@@ -83,6 +83,7 @@ pub(super) fn repair_structured_rows_from_live_workers(
             inst.agent_model = record.model.clone();
         }
         inst.acp_session_id = Some(acp_session_id.clone());
+        inst.acp_load_session_capable = None;
         tracing::warn!(
             target: "server.file_watch",
             session = %inst.id,
@@ -285,6 +286,7 @@ mod tests {
             Instance::new("repair-empty-id", "/tmp/repo"),
         ];
         rows[0].id = "repair-live".to_string();
+        rows[0].acp_load_session_capable = Some(true);
         rows[1].id = "repair-existing".to_string();
         rows[1].agent_name = Some("custom-agent".to_string());
         rows[1].agent_model = Some("custom-model".to_string());
@@ -301,6 +303,7 @@ mod tests {
         assert_eq!(rows[0].agent_name.as_deref(), Some("codex"));
         assert_eq!(rows[0].agent_model.as_deref(), Some("gpt-5"));
         assert_eq!(rows[0].acp_session_id.as_deref(), Some("acp-session-1"));
+        assert_eq!(rows[0].acp_load_session_capable, None);
         assert_eq!(rows[1].view, crate::session::View::Structured);
         assert_eq!(rows[1].agent_name.as_deref(), Some("custom-agent"));
         assert_eq!(rows[1].agent_model.as_deref(), Some("custom-model"));

--- a/src/session/instance/accessors.rs
+++ b/src/session/instance/accessors.rs
@@ -73,6 +73,7 @@ impl Instance {
             acp_session_id: None,
             import_pending: None,
             fork_pending: None,
+            acp_load_session_capable: None,
             last_error_check: None,
             last_start_time: None,
             live_status_baseline: None,
@@ -512,6 +513,7 @@ impl Instance {
             self.resume_intent = ResumeIntent::Use(sid);
         }
         self.import_pending = None;
+        self.acp_load_session_capable = None;
         self.view = View::Terminal;
     }
 }
@@ -541,17 +543,29 @@ mod tests {
         inst.view = View::Structured;
         inst.acp_session_id = Some("sid-abc".to_string());
         inst.import_pending = Some(true);
+        inst.acp_load_session_capable = Some(true);
 
         inst.switch_to_terminal_keep_context();
 
         assert_eq!(inst.view, View::Terminal);
         assert_eq!(inst.agent_session_id.as_deref(), Some("sid-abc"));
         assert_eq!(inst.resume_intent, ResumeIntent::Use("sid-abc".to_string()));
-        // Structured-view-only ids are dropped: terminal mode reads
-        // agent_session_id, and a stale acp_session_id would wrongly drive a
-        // session/load on a later re-enable.
+        // Structured-view-only state is dropped before terminal launch.
         assert_eq!(inst.acp_session_id, None);
         assert_eq!(inst.import_pending, None);
+        assert_eq!(inst.acp_load_session_capable, None);
+    }
+
+    #[test]
+    fn acp_load_session_capability_is_runtime_only() {
+        let mut inst = Instance::new("structured", "/tmp");
+        inst.acp_load_session_capable = Some(true);
+
+        let json = serde_json::to_value(&inst).unwrap();
+        assert!(json.get("acp_load_session_capable").is_none());
+
+        let decoded: Instance = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.acp_load_session_capable, None);
     }
 
     #[test]

--- a/src/session/instance/merge.rs
+++ b/src/session/instance/merge.rs
@@ -109,6 +109,7 @@ impl Instance {
         self.session_id_poller = previous.session_id_poller.clone();
         self.session_id_poller_retry_after = previous.session_id_poller_retry_after;
         self.retroactive_capture_excludes = previous.retroactive_capture_excludes.clone();
+        self.acp_load_session_capable = previous.acp_load_session_capable;
     }
 
     /// Carry every in-process field from a pre-move live row onto the
@@ -214,6 +215,7 @@ impl Instance {
             .unwrap_or_default();
         self.agent_session_id = restored.agent_session_id;
         self.acp_session_id = restored.acp_session_id;
+        self.acp_load_session_capable = None;
         self.resume_probe_failed_sid = None;
         // A pin/clear/fork directive names an id in the old agent's namespace,
         // so it cannot survive the swap either.
@@ -520,6 +522,7 @@ mod tests {
         previous.last_error = Some("old observation".to_string());
         let previous_floor = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
         previous.capture_started_at = Some(previous_floor);
+        previous.acp_load_session_capable = Some(true);
 
         previous.detection = DetectionState {
             pending: Some(Status::Idle),
@@ -535,20 +538,22 @@ mod tests {
         reloaded.capture_started_at = Some(committed_floor);
         // A disk load leaves every `#[serde(skip)]` field at its default.
         reloaded.detection = DetectionState::default();
+        reloaded.acp_load_session_capable = None;
         reloaded.merge_runtime_from_reload(&previous);
 
         // Generation-governed fields: the strictly-newer disk snapshot wins.
         assert_eq!(reloaded.lifecycle_generation, 4);
         assert_eq!(reloaded.status, Status::Stopped);
         assert_eq!(reloaded.idle_entered_at, None);
-        // last_error is runtime-only: the in-memory poller value survives even a
-        // newer generation, since no lifecycle writer persists last_error.
+        // Runtime-only values survive a newer generation because no lifecycle
+        // writer persists them.
         assert_eq!(reloaded.last_error.as_deref(), Some("old observation"));
         assert_eq!(
             reloaded.capture_started_at,
             Some(committed_floor),
             "reload must retain the exact launch-owned floor from disk"
         );
+        assert_eq!(reloaded.acp_load_session_capable, Some(true));
         // So is the detection bookkeeping: a reload between two poll cycles
         // must not drop a proposal awaiting its confirming poll (#3642).
         assert_eq!(reloaded.detection.pending, Some(Status::Idle));
@@ -1530,6 +1535,7 @@ mod tests {
         inst.tool = "claude".to_string();
         inst.agent_session_id = Some("claude-session-123".to_string());
         inst.acp_session_id = Some("acp-claude-1".to_string());
+        inst.acp_load_session_capable = Some(true);
         inst.resume_probe_failed_sid = Some("claude-session-123".to_string());
         inst.acp_effort = Some("high".to_string());
         inst.agent_model = Some("claude-opus-4-7".to_string());
@@ -1543,6 +1549,7 @@ mod tests {
             "a Claude sid would make pi launch with --resume <foreign-sid>"
         );
         assert_eq!(inst.acp_session_id, None);
+        assert_eq!(inst.acp_load_session_capable, None);
         assert_eq!(inst.acp_effort, None);
         assert_eq!(inst.agent_model, None);
         assert_eq!(inst.agent_name, None);
@@ -1551,6 +1558,7 @@ mod tests {
 
         // pi runs and captures a sid of its own, then the user swaps back.
         inst.agent_session_id = Some("pi-session-9".to_string());
+        inst.acp_load_session_capable = Some(false);
         inst.swap_tool("claude");
         assert_eq!(
             inst.agent_session_id.as_deref(),
@@ -1558,6 +1566,7 @@ mod tests {
             "swapping back must resume the parked Claude conversation"
         );
         assert_eq!(inst.acp_session_id.as_deref(), Some("acp-claude-1"));
+        assert_eq!(inst.acp_load_session_capable, None);
         assert_eq!(
             inst.prior_tool_session_ids["pi"]
                 .agent_session_id

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -584,6 +584,10 @@ pub struct Instance {
     pub fork_pending: Option<String>,
 
     // Live process state and durable capture-generation guards.
+    /// Latest ACP initialize result for session/load. A daemon restart returns
+    /// this to unknown until the worker reconnects.
+    #[serde(skip)]
+    pub acp_load_session_capable: Option<bool>,
     #[serde(skip)]
     pub last_error_check: Option<std::time::Instant>,
     #[serde(skip)]

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -463,6 +463,7 @@ mod tests {
                 image: false,
                 audio: false,
                 embedded_context: false,
+                load_session: None,
             },
             Event::CancelRequested {
                 escalates_at: Utc::now(),

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -464,7 +464,6 @@ mod tests {
                 audio: false,
                 embedded_context: false,
                 load_session: None,
-                worker_generation: None,
             },
             Event::CancelRequested {
                 escalates_at: Utc::now(),

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -464,6 +464,7 @@ mod tests {
                 audio: false,
                 embedded_context: false,
                 load_session: None,
+                worker_generation: None,
             },
             Event::CancelRequested {
                 escalates_at: Utc::now(),

--- a/tests/e2e/fork_structured_e2e.rs
+++ b/tests/e2e/fork_structured_e2e.rs
@@ -183,6 +183,24 @@ fn structured_fork_mints_distinct_child_id_and_preserves_parent() {
     );
     let _parent_session_id = parse_session_id(&String::from_utf8_lossy(&add.stdout));
     let parent_acp_id = wait_for_acp_id(&h, "ForkParent", Duration::from_secs(45));
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let parent_context_resume = rt.block_on(async {
+        reqwest::get(format!("http://127.0.0.1:{port}/api/sessions"))
+            .await
+            .expect("GET /api/sessions")
+            .json::<serde_json::Value>()
+            .await
+            .expect("decode sessions response")["sessions"]
+            .as_array()
+            .and_then(|rows| rows.iter().find(|row| row["title"] == "ForkParent"))
+            .map(|row| row["context_resume"].clone())
+            .expect("ForkParent context_resume")
+    });
+    assert_eq!(
+        parent_context_resume,
+        serde_json::json!({ "state": "available" }),
+        "the negotiated loadSession capability must reach GET /api/sessions"
+    );
 
     // Fork: request a STRUCTURED fork through the REST create endpoint. The CLI
     // `--fork-from` only builds a terminal seed; the structured path is the
@@ -191,7 +209,6 @@ fn structured_fork_mints_distinct_child_id_and_preserves_parent() {
     // caller means no token is required.
     let project_str = project.to_str().unwrap().to_string();
     let parent_acp_for_post = parent_acp_id.clone();
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let post: Result<(), String> = rt.block_on(async move {
         let base = format!("http://127.0.0.1:{port}");
         let client = reqwest::Client::builder()


### PR DESCRIPTION
## Description

Follow-up to #3647, completing the remaining client-context review findings:

- project the negotiated ACP `loadSession` capability into `context_resume`, including runtime reloads and capability downgrades
- bind capability updates to the currently installed ACP worker generation, rotating it on initial spawn, attach, and automatic respawn so queued events from a replaced worker cannot restore stale state
- clear runtime capability state across agent, view, enable, disable, and tool lifecycle transitions

The capability remains runtime-only. Persisted sessions return to `agent_handshake_required` after daemon restart until the current worker reconnects, rather than trusting a stale adapter capability.

The branch is based on latest `upstream/main` at `74d87e64`. Main already contains the equivalent tmux locale correction from the original follow-up scope, so that change is no longer part of this PR's diff.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The targeted structured-fork e2e was attempted locally, but the fixture timed out at its existing `wait_for_acp_id` step before reaching this PR's assertion. Direct probing confirmed the fake ACP agent answers `initialize`; runner logs stop before the new capability event path. The full-binary assertion remains in `tests/e2e/fork_structured_e2e.rs` for CI coverage.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the frontend contract is unchanged; the negotiated server value is covered through `GET /api/sessions` in the full-binary structured-fork e2e

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Verification after merging latest `upstream/main`:

- `cargo test`: 6,883 passed, 8 ignored
- `cargo clippy`
- `cargo fmt --check`
- `cargo test load_session --lib`: 4 passed
- `cargo test worker_stopping_acp_endpoints_wait_for_an_in_flight_submission --lib`: passed
- `cargo test test_batch_output_frames_records_against_a_real_tmux --lib`: passed against tmux 3.7c

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

OpenAI Codex, `openai-codex/gpt-5.6-sol`

**Any Additional AI Details you'd like to share:**

The review findings were independently audited and cross-validated against the merged code and installed ACP schema before implementation.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Tracks the negotiated ACP `session/load` capability at runtime.
- Updates `context_resume` when workers reconnect, reload, or change.
- Ignores capability updates from replaced workers.
- Clears stale capability data during agent, view, enable, disable, and tool transitions.
- Keeps capability state out of persisted sessions and resets it after daemon restarts.
- Adds coverage for capability states, worker replacement, reloads, legacy data, structured forks, and tmux behavior.

## Benefits

- Reports accurate context-resume availability.
- Prevents stale worker data from changing session state.
- Avoids reusing capability data after agent or view changes.
- Improves ACP lifecycle reliability and regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->