### PR TITLE
fix: unbreak the macOS build and repair two failing checks

### DIFF
--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -904,10 +904,18 @@ mod tests {
         // separate elements, so the prompt is never shell-parsed.
         assert_eq!(&argv[9..], &oneshot_argv()[..]);
 
+        // `printf` sits in /usr/bin on macOS and in /bin on most Linux
+        // images. The probe is about an absolute path running without a
+        // usable PATH, not about where that path happens to be, so resolve it
+        // rather than hardcoding one layout and failing on the other.
+        let printf = ["/usr/bin/printf", "/bin/printf"]
+            .into_iter()
+            .find(|candidate| std::path::Path::new(candidate).exists())
+            .expect("an absolute printf to prove PATH independence with");
         let executable = ContainerRuntime::apple_container().build_exec_argv(
             "aoe-sandbox-test1234",
             "",
-            &["/bin/printf".to_string(), "PATH_INDEPENDENT".to_string()],
+            &[printf.to_string(), "PATH_INDEPENDENT".to_string()],
         );
         let output = std::process::Command::new(&executable[3])
             .args(&executable[4..])
@@ -915,7 +923,10 @@ mod tests {
             .env("PATH", "/definitely-missing")
             .output()
             .unwrap();
-        assert!(output.status.success());
+        assert!(
+            output.status.success(),
+            "{printf} must run with no usable PATH, got {output:?}"
+        );
         assert_eq!(output.stdout, b"PATH_INDEPENDENT");
     }
 

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -1024,7 +1024,9 @@ fn copy_tree_from_fd(
             };
             copy_tree_from_fd(child, &target, None, &relative.join(name), overwrite_newer)?;
             if !existed || source_stat_is_newer(&stat, &target)? {
-                fs::set_permissions(&target, fs::Permissions::from_mode(stat.st_mode))?;
+                // `st_mode` is u32 on Linux and u16 on Darwin, so the cast is
+                // a no-op on one and a widening on the other.
+                fs::set_permissions(&target, fs::Permissions::from_mode(stat.st_mode as u32))?;
             }
         } else if kind == nix::libc::S_IFREG {
             let file = openat(
@@ -1065,7 +1067,7 @@ fn copy_tree_from_fd(
             }
             let mut output = options.open(&target)?;
             std::io::copy(&mut input, &mut output)?;
-            output.set_permissions(fs::Permissions::from_mode(opened.st_mode))?;
+            output.set_permissions(fs::Permissions::from_mode(opened.st_mode as u32))?;
             futimens(
                 &output,
                 &TimeSpec::new(opened.st_atime, opened.st_atime_nsec),

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -3634,36 +3634,49 @@ mod tests {
             .expect("tmux new-session");
         assert!(output.status.success(), "Failed to create tmux session");
 
-        // Wait for printenv to run and exit
-        std::thread::sleep(std::time::Duration::from_millis(1000));
+        // Poll rather than sleep a fixed interval. On a loaded runner the
+        // pane can take longer than any one sleep to spawn, exec, and render,
+        // and the blank capture that follows reads as a failed export rather
+        // than as "not yet". `remain-on-exit on` holds the output after the
+        // process dies, so waiting past the exit never loses it.
+        let capture_pane = || {
+            let capture = tmux_command()
+                .args([
+                    "capture-pane",
+                    "-t",
+                    &format!("{}:^.0", session_name),
+                    "-p",
+                    "-S",
+                    "-10",
+                ])
+                .output()
+                .expect("capture-pane");
+            String::from_utf8_lossy(&capture.stdout).into_owned()
+        };
+        let pane_is_dead = || {
+            let dead_check = tmux_command()
+                .args(["display-message", "-t", &session_name, "-p", "#{pane_dead}"])
+                .output()
+                .expect("pane dead check");
+            String::from_utf8_lossy(&dead_check.stdout).trim() == "1"
+        };
 
-        // Capture pane output: should contain the secret value
-        let capture = tmux_command()
-            .args([
-                "capture-pane",
-                "-t",
-                &format!("{}:^.0", session_name),
-                "-p",
-                "-S",
-                "-10",
-            ])
-            .output()
-            .expect("capture-pane");
-        let pane_content = String::from_utf8_lossy(&capture.stdout);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut pane_content = capture_pane();
+        while std::time::Instant::now() < deadline
+            && !(pane_content.contains(secret_value) && pane_is_dead())
+        {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            pane_content = capture_pane();
+        }
+
         assert!(
             pane_content.contains(secret_value),
-            "Expected secret value in pane output (proves export reached exec'd process).\nPane:\n{}",
-            pane_content
+            "Expected secret value in pane output (proves export reached exec'd process).\nPane:\n{pane_content}"
         );
-
         // Pane should be dead (exec replaced the shell, printenv exited)
-        let dead_check = tmux_command()
-            .args(["display-message", "-t", &session_name, "-p", "#{pane_dead}"])
-            .output()
-            .expect("pane dead check");
-        let is_dead = String::from_utf8_lossy(&dead_check.stdout).trim().eq("1");
         assert!(
-            is_dead,
+            pane_is_dead(),
             "Pane should be dead after exec'd command exits (lifecycle preserved)"
         );
     }


### PR DESCRIPTION
## Description

Repairs three required checks that fail on `main`. `main` is currently red and cannot produce a macOS build.

**`Build and push (macos-latest)`: `main` does not compile on macOS.** `stat.st_mode` is `u32` on Linux and `u16` on Darwin, where `mode_t` is 16 bits, so `Permissions::from_mode` type-checks on one platform and not the other. Both copy paths in migration v027 passed it through unconverted, so the macOS build has failed with `E0308` since #3678 landed (`b2569c75e`); it was green on the four commits before that. Like the macOS test job, this workflow does not run on pull requests, so it could only surface after the merge.

**`Cargo Test (macos)`: broken, not flaky.** `build_exec_argv_apple_container_wraps_for_path_without_splicing` hardcoded `/bin/printf` to prove the apple-container wrapper runs an absolute path with no usable PATH. macOS keeps printf in `/usr/bin` and ships no `/bin/printf`, so the spawn exits 127 there while passing on Linux. It has failed on every `main` commit that ran the job since the probe landed in #3732 (`7b1f2fdb4`, `471afe195`, `b2569c75e`). It stayed hidden because the macOS job is short-circuited on pull requests, finishing in seconds without running the suite, so it only fails after a merge. The probe now resolves whichever absolute printf exists; where it lives was never the point.

**`Cargo Test (linux, core-rest)`: a real race.** `test_export_exec_compound_command_passes_env` slept 1000 ms and captured the pane once. On a loaded runner the pane has not always spawned, exec'd and rendered by then, and the blank capture reads as a failed export rather than as "not yet". It failed that way on #3678 today and passed on a re-run with no code change. The capture now polls to a 15 second deadline; `remain-on-exit on` holds the output after the process exits, so waiting past the exit cannot lose it. The common case no longer pays the fixed second.

### Not fixed here

`Playwright (live, shard 1/2)` fails on `471afe195` at `composer-stop.spec.ts:138`, "Stop while reasoning". The locator matches on the composer's placeholder-derived accessible name, and `Composer.tsx:1000` renders `"Send a message…"` only while `turnActive` is false, so "element(s) not found" means the turn never went inactive after Stop rather than that the textbox vanished. That case is also the only one in `CASES` with `marker: null`, so it clicks Stop without first waiting for any rendered output. Diagnosed but not fixed: one occurrence, and it needs the live stack to tell a cancel race from a product bug. Left for a follow-up rather than guessed at.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
  - `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo test --lib --bins`: 6594 passed. The macOS probe cannot be executed on Linux; it is verified by resolution rather than by running the macOS job.
- [x] Documentation was updated where necessary
  - No user-facing behavior changes, so none needed.
- [ ] For UI changes: included screenshot or recording
  - No UI changes.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Both changes are to test code. The tmux fix was exercised by running the repaired test five times locally against real tmux 3.6.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**

Root causes were established from CI history per commit rather than from the failure text: the macOS job's run/skip pattern is what showed it was deterministic rather than flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZgLCCADgHXfvUasSGcApg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed the macOS container test by locating an available absolute `printf` path at runtime.
- Improved tmux test reliability by polling for output and process exit for up to 15 seconds.
- Preserved tmux pane output after process exit.
- Fixed macOS compilation in migration v027 by converting file mode values to the expected type.

These changes remove platform assumptions and reduce failures caused by slow process startup, rendering delays, and platform-specific type differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->