### PR TITLE
fix(status): stop reading the background-shell count as agent activity

### DIFF
--- a/src/tmux/detect/manifests/claude.toml
+++ b/src/tmux/detect/manifests/claude.toml
@@ -94,18 +94,11 @@ region = "last_non_empty_above_prompt_box"
 visible = true
 line_regex = ['(?i)^\s*[\x{00B7}\x{2722}\x{2733}\x{2736}\x{273B}\x{273D}*\x{25CF}]\s+waiting for \d+ background agents? to finish\s*$']
 
-# Background shells the agent started and has not reaped: a build, a test run,
-# a server. The footer's count is live, dropping the segment when the last one
-# exits, so this reads a real running process rather than a banner. A shell the
-# agent leaves up for good (a dev server) does keep the session Running, which
-# is true rather than stale.
-[[rules]]
-id = "background_shell"
-state = "running"
-priority = 970
-region = "bottom_non_empty_lines(5)"
-visible = true
-line_regex = ['(?i)^\s*[\x{23F8}\x{23F5}].*\x{b7}\s*[1-9]\d*\s+shells?\s*(?:\x{b7}|$)']
+# There is deliberately no rule for the footer's `· N shells ·` segment: it
+# counts live children of the pane's shell, which a user can attach to for the
+# session's lifetime, not work the agent is doing. The two rules around this
+# one count work the agent dispatched and will report back on, which nothing
+# outside the session can inflate.
 
 # MCP tasks still running behind a finished turn. Same argument as the
 # background agents above, and the same anchoring problem: the count sits on an

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1817,23 +1817,25 @@ enter to select · esc to cancel";
     #[test]
     fn test_claude_background_work_outlives_the_turn() {
         // A finished turn whose background work is still going: the REPL is
-        // parked and the box is free, but shells, MCP tasks or agents the
-        // agent started are still running. Captured from a live footer.
+        // parked and the box is free, but MCP tasks or agents the agent
+        // started are still running. Captured from a live footer.
         let parked = "✻ Cooked for 1m 58s\n❯ \n";
         let footer =
             |tail: &str| format!("{parked}  ⏵⏵ auto mode on (shift+tab to cycle) · PR #3600{tail}");
 
-        // The footer's shells segment is live: present while they run, gone
-        // when the last one exits, so its absence is the parked case.
+        // #3738: the footer's shell count is of live children of the pane's
+        // shell, which a user can attach to for the session's lifetime, so it
+        // is not read as the agent working. A turn that is genuinely running
+        // still is, from its own chrome, which is what the deletion must not
+        // have taken with it.
         let with_shells = footer(" · 5 shells · ← for agents");
-        assert!(claude_rule_matches("background_shell", &with_shells));
-        assert_eq!(detect_claude(&with_shells, "", None), Status::Running);
+        assert_eq!(detect_claude(&with_shells, "", None), Status::Idle);
+        assert_eq!(claude_rule(&with_shells), "completed_turn");
+        let live = format!("✻ Brewing… (17s · esc to interrupt)\n{with_shells}");
+        assert_eq!(detect_claude(&live, "", None), Status::Running);
 
-        let without = footer(" · ← for agents");
-        assert!(!claude_rule_matches("background_shell", &without));
-        assert_eq!(detect_claude(&without, "", None), Status::Idle);
-
-        // MCP tasks outliving the turn that started them.
+        // MCP tasks outliving the turn that started them. The agent dispatched
+        // these and will report back on them, so they still read as work.
         let mcp = format!("{parked}✻ Ran 3 tools · 2 MCP tasks still running\n");
         assert!(claude_rule_matches("background_mcp_task", &mcp));
         assert_eq!(detect_claude(&mcp, "", None), Status::Running);


### PR DESCRIPTION
## Description

Agent of Empires decides whether a session is busy partly from what Claude draws
at the bottom of its pane. One of those signals was the footer's "5 shells"
count, which Claude shows whenever background processes are alive under that
pane, and it beat every other signal including Claude's own report that it had
finished and was waiting for you.

That count is of live child processes, not of work the agent is doing. Anyone
who deliberately keeps a small helper attached to a session (a log tailer, a
file watcher, a message-queue daemon) has one running for the session's entire
life, so the segment never goes away and the session shows as busy forever. In a
fleet of sessions that destroys the whole point of the status column: everything
is green, all the time, and the reporter rolled back a release over it.

The first attempt was to keep the rule and ignore it when Claude's status hook
said the turn was over. That does not work, and it is worth saying why, because
it looks like it should. Claude writes "idle" at the end of every turn no matter
what is still alive, so that gate cannot tell a helper daemon apart from a build
the agent kicked off a minute ago. It switches the rule off for both. Which
means this was never a detection bug that a better signal could fix. It is a
question about what a session's status means, and the answer this takes is that
it describes the agent, not the agent's children: Claude does not wake up when a
background shell exits, so the count says nothing about the agent either way.

So the rule is gone rather than gated. The two rules around it stay, because
their counts are of work the agent itself dispatched and will report back on,
and nothing outside the session can inflate them.

What changes for you: a session with a helper process attached now reports its
real status. A session where the agent left a build or a dev server running in
the background now reads Idle rather than Running once the turn ends. That
second one is a real trade and not just a false-positive fix, but a permanently
green fleet carries no signal at all, while a session that reads Idle with a
build still going is wrong only until you look at it.

Fixes #3738

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt --check` and `cargo clippy --all-targets` are clean. `cargo test`:
6606 pass, 2 fail. Both failures are pre-existing and environmental, unrelated to
this diff: `acp::supervisor::tests::shutdown_and_wait_degrades_when_load_errs_without_peer`
and `process::worker_registry::tests::pid_source_for_falls_back_to_peer_pid_on_load_err`
both `chmod 0o000` a file to force a read error, which does not block reads for
uid 0, and this sandbox runs as root.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the change is pure pane-detection logic, which the
  manifest unit tests cover directly and far more cheaply than driving a real
  agent with a live background process from an e2e harness.
  `test_claude_background_work_outlives_the_turn` in
  `src/tmux/status_detection.rs` now pins the parked-with-shells footer to Idle
  and names the rule that decides it, and still pins the MCP-task case to
  Running so the deletion cannot quietly take its neighbours with it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Root cause analysis and drafting were Claude's. The call that decided the shape
of this PR was @njbrake's: an earlier revision gated the rule on the status hook
instead of deleting it, and he took the position that a session's status
describes the agent rather than its children, which is what turned a conditional
rule into a deletion.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Htqq3jQVDQuuizSo8ocWND


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Removed Claude’s `background_shell` status rule.
- Prevented long-lived companion processes from keeping idle sessions marked as running.
- Preserved agent-dispatched background task detection.
- Updated tests for idle sessions with active shells and genuine running turns.
- Added comments explaining why shell counts do not represent agent work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->