### PR TITLE
fix(web): stop Android IMEs from re-sending a word they retroactively compose

### DIFF
--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -303,6 +303,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
           enterReading={live.enterReading}
           returnToLive={live.returnToLive}
           sendData={live.sendData}
+          typedWordRef={live.typedWordRef}
           uploadPastedImage={uploadPastedImage}
           forwardWheel={live.forwardWheel}
           forwardButton={live.forwardButton}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1132,8 +1132,8 @@ export function MobileLiveTerminal({
   // composition after the fact, so `compositionend` carries the whole word a
   // second time and "test" reached the pane as "testtest"; whatever the run
   // already delivered is dropped from that word. Sending clears it below, so it
-  // stays a suffix of what the pane received and the strip can never swallow
-  // bytes the pane never saw; the two paths that continue a word re-arm it.
+  // only ever holds bytes the pane received and the strip can never swallow
+  // bytes it never saw; the paths that continue a word re-arm it.
   const plainRunRef = useRef("");
   // Typed input interrupts the coast. Without this, keystrokes sent in the
   // coast's 1-2s tail interleave with the wheel storm and the app is busy
@@ -1712,6 +1712,10 @@ export function MobileLiveTerminal({
       // edits; only the part the pane has not seen yet is new.
       const rest = run && data.startsWith(run) ? data.slice(run.length) : data;
       if (rest) sendKeys(rest);
+      // The composed word is still the one under the caret, so a second
+      // composition over it (a suggestion tap, then the space commit) has to
+      // be stripped against everything the pane has of that word.
+      plainRunRef.current = plainRunAfter(run, rest);
       if (e.currentTarget instanceof HTMLTextAreaElement) e.currentTarget.value = "";
     },
     [sendKeys],

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -126,7 +126,8 @@ export interface MobileLiveTerminalProps {
   setCadence: (fast: boolean) => void;
   enterReading: (rows: number) => void;
   returnToLive: (rows: number) => void;
-  sendData: (data: string) => void;
+  /** Returns whether the pane will receive the data; see useLiveTerminal. */
+  sendData: (data: string) => boolean;
   /** Upload a clipboard image pasted into the pane and resolve to the path
    *  the tmux pane can read (host path, or the container mount for sandboxed
    *  sessions), or null on failure. See #2678. */
@@ -323,12 +324,19 @@ function navigationKeySequence(e: TerminalKeyLike): string | null {
   }
 }
 
-const PLAIN_RUN_MAX = 64;
-
-/** Longest run of non-whitespace at the end of `run + typed`, capped: only the
- *  word still under the caret can be swallowed by a retroactive composition. */
+/** The word under the caret: the run of non-whitespace ending `run + typed`.
+ *  Uncapped, because a shorter run than the IME's own word fails the prefix
+ *  test and lets the whole word through twice. */
 function plainRunAfter(run: string, typed: string): string {
-  return (/\S*$/.exec(run + typed)?.[0] ?? "").slice(-PLAIN_RUN_MAX);
+  return /\S*$/.exec(run + typed)?.[0] ?? "";
+}
+
+/** Drop the last code point, so backspacing a surrogate pair or an emoji does
+ *  not leave half of it in the run and break the prefix test. */
+function dropLastCodePoint(run: string): string {
+  const points = Array.from(run);
+  points.pop();
+  return points.join("");
 }
 
 function specialKeySequence(e: TerminalKeyLike): string | null {
@@ -1146,7 +1154,7 @@ export function MobileLiveTerminal({
       stopMomentum();
       cancelTouchWheelQueue();
       plainRunRef.current = "";
-      sendDataRaw(data);
+      return sendDataRaw(data);
     },
     [sendDataRaw, stopMomentum, cancelTouchWheelQueue],
   );
@@ -1528,6 +1536,9 @@ export function MobileLiveTerminal({
 
   // --- keyboard input -----------------------------------------------------------
   const composingRef = useRef(false);
+  // Returns whether `data` itself reached the pane, so a caller can tell
+  // whether the run may record it. A Ctrl chord sends a control code instead,
+  // and a non-owner's keystrokes are dropped outright.
   const sendKeys = useCallback(
     (data: string) => {
       if (ctrlActiveRef.current && data.length === 1) {
@@ -1535,10 +1546,10 @@ export function MobileLiveTerminal({
         if (code >= 65 && code <= 90) {
           sendData(String.fromCharCode(code - 64));
           clearCtrl();
-          return;
+          return false;
         }
       }
-      sendData(data);
+      return sendData(data);
     },
     [sendData, ctrlActiveRef, clearCtrl],
   );
@@ -1554,7 +1565,7 @@ export function MobileLiveTerminal({
       switch (input.inputType) {
         case "insertText": {
           const data = input.data ?? "";
-          if (data) sendKeys(data);
+          if (data && !sendKeys(data)) break;
           plainRunRef.current = plainRunAfter(run, data);
           break;
         }
@@ -1565,8 +1576,8 @@ export function MobileLiveTerminal({
         case "deleteContentBackward":
           // One character, so the IME's word loses its last one too;
           // `deleteWordBackward` is a separate input type and not forwarded.
-          sendKeys("\x7f");
-          plainRunRef.current = run.slice(0, -1);
+          if (!sendKeys("\x7f")) break;
+          plainRunRef.current = dropLastCodePoint(run);
           break;
         case "insertFromPaste": {
           const text = input.data ?? "";
@@ -1711,11 +1722,10 @@ export function MobileLiveTerminal({
       // The composition may have taken over a word already spelled out as plain
       // edits; only the part the pane has not seen yet is new.
       const rest = run && data.startsWith(run) ? data.slice(run.length) : data;
-      if (rest) sendKeys(rest);
       // The composed word is still the one under the caret, so a second
       // composition over it (a suggestion tap, then the space commit) has to
       // be stripped against everything the pane has of that word.
-      plainRunRef.current = plainRunAfter(run, rest);
+      if (!rest || sendKeys(rest)) plainRunRef.current = plainRunAfter(run, rest);
       if (e.currentTarget instanceof HTMLTextAreaElement) e.currentTarget.value = "";
     },
     [sendKeys],

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -323,6 +323,14 @@ function navigationKeySequence(e: TerminalKeyLike): string | null {
   }
 }
 
+const PLAIN_RUN_MAX = 64;
+
+/** Longest run of non-whitespace at the end of `run + typed`, capped: only the
+ *  word still under the caret can be swallowed by a retroactive composition. */
+function plainRunAfter(run: string, typed: string): string {
+  return (/\S*$/.exec(run + typed)?.[0] ?? "").slice(-PLAIN_RUN_MAX);
+}
+
 function specialKeySequence(e: TerminalKeyLike): string | null {
   switch (e.key) {
     case "Enter":
@@ -1119,6 +1127,14 @@ export function MobileLiveTerminal({
     },
     [stopMomentum, enqueueTouchWheelDelta, forwardModeRef],
   );
+  // The word being typed as plain `insertText` edits. Android IMEs (SwiftKey,
+  // #3746) spell a word out as plain edits and then, on space, wrap it in a
+  // composition after the fact, so `compositionend` carries the whole word a
+  // second time and "test" reached the pane as "testtest"; whatever the run
+  // already delivered is dropped from that word. Sending clears it below, so it
+  // stays a suffix of what the pane received and the strip can never swallow
+  // bytes the pane never saw; the two paths that continue a word re-arm it.
+  const plainRunRef = useRef("");
   // Typed input interrupts the coast. Without this, keystrokes sent in the
   // coast's 1-2s tail interleave with the wheel storm and the app is busy
   // redrawing scroll frames instead of echoing them (reported as "I start
@@ -1129,6 +1145,7 @@ export function MobileLiveTerminal({
     (data: string) => {
       stopMomentum();
       cancelTouchWheelQueue();
+      plainRunRef.current = "";
       sendDataRaw(data);
     },
     [sendDataRaw, stopMomentum, cancelTouchWheelQueue],
@@ -1532,16 +1549,24 @@ export function MobileLiveTerminal({
   const handleMobileKeyboardProxyInput = useCallback(
     (input: MobileKeyboardProxyInput) => {
       if (composingRef.current || input.isComposing) return;
+      const run = plainRunRef.current;
+      plainRunRef.current = "";
       switch (input.inputType) {
-        case "insertText":
-          if (input.data) sendKeys(input.data);
+        case "insertText": {
+          const data = input.data ?? "";
+          if (data) sendKeys(data);
+          plainRunRef.current = plainRunAfter(run, data);
           break;
+        }
         case "insertLineBreak":
         case "insertParagraph":
           sendKeys("\r");
           break;
         case "deleteContentBackward":
+          // One character, so the IME's word loses its last one too;
+          // `deleteWordBackward` is a separate input type and not forwarded.
           sendKeys("\x7f");
+          plainRunRef.current = run.slice(0, -1);
           break;
         case "insertFromPaste": {
           const text = input.data ?? "";
@@ -1680,7 +1705,13 @@ export function MobileLiveTerminal({
   const handleCompositionEnd = useCallback(
     (e: CompositionEvent) => {
       composingRef.current = false;
-      if (e.data) sendKeys(e.data);
+      const run = plainRunRef.current;
+      plainRunRef.current = "";
+      const data = e.data ?? "";
+      // The composition may have taken over a word already spelled out as plain
+      // edits; only the part the pane has not seen yet is new.
+      const rest = run && data.startsWith(run) ? data.slice(run.length) : data;
+      if (rest) sendKeys(rest);
       if (e.currentTarget instanceof HTMLTextAreaElement) e.currentTarget.value = "";
     },
     [sendKeys],

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1589,7 +1589,7 @@ export function MobileLiveTerminal({
           break;
       }
     },
-    [sendKeys, sendData],
+    [sendKeys, sendData, typedWordRef],
   );
   const handleBeforeInput = useCallback(
     (ev: InputEvent) => {
@@ -1735,10 +1735,13 @@ export function MobileLiveTerminal({
       // Only a composition that took over the typed word may have its prefix
       // dropped; anything else is new text and goes to the pane whole.
       const rest = retroactive && data.startsWith(run) ? data.slice(run.length) : data;
-      // The composed word is still the one under the caret, so a second
+      // The typed word is still the one under the caret, so a second
       // composition over it (a suggestion tap, then the space commit) has to
-      // be stripped against everything the pane has of that word.
-      if (!rest || sendKeys(rest)) typedWordRef.current = plainRunAfter(run, rest);
+      // be stripped against everything the pane has of that word. A
+      // composition that stood on its own leaves no typed word behind: its
+      // result must not become a run for the next composition to strip.
+      if (!rest) typedWordRef.current = run;
+      else if (sendKeys(rest) && retroactive) typedWordRef.current = plainRunAfter(run, rest);
       if (e.currentTarget instanceof HTMLTextAreaElement) e.currentTarget.value = "";
     },
     [sendKeys, typedWordRef],

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -128,6 +128,8 @@ export interface MobileLiveTerminalProps {
   returnToLive: (rows: number) => void;
   /** Returns whether the pane will receive the data; see useLiveTerminal. */
   sendData: (data: string) => boolean;
+  /** Shared IME word run; `sendData` clears it, see useLiveTerminal. */
+  typedWordRef: React.RefObject<string>;
   /** Upload a clipboard image pasted into the pane and resolve to the path
    *  the tmux pane can read (host path, or the container mount for sandboxed
    *  sessions), or null on failure. See #2678. */
@@ -499,6 +501,7 @@ export function MobileLiveTerminal({
   enterReading,
   returnToLive,
   sendData: sendDataRaw,
+  typedWordRef,
   uploadPastedImage,
   forwardWheel,
   forwardButton,
@@ -1135,14 +1138,6 @@ export function MobileLiveTerminal({
     },
     [stopMomentum, enqueueTouchWheelDelta, forwardModeRef],
   );
-  // The word being typed as plain `insertText` edits. Android IMEs (SwiftKey,
-  // #3746) spell a word out as plain edits and then, on space, wrap it in a
-  // composition after the fact, so `compositionend` carries the whole word a
-  // second time and "test" reached the pane as "testtest"; whatever the run
-  // already delivered is dropped from that word. Sending clears it below, so it
-  // only ever holds bytes the pane received and the strip can never swallow
-  // bytes it never saw; the paths that continue a word re-arm it.
-  const plainRunRef = useRef("");
   // Typed input interrupts the coast. Without this, keystrokes sent in the
   // coast's 1-2s tail interleave with the wheel storm and the app is busy
   // redrawing scroll frames instead of echoing them (reported as "I start
@@ -1153,7 +1148,6 @@ export function MobileLiveTerminal({
     (data: string) => {
       stopMomentum();
       cancelTouchWheelQueue();
-      plainRunRef.current = "";
       return sendDataRaw(data);
     },
     [sendDataRaw, stopMomentum, cancelTouchWheelQueue],
@@ -1536,6 +1530,9 @@ export function MobileLiveTerminal({
 
   // --- keyboard input -----------------------------------------------------------
   const composingRef = useRef(false);
+  // Whether the composition in flight took over already-typed text: null until
+  // its first update settles it. See handleCompositionUpdate.
+  const retroactiveRef = useRef<boolean | null>(null);
   // Returns whether `data` itself reached the pane, so a caller can tell
   // whether the run may record it. A Ctrl chord sends a control code instead,
   // and a non-owner's keystrokes are dropped outright.
@@ -1560,13 +1557,13 @@ export function MobileLiveTerminal({
   const handleMobileKeyboardProxyInput = useCallback(
     (input: MobileKeyboardProxyInput) => {
       if (composingRef.current || input.isComposing) return;
-      const run = plainRunRef.current;
-      plainRunRef.current = "";
+      const run = typedWordRef.current;
+      typedWordRef.current = "";
       switch (input.inputType) {
         case "insertText": {
           const data = input.data ?? "";
           if (data && !sendKeys(data)) break;
-          plainRunRef.current = plainRunAfter(run, data);
+          typedWordRef.current = plainRunAfter(run, data);
           break;
         }
         case "insertLineBreak":
@@ -1577,7 +1574,7 @@ export function MobileLiveTerminal({
           // One character, so the IME's word loses its last one too;
           // `deleteWordBackward` is a separate input type and not forwarded.
           if (!sendKeys("\x7f")) break;
-          plainRunRef.current = dropLastCodePoint(run);
+          typedWordRef.current = dropLastCodePoint(run);
           break;
         case "insertFromPaste": {
           const text = input.data ?? "";
@@ -1712,23 +1709,39 @@ export function MobileLiveTerminal({
 
   const handleCompositionStart = useCallback(() => {
     composingRef.current = true;
+    retroactiveRef.current = null;
   }, []);
+  // A retroactive composition announces itself on its first update: SwiftKey
+  // adopts the word already typed, so that update carries the whole run
+  // (`compositionupdate "test"` right after `compositionstart ""` in #3746's
+  // trace). A composition genuinely starting here builds from its own first
+  // character instead, so it never matches and its result is sent whole.
+  const handleCompositionUpdate = useCallback(
+    (e: CompositionEvent) => {
+      if (retroactiveRef.current !== null) return;
+      const run = typedWordRef.current;
+      retroactiveRef.current = run !== "" && (e.data ?? "").startsWith(run);
+    },
+    [typedWordRef],
+  );
   const handleCompositionEnd = useCallback(
     (e: CompositionEvent) => {
       composingRef.current = false;
-      const run = plainRunRef.current;
-      plainRunRef.current = "";
+      const retroactive = retroactiveRef.current === true;
+      retroactiveRef.current = null;
+      const run = typedWordRef.current;
+      typedWordRef.current = "";
       const data = e.data ?? "";
-      // The composition may have taken over a word already spelled out as plain
-      // edits; only the part the pane has not seen yet is new.
-      const rest = run && data.startsWith(run) ? data.slice(run.length) : data;
+      // Only a composition that took over the typed word may have its prefix
+      // dropped; anything else is new text and goes to the pane whole.
+      const rest = retroactive && data.startsWith(run) ? data.slice(run.length) : data;
       // The composed word is still the one under the caret, so a second
       // composition over it (a suggestion tap, then the space commit) has to
       // be stripped against everything the pane has of that word.
-      if (!rest || sendKeys(rest)) plainRunRef.current = plainRunAfter(run, rest);
+      if (!rest || sendKeys(rest)) typedWordRef.current = plainRunAfter(run, rest);
       if (e.currentTarget instanceof HTMLTextAreaElement) e.currentTarget.value = "";
     },
-    [sendKeys],
+    [sendKeys, typedWordRef],
   );
 
   // Session selection focuses App's persistent, in-viewport keyboard input
@@ -1745,6 +1758,7 @@ export function MobileLiveTerminal({
     proxy.addEventListener("keydown", handleKeyDown);
     proxy.addEventListener("paste", handlePaste);
     proxy.addEventListener("compositionstart", handleCompositionStart);
+    proxy.addEventListener("compositionupdate", handleCompositionUpdate);
     proxy.addEventListener("compositionend", handleCompositionEnd);
     return () => {
       unregisterProxyInput();
@@ -1752,6 +1766,7 @@ export function MobileLiveTerminal({
       proxy.removeEventListener("keydown", handleKeyDown);
       proxy.removeEventListener("paste", handlePaste);
       proxy.removeEventListener("compositionstart", handleCompositionStart);
+      proxy.removeEventListener("compositionupdate", handleCompositionUpdate);
       proxy.removeEventListener("compositionend", handleCompositionEnd);
     };
   }, [
@@ -1761,6 +1776,7 @@ export function MobileLiveTerminal({
     handleMobileKeyboardProxyInput,
     handlePaste,
     handleCompositionStart,
+    handleCompositionUpdate,
     handleCompositionEnd,
   ]);
 
@@ -2016,6 +2032,7 @@ export function MobileLiveTerminal({
         onKeyDown={(e) => handleKeyDown(e.nativeEvent)}
         onPaste={(e) => handlePaste(e.nativeEvent)}
         onCompositionStart={() => handleCompositionStart()}
+        onCompositionUpdate={(e) => handleCompositionUpdate(e.nativeEvent)}
         onCompositionEnd={(e) => handleCompositionEnd(e.nativeEvent)}
       />
     </div>

--- a/web/src/components/__tests__/MobileLiveTerminal.align.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.align.test.tsx
@@ -47,6 +47,7 @@ function renderTerm(bottomAlign: boolean) {
       enterReading={vi.fn()}
       returnToLive={vi.fn()}
       sendData={vi.fn()}
+      typedWordRef={{ current: "" }}
       forwardWheel={vi.fn()}
       forwardButton={vi.fn()}
       ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}

--- a/web/src/components/__tests__/MobileLiveTerminal.clipboard.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.clipboard.test.tsx
@@ -44,6 +44,7 @@ describe("MobileLiveTerminal OSC 52 clipboard", () => {
         enterReading={vi.fn()}
         returnToLive={vi.fn()}
         sendData={vi.fn()}
+        typedWordRef={{ current: "" }}
         uploadPastedImage={vi.fn().mockResolvedValue(null)}
         forwardWheel={vi.fn()}
         forwardButton={vi.fn()}

--- a/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
@@ -46,9 +46,11 @@ interface Term {
   sent: () => string[];
 }
 
-function renderTerm(): Term {
+// `accepted` models useLiveTerminal.sendData's contract: false is a keystroke
+// the pane never receives (a confirmed non-owner, or a full pending queue).
+function renderTerm(accepted = true): Term {
   const inputRef = createRef<HTMLTextAreaElement>();
-  const sendData = vi.fn();
+  const sendData = vi.fn(() => accepted);
   render(
     <MobileLiveTerminal
       frame={frame}
@@ -89,7 +91,7 @@ function renderTerm(): Term {
 }
 
 describe("MobileLiveTerminal Android IME word commits", () => {
-  const cases: { name: string; run: (t: Term) => void; sent: string[] }[] = [
+  const cases: { name: string; accepted?: boolean; run: (t: Term) => void; sent: string[] }[] = [
     {
       name: "sends a SwiftKey word once when the composition repeats it",
       // The reporter's trace: "test" typed plainly, composed on space, then " ".
@@ -141,6 +143,38 @@ describe("MobileLiveTerminal Android IME word commits", () => {
       sent: ["t", "e", "s", "t", "s", " "],
     },
     {
+      // A path or token can outrun any fixed cap on the tracked word.
+      name: "strips a word longer than any cap on the tracked run",
+      run: (t) => {
+        const word = "a".repeat(70);
+        t.type(word);
+        t.compose(word);
+        t.type(" ");
+      },
+      sent: [...Array.from({ length: 70 }, () => "a"), " "],
+    },
+    {
+      // Backspacing an emoji must not leave half a surrogate pair behind.
+      name: "tracks a backspace over a non-BMP character",
+      run: (t) => {
+        t.type("hi\u{1F642}");
+        t.input("deleteContentBackward");
+        t.compose("hi");
+      },
+      sent: ["h", "i", "\u{1F642}", "\x7f"],
+    },
+    {
+      // A read-only viewer's keystrokes are dropped, so the pane never got the
+      // word and the composition that follows a take-over must be sent whole.
+      name: "does not record input the pane never received",
+      accepted: false,
+      run: (t) => {
+        t.type("test");
+        t.compose("test");
+      },
+      sent: ["t", "e", "s", "t", "test"],
+    },
+    {
       name: "sends a composed word that does not continue what was typed",
       run: (t) => {
         t.type("a");
@@ -181,7 +215,7 @@ describe("MobileLiveTerminal Android IME word commits", () => {
 
   for (const c of cases) {
     it(c.name, () => {
-      const t = renderTerm();
+      const t = renderTerm(c.accepted);
       c.run(t);
       expect(t.sent()).toEqual(c.sent);
     });

--- a/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
@@ -120,6 +120,27 @@ describe("MobileLiveTerminal Android IME word commits", () => {
       sent: ["t", "e", "s", "t"],
     },
     {
+      name: "sends the word once when a second composition commits it",
+      run: (t) => {
+        t.type("tes");
+        t.compose("test");
+        t.compose("test");
+        t.type(" ");
+      },
+      sent: ["t", "e", "s", "t", " "],
+    },
+    {
+      name: "keeps stripping a word typed on after a composition",
+      run: (t) => {
+        t.type("test");
+        t.compose("test");
+        t.type("s");
+        t.compose("tests");
+        t.type(" ");
+      },
+      sent: ["t", "e", "s", "t", "s", " "],
+    },
+    {
       name: "sends a composed word that does not continue what was typed",
       run: (t) => {
         t.type("a");

--- a/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// Android IME word handling in the live terminal (#3746). SwiftKey spells a
+// word out as plain `insertText` edits and then, when space is pressed, wraps
+// that same word in a composition after the fact, so `compositionend` carries
+// it a second time and "test" reached the pane as "testtest". The traced
+// sequence from the reporter's device is the first case below. Only the part
+// of the composed word the pane has not already seen may be sent, and typing
+// without a composition must be untouched.
+
+import { createRef } from "react";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+import type { LiveFrame } from "../../hooks/useLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const frame: LiveFrame = {
+  content: "$ \n",
+  rows: 3,
+  history: 1000,
+  cursor: null,
+  altScreen: false,
+  mouse: false,
+  mouseSgr: false,
+  pane0: null,
+};
+
+interface Term {
+  /** Plain edits, one per character, as a soft keyboard sends them. */
+  type: (text: string) => void;
+  /** A composition that hands back `data` when it ends. */
+  compose: (data: string) => void;
+  input: (inputType: string) => void;
+  sent: () => string[];
+}
+
+function renderTerm(): Term {
+  const inputRef = createRef<HTMLTextAreaElement>();
+  const sendData = vi.fn();
+  render(
+    <MobileLiveTerminal
+      frame={frame}
+      connected
+      active
+      reading={false}
+      sendResize={vi.fn()}
+      setWindow={vi.fn()}
+      setCadence={vi.fn()}
+      enterReading={vi.fn()}
+      returnToLive={vi.fn()}
+      sendData={sendData}
+      uploadPastedImage={vi.fn().mockResolvedValue(null)}
+      forwardWheel={vi.fn()}
+      forwardButton={vi.fn()}
+      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+      clearCtrl={vi.fn()}
+      inputRef={inputRef}
+      onInputFocusChange={vi.fn()}
+      bottomAlign
+      keyboardOpen={false}
+    />,
+  );
+  const input = inputRef.current!;
+  const beforeInput = (inputType: string, data: string | null) =>
+    input.dispatchEvent(new InputEvent("beforeinput", { inputType, data, bubbles: true, cancelable: true }));
+  return {
+    type: (text) => {
+      for (const ch of text) beforeInput("insertText", ch);
+    },
+    compose: (data) => {
+      fireEvent.compositionStart(input);
+      fireEvent.compositionEnd(input, { data });
+    },
+    input: (inputType) => beforeInput(inputType, null),
+    sent: () => sendData.mock.calls.map(([d]: [string]) => d),
+  };
+}
+
+describe("MobileLiveTerminal Android IME word commits", () => {
+  const cases: { name: string; run: (t: Term) => void; sent: string[] }[] = [
+    {
+      name: "sends a SwiftKey word once when the composition repeats it",
+      // The reporter's trace: "test" typed plainly, composed on space, then " ".
+      run: (t) => {
+        t.type("test");
+        t.compose("test");
+        t.type(" ");
+      },
+      sent: ["t", "e", "s", "t", " "],
+    },
+    {
+      name: "keeps every word of a sentence typed that way",
+      run: (t) => {
+        t.type("hi");
+        t.compose("hi");
+        t.type(" you");
+        t.compose("you");
+        t.type(" ");
+      },
+      sent: ["h", "i", " ", "y", "o", "u", " "],
+    },
+    {
+      name: "sends only the tail when the composition extends the typed word",
+      run: (t) => {
+        t.type("tes");
+        t.compose("test");
+      },
+      sent: ["t", "e", "s", "t"],
+    },
+    {
+      name: "sends a composed word that does not continue what was typed",
+      run: (t) => {
+        t.type("a");
+        t.compose("日本");
+      },
+      sent: ["a", "日本"],
+    },
+    {
+      name: "sends a composition that follows no plain typing",
+      run: (t) => t.compose("日本"),
+      sent: ["日本"],
+    },
+    {
+      name: "keeps repeated characters typed without a composition",
+      run: (t) => t.type("aa"),
+      sent: ["a", "a"],
+    },
+    {
+      name: "forgets the word once Enter has ended the line",
+      run: (t) => {
+        t.type("ls");
+        t.input("insertParagraph");
+        t.type("ls");
+        t.compose("ls");
+      },
+      sent: ["l", "s", "\r", "l", "s"],
+    },
+    {
+      name: "tracks a backspace before the composition arrives",
+      run: (t) => {
+        t.type("test");
+        t.input("deleteContentBackward");
+        t.compose("tes");
+      },
+      sent: ["t", "e", "s", "t", "\x7f"],
+    },
+  ];
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const t = renderTerm();
+      c.run(t);
+      expect(t.sent()).toEqual(c.sent);
+    });
+  }
+});

--- a/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
@@ -40,9 +40,15 @@ const frame: LiveFrame = {
 interface Term {
   /** Plain edits, one per character, as a soft keyboard sends them. */
   type: (text: string) => void;
-  /** A composition that hands back `data` when it ends. */
+  /** A retroactive composition: its first update carries the word already
+   *  typed, as SwiftKey's trace on #3746 does, then it ends with `data`. */
   compose: (data: string) => void;
+  /** A composition that starts fresh here, building from its own first
+   *  character rather than adopting what was typed before it. */
+  composeFresh: (first: string, data: string) => void;
   input: (inputType: string) => void;
+  /** A toolbar button, which writes past this component to live.sendData. */
+  toolbar: (data: string) => void;
   sent: () => string[];
 }
 
@@ -50,7 +56,13 @@ interface Term {
 // the pane never receives (a confirmed non-owner, or a full pending queue).
 function renderTerm(accepted = true): Term {
   const inputRef = createRef<HTMLTextAreaElement>();
-  const sendData = vi.fn(() => accepted);
+  // The hook clears the shared word on every write; that is what makes a
+  // toolbar button invalidate the run this component is tracking.
+  const typedWordRef = { current: "" };
+  const sendData = vi.fn((_data: string) => {
+    typedWordRef.current = "";
+    return accepted;
+  });
   render(
     <MobileLiveTerminal
       frame={frame}
@@ -63,6 +75,7 @@ function renderTerm(accepted = true): Term {
       enterReading={vi.fn()}
       returnToLive={vi.fn()}
       sendData={sendData}
+      typedWordRef={typedWordRef}
       uploadPastedImage={vi.fn().mockResolvedValue(null)}
       forwardWheel={vi.fn()}
       forwardButton={vi.fn()}
@@ -83,9 +96,16 @@ function renderTerm(accepted = true): Term {
     },
     compose: (data) => {
       fireEvent.compositionStart(input);
+      fireEvent.compositionUpdate(input, { data: typedWordRef.current });
+      fireEvent.compositionEnd(input, { data });
+    },
+    composeFresh: (first, data) => {
+      fireEvent.compositionStart(input);
+      fireEvent.compositionUpdate(input, { data: first });
       fireEvent.compositionEnd(input, { data });
     },
     input: (inputType) => beforeInput(inputType, null),
+    toolbar: (data) => sendData(data),
     sent: () => sendData.mock.calls.map(([d]: [string]) => d),
   };
 }
@@ -173,6 +193,27 @@ describe("MobileLiveTerminal Android IME word commits", () => {
         t.compose("test");
       },
       sent: ["t", "e", "s", "t", "test"],
+    },
+    {
+      // jerome-benoit on #3751: compositionend.data describes only its own
+      // session, so a composition that starts here is not a replacement.
+      name: "sends a fresh composition that merely shares the typed prefix",
+      run: (t) => {
+        t.type("a");
+        t.composeFresh("n", "android");
+      },
+      sent: ["a", "android"],
+    },
+    {
+      // The toolbar writes past this component straight to live.sendData.
+      name: "forgets the word after a toolbar interrupt",
+      run: (t) => {
+        t.type("test");
+        t.toolbar("\x03");
+        t.type("test");
+        t.compose("test");
+      },
+      sent: ["t", "e", "s", "t", "\x03", "t", "e", "s", "t"],
     },
     {
       name: "sends a composed word that does not continue what was typed",

--- a/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx
@@ -43,9 +43,9 @@ interface Term {
   /** A retroactive composition: its first update carries the word already
    *  typed, as SwiftKey's trace on #3746 does, then it ends with `data`. */
   compose: (data: string) => void;
-  /** A composition that starts fresh here, building from its own first
-   *  character rather than adopting what was typed before it. */
-  composeFresh: (first: string, data: string) => void;
+  /** A composition whose first update carries `first`, which is what decides
+   *  whether it read as taking over the typed word or standing on its own. */
+  composeUpdating: (first: string, data: string) => void;
   input: (inputType: string) => void;
   /** A toolbar button, which writes past this component to live.sendData. */
   toolbar: (data: string) => void;
@@ -99,7 +99,7 @@ function renderTerm(accepted = true): Term {
       fireEvent.compositionUpdate(input, { data: typedWordRef.current });
       fireEvent.compositionEnd(input, { data });
     },
-    composeFresh: (first, data) => {
+    composeUpdating: (first, data) => {
       fireEvent.compositionStart(input);
       fireEvent.compositionUpdate(input, { data: first });
       fireEvent.compositionEnd(input, { data });
@@ -200,9 +200,20 @@ describe("MobileLiveTerminal Android IME word commits", () => {
       name: "sends a fresh composition that merely shares the typed prefix",
       run: (t) => {
         t.type("a");
-        t.composeFresh("n", "android");
+        t.composeUpdating("n", "android");
       },
       sent: ["a", "android"],
+    },
+    {
+      // A suggestion tap corrects the word in the same breath as adopting it,
+      // so the first update carries more than the run. Pins the classifier to
+      // a prefix test: an equality test would send the whole word again.
+      name: "strips an adopting composition that corrects as it takes over",
+      run: (t) => {
+        t.type("tes");
+        t.composeUpdating("test", "test");
+      },
+      sent: ["t", "e", "s", "t"],
     },
     {
       // The toolbar writes past this component straight to live.sendData.
@@ -227,6 +238,17 @@ describe("MobileLiveTerminal Android IME word commits", () => {
       name: "sends a composition that follows no plain typing",
       run: (t) => t.compose("日本"),
       sent: ["日本"],
+    },
+    {
+      // A composition that stood on its own is not a typed word under the
+      // caret, so the next one must reach the pane whole even when it repeats
+      // it. Samsung's trace on #3746 composes every word this way.
+      name: "sends a character composed twice in a row",
+      run: (t) => {
+        t.composeUpdating("a", "a");
+        t.composeUpdating("a", "a");
+      },
+      sent: ["a", "a"],
     },
     {
       name: "keeps repeated characters typed without a composition",

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
@@ -47,6 +47,7 @@ function renderTerm() {
       enterReading={vi.fn()}
       returnToLive={vi.fn()}
       sendData={vi.fn()}
+      typedWordRef={{ current: "" }}
       uploadPastedImage={vi.fn()}
       forwardWheel={vi.fn()}
       forwardButton={vi.fn()}

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -57,6 +57,7 @@ function renderTerm(f: LiveFrame, forwardWheel = vi.fn(), forwardButton = vi.fn(
       enterReading={vi.fn()}
       returnToLive={vi.fn()}
       sendData={sendData}
+      typedWordRef={{ current: "" }}
       forwardWheel={forwardWheel}
       forwardButton={forwardButton}
       ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
@@ -278,6 +279,7 @@ describe("MobileLiveTerminal wheel forwarding", () => {
         enterReading={enterReading}
         returnToLive={vi.fn()}
         sendData={vi.fn()}
+        typedWordRef={{ current: "" }}
         forwardWheel={vi.fn()}
         forwardButton={vi.fn()}
         ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}

--- a/web/src/components/__tests__/MobileLiveTerminal.keyboardResize.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.keyboardResize.test.tsx
@@ -74,6 +74,7 @@ function props(keyboardOpen: boolean, sendResize = vi.fn()) {
     enterReading: vi.fn(),
     returnToLive: vi.fn(),
     sendData: vi.fn(),
+    typedWordRef: { current: "" },
     uploadPastedImage: vi.fn(),
     forwardWheel: vi.fn(),
     forwardButton: vi.fn(),

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -57,6 +57,7 @@ function renderTerm(uploadPastedImage = vi.fn().mockResolvedValue(null)) {
       enterReading={vi.fn()}
       returnToLive={vi.fn()}
       sendData={sendData}
+      typedWordRef={{ current: "" }}
       uploadPastedImage={uploadPastedImage}
       forwardWheel={vi.fn()}
       forwardButton={vi.fn()}

--- a/web/src/components/__tests__/MobileLiveTerminal.scrollPin.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.scrollPin.test.tsx
@@ -99,6 +99,7 @@ function props() {
     enterReading: vi.fn(),
     returnToLive: vi.fn(),
     sendData: vi.fn(),
+    typedWordRef: { current: "" },
     forwardWheel: vi.fn(),
     forwardButton: vi.fn(),
     ctrlActiveRef: createRef<boolean>() as React.RefObject<boolean>,

--- a/web/src/components/__tests__/MobileLiveTerminal.tapFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.tapFocus.test.tsx
@@ -48,6 +48,7 @@ function renderTerm() {
       enterReading={vi.fn()}
       returnToLive={vi.fn()}
       sendData={vi.fn()}
+      typedWordRef={{ current: "" }}
       forwardWheel={vi.fn()}
       forwardButton={vi.fn()}
       ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}

--- a/web/src/hooks/useLiveTerminal.sizeOwner.test.ts
+++ b/web/src/hooks/useLiveTerminal.sizeOwner.test.ts
@@ -101,12 +101,21 @@ describe("useLiveTerminal size-owner", () => {
     socket.sent.length = 0;
 
     deliver(socket, { type: "size_owner", is_owner: false });
-    act(() => result.current.sendData("x"));
+    // The return value is what tells a caller the pane never got these bytes,
+    // so nothing downstream may record them as delivered.
+    let accepted: boolean | undefined;
+    act(() => {
+      accepted = result.current.sendData("x");
+    });
+    expect(accepted).toBe(false);
     expect(socket.sent).toHaveLength(0);
 
     deliver(socket, { type: "size_owner", is_owner: true });
     expect(socket.sent.some((m) => m instanceof Uint8Array)).toBe(false);
-    act(() => result.current.sendData("y"));
+    act(() => {
+      accepted = result.current.sendData("y");
+    });
+    expect(accepted).toBe(true);
     const typed = socket.sent.find((m): m is Uint8Array => m instanceof Uint8Array);
     expect(new TextDecoder().decode(typed)).toBe("y");
   });
@@ -114,7 +123,13 @@ describe("useLiveTerminal size-owner", () => {
   it("queues the first typed bytes until a newly selected session owns the pane", () => {
     const { result } = renderHook(() => useLiveTerminal("s1"));
     const socket = sockets[0];
-    act(() => result.current.sendData("first"));
+    // Queued during the unresolved handshake still counts as accepted: the
+    // flush on ownership delivers it.
+    let accepted: boolean | undefined;
+    act(() => {
+      accepted = result.current.sendData("first");
+    });
+    expect(accepted).toBe(true);
     expect(socket.sent).toHaveLength(0);
 
     open(socket);

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -422,23 +422,26 @@ export function useLiveTerminal(
     };
   }, [sessionId, wsPath, setState]);
 
-  const sendData = useCallback((data: string) => {
+  /** True when the pane will receive `data`: sent now, or queued for a flush
+   *  that is still expected. False means it was dropped and no caller may
+   *  treat it as delivered. */
+  const sendData = useCallback((data: string): boolean => {
     const ws = wsRef.current;
     const canSend = ownerKnownRef.current && storeRef.current!.snapshot.isOwner;
     if (canSend && ws?.readyState === WebSocket.OPEN) {
       ws.send(new TextEncoder().encode(data));
-      return;
+      return true;
     }
     // A confirmed non-owner must not leave keystrokes queued for a later
     // takeover. Only the short, unresolved initial handshake (or a socket
     // reconnect while we were the owner) may retain input.
-    if (ownerKnownRef.current && !storeRef.current!.snapshot.isOwner) return;
+    if (ownerKnownRef.current && !storeRef.current!.snapshot.isOwner) return false;
     const bytes = new TextEncoder().encode(data);
     const pending = pendingInputRef.current;
     const used = pending.reduce((total, item) => total + item.byteLength, 0);
-    if (bytes.byteLength <= MAX_PENDING_INPUT_BYTES - used) {
-      pending.push(bytes);
-    }
+    if (bytes.byteLength > MAX_PENDING_INPUT_BYTES - used) return false;
+    pending.push(bytes);
+    return true;
   }, []);
 
   /** Explicit take-over from a read-only viewer: steal the size-owner lock

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -422,10 +422,17 @@ export function useLiveTerminal(
     };
   }, [sessionId, wsPath, setState]);
 
+  /** The plain-typed word the pane currently holds, for the mobile IME word
+   *  dedup (#3746). It lives here because `sendData` is the one funnel every
+   *  writer uses (terminal, toolbar), so no writer can leave a stale word
+   *  behind: sending clears it and only the typing path re-arms it. */
+  const typedWordRef = useRef("");
+
   /** True when the pane will receive `data`: sent now, or queued for a flush
    *  that is still expected. False means it was dropped and no caller may
    *  treat it as delivered. */
   const sendData = useCallback((data: string): boolean => {
+    typedWordRef.current = "";
     const ws = wsRef.current;
     const canSend = ownerKnownRef.current && storeRef.current!.snapshot.isOwner;
     if (canSend && ws?.readyState === WebSocket.OPEN) {
@@ -553,6 +560,7 @@ export function useLiveTerminal(
   return {
     state,
     sendData,
+    typedWordRef,
     forwardWheel,
     forwardButton,
     sendResize,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -203,6 +203,13 @@
       ]
     },
     {
+      "id": "terminal.mobile-ime-word-commit",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/MobileLiveTerminal.composition.test.tsx"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
       "id": "terminal.mobile-live-scrollback",
       "kind": "mocked-playwright",
       "risk": "high",


### PR DESCRIPTION
## Description

On Android, some keyboards (SwiftKey is the reported one) type a word out one
letter at a time and then, the moment you press space, tell the page a second
time "the word you just finished was `test`". The mobile terminal took that
second message at face value and typed the word again, so every word came out
doubled: you typed `test`, the pane showed `testtest`. The terminal now
remembers the word you are part-way through typing, so when the keyboard hands
the finished word back it only passes along whatever is genuinely new. Typing on
Android produces one copy of each word again, and keyboards that do not behave
this way are untouched.

The reporter's device trace on #3746 is what this is built on:

```
beforeinput "t"/"e"/"s"/"t"  insertText            isComposing:false
compositionstart ""
compositionupdate "test"
compositionend "test"
beforeinput " "              insertText            isComposing:false
```

The word arrives as plain `insertText` edits *before* any composition exists;
SwiftKey then wraps it in a composition after the fact, and `compositionend`
carries the whole word again.

`typedWordRef` holds the word under the caret. It lives in `useLiveTerminal`
beside `sendData`, the one funnel every writer uses, so nothing (including
`MobileTerminalToolbar`, which writes straight to `live.sendData`) can leave a
stale word behind. `sendData` now reports whether the pane will actually receive
the bytes, so a confirmed non-owner's dropped keystrokes are never recorded as
delivered. `compositionend` sends only the part of its data the run has not
already delivered.

Suppression is gated on evidence rather than on a bare prefix match. A
retroactive composition announces itself on its first `compositionupdate` by
carrying the whole typed word, as the trace above shows; a composition that
genuinely starts at the caret builds from its own first character, as the
Samsung trace on the same issue does. A composition with no update to settle it,
and one that stood on its own, are both sent whole.

Two limits worth stating rather than burying:

Autocorrect that *replaces* letters is not fixed. `ted` corrected to `test`
leaves the pane with `tedtest`, because undoing it means erasing what the pane
already showed. That is #3812, and behaviour there is unchanged.

The prefix test cannot be right in both directions. A composition adopting the
typed word and one starting fresh beside it are indistinguishable at the DOM
level once `insertText` is `preventDefault`ed, so a fresh composition sharing
the typed prefix loses that prefix. An equality test instead of a prefix test
trades that for re-doubling a mid-word suggestion tap. Adopt-and-replay is the
only behaviour any device trace shows, so the prefix test is the default here.
The failure direction throughout is a duplicate, never dropped input.

Fixes #3746

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot: the change is what bytes reach the pane, not pixels. The traced
event sequence in the first test case is the evidence.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Vitest rather than Playwright: the behavior is the component's own event
handling, which RTL drives directly and more cheaply than a browser.
`web/src/components/__tests__/MobileLiveTerminal.composition.test.tsx` replays
the traced SwiftKey sequence plus the surrounding cases (multi-word sentences, a
composition that extends the run, an unrelated composition, plain repeated
characters, Enter, backspace). Five of the eight fail on unfixed HEAD.
`terminal.mobile-ime-word-commit` added to the matrix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Diagnosis came from the event trace the reporter ran on their device. An earlier
revision of this branch guarded the opposite ordering and the trace ruled it
out; that approach is gone.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdNyjG6kyGSfoVxxSPjzLq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed duplicate words from Android keyboards such as SwiftKey.
- Shared typed-word tracking between terminal input and the mobile terminal.
- Suppressed only composition text that repeats accepted plain-text input.
- Preserved standalone composition behavior.
- Improved state handling for backspace, Enter, dropped input, and toolbar actions.
- Added regression tests for SwiftKey-like input, long words, Unicode deletion, and related cases.
- Added the test coverage entry.

## Benefits

Mobile users can type with Android keyboards without duplicated words. Accepted input is tracked more reliably, and broader test coverage reduces regression risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
