### PR TITLE
fix(sandbox): reclaim named ignore volumes stranded by a worktree move

### DIFF
--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -124,9 +124,11 @@ ancestor of the workspace and every repo. Build caches (`target/`,
 `node_modules/`) go with the container under the default
 [volume ignores strategy](sandbox.md#volume-ignores-strategy-macosvirtiofs). Under
 `"named"` they are keyed on their container path, so they survive an attach that
-leaves that path alone; attaching a repo from outside the current common ancestor
-moves every mount, so those caches start empty and the volumes they leave behind
-are reclaimed at the next start.
+leaves that path alone. Attaching a repo from outside the current common ancestor
+moves every mount, so those caches start empty, and the volumes they leave behind
+are not reclaimed: the attach clears the pin AoE compares against to recognize a
+move. Remove them by hand with the `docker volume ls` command under
+[Volume Ignores Strategy](sandbox.md#volume-ignores-strategy-macosvirtiofs).
 
 ## The Project Registry
 

--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -121,11 +121,12 @@ throwaway directory that deletion removes.
 Sandboxed sessions have their container removed and recreated, since bind mounts
 are fixed when the container is created and the container mounts the common
 ancestor of the workspace and every repo. Build caches (`target/`,
-`node_modules/`) are named volumes keyed on their container path, so they
-survive an attach that leaves that path alone. Attaching a repo from outside the
-current common ancestor moves every mount, so those caches start empty; see
-[Volume Ignores Strategy](sandbox.md#volume-ignores-strategy-macosvirtiofs) for
-what happens to the volumes they leave behind.
+`node_modules/`) go with the container under the default
+[volume ignores strategy](sandbox.md#volume-ignores-strategy-macosvirtiofs). Under
+`"named"` they are keyed on their container path, so they survive an attach that
+leaves that path alone; attaching a repo from outside the current common ancestor
+moves every mount, so those caches start empty and the volumes they leave behind
+are reclaimed at the next start.
 
 ## The Project Registry
 

--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -121,7 +121,11 @@ throwaway directory that deletion removes.
 Sandboxed sessions have their container removed and recreated, since bind mounts
 are fixed when the container is created and the container mounts the common
 ancestor of the workspace and every repo. Build caches (`target/`,
-`node_modules/`) are named volumes and survive.
+`node_modules/`) are named volumes keyed on their container path, so they
+survive an attach that leaves that path alone. Attaching a repo from outside the
+current common ancestor moves every mount, so those caches start empty; see
+[Volume Ignores Strategy](sandbox.md#volume-ignores-strategy-macosvirtiofs) for
+what happens to the volumes they leave behind.
 
 ## The Project Registry
 

--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -125,10 +125,8 @@ ancestor of the workspace and every repo. Build caches (`target/`,
 [volume ignores strategy](sandbox.md#volume-ignores-strategy-macosvirtiofs). Under
 `"named"` they are keyed on their container path, so they survive an attach that
 leaves that path alone. Attaching a repo from outside the current common ancestor
-moves every mount, so those caches start empty, and the volumes they leave behind
-are not reclaimed: the attach clears the pin AoE compares against to recognize a
-move. Remove them by hand with the `docker volume ls` command under
-[Volume Ignores Strategy](sandbox.md#volume-ignores-strategy-macosvirtiofs).
+moves every mount, so those caches start empty and the volumes they leave behind
+have to be removed by hand.
 
 ## The Project Registry
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -103,7 +103,9 @@ To fix this on macOS, set `volume_ignores_strategy = "named"`. This mounts each 
 
 A volume's name is derived from its mount path, so moving a session's worktree changes it. The recreated container starts from an empty cache for the paths that moved, and the volumes those paths left behind are removed the next time the session starts.
 
-The reclaim removes the volumes belonging to the paths that moved, and nothing else. A volume orphaned any other way is left alone, because AoE cannot tell it apart from a cache you are still using: dropping an entry from `volume_ignores`, switching back to `"anonymous"`, or attaching a repo to a multi-repo workspace all strand a volume without a move it can recognize. Moves that happened before this behavior existed are not reclaimed either, since the session has since started at its new path. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
+Moving a worktree therefore costs the cache in both directions: move it back and the volumes from the first location are already gone, so that side rebuilds cold too.
+
+The reclaim removes the volumes belonging to the paths that moved, and nothing else. A volume orphaned any other way is left alone, because AoE cannot tell it apart from a cache you are still using: dropping an entry from `volume_ignores`, switching back to `"anonymous"`, or attaching a repo to a multi-repo workspace all strand a volume without a move it can recognize. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
 
 ```toml
 [sandbox]

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -101,7 +101,9 @@ By default, `volume_ignores` paths are mounted as **anonymous volumes** (`volume
 
 To fix this on macOS, set `volume_ignores_strategy = "named"`. This mounts each `volume_ignores` path as a **deterministic named Docker/Podman volume** stored entirely inside the Docker VM, bypassing VirtioFS. Named volumes are explicitly removed when the session is deleted.
 
-A volume's name is derived from its mount path, so moving a session's worktree changes it. The recreated container starts from an empty cache for the paths that moved, and the volumes those paths left behind are removed the next time the session starts, rather than lingering as orphans. Note that `docker volume prune` skips named volumes unless you pass `-a`.
+A volume's name is derived from its mount path, so moving a session's worktree changes it. The recreated container starts from an empty cache for the paths that moved, and the volumes those paths left behind are removed the next time the session starts.
+
+That reclaim is deliberately conservative: it is skipped while a session's worktree linkage is broken, while a glob `volume_ignores` entry matches nothing, and after a switch back to `"anonymous"`, because in each of those states the config cannot tell a stranded volume from a live cache. To find what is left over, list them yourself with `docker volume ls -q --filter name=aoe-vi-`; note that `docker volume prune` skips named volumes unless you pass `-a`.
 
 ```toml
 [sandbox]

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -103,7 +103,7 @@ To fix this on macOS, set `volume_ignores_strategy = "named"`. This mounts each 
 
 A volume's name is derived from its mount path, so moving a session's worktree changes it. The recreated container starts from an empty cache for the paths that moved, and the volumes those paths left behind are removed the next time the session starts.
 
-The reclaim removes the volumes belonging to the paths that moved, and nothing else. A volume orphaned any other way is left alone, because AoE cannot tell it apart from a cache you are still using: dropping an entry from `volume_ignores`, switching back to `"anonymous"`, or attaching a repo to a multi-repo workspace all strand a volume without a move it can recognize. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
+The reclaim removes the volumes belonging to the paths that moved, and nothing else. A volume orphaned any other way is left alone, because AoE cannot tell it apart from a cache you are still using: dropping an entry from `volume_ignores`, switching back to `"anonymous"`, or attaching a repo to a multi-repo workspace all strand a volume without a move it can recognize. Moves that happened before this behavior existed are not reclaimed either, since the session has since started at its new path. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
 
 ```toml
 [sandbox]

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -103,7 +103,7 @@ To fix this on macOS, set `volume_ignores_strategy = "named"`. This mounts each 
 
 A volume's name is derived from its mount path, so moving a session's worktree changes it. The recreated container starts from an empty cache for the paths that moved, and the volumes those paths left behind are removed the next time the session starts.
 
-That reclaim is deliberately conservative: it is skipped while a session's worktree linkage is broken, while a glob `volume_ignores` entry matches nothing, and after a switch back to `"anonymous"`, because in each of those states the config cannot tell a stranded volume from a live cache. To find what is left over, list them yourself with `docker volume ls -q --filter name=aoe-vi-`; note that `docker volume prune` skips named volumes unless you pass `-a`.
+Only a move triggers that reclaim. Volumes orphaned any other way are left alone, because AoE cannot tell them apart from a cache you are still using: dropping an entry from `volume_ignores`, or switching back to `"anonymous"`, makes a volume unreachable without moving anything. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
 
 ```toml
 [sandbox]

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -105,7 +105,7 @@ A volume's name is derived from its mount path, so moving a session's worktree c
 
 Moving a worktree therefore costs the cache in both directions: move it back and the volumes from the first location are already gone, so that side rebuilds cold too.
 
-The reclaim removes the volumes belonging to the paths that moved, and nothing else. A volume orphaned any other way is left alone, because AoE cannot tell it apart from a cache you are still using: dropping an entry from `volume_ignores`, switching back to `"anonymous"`, or attaching a repo to a multi-repo workspace all strand a volume without a move it can recognize. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
+The reclaim covers the paths that moved with the worktree, and nothing else. A volume orphaned any other way is left alone, because AoE cannot tell it apart from a cache you are still using: dropping an entry from `volume_ignores`, switching back to `"anonymous"`, or attaching a repo to a multi-repo workspace all strand a volume without a move it can recognize. Neither is anything already orphaned, including the leftovers from a move the session has since restarted after, so a volume that has been sitting there stays. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
 
 ```toml
 [sandbox]

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -103,7 +103,7 @@ To fix this on macOS, set `volume_ignores_strategy = "named"`. This mounts each 
 
 A volume's name is derived from its mount path, so moving a session's worktree changes it. The recreated container starts from an empty cache for the paths that moved, and the volumes those paths left behind are removed the next time the session starts.
 
-Only a move triggers that reclaim. Volumes orphaned any other way are left alone, because AoE cannot tell them apart from a cache you are still using: dropping an entry from `volume_ignores`, or switching back to `"anonymous"`, makes a volume unreachable without moving anything. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
+The reclaim removes the volumes belonging to the paths that moved, and nothing else. A volume orphaned any other way is left alone, because AoE cannot tell it apart from a cache you are still using: dropping an entry from `volume_ignores`, switching back to `"anonymous"`, or attaching a repo to a multi-repo workspace all strand a volume without a move it can recognize. To find what is left over, list them with `docker volume ls -q --filter name=aoe-vi-` and remove what you recognize; `docker volume prune` skips named volumes unless you pass `-a`.
 
 ```toml
 [sandbox]

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -101,6 +101,8 @@ By default, `volume_ignores` paths are mounted as **anonymous volumes** (`volume
 
 To fix this on macOS, set `volume_ignores_strategy = "named"`. This mounts each `volume_ignores` path as a **deterministic named Docker/Podman volume** stored entirely inside the Docker VM, bypassing VirtioFS. Named volumes are explicitly removed when the session is deleted.
 
+A volume's name is derived from its mount path, so moving a session's worktree changes it. The recreated container starts from an empty cache for the paths that moved, and the volumes those paths left behind are removed the next time the session starts, rather than lingering as orphans. Note that `docker volume prune` skips named volumes unless you pass `-a`.
+
 ```toml
 [sandbox]
 volume_ignores = ["node_modules", ".venv", "target"]

--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -90,14 +90,13 @@ pub struct ContainerConfig {
     pub anonymous_volumes: Vec<String>,
     /// Named volumes for volume_ignores when strategy = "named". Cleaned up explicitly on session delete.
     pub named_ignore_volumes: Vec<NamedVolumeMount>,
-    /// Whether `named_ignore_volumes` is the whole set this session's mounts imply,
-    /// so a volume outside it is provably stranded rather than merely unresolved.
+    /// Whether these paths, `working_dir` included, follow from the project's real
+    /// layout rather than from the collapsed fallback a failed `find_main_repo` takes.
     ///
-    /// False when the mount resolve was degraded (broken worktree linkage) or a glob
-    /// `volume_ignores` entry matched nothing, where the set is a floor. Gates the
-    /// reclaim in `DockerContainer::prune_stale_named_ignore_volumes`, so it defaults
-    /// to false: a config that has not positively established completeness never
-    /// drives a deletion.
+    /// Gates the volume reclaim in `stranded_named_ignore_volumes`, which reads a
+    /// changed `working_dir` as a move; under the fallback that change may be nothing
+    /// but the failure. Defaults to false, so a config that has not positively
+    /// established its paths never drives a deletion.
     pub named_ignore_volumes_authoritative: bool,
     pub environment: Vec<EnvEntry>,
     pub cpu_limit: Option<String>,

--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -90,6 +90,15 @@ pub struct ContainerConfig {
     pub anonymous_volumes: Vec<String>,
     /// Named volumes for volume_ignores when strategy = "named". Cleaned up explicitly on session delete.
     pub named_ignore_volumes: Vec<NamedVolumeMount>,
+    /// Whether `named_ignore_volumes` is the whole set this session's mounts imply,
+    /// so a volume outside it is provably stranded rather than merely unresolved.
+    ///
+    /// False when the mount resolve was degraded (broken worktree linkage) or a glob
+    /// `volume_ignores` entry matched nothing, where the set is a floor. Gates the
+    /// reclaim in `DockerContainer::prune_stale_named_ignore_volumes`, so it defaults
+    /// to false: a config that has not positively established completeness never
+    /// drives a deletion.
+    pub named_ignore_volumes_authoritative: bool,
     pub environment: Vec<EnvEntry>,
     pub cpu_limit: Option<String>,
     pub memory_limit: Option<String>,

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -125,18 +125,28 @@ fn classify_running_probe(result: Result<bool>) -> Probe {
 }
 
 /// The named ignore volumes a create is about to mount, or `None` when the prune
-/// must be skipped because the config does not establish what the session should
-/// have.
+/// must be skipped.
 ///
-/// Two ways it does not. The set can be incomplete, which
-/// [`ContainerConfig::named_ignore_volumes_authoritative`] reports: a mount resolve
-/// that fell back to `/workspace/{basename}` names volumes the session never had, so
-/// every volume it does have reads as stale. The set can also be empty, which does
-/// not distinguish "this session has no caches" from a switch to the anonymous
-/// strategy. Either way the difference between the config and reality is not evidence
-/// of a stranded volume, and a cache is worth more than a prompt reclaim.
-fn named_ignore_volumes_to_keep(config: &ContainerConfig) -> Option<HashSet<&str>> {
+/// A volume is stranded when the mounts moved out from under it, so the prune needs
+/// evidence of a move, not merely a config that differs from the volumes on disk.
+/// `previous_workdir` is that evidence: the workdir the last container was created
+/// with (`SandboxInfo::container_workdir`, pinned at create for #2414). Equal to this
+/// config's, or absent, and the session's mounts sit where they always did, so a
+/// volume outside the config was dropped by an edited `volume_ignores` or a glob that
+/// matched nothing this time, and deleting it would destroy a live cache.
+///
+/// Two further skips. `named_ignore_volumes_authoritative` is false when the mount
+/// resolve was degraded, where the paths (workdir included) are provisional, so the
+/// "move" may be nothing but a `find_main_repo` failure. An empty set does not
+/// distinguish "this session has no caches" from a switch to the anonymous strategy.
+fn named_ignore_volumes_to_keep<'a>(
+    config: &'a ContainerConfig,
+    previous_workdir: Option<&str>,
+) -> Option<HashSet<&'a str>> {
     if !config.named_ignore_volumes_authoritative || config.named_ignore_volumes.is_empty() {
+        return None;
+    }
+    if previous_workdir.is_none_or(|previous| previous == config.working_dir) {
         return None;
     }
     Some(
@@ -276,10 +286,15 @@ impl DockerContainer {
     ///
     /// Must be called before the create, while no container holds the volumes.
     ///
-    /// Prunes nothing unless the config establishes the whole set the session should
-    /// have; see [`named_ignore_volumes_to_keep`].
-    pub fn prune_stale_named_ignore_volumes(&self, session_id: &str, config: &ContainerConfig) {
-        let Some(keep) = named_ignore_volumes_to_keep(config) else {
+    /// Prunes nothing unless the session's mounts are established to have moved;
+    /// `previous_workdir` is that evidence, see [`named_ignore_volumes_to_keep`].
+    pub fn prune_stale_named_ignore_volumes(
+        &self,
+        session_id: &str,
+        config: &ContainerConfig,
+        previous_workdir: Option<&str>,
+    ) {
+        let Some(keep) = named_ignore_volumes_to_keep(config, previous_workdir) else {
             return;
         };
         let prefix = format!("aoe-vi-{}-", session_id);
@@ -392,9 +407,11 @@ impl DockerContainer {
 mod tests {
     use super::*;
 
-    #[test]
-    fn keep_set_is_the_configs_volume_names() {
-        let config = ContainerConfig {
+    /// A config that mounts these two, for a session whose worktree moved from
+    /// otari-worktrees/905 to otari-worktrees/rev-912 (#3742).
+    fn moved_config() -> ContainerConfig {
+        ContainerConfig {
+            working_dir: "/workspace/otari-worktrees/rev-912".to_string(),
             named_ignore_volumes: vec![
                 NamedVolumeMount {
                     volume_name: "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0".to_string(),
@@ -409,47 +426,65 @@ mod tests {
             ],
             named_ignore_volumes_authoritative: true,
             ..Default::default()
-        };
+        }
+    }
 
-        let keep = named_ignore_volumes_to_keep(&config).expect("an authoritative config prunes");
+    #[test]
+    fn a_moved_workdir_keeps_exactly_what_the_new_container_mounts() {
+        let config = moved_config();
+        let keep = named_ignore_volumes_to_keep(&config, Some("/workspace/otari-worktrees/905"))
+            .expect("a moved workdir is evidence of a strand");
+
         assert_eq!(keep.len(), 2);
         assert!(keep.contains("aoe-vi-sess1-workspace-otari-target-8ec07926d6b0"));
         assert!(keep.contains("aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47"));
     }
 
     #[test]
-    fn an_unestablished_volume_set_skips_the_prune() {
-        let volumes = || {
-            vec![NamedVolumeMount {
-                volume_name: "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0".to_string(),
-                container_path: "/workspace/otari/target".to_string(),
-            }]
+    fn without_evidence_of_a_move_nothing_is_pruned() {
+        let unmoved = "/workspace/otari-worktrees/rev-912";
+
+        let degraded = ContainerConfig {
+            named_ignore_volumes_authoritative: false,
+            ..moved_config()
+        };
+        let no_volumes = ContainerConfig {
+            named_ignore_volumes: vec![],
+            ..moved_config()
         };
 
-        for (case, config) in [
+        for (case, config, previous_workdir) in [
             (
-                // A degraded mount resolve names volumes the session never had, so
-                // every volume it does have would read as stale.
-                "not authoritative",
-                ContainerConfig {
-                    named_ignore_volumes: volumes(),
-                    named_ignore_volumes_authoritative: false,
-                    ..Default::default()
-                },
+                // An edited volume_ignores or a glob that matched nothing this time
+                // drops a volume from the config while the mounts sit where they
+                // always did. The cache is live, not stranded.
+                "the workdir did not move",
+                moved_config(),
+                Some(unmoved),
+            ),
+            (
+                // A session that has never had a container has nothing to reclaim.
+                "no previous workdir",
+                moved_config(),
+                None,
+            ),
+            (
+                // A degraded resolve makes the workdir provisional too, so the
+                // apparent move may be nothing but a find_main_repo failure.
+                "a degraded mount resolve",
+                degraded,
+                Some("/workspace/otari-worktrees/905"),
             ),
             (
                 // Does not distinguish "no caches" from a switch to the anonymous
                 // strategy.
-                "empty",
-                ContainerConfig {
-                    named_ignore_volumes_authoritative: true,
-                    ..Default::default()
-                },
+                "an empty volume set",
+                no_volumes,
+                Some("/workspace/otari-worktrees/905"),
             ),
-            ("empty and not authoritative", ContainerConfig::default()),
         ] {
             assert!(
-                named_ignore_volumes_to_keep(&config).is_none(),
+                named_ignore_volumes_to_keep(&config, previous_workdir).is_none(),
                 "{case} must not drive a deletion"
             );
         }

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -241,21 +241,25 @@ impl DockerContainer {
         }
     }
 
-    /// Remove the named ignore volumes a worktree move stranded.
+    /// Remove the named ignore volumes a worktree move stranded (#3742).
     ///
-    /// [`Self::discard`] deliberately preserves a session's volumes across the container
-    /// rebuild a move forces, which keeps the caches whose container path survives the
-    /// move and strands the rest, since a volume's name encodes that path. This reclaims
-    /// the stranded ones at the next create (#3742).
+    /// `names` is an allowlist, and the caller owns what belongs in it;
+    /// `stranded_named_ignore_volumes` computes it. Must be called before the create,
+    /// while no container holds the volumes.
     ///
-    /// `names` is an allowlist and the caller owns the decision of what belongs in it;
-    /// see
-    /// [`stranded_named_ignore_volumes`](crate::session::config::container_config::stranded_named_ignore_volumes).
-    /// Must be called before the create, while no container holds the volumes.
+    /// Logs at `info`: this is an irreversible delete of a build cache, and a wrong one
+    /// would otherwise reach the user as an unexplained cold rebuild with nothing to
+    /// attribute it to.
     pub fn remove_stale_named_ignore_volumes(&self, session_id: &str, names: &[String]) {
         if names.is_empty() {
             return;
         }
+        tracing::info!(
+            target: "containers.runtime",
+            %session_id,
+            ?names,
+            "reclaiming named ignore volumes stranded by a worktree move"
+        );
         let names: HashSet<&str> = names.iter().map(String::as_str).collect();
         let prefix = format!("aoe-vi-{}-", session_id);
         if let Err(e) = self
@@ -297,8 +301,8 @@ impl DockerContainer {
     /// intact so the recreated container re-attaches the ones whose container
     /// path is unchanged. Used on the worktree-move discard path where the
     /// container is dropped to pick up a new bind mount and will be recreated
-    /// immediately. The volumes the new paths strand are reclaimed by
-    /// [`Self::remove_stale_named_ignore_volumes`] at that create.
+    /// immediately; [`Self::remove_stale_named_ignore_volumes`] reclaims the rest
+    /// at that create.
     ///
     /// The same invariant as [`Self::teardown`] applies: callers must invoke
     /// this unconditionally and act on the returned outcome; it must never

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -5,7 +5,7 @@ mod runtime;
 pub(crate) mod runtime_base;
 pub mod stats;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::cli::truncate_id;
 use crate::session::{Config, ContainerRuntimeName};
@@ -122,6 +122,25 @@ fn classify_running_probe(result: Result<bool>) -> Probe {
         Ok(false) => Probe::NotRunning,
         Err(e) => Probe::Unknown(e),
     }
+}
+
+/// The named ignore volumes a create is about to mount, or `None` when the config
+/// carries none and the prune must be skipped.
+///
+/// Keeping the skip here, rather than as an empty keep set, is what stops an
+/// ambiguous config from reading as "every volume this session has is stale". See
+/// [`DockerContainer::prune_stale_named_ignore_volumes`].
+fn named_ignore_volumes_to_keep(config: &ContainerConfig) -> Option<HashSet<&str>> {
+    if config.named_ignore_volumes.is_empty() {
+        return None;
+    }
+    Some(
+        config
+            .named_ignore_volumes
+            .iter()
+            .map(|v| v.volume_name.as_str())
+            .collect(),
+    )
 }
 
 pub struct DockerContainer {
@@ -241,6 +260,37 @@ impl DockerContainer {
         }
     }
 
+    /// Drop this session's named ignore volumes that `config` does not mount.
+    ///
+    /// A volume's name encodes its container mount path
+    /// (`aoe-vi-{session_id}-{slug}-{hash}`), so any path change leaves the previous
+    /// volumes with no container that will ever re-attach them. [`Self::discard`]
+    /// deliberately preserves the session's volumes across a container rebuild, which
+    /// keeps the caches that survive the change and strands the rest; this reclaims the
+    /// stranded ones at the next create, when the surviving set is known (#3742).
+    ///
+    /// Must be called before the create, while no container holds the volumes.
+    ///
+    /// A config with no named ignore volumes prunes nothing: the empty set does not
+    /// distinguish "this session has no caches" from a glob that momentarily matched
+    /// nothing or a switch to the anonymous strategy, and the caches are worth more than
+    /// a prompt reclaim on an ambiguous signal.
+    pub fn prune_stale_named_ignore_volumes(&self, session_id: &str, config: &ContainerConfig) {
+        let Some(keep) = named_ignore_volumes_to_keep(config) else {
+            return;
+        };
+        let prefix = format!("aoe-vi-{}-", session_id);
+        if let Err(e) = self.runtime.base.prune_named_ignore_volumes(&prefix, &keep) {
+            tracing::warn!(
+                target: "containers.runtime",
+                name = %self.name,
+                %session_id,
+                error = %e,
+                "failed to prune stale named ignore volumes"
+            );
+        }
+    }
+
     /// Force-remove this container, then sweep its named ignore volumes.
     ///
     /// Idempotent: a container that is already gone yields
@@ -262,9 +312,11 @@ impl DockerContainer {
     /// Idempotent counterpart to [`Self::teardown`]: same removal and
     /// classification, but the session-scoped named ignore volumes
     /// (`aoe-vi-{session_id}-*`, e.g. `target/`, `node_modules/`) are left
-    /// intact so the recreated container re-attaches them on next start.
-    /// Used on the worktree-move discard path where the container is dropped
-    /// to pick up a new bind mount and will be recreated immediately.
+    /// intact so the recreated container re-attaches the ones whose container
+    /// path is unchanged. Used on the worktree-move discard path where the
+    /// container is dropped to pick up a new bind mount and will be recreated
+    /// immediately. The volumes the new paths strand are reclaimed by
+    /// [`Self::prune_stale_named_ignore_volumes`] at that create.
     ///
     /// The same invariant as [`Self::teardown`] applies: callers must invoke
     /// this unconditionally and act on the returned outcome; it must never
@@ -336,6 +388,37 @@ impl DockerContainer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn keep_set_is_the_configs_volume_names() {
+        let config = ContainerConfig {
+            named_ignore_volumes: vec![
+                NamedVolumeMount {
+                    volume_name: "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0".to_string(),
+                    container_path: "/workspace/otari/target".to_string(),
+                },
+                NamedVolumeMount {
+                    volume_name: "aoe-vi-sess1-workspace-otari-worktrees-912-target-873cf2685e47"
+                        .to_string(),
+                    container_path: "/workspace/otari/worktrees/912/target".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let keep = named_ignore_volumes_to_keep(&config).expect("a non-empty config prunes");
+        assert_eq!(keep.len(), 2);
+        assert!(keep.contains("aoe-vi-sess1-workspace-otari-target-8ec07926d6b0"));
+        assert!(keep.contains("aoe-vi-sess1-workspace-otari-worktrees-912-target-873cf2685e47"));
+    }
+
+    #[test]
+    fn no_named_ignore_volumes_skips_the_prune() {
+        // An empty set does not distinguish "no caches" from a glob that matched
+        // nothing or a switch to the anonymous strategy, so it must not be read as
+        // "every volume this session has is stale".
+        assert!(named_ignore_volumes_to_keep(&ContainerConfig::default()).is_none());
+    }
 
     #[test]
     fn classify_ok_is_removed() {

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -124,40 +124,6 @@ fn classify_running_probe(result: Result<bool>) -> Probe {
     }
 }
 
-/// The named ignore volumes a create is about to mount, or `None` when the prune
-/// must be skipped.
-///
-/// A volume is stranded when the mounts moved out from under it, so the prune needs
-/// evidence of a move, not merely a config that differs from the volumes on disk.
-/// `previous_workdir` is that evidence: the workdir the last container was created
-/// with (`SandboxInfo::container_workdir`, pinned at create for #2414). Equal to this
-/// config's, or absent, and the session's mounts sit where they always did, so a
-/// volume outside the config was dropped by an edited `volume_ignores` or a glob that
-/// matched nothing this time, and deleting it would destroy a live cache.
-///
-/// Two further skips. `named_ignore_volumes_authoritative` is false when the mount
-/// resolve was degraded, where the paths (workdir included) are provisional, so the
-/// "move" may be nothing but a `find_main_repo` failure. An empty set does not
-/// distinguish "this session has no caches" from a switch to the anonymous strategy.
-fn named_ignore_volumes_to_keep<'a>(
-    config: &'a ContainerConfig,
-    previous_workdir: Option<&str>,
-) -> Option<HashSet<&'a str>> {
-    if !config.named_ignore_volumes_authoritative || config.named_ignore_volumes.is_empty() {
-        return None;
-    }
-    if previous_workdir.is_none_or(|previous| previous == config.working_dir) {
-        return None;
-    }
-    Some(
-        config
-            .named_ignore_volumes
-            .iter()
-            .map(|v| v.volume_name.as_str())
-            .collect(),
-    )
-}
-
 pub struct DockerContainer {
     pub name: String,
     pub image: String,
@@ -275,36 +241,34 @@ impl DockerContainer {
         }
     }
 
-    /// Drop this session's named ignore volumes that `config` does not mount.
+    /// Remove the named ignore volumes a worktree move stranded.
     ///
-    /// A volume's name encodes its container mount path
-    /// (`aoe-vi-{session_id}-{slug}-{hash}`), so any path change leaves the previous
-    /// volumes with no container that will ever re-attach them. [`Self::discard`]
-    /// deliberately preserves the session's volumes across a container rebuild, which
-    /// keeps the caches that survive the change and strands the rest; this reclaims the
-    /// stranded ones at the next create, when the surviving set is known (#3742).
+    /// [`Self::discard`] deliberately preserves a session's volumes across the container
+    /// rebuild a move forces, which keeps the caches whose container path survives the
+    /// move and strands the rest, since a volume's name encodes that path. This reclaims
+    /// the stranded ones at the next create (#3742).
     ///
+    /// `names` is an allowlist and the caller owns the decision of what belongs in it;
+    /// see
+    /// [`stranded_named_ignore_volumes`](crate::session::config::container_config::stranded_named_ignore_volumes).
     /// Must be called before the create, while no container holds the volumes.
-    ///
-    /// Prunes nothing unless the session's mounts are established to have moved;
-    /// `previous_workdir` is that evidence, see [`named_ignore_volumes_to_keep`].
-    pub fn prune_stale_named_ignore_volumes(
-        &self,
-        session_id: &str,
-        config: &ContainerConfig,
-        previous_workdir: Option<&str>,
-    ) {
-        let Some(keep) = named_ignore_volumes_to_keep(config, previous_workdir) else {
+    pub fn remove_stale_named_ignore_volumes(&self, session_id: &str, names: &[String]) {
+        if names.is_empty() {
             return;
-        };
+        }
+        let names: HashSet<&str> = names.iter().map(String::as_str).collect();
         let prefix = format!("aoe-vi-{}-", session_id);
-        if let Err(e) = self.runtime.base.prune_named_ignore_volumes(&prefix, &keep) {
+        if let Err(e) = self
+            .runtime
+            .base
+            .remove_named_ignore_volumes_in(&prefix, &names)
+        {
             tracing::warn!(
                 target: "containers.runtime",
                 name = %self.name,
                 %session_id,
                 error = %e,
-                "failed to prune stale named ignore volumes"
+                "failed to remove stale named ignore volumes"
             );
         }
     }
@@ -334,7 +298,7 @@ impl DockerContainer {
     /// path is unchanged. Used on the worktree-move discard path where the
     /// container is dropped to pick up a new bind mount and will be recreated
     /// immediately. The volumes the new paths strand are reclaimed by
-    /// [`Self::prune_stale_named_ignore_volumes`] at that create.
+    /// [`Self::remove_stale_named_ignore_volumes`] at that create.
     ///
     /// The same invariant as [`Self::teardown`] applies: callers must invoke
     /// this unconditionally and act on the returned outcome; it must never
@@ -406,89 +370,6 @@ impl DockerContainer {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A config that mounts these two, for a session whose worktree moved from
-    /// otari-worktrees/905 to otari-worktrees/rev-912 (#3742).
-    fn moved_config() -> ContainerConfig {
-        ContainerConfig {
-            working_dir: "/workspace/otari-worktrees/rev-912".to_string(),
-            named_ignore_volumes: vec![
-                NamedVolumeMount {
-                    volume_name: "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0".to_string(),
-                    container_path: "/workspace/otari/target".to_string(),
-                },
-                NamedVolumeMount {
-                    volume_name:
-                        "aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47"
-                            .to_string(),
-                    container_path: "/workspace/otari-worktrees/rev-912/target".to_string(),
-                },
-            ],
-            named_ignore_volumes_authoritative: true,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn a_moved_workdir_keeps_exactly_what_the_new_container_mounts() {
-        let config = moved_config();
-        let keep = named_ignore_volumes_to_keep(&config, Some("/workspace/otari-worktrees/905"))
-            .expect("a moved workdir is evidence of a strand");
-
-        assert_eq!(keep.len(), 2);
-        assert!(keep.contains("aoe-vi-sess1-workspace-otari-target-8ec07926d6b0"));
-        assert!(keep.contains("aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47"));
-    }
-
-    #[test]
-    fn without_evidence_of_a_move_nothing_is_pruned() {
-        let unmoved = "/workspace/otari-worktrees/rev-912";
-
-        let degraded = ContainerConfig {
-            named_ignore_volumes_authoritative: false,
-            ..moved_config()
-        };
-        let no_volumes = ContainerConfig {
-            named_ignore_volumes: vec![],
-            ..moved_config()
-        };
-
-        for (case, config, previous_workdir) in [
-            (
-                // An edited volume_ignores or a glob that matched nothing this time
-                // drops a volume from the config while the mounts sit where they
-                // always did. The cache is live, not stranded.
-                "the workdir did not move",
-                moved_config(),
-                Some(unmoved),
-            ),
-            (
-                // A session that has never had a container has nothing to reclaim.
-                "no previous workdir",
-                moved_config(),
-                None,
-            ),
-            (
-                // A degraded resolve makes the workdir provisional too, so the
-                // apparent move may be nothing but a find_main_repo failure.
-                "a degraded mount resolve",
-                degraded,
-                Some("/workspace/otari-worktrees/905"),
-            ),
-            (
-                // Does not distinguish "no caches" from a switch to the anonymous
-                // strategy.
-                "an empty volume set",
-                no_volumes,
-                Some("/workspace/otari-worktrees/905"),
-            ),
-        ] {
-            assert!(
-                named_ignore_volumes_to_keep(&config, previous_workdir).is_none(),
-                "{case} must not drive a deletion"
-            );
-        }
-    }
 
     #[test]
     fn classify_ok_is_removed() {

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -124,14 +124,19 @@ fn classify_running_probe(result: Result<bool>) -> Probe {
     }
 }
 
-/// The named ignore volumes a create is about to mount, or `None` when the config
-/// carries none and the prune must be skipped.
+/// The named ignore volumes a create is about to mount, or `None` when the prune
+/// must be skipped because the config does not establish what the session should
+/// have.
 ///
-/// Keeping the skip here, rather than as an empty keep set, is what stops an
-/// ambiguous config from reading as "every volume this session has is stale". See
-/// [`DockerContainer::prune_stale_named_ignore_volumes`].
+/// Two ways it does not. The set can be incomplete, which
+/// [`ContainerConfig::named_ignore_volumes_authoritative`] reports: a mount resolve
+/// that fell back to `/workspace/{basename}` names volumes the session never had, so
+/// every volume it does have reads as stale. The set can also be empty, which does
+/// not distinguish "this session has no caches" from a switch to the anonymous
+/// strategy. Either way the difference between the config and reality is not evidence
+/// of a stranded volume, and a cache is worth more than a prompt reclaim.
 fn named_ignore_volumes_to_keep(config: &ContainerConfig) -> Option<HashSet<&str>> {
-    if config.named_ignore_volumes.is_empty() {
+    if !config.named_ignore_volumes_authoritative || config.named_ignore_volumes.is_empty() {
         return None;
     }
     Some(
@@ -271,10 +276,8 @@ impl DockerContainer {
     ///
     /// Must be called before the create, while no container holds the volumes.
     ///
-    /// A config with no named ignore volumes prunes nothing: the empty set does not
-    /// distinguish "this session has no caches" from a glob that momentarily matched
-    /// nothing or a switch to the anonymous strategy, and the caches are worth more than
-    /// a prompt reclaim on an ambiguous signal.
+    /// Prunes nothing unless the config establishes the whole set the session should
+    /// have; see [`named_ignore_volumes_to_keep`].
     pub fn prune_stale_named_ignore_volumes(&self, session_id: &str, config: &ContainerConfig) {
         let Some(keep) = named_ignore_volumes_to_keep(config) else {
             return;
@@ -398,26 +401,58 @@ mod tests {
                     container_path: "/workspace/otari/target".to_string(),
                 },
                 NamedVolumeMount {
-                    volume_name: "aoe-vi-sess1-workspace-otari-worktrees-912-target-873cf2685e47"
-                        .to_string(),
-                    container_path: "/workspace/otari/worktrees/912/target".to_string(),
+                    volume_name:
+                        "aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47"
+                            .to_string(),
+                    container_path: "/workspace/otari-worktrees/rev-912/target".to_string(),
                 },
             ],
+            named_ignore_volumes_authoritative: true,
             ..Default::default()
         };
 
-        let keep = named_ignore_volumes_to_keep(&config).expect("a non-empty config prunes");
+        let keep = named_ignore_volumes_to_keep(&config).expect("an authoritative config prunes");
         assert_eq!(keep.len(), 2);
         assert!(keep.contains("aoe-vi-sess1-workspace-otari-target-8ec07926d6b0"));
-        assert!(keep.contains("aoe-vi-sess1-workspace-otari-worktrees-912-target-873cf2685e47"));
+        assert!(keep.contains("aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47"));
     }
 
     #[test]
-    fn no_named_ignore_volumes_skips_the_prune() {
-        // An empty set does not distinguish "no caches" from a glob that matched
-        // nothing or a switch to the anonymous strategy, so it must not be read as
-        // "every volume this session has is stale".
-        assert!(named_ignore_volumes_to_keep(&ContainerConfig::default()).is_none());
+    fn an_unestablished_volume_set_skips_the_prune() {
+        let volumes = || {
+            vec![NamedVolumeMount {
+                volume_name: "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0".to_string(),
+                container_path: "/workspace/otari/target".to_string(),
+            }]
+        };
+
+        for (case, config) in [
+            (
+                // A degraded mount resolve names volumes the session never had, so
+                // every volume it does have would read as stale.
+                "not authoritative",
+                ContainerConfig {
+                    named_ignore_volumes: volumes(),
+                    named_ignore_volumes_authoritative: false,
+                    ..Default::default()
+                },
+            ),
+            (
+                // Does not distinguish "no caches" from a switch to the anonymous
+                // strategy.
+                "empty",
+                ContainerConfig {
+                    named_ignore_volumes_authoritative: true,
+                    ..Default::default()
+                },
+            ),
+            ("empty and not authoritative", ContainerConfig::default()),
+        ] {
+            assert!(
+                named_ignore_volumes_to_keep(&config).is_none(),
+                "{case} must not drive a deletion"
+            );
+        }
     }
 
     #[test]

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -252,7 +252,7 @@ impl DockerContainer {
     /// attribute it to. Runtimes without named volumes never reach that log, since
     /// `named_ignore_volumes` stays populated there while the mounts render as
     /// anonymous, so there is nothing to delete.
-    pub fn remove_stale_named_ignore_volumes(&self, session_id: &str, names: &[String]) {
+    pub fn remove_stranded_named_ignore_volumes(&self, session_id: &str, names: &[String]) {
         if names.is_empty() || !self.runtime.base.supports_named_volumes {
             return;
         }
@@ -274,7 +274,7 @@ impl DockerContainer {
                 name = %self.name,
                 %session_id,
                 error = %e,
-                "failed to remove stale named ignore volumes"
+                "failed to remove stranded named ignore volumes"
             );
         }
     }
@@ -303,7 +303,7 @@ impl DockerContainer {
     /// intact so the recreated container re-attaches the ones whose container
     /// path is unchanged. Used on the worktree-move discard path where the
     /// container is dropped to pick up a new bind mount and will be recreated
-    /// immediately; [`Self::remove_stale_named_ignore_volumes`] reclaims the rest
+    /// immediately; [`Self::remove_stranded_named_ignore_volumes`] reclaims the rest
     /// at that create.
     ///
     /// The same invariant as [`Self::teardown`] applies: callers must invoke

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -249,9 +249,11 @@ impl DockerContainer {
     ///
     /// Logs at `info`: this is an irreversible delete of a build cache, and a wrong one
     /// would otherwise reach the user as an unexplained cold rebuild with nothing to
-    /// attribute it to.
+    /// attribute it to. Runtimes without named volumes never reach that log, since
+    /// `named_ignore_volumes` stays populated there while the mounts render as
+    /// anonymous, so there is nothing to delete.
     pub fn remove_stale_named_ignore_volumes(&self, session_id: &str, names: &[String]) {
-        if names.is_empty() {
+        if names.is_empty() || !self.runtime.base.supports_named_volumes {
             return;
         }
         tracing::info!(

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -1,5 +1,6 @@
 use super::container_interface::{docker_env_args, ContainerConfig};
 use super::error::{sanitize_stderr, DockerError, Result};
+use std::collections::HashSet;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -660,6 +661,17 @@ impl RuntimeBase {
     ///
     /// This is a no-op on runtimes that don't support named volumes (e.g. Apple Container).
     pub fn remove_named_ignore_volumes(&self, prefix: &str) -> Result<()> {
+        self.prune_named_ignore_volumes(prefix, &HashSet::new())
+    }
+
+    /// Remove the named ignore volumes under `prefix` that are not in `keep`.
+    ///
+    /// The reconcile counterpart to [`Self::remove_named_ignore_volumes`]: a volume name
+    /// encodes its container mount path, so any path change (a worktree move, an edited
+    /// `volume_ignores`) leaves the session's previous volumes with no container that will
+    /// ever mount them again. Called with the set the next container is created with, so
+    /// those orphans are reclaimed while the still-mounted ones survive.
+    pub fn prune_named_ignore_volumes(&self, prefix: &str, keep: &HashSet<&str>) -> Result<()> {
         if !self.supports_named_volumes {
             return Ok(());
         }
@@ -682,12 +694,7 @@ impl RuntimeBase {
         }
 
         let stdout = String::from_utf8_lossy(&list_output.stdout);
-        // Filter in Rust to exact prefix match (docker's --filter is substring-based).
-        let names: Vec<&str> = stdout
-            .lines()
-            .map(str::trim)
-            .filter(|n| !n.is_empty() && n.starts_with(prefix))
-            .collect();
+        let names = stale_named_ignore_volumes(&stdout, prefix, keep);
 
         if names.is_empty() {
             return Ok(());
@@ -745,6 +752,22 @@ impl RuntimeBase {
         command.args(&args);
         self.probe_output_with_timeout(&mut command, RUNTIME_EXEC_TIMEOUT)
     }
+}
+
+/// Pick the volumes to remove out of a `volume ls -q` listing.
+///
+/// Re-filters on the prefix in Rust because docker's `--filter name=` is a substring
+/// match, so `aoe-vi-sess1-` also lists `aoe-vi-sess10-...`.
+fn stale_named_ignore_volumes<'a>(
+    listing: &'a str,
+    prefix: &str,
+    keep: &HashSet<&str>,
+) -> Vec<&'a str> {
+    listing
+        .lines()
+        .map(str::trim)
+        .filter(|n| !n.is_empty() && n.starts_with(prefix) && !keep.contains(n))
+        .collect()
 }
 
 #[cfg(test)]
@@ -1504,6 +1527,48 @@ mod tests {
         assert_eq!(p_indices.len(), 2);
         assert_eq!(args[p_indices[0] + 1], "3000:3000");
         assert_eq!(args[p_indices[1] + 1], "5432:5432");
+    }
+
+    #[test]
+    fn stale_named_ignore_volumes_selects_the_ones_the_next_create_strands() {
+        // A worktree move from worktrees/905 to worktrees/rev-912 keeps the main
+        // repo's volume (its container path is unchanged) and strands the
+        // worktree's, whose name encodes the old path (#3742).
+        let listing = "\
+aoe-vi-sess1-workspace-otari-target-8ec07926d6b0
+aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290
+aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47
+";
+        let keep = HashSet::from([
+            "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0",
+            "aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47",
+        ]);
+
+        assert_eq!(
+            stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &keep),
+            vec!["aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290"]
+        );
+    }
+
+    #[test]
+    fn stale_named_ignore_volumes_with_an_empty_keep_set_takes_everything() {
+        // The session-deletion sweep, expressed as a prune that keeps nothing.
+        let listing = "aoe-vi-sess1-a-1\naoe-vi-sess1-b-2\n";
+        assert_eq!(
+            stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &HashSet::new()),
+            vec!["aoe-vi-sess1-a-1", "aoe-vi-sess1-b-2"]
+        );
+    }
+
+    #[test]
+    fn stale_named_ignore_volumes_ignores_another_sessions_volumes() {
+        // docker's `--filter name=` is a substring match, so the listing can carry
+        // a longer session id that must not be pruned under this one's prefix.
+        let listing = "aoe-vi-sess1-a-1\naoe-vi-sess10-a-1\n\n";
+        assert_eq!(
+            stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &HashSet::new()),
+            vec!["aoe-vi-sess1-a-1"]
+        );
     }
 
     #[test]

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -666,11 +666,10 @@ impl RuntimeBase {
 
     /// Remove the named ignore volumes under `prefix` that are not in `keep`.
     ///
-    /// The reconcile counterpart to [`Self::remove_named_ignore_volumes`]: a volume name
-    /// encodes its container mount path, so any path change (a worktree move, an edited
-    /// `volume_ignores`) leaves the session's previous volumes with no container that will
-    /// ever mount them again. Called with the set the next container is created with, so
-    /// those orphans are reclaimed while the still-mounted ones survive.
+    /// The reconcile counterpart to [`Self::remove_named_ignore_volumes`], called with the
+    /// set the next container is created with. See
+    /// [`DockerContainer::prune_stale_named_ignore_volumes`](crate::containers::DockerContainer::prune_stale_named_ignore_volumes)
+    /// for what strands a volume and when reclaiming one is safe.
     pub fn prune_named_ignore_volumes(&self, prefix: &str, keep: &HashSet<&str>) -> Result<()> {
         if !self.supports_named_volumes {
             return Ok(());
@@ -1530,45 +1529,50 @@ mod tests {
     }
 
     #[test]
-    fn stale_named_ignore_volumes_selects_the_ones_the_next_create_strands() {
-        // A worktree move from worktrees/905 to worktrees/rev-912 keeps the main
-        // repo's volume (its container path is unchanged) and strands the
-        // worktree's, whose name encodes the old path (#3742).
-        let listing = "\
-aoe-vi-sess1-workspace-otari-target-8ec07926d6b0
-aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290
-aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47
-";
-        let keep = HashSet::from([
-            "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0",
-            "aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47",
-        ]);
+    fn stale_named_ignore_volumes_selects_only_this_sessions_unkept_volumes() {
+        // The reporter's own listing (#3742): a sibling-worktree layout whose
+        // session moved from otari-worktrees/905 to otari-worktrees/rev-912.
+        const MAIN: &str = "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0";
+        const PRE_MOVE: &str = "aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290";
+        const POST_MOVE: &str =
+            "aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47";
 
-        assert_eq!(
-            stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &keep),
-            vec!["aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290"]
-        );
-    }
+        let moved = format!("{MAIN}\n{PRE_MOVE}\n{POST_MOVE}\n");
+        let both = format!("{MAIN}\n{PRE_MOVE}\n");
 
-    #[test]
-    fn stale_named_ignore_volumes_with_an_empty_keep_set_takes_everything() {
-        // The session-deletion sweep, expressed as a prune that keeps nothing.
-        let listing = "aoe-vi-sess1-a-1\naoe-vi-sess1-b-2\n";
-        assert_eq!(
-            stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &HashSet::new()),
-            vec!["aoe-vi-sess1-a-1", "aoe-vi-sess1-b-2"]
-        );
-    }
+        let cases: [(&str, &str, HashSet<&str>, Vec<&str>); 3] = [
+            (
+                // The move leaves the main repo's mount path alone, so only the
+                // worktree's volume is stranded.
+                "a worktree move",
+                &moved,
+                HashSet::from([MAIN, POST_MOVE]),
+                vec![PRE_MOVE],
+            ),
+            (
+                // The session-deletion sweep, expressed as a prune that keeps nothing.
+                "an empty keep set",
+                &both,
+                HashSet::new(),
+                vec![MAIN, PRE_MOVE],
+            ),
+            (
+                // docker's `--filter name=` is a substring match, so the listing can
+                // carry a longer session id that this prefix must not claim.
+                "a longer session id in the listing",
+                "aoe-vi-sess1-a-1\naoe-vi-sess10-a-1\n\n",
+                HashSet::new(),
+                vec!["aoe-vi-sess1-a-1"],
+            ),
+        ];
 
-    #[test]
-    fn stale_named_ignore_volumes_ignores_another_sessions_volumes() {
-        // docker's `--filter name=` is a substring match, so the listing can carry
-        // a longer session id that must not be pruned under this one's prefix.
-        let listing = "aoe-vi-sess1-a-1\naoe-vi-sess10-a-1\n\n";
-        assert_eq!(
-            stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &HashSet::new()),
-            vec!["aoe-vi-sess1-a-1"]
-        );
+        for (case, listing, keep, expected) in cases {
+            assert_eq!(
+                stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &keep),
+                expected,
+                "{case}"
+            );
+        }
     }
 
     #[test]

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -669,7 +669,7 @@ impl RuntimeBase {
     /// The targeted counterpart to [`Self::remove_named_ignore_volumes`], for reclaiming
     /// the volumes a worktree move stranded. `names` is an allowlist, so a volume the
     /// caller did not name is never touched; see
-    /// [`DockerContainer::remove_stale_named_ignore_volumes`](crate::containers::DockerContainer::remove_stale_named_ignore_volumes).
+    /// [`DockerContainer::remove_stranded_named_ignore_volumes`](crate::containers::DockerContainer::remove_stranded_named_ignore_volumes).
     pub fn remove_named_ignore_volumes_in(
         &self,
         prefix: &str,

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -1544,6 +1544,10 @@ mod tests {
     fn selected_named_ignore_volumes_never_reaches_outside_the_prefix() {
         // The reporter's own listing (#3742): a sibling-worktree layout whose
         // session moved from otari-worktrees/905 to otari-worktrees/rev-912.
+        // The hash suffixes are real `named_volume_for` output, kept literal on
+        // purpose: `DefaultHasher` is not stable across Rust releases, and a bump
+        // that changed it would orphan every existing named volume, so these
+        // constants are the canary for that.
         const MAIN: &str = "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0";
         const PRE_MOVE: &str = "aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290";
         const POST_MOVE: &str =

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -661,16 +661,28 @@ impl RuntimeBase {
     ///
     /// This is a no-op on runtimes that don't support named volumes (e.g. Apple Container).
     pub fn remove_named_ignore_volumes(&self, prefix: &str) -> Result<()> {
-        self.prune_named_ignore_volumes(prefix, &HashSet::new())
+        self.remove_named_ignore_volumes_where(prefix, |_| true)
     }
 
-    /// Remove the named ignore volumes under `prefix` that are not in `keep`.
+    /// Remove the named ignore volumes under `prefix` that are in `names`.
     ///
-    /// The reconcile counterpart to [`Self::remove_named_ignore_volumes`], called with the
-    /// set the next container is created with. See
-    /// [`DockerContainer::prune_stale_named_ignore_volumes`](crate::containers::DockerContainer::prune_stale_named_ignore_volumes)
-    /// for what strands a volume and when reclaiming one is safe.
-    pub fn prune_named_ignore_volumes(&self, prefix: &str, keep: &HashSet<&str>) -> Result<()> {
+    /// The targeted counterpart to [`Self::remove_named_ignore_volumes`], for reclaiming
+    /// the volumes a worktree move stranded. `names` is an allowlist, so a volume the
+    /// caller did not name is never touched; see
+    /// [`DockerContainer::remove_stale_named_ignore_volumes`](crate::containers::DockerContainer::remove_stale_named_ignore_volumes).
+    pub fn remove_named_ignore_volumes_in(
+        &self,
+        prefix: &str,
+        names: &HashSet<&str>,
+    ) -> Result<()> {
+        self.remove_named_ignore_volumes_where(prefix, |name| names.contains(name))
+    }
+
+    fn remove_named_ignore_volumes_where(
+        &self,
+        prefix: &str,
+        select: impl Fn(&str) -> bool,
+    ) -> Result<()> {
         if !self.supports_named_volumes {
             return Ok(());
         }
@@ -693,7 +705,7 @@ impl RuntimeBase {
         }
 
         let stdout = String::from_utf8_lossy(&list_output.stdout);
-        let names = stale_named_ignore_volumes(&stdout, prefix, keep);
+        let names = selected_named_ignore_volumes(&stdout, prefix, select);
 
         if names.is_empty() {
             return Ok(());
@@ -757,15 +769,15 @@ impl RuntimeBase {
 ///
 /// Re-filters on the prefix in Rust because docker's `--filter name=` is a substring
 /// match, so `aoe-vi-sess1-` also lists `aoe-vi-sess10-...`.
-fn stale_named_ignore_volumes<'a>(
+fn selected_named_ignore_volumes<'a>(
     listing: &'a str,
     prefix: &str,
-    keep: &HashSet<&str>,
+    select: impl Fn(&str) -> bool,
 ) -> Vec<&'a str> {
     listing
         .lines()
         .map(str::trim)
-        .filter(|n| !n.is_empty() && n.starts_with(prefix) && !keep.contains(n))
+        .filter(|n| !n.is_empty() && n.starts_with(prefix) && select(n))
         .collect()
 }
 
@@ -1529,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_named_ignore_volumes_selects_only_this_sessions_unkept_volumes() {
+    fn selected_named_ignore_volumes_never_reaches_outside_the_prefix() {
         // The reporter's own listing (#3742): a sibling-worktree layout whose
         // session moved from otari-worktrees/905 to otari-worktrees/rev-912.
         const MAIN: &str = "aoe-vi-sess1-workspace-otari-target-8ec07926d6b0";
@@ -1538,40 +1550,40 @@ mod tests {
             "aoe-vi-sess1-workspace-otari-worktrees-rev-912-target-873cf2685e47";
 
         let moved = format!("{MAIN}\n{PRE_MOVE}\n{POST_MOVE}\n");
-        let both = format!("{MAIN}\n{PRE_MOVE}\n");
+        // docker's `--filter name=` is a substring match, so a listing under
+        // `aoe-vi-sess1-` can carry a longer session id this prefix must not claim.
+        let other_session =
+            format!("{PRE_MOVE}\naoe-vi-sess10-workspace-a-target-1f93a3fc1487\n\n");
 
-        let cases: [(&str, &str, HashSet<&str>, Vec<&str>); 3] = [
+        // `None` selects everything, the shape the session-deletion sweep uses.
+        let cases = [
             (
-                // The move leaves the main repo's mount path alone, so only the
-                // worktree's volume is stranded.
-                "a worktree move",
-                &moved,
-                HashSet::from([MAIN, POST_MOVE]),
+                // The reclaim: only the name the caller computed for the moved path,
+                // never the main repo's volume or the one the new container mounts.
+                "an allowlist of one stranded name",
+                moved.as_str(),
+                Some(HashSet::from([PRE_MOVE])),
                 vec![PRE_MOVE],
             ),
             (
-                // The session-deletion sweep, expressed as a prune that keeps nothing.
-                "an empty keep set",
-                &both,
-                HashSet::new(),
-                vec![MAIN, PRE_MOVE],
+                "the deletion sweep",
+                moved.as_str(),
+                None::<HashSet<&str>>,
+                vec![MAIN, PRE_MOVE, POST_MOVE],
             ),
             (
-                // docker's `--filter name=` is a substring match, so the listing can
-                // carry a longer session id that this prefix must not claim.
                 "a longer session id in the listing",
-                "aoe-vi-sess1-a-1\naoe-vi-sess10-a-1\n\n",
-                HashSet::new(),
-                vec!["aoe-vi-sess1-a-1"],
+                other_session.as_str(),
+                None,
+                vec![PRE_MOVE],
             ),
         ];
 
-        for (case, listing, keep, expected) in cases {
-            assert_eq!(
-                stale_named_ignore_volumes(listing, "aoe-vi-sess1-", &keep),
-                expected,
-                "{case}"
-            );
+        for (case, listing, allowed, expected) in cases {
+            let selected = selected_named_ignore_volumes(listing, "aoe-vi-sess1-", |name| {
+                allowed.as_ref().is_none_or(|names| names.contains(name))
+            });
+            assert_eq!(selected, expected, "{case}");
         }
     }
 

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -1553,7 +1553,7 @@ mod tests {
         // docker's `--filter name=` is a substring match, so a listing under
         // `aoe-vi-sess1-` can carry a longer session id this prefix must not claim.
         let other_session =
-            format!("{PRE_MOVE}\naoe-vi-sess10-workspace-a-target-1f93a3fc1487\n\n");
+            format!("{PRE_MOVE}\naoe-vi-sess10-workspace-a-target-c8c9b4754ab1\n\n");
 
         // `None` selects everything, the shape the session-deletion sweep uses.
         let cases = [

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1658,6 +1658,17 @@ fn glob_roots(project_volumes: &[VolumeMount]) -> Vec<(String, String)> {
         .collect()
 }
 
+/// True when `project_path` presents as a git worktree whose linkage is broken.
+///
+/// [`compute_volume_paths`] resolves a worktree's mounts through
+/// `find_main_repo`; when that fails it falls through to `/workspace/{basename}`,
+/// a path the session's container never mounted (#2414). Every container path
+/// derived in that state is provisional, so a caller about to act destructively
+/// on the difference between the derived set and reality must not.
+fn worktree_linkage_broken(project_path: &Path) -> bool {
+    project_path.join(".git").exists() && GitWorktree::find_main_repo(project_path).is_err()
+}
+
 /// Produce a deterministic Docker volume name for a named volume_ignores mount.
 ///
 /// Uses the full session ID as a prefix so volumes can be enumerated on deletion.
@@ -2199,9 +2210,12 @@ pub(crate) fn build_container_config(
     // expanded against the host filesystem now (#2045): a point-in-time snapshot,
     // since Docker needs concrete mount paths when the container starts.
     let mut resolved_ignore_paths: Vec<String> = Vec::new();
+    let mut glob_matched_nothing = false;
     for ignore in &sandbox_config.volume_ignores {
         if has_glob_metachars(ignore) {
-            resolved_ignore_paths.extend(expand_glob_ignore(ignore, &glob_roots));
+            let matches = expand_glob_ignore(ignore, &glob_roots);
+            glob_matched_nothing |= matches.is_empty();
+            resolved_ignore_paths.extend(matches);
         } else {
             for base_path in &volume_ignore_bases {
                 resolved_ignore_paths.push(format!("{}/{}", base_path, ignore));
@@ -2225,6 +2239,12 @@ pub(crate) fn build_container_config(
             })
         })
         .collect();
+
+    // A degraded mount resolve or a glob that matched nothing both leave the
+    // resolved set a floor rather than the whole truth, which is the difference
+    // between reclaiming a stranded volume and destroying a live cache.
+    let named_ignore_volumes_authoritative = !glob_matched_nothing
+        && !(workspace_info.is_none() && worktree_linkage_broken(project_path));
 
     // Route by strategy: anonymous volumes are the default; named volumes fix VirtioFS on macOS.
     let (anonymous_volumes, named_ignore_volumes): (Vec<String>, Vec<NamedVolumeMount>) =
@@ -2279,6 +2299,7 @@ pub(crate) fn build_container_config(
         volumes: deduped,
         anonymous_volumes,
         named_ignore_volumes,
+        named_ignore_volumes_authoritative,
         environment,
         cpu_limit: sandbox_config.cpu_limit,
         memory_limit: sandbox_config.memory_limit,
@@ -2582,6 +2603,33 @@ mod tests {
         );
         // Container path and working dir should be the same
         assert_eq!(volumes[0].container_path, working_dir);
+    }
+
+    #[test]
+    fn worktree_linkage_broken_flags_only_the_degraded_resolve() {
+        let dir = TempDir::new().unwrap();
+
+        // An orphaned worktree: a `.git` file whose gitdir points nowhere, the
+        // state a pruned admin entry leaves behind. compute_volume_paths collapses
+        // to /workspace/{basename} here (#2414), so the paths it derives are
+        // provisional and must not drive a deletion.
+        let orphaned = dir.path().join("myrepo-worktrees").join("contexec");
+        std::fs::create_dir_all(&orphaned).unwrap();
+        std::fs::write(
+            orphaned.join(".git"),
+            "gitdir: ../../does-not-exist/.git/worktrees/contexec\n",
+        )
+        .unwrap();
+        assert!(worktree_linkage_broken(&orphaned));
+
+        // A plain directory has no linkage to break, and neither does a healthy
+        // repo; both resolve to /workspace/{basename} legitimately.
+        let plain = dir.path().join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        assert!(!worktree_linkage_broken(&plain));
+
+        let (_repo_dir, repo_path) = setup_regular_repo();
+        assert!(!worktree_linkage_broken(&repo_path));
     }
 
     #[test]
@@ -4192,6 +4240,71 @@ volume_ignores = ["**/bin", "**/obj", "target"]
                 .any(|p| p.contains('*') || p.contains('?')),
             "no glob metachar may reach a mount path, got: {:?}",
             config.anonymous_volumes
+        );
+    }
+
+    /// The named-volume reclaim (#3742) only runs against a resolve that establishes
+    /// the whole set. A literal entry always mounts, so it alone keeps the set
+    /// non-empty while a glob silently contributes nothing.
+    #[test]
+    #[serial_test::serial]
+    fn named_ignore_volumes_are_authoritative_only_when_every_glob_matched() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let build = |glob_dir_exists: bool| {
+            let project_dir = TempDir::new().unwrap();
+            if glob_dir_exists {
+                fs::create_dir_all(project_dir.path().join("src/App/bin")).unwrap();
+            }
+            let config_dir = project_dir.path().join(".agent-of-empires");
+            fs::create_dir_all(&config_dir).unwrap();
+            fs::write(
+                config_dir.join("config.toml"),
+                r#"
+[sandbox]
+volume_ignores = ["target", "**/bin"]
+volume_ignores_strategy = "named"
+"#,
+            )
+            .unwrap();
+            git2::Repository::init(project_dir.path()).unwrap();
+
+            let sandbox_info = crate::session::instance::SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "test:latest".to_string(),
+                container_name: "test-container".to_string(),
+                extra_env: None,
+                custom_instruction: None,
+                before_start_env: Vec::new(),
+                container_workdir: None,
+            };
+            build_container_config(
+                project_dir.path().to_str().unwrap(),
+                &sandbox_info,
+                ContainerAgentSelection::new("claude", None),
+                false,
+                "test-instance-id",
+                None,
+                "",
+            )
+            .unwrap()
+        };
+
+        let matched = build(true);
+        assert!(matched.named_ignore_volumes_authoritative);
+
+        let unmatched = build(false);
+        assert!(
+            !unmatched.named_ignore_volumes.is_empty(),
+            "the literal entry must still mount, so the empty-set guard cannot be what saves this case"
+        );
+        assert!(
+            !unmatched.named_ignore_volumes_authoritative,
+            "a glob that matched nothing leaves the set a floor, so it must not drive a deletion"
         );
     }
 

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1062,18 +1062,17 @@ pub(crate) fn install_pi_sandbox_extension_at(root: &Path) -> Result<()> {
 }
 /// Which branch [`compute_volume_paths_with_resolve`] resolved the mounts through.
 ///
-/// Reported rather than re-derived, because a caller about to act destructively on
-/// the difference between the derived paths and reality needs the state of the
-/// resolve that produced *those* paths, not a fresh look taken afterwards.
+/// Reported rather than re-derived, so a caller acting on the difference between the
+/// derived paths and reality reads the resolve that produced *those* paths.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MountResolve {
-    /// The mounts follow from the project's git layout, or from a path that has no
-    /// git linkage to resolve.
+    /// The mounts follow from the project's git layout.
     Resolved,
-    /// `find_main_repo` failed for a path that presents as a worktree, so the mounts
-    /// collapsed to `/workspace/{basename}` (#2414). Every path derived here is
-    /// provisional: it names a location the session's container never mounted.
-    Degraded,
+    /// The mounts fell through to `/workspace/{basename}`, which is where a worktree
+    /// lands when its linkage is broken (#2414) and its container never mounted those
+    /// paths. Also where a plain directory and a repo root legitimately land, but their
+    /// workdir never moves, so nothing keys a decision on the difference.
+    Fallthrough,
 }
 
 pub(crate) fn compute_volume_paths(
@@ -1090,7 +1089,6 @@ pub(crate) fn compute_volume_paths_with_resolve(
     project_path: &Path,
     project_path_str: &str,
 ) -> Result<(Vec<VolumeMount>, String, MountResolve)> {
-    let mut resolve = MountResolve::Resolved;
     // Only look for a main repo if the project path itself has a .git entry (file or
     // directory). This prevents git2::Repository::discover from walking up the directory
     // tree and finding an unrelated ancestor repo (e.g., a dotfile-managed home directory),
@@ -1101,7 +1099,7 @@ pub(crate) fn compute_volume_paths_with_resolve(
     // gitdir pointer. Both cases are covered by this check.
     if project_path.join(".git").exists() {
         match GitWorktree::find_main_repo(project_path) {
-            Err(_) => resolve = MountResolve::Degraded,
+            Err(_) => {}
             Ok(main_repo) => {
                 // Canonicalize paths for reliable comparison (handles symlinks like /tmp -> /private/tmp)
                 let main_repo_canonical = main_repo
@@ -1195,7 +1193,7 @@ pub(crate) fn compute_volume_paths_with_resolve(
             read_only: false,
         }],
         workspace_path,
-        resolve,
+        MountResolve::Fallthrough,
     ))
 }
 
@@ -1720,22 +1718,18 @@ fn named_volume_for(session_id: &str, container_path: &str) -> String {
 }
 
 /// The volume names a move stranded: the names the paths under `config.working_dir`
-/// carried back when the container was created at `previous_workdir`.
+/// carried when the container was created at `previous_workdir` (#3742).
 ///
-/// Deliberately scoped to the mounts that provably moved. A session's other mounts
-/// keep their container paths across a worktree move (the main repo, in a
-/// sibling-worktree layout), so their volumes are never named here even when this
-/// run's config fails to resolve them, which is what a glob whose directory is
-/// absent from the host looks like. Naming only what moved is what separates a
-/// stranded volume from a live cache; "everything this config does not mount" does
-/// not (#3742).
+/// Scoped to the mounts that provably moved. A mount whose container path survives the
+/// move keeps its volume even when this run's config fails to resolve it, which is what
+/// a glob whose directory is absent from the host looks like.
 ///
 /// Empty unless the mounts are established to have moved. `previous_workdir` is that
-/// evidence, pinned at create on `SandboxInfo::container_workdir` for #2414: absent
-/// (a session that never had a container, or an attach that cleared the pin) or equal
-/// to this config's, and nothing moved. A degraded resolve withholds it too, since
-/// there the workdir is provisional and the apparent move may be nothing but a
-/// `find_main_repo` failure.
+/// evidence, pinned on `SandboxInfo::container_workdir` at create for #2414: absent (a
+/// session that never had a container, or an attach, which clears the pin) or equal to
+/// this config's, and nothing moved. A resolve that fell through to the collapsed
+/// `/workspace/{basename}` withholds it too, since there the workdir is provisional and
+/// the apparent move may be nothing but that fallthrough.
 pub(crate) fn stranded_named_ignore_volumes(
     config: &ContainerConfig,
     instance_id: &str,
@@ -1747,12 +1741,20 @@ pub(crate) fn stranded_named_ignore_volumes(
     if !config.named_ignore_volumes_authoritative || previous == config.working_dir {
         return Vec::new();
     }
+    // A remapped name that the create is about to mount is a live cache, not a strand:
+    // the previous workdir can be the mount root of a mount that survived.
+    let live: std::collections::HashSet<&str> = config
+        .named_ignore_volumes
+        .iter()
+        .map(|volume| volume.volume_name.as_str())
+        .collect();
     let moved = format!("{}/", config.working_dir);
     config
         .named_ignore_volumes
         .iter()
         .filter_map(|volume| volume.container_path.strip_prefix(moved.as_str()))
         .map(|relative| named_volume_for(instance_id, &format!("{}/{}", previous, relative)))
+        .filter(|name| !live.contains(name.as_str()))
         .collect()
 }
 
@@ -2661,10 +2663,11 @@ mod tests {
         assert_eq!(volumes[0].container_path, working_dir);
     }
 
-    /// The collapse to `/workspace/{basename}` is reported as `Degraded` rather than
-    /// left indistinguishable from the two resolves that land there legitimately.
+    /// Every arrival at `/workspace/{basename}` is reported as `Fallthrough`, including
+    /// a worktree whose `.git` file is gone rather than merely unresolvable, which
+    /// collapses the same way without `find_main_repo` ever being asked.
     #[test]
-    fn compute_volume_paths_reports_the_collapsed_resolve_as_degraded() {
+    fn compute_volume_paths_reports_every_collapsed_resolve() {
         let dir = TempDir::new().unwrap();
 
         // An orphaned worktree: a `.git` file whose gitdir points nowhere, the
@@ -2682,15 +2685,19 @@ mod tests {
         let (_repo_dir, repo_path) = setup_regular_repo();
 
         for (case, path, expected) in [
-            ("an orphaned worktree", &orphaned, MountResolve::Degraded),
-            ("a plain directory", &plain, MountResolve::Resolved),
-            ("a healthy repo root", &repo_path, MountResolve::Resolved),
+            ("an orphaned worktree", &orphaned, MountResolve::Fallthrough),
+            (
+                "a worktree with no .git at all",
+                &plain,
+                MountResolve::Fallthrough,
+            ),
+            ("a healthy repo root", &repo_path, MountResolve::Fallthrough),
         ] {
             let (_volumes, workspace_path, resolve) =
                 compute_volume_paths_with_resolve(path, path.to_str().unwrap()).unwrap();
             assert_eq!(resolve, expected, "{case}");
-            // All three land on the same shape of path, which is why the resolve
-            // has to be reported rather than inferred from the result.
+            // All three land on the same path, which is why a caller cannot tell
+            // them apart from the result alone.
             assert_eq!(
                 workspace_path,
                 format!("/workspace/{}", path.file_name().unwrap().to_string_lossy()),
@@ -4320,32 +4327,39 @@ volume_ignores = ["**/bin", "**/obj", "target"]
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
-        let build = |healthy_repo: bool| {
-            let project_dir = TempDir::new().unwrap();
-            fs::create_dir_all(project_dir.path().join("src/App/bin")).unwrap();
-            let config_dir = project_dir.path().join(".agent-of-empires");
+        let (_dir, repo_path) = setup_regular_repo();
+        let worktree_path = repo_path.parent().unwrap().join("my-worktree");
+        {
+            let repo = git2::Repository::open(&repo_path).unwrap();
+            let head = repo.head().unwrap().peel_to_commit().unwrap();
+            repo.branch("wt-branch", &head, false).unwrap();
+        }
+        let added = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "wt-branch",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+        if !added.status.success() {
+            return; // git not available
+        }
+
+        let build = |project: &Path| {
+            let config_dir = project.join(".agent-of-empires");
             fs::create_dir_all(&config_dir).unwrap();
             fs::write(
                 config_dir.join("config.toml"),
                 r#"
 [sandbox]
-volume_ignores = ["target", "**/bin"]
+volume_ignores = ["target"]
 volume_ignores_strategy = "named"
 "#,
             )
             .unwrap();
-            if healthy_repo {
-                git2::Repository::init(project_dir.path()).unwrap();
-            } else {
-                // An orphaned worktree, whose collapsed resolve makes every derived
-                // path (the workdir included) provisional.
-                fs::write(
-                    project_dir.path().join(".git"),
-                    "gitdir: ../does-not-exist/.git/worktrees/x\n",
-                )
-                .unwrap();
-            }
-
             let sandbox_info = crate::session::instance::SandboxInfo {
                 enabled: true,
                 container_id: None,
@@ -4357,7 +4371,7 @@ volume_ignores_strategy = "named"
                 container_workdir: None,
             };
             build_container_config(
-                project_dir.path().to_str().unwrap(),
+                project.to_str().unwrap(),
                 &sandbox_info,
                 ContainerAgentSelection::new("claude", None),
                 false,
@@ -4368,17 +4382,29 @@ volume_ignores_strategy = "named"
             .unwrap()
         };
 
-        let healthy = build(true);
-        assert!(healthy.named_ignore_volumes_authoritative);
-
-        let degraded = build(false);
+        let healthy = build(&worktree_path);
         assert!(
-            !degraded.named_ignore_volumes.is_empty(),
-            "the literal entry still mounts, so the empty-set guard cannot be what saves this case"
+            healthy.named_ignore_volumes_authoritative,
+            "a worktree that resolves to its main repo derives real mount paths"
+        );
+
+        // Break the linkage: the same worktree now collapses to /workspace/{basename},
+        // naming volumes the session never had.
+        fs::remove_file(worktree_path.join(".git")).unwrap();
+        fs::write(
+            worktree_path.join(".git"),
+            "gitdir: ../does-not-exist/.git/worktrees/my-worktree\n",
+        )
+        .unwrap();
+
+        let orphaned = build(&worktree_path);
+        assert!(
+            !orphaned.named_ignore_volumes.is_empty(),
+            "the literal entry still mounts, so an empty set cannot be what saves this case"
         );
         assert!(
-            !degraded.named_ignore_volumes_authoritative,
-            "a collapsed resolve names volumes the session never had, so it must not drive a deletion"
+            !orphaned.named_ignore_volumes_authoritative,
+            "a collapsed resolve must not drive a deletion"
         );
     }
 
@@ -6749,6 +6775,37 @@ volume_ignores = ["target"]
             stranded,
             vec!["aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290"],
             "a config gap under an unmoved mount must not name anything"
+        );
+    }
+
+    #[test]
+    fn a_remap_onto_a_live_volume_is_not_a_strand() {
+        // The previous workdir can be the mount root of a mount that survived: a
+        // session whose worktree leaf slugs to the repo's own name, whose pin was
+        // taken while the linkage was broken. The remap then lands exactly on the
+        // main repo's volume, which the create is about to mount.
+        let config = ContainerConfig {
+            working_dir: "/workspace/otari-worktrees/otari".to_string(),
+            named_ignore_volumes: vec![
+                NamedVolumeMount {
+                    volume_name: named_volume_for("sess1", "/workspace/otari/target"),
+                    container_path: "/workspace/otari/target".to_string(),
+                },
+                NamedVolumeMount {
+                    volume_name: named_volume_for(
+                        "sess1",
+                        "/workspace/otari-worktrees/otari/target",
+                    ),
+                    container_path: "/workspace/otari-worktrees/otari/target".to_string(),
+                },
+            ],
+            named_ignore_volumes_authoritative: true,
+            ..Default::default()
+        };
+
+        assert!(
+            stranded_named_ignore_volumes(&config, "sess1", Some("/workspace/otari")).is_empty(),
+            "a volume the create re-attaches must never be named for deletion"
         );
     }
 

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1098,82 +1098,79 @@ pub(crate) fn compute_volume_paths_with_resolve(
     // Legitimate git repos have a .git directory; worktrees have a .git file containing a
     // gitdir pointer. Both cases are covered by this check.
     if project_path.join(".git").exists() {
-        match GitWorktree::find_main_repo(project_path) {
-            Err(_) => {}
-            Ok(main_repo) => {
-                // Canonicalize paths for reliable comparison (handles symlinks like /tmp -> /private/tmp)
-                let main_repo_canonical = main_repo
-                    .canonicalize()
-                    .unwrap_or_else(|_| main_repo.clone());
-                let project_canonical = project_path
-                    .canonicalize()
-                    .unwrap_or_else(|_| project_path.to_path_buf());
+        if let Ok(main_repo) = GitWorktree::find_main_repo(project_path) {
+            // Canonicalize paths for reliable comparison (handles symlinks like /tmp -> /private/tmp)
+            let main_repo_canonical = main_repo
+                .canonicalize()
+                .unwrap_or_else(|_| main_repo.clone());
+            let project_canonical = project_path
+                .canonicalize()
+                .unwrap_or_else(|_| project_path.to_path_buf());
 
-                // Check if project_path is a worktree (different from the main repo root).
-                // Mount enough of the filesystem so the worktree's relative gitdir reference
-                // resolves correctly inside the container.
-                if main_repo_canonical != project_canonical {
-                    if project_canonical.starts_with(&main_repo_canonical) {
-                        // Worktree is inside the main repo (bare repo layout) --
-                        // mounting the main repo is sufficient.
-                        let name = main_repo_canonical
-                            .file_name()
-                            .map(|n| n.to_string_lossy().to_string())
-                            .unwrap_or_else(|| "workspace".to_string());
-                        let container_base = format!("/workspace/{}", name);
-                        let relative_worktree = project_canonical
-                            .strip_prefix(&main_repo_canonical)
-                            .map(|p| p.to_path_buf())
-                            .unwrap_or_default();
-                        let working_dir = if relative_worktree.as_os_str().is_empty() {
-                            container_base.clone()
-                        } else {
-                            format!("{}/{}", container_base, relative_worktree.display())
-                        };
-
-                        return Ok((
-                            vec![VolumeMount {
-                                host_path: main_repo_canonical.to_string_lossy().to_string(),
-                                container_path: container_base,
-                                read_only: false,
-                            }],
-                            working_dir,
-                            MountResolve::Resolved,
-                        ));
+            // Check if project_path is a worktree (different from the main repo root).
+            // Mount enough of the filesystem so the worktree's relative gitdir reference
+            // resolves correctly inside the container.
+            if main_repo_canonical != project_canonical {
+                if project_canonical.starts_with(&main_repo_canonical) {
+                    // Worktree is inside the main repo (bare repo layout) --
+                    // mounting the main repo is sufficient.
+                    let name = main_repo_canonical
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "workspace".to_string());
+                    let container_base = format!("/workspace/{}", name);
+                    let relative_worktree = project_canonical
+                        .strip_prefix(&main_repo_canonical)
+                        .map(|p| p.to_path_buf())
+                        .unwrap_or_default();
+                    let working_dir = if relative_worktree.as_os_str().is_empty() {
+                        container_base.clone()
                     } else {
-                        // Worktree is a sibling of the main repo (non-bare layout).
-                        // Mount each separately under /workspace/, preserving their
-                        // relative path structure from their common ancestor. This
-                        // ensures the worktree's .git file (which contains a relative
-                        // gitdir path) resolves correctly inside the container.
-                        let common = common_ancestor(&main_repo_canonical, &project_canonical);
-                        let repo_rel = main_repo_canonical
-                            .strip_prefix(&common)
-                            .unwrap_or(&main_repo_canonical);
-                        let wt_rel = project_canonical
-                            .strip_prefix(&common)
-                            .unwrap_or(&project_canonical);
+                        format!("{}/{}", container_base, relative_worktree.display())
+                    };
 
-                        let repo_container = format!("/workspace/{}", repo_rel.display());
-                        let wt_container = format!("/workspace/{}", wt_rel.display());
+                    return Ok((
+                        vec![VolumeMount {
+                            host_path: main_repo_canonical.to_string_lossy().to_string(),
+                            container_path: container_base,
+                            read_only: false,
+                        }],
+                        working_dir,
+                        MountResolve::Resolved,
+                    ));
+                } else {
+                    // Worktree is a sibling of the main repo (non-bare layout).
+                    // Mount each separately under /workspace/, preserving their
+                    // relative path structure from their common ancestor. This
+                    // ensures the worktree's .git file (which contains a relative
+                    // gitdir path) resolves correctly inside the container.
+                    let common = common_ancestor(&main_repo_canonical, &project_canonical);
+                    let repo_rel = main_repo_canonical
+                        .strip_prefix(&common)
+                        .unwrap_or(&main_repo_canonical);
+                    let wt_rel = project_canonical
+                        .strip_prefix(&common)
+                        .unwrap_or(&project_canonical);
 
-                        return Ok((
-                            vec![
-                                VolumeMount {
-                                    host_path: main_repo_canonical.to_string_lossy().to_string(),
-                                    container_path: repo_container,
-                                    read_only: false,
-                                },
-                                VolumeMount {
-                                    host_path: project_canonical.to_string_lossy().to_string(),
-                                    container_path: wt_container.clone(),
-                                    read_only: false,
-                                },
-                            ],
-                            wt_container,
-                            MountResolve::Resolved,
-                        ));
-                    }
+                    let repo_container = format!("/workspace/{}", repo_rel.display());
+                    let wt_container = format!("/workspace/{}", wt_rel.display());
+
+                    return Ok((
+                        vec![
+                            VolumeMount {
+                                host_path: main_repo_canonical.to_string_lossy().to_string(),
+                                container_path: repo_container,
+                                read_only: false,
+                            },
+                            VolumeMount {
+                                host_path: project_canonical.to_string_lossy().to_string(),
+                                container_path: wt_container.clone(),
+                                read_only: false,
+                            },
+                        ],
+                        wt_container,
+                        MountResolve::Resolved,
+                    ));
                 }
             }
         }

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1719,6 +1719,43 @@ fn named_volume_for(session_id: &str, container_path: &str) -> String {
     format!("aoe-vi-{}-{}-{}", session_id, slug, hash12)
 }
 
+/// The volume names a move stranded: the names the paths under `config.working_dir`
+/// carried back when the container was created at `previous_workdir`.
+///
+/// Deliberately scoped to the mounts that provably moved. A session's other mounts
+/// keep their container paths across a worktree move (the main repo, in a
+/// sibling-worktree layout), so their volumes are never named here even when this
+/// run's config fails to resolve them, which is what a glob whose directory is
+/// absent from the host looks like. Naming only what moved is what separates a
+/// stranded volume from a live cache; "everything this config does not mount" does
+/// not (#3742).
+///
+/// Empty unless the mounts are established to have moved. `previous_workdir` is that
+/// evidence, pinned at create on `SandboxInfo::container_workdir` for #2414: absent
+/// (a session that never had a container, or an attach that cleared the pin) or equal
+/// to this config's, and nothing moved. A degraded resolve withholds it too, since
+/// there the workdir is provisional and the apparent move may be nothing but a
+/// `find_main_repo` failure.
+pub(crate) fn stranded_named_ignore_volumes(
+    config: &ContainerConfig,
+    instance_id: &str,
+    previous_workdir: Option<&str>,
+) -> Vec<String> {
+    let Some(previous) = previous_workdir else {
+        return Vec::new();
+    };
+    if !config.named_ignore_volumes_authoritative || previous == config.working_dir {
+        return Vec::new();
+    }
+    let moved = format!("{}/", config.working_dir);
+    config
+        .named_ignore_volumes
+        .iter()
+        .filter_map(|volume| volume.container_path.strip_prefix(moved.as_str()))
+        .map(|relative| named_volume_for(instance_id, &format!("{}/{}", previous, relative)))
+        .collect()
+}
+
 /// Build a full `ContainerConfig` for creating a sandboxed container.
 ///
 /// `profile` selects which profile's overrides (volumes, mount_ssh, volume_ignores)
@@ -6656,6 +6693,102 @@ volume_ignores = ["target"]
     }
 
     // --- named_volume_for tests ---
+
+    /// The reporter's layout (#3742): a sibling-worktree session whose worktree
+    /// moved from otari-worktrees/905 to otari-worktrees/rev-912. The main repo's
+    /// mount does not move, so its volume must never be named.
+    fn moved_config() -> ContainerConfig {
+        ContainerConfig {
+            working_dir: "/workspace/otari-worktrees/rev-912".to_string(),
+            named_ignore_volumes: vec![
+                NamedVolumeMount {
+                    volume_name: named_volume_for("sess1", "/workspace/otari/target"),
+                    container_path: "/workspace/otari/target".to_string(),
+                },
+                NamedVolumeMount {
+                    volume_name: named_volume_for(
+                        "sess1",
+                        "/workspace/otari-worktrees/rev-912/target",
+                    ),
+                    container_path: "/workspace/otari-worktrees/rev-912/target".to_string(),
+                },
+            ],
+            named_ignore_volumes_authoritative: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn stranded_volumes_are_the_moved_paths_old_names() {
+        let stranded = stranded_named_ignore_volumes(
+            &moved_config(),
+            "sess1",
+            Some("/workspace/otari-worktrees/905"),
+        );
+
+        // Exactly the volume the reporter found orphaned, and not the main repo's,
+        // whose container path a worktree move leaves alone.
+        assert_eq!(
+            stranded,
+            vec!["aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290"]
+        );
+    }
+
+    #[test]
+    fn a_mount_that_did_not_move_is_never_stranded_by_one_that_did() {
+        // The main repo's `**/bin` is absent from the host this run, so the config
+        // does not mount it. Its container path did not move, so its volume is a
+        // live cache the next matching create re-attaches, not a strand.
+        let mut config = moved_config();
+        config.named_ignore_volumes.remove(0);
+
+        let stranded =
+            stranded_named_ignore_volumes(&config, "sess1", Some("/workspace/otari-worktrees/905"));
+
+        assert_eq!(
+            stranded,
+            vec!["aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290"],
+            "a config gap under an unmoved mount must not name anything"
+        );
+    }
+
+    #[test]
+    fn nothing_is_stranded_without_evidence_of_a_move() {
+        let degraded = ContainerConfig {
+            named_ignore_volumes_authoritative: false,
+            ..moved_config()
+        };
+        let previous = Some("/workspace/otari-worktrees/905");
+
+        for (case, config, previous_workdir) in [
+            (
+                // An edited volume_ignores, or a glob that matched nothing, changes
+                // the config without moving a mount.
+                "the workdir did not move",
+                moved_config(),
+                Some("/workspace/otari-worktrees/rev-912"),
+            ),
+            (
+                // A session that never had a container, and the attach path, which
+                // clears the pin.
+                "no pinned workdir",
+                moved_config(),
+                None,
+            ),
+            (
+                // The workdir is provisional too, so the apparent move may be
+                // nothing but a find_main_repo failure.
+                "a degraded mount resolve",
+                degraded,
+                previous,
+            ),
+        ] {
+            assert!(
+                stranded_named_ignore_volumes(&config, "sess1", previous_workdir).is_empty(),
+                "{case} must not name a volume for deletion"
+            );
+        }
+    }
 
     #[test]
     fn test_named_volume_for_is_deterministic() {

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1060,10 +1060,37 @@ pub(crate) fn install_pi_sandbox_extension_at(root: &Path) -> Result<()> {
     }
     Ok(())
 }
+/// Which branch [`compute_volume_paths_with_resolve`] resolved the mounts through.
+///
+/// Reported rather than re-derived, because a caller about to act destructively on
+/// the difference between the derived paths and reality needs the state of the
+/// resolve that produced *those* paths, not a fresh look taken afterwards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MountResolve {
+    /// The mounts follow from the project's git layout, or from a path that has no
+    /// git linkage to resolve.
+    Resolved,
+    /// `find_main_repo` failed for a path that presents as a worktree, so the mounts
+    /// collapsed to `/workspace/{basename}` (#2414). Every path derived here is
+    /// provisional: it names a location the session's container never mounted.
+    Degraded,
+}
+
 pub(crate) fn compute_volume_paths(
     project_path: &Path,
     project_path_str: &str,
 ) -> Result<(Vec<VolumeMount>, String)> {
+    let (volumes, workspace_path, _) =
+        compute_volume_paths_with_resolve(project_path, project_path_str)?;
+    Ok((volumes, workspace_path))
+}
+
+/// [`compute_volume_paths`] plus the branch it resolved through; see [`MountResolve`].
+pub(crate) fn compute_volume_paths_with_resolve(
+    project_path: &Path,
+    project_path_str: &str,
+) -> Result<(Vec<VolumeMount>, String, MountResolve)> {
+    let mut resolve = MountResolve::Resolved;
     // Only look for a main repo if the project path itself has a .git entry (file or
     // directory). This prevents git2::Repository::discover from walking up the directory
     // tree and finding an unrelated ancestor repo (e.g., a dotfile-managed home directory),
@@ -1073,77 +1100,82 @@ pub(crate) fn compute_volume_paths(
     // Legitimate git repos have a .git directory; worktrees have a .git file containing a
     // gitdir pointer. Both cases are covered by this check.
     if project_path.join(".git").exists() {
-        if let Ok(main_repo) = GitWorktree::find_main_repo(project_path) {
-            // Canonicalize paths for reliable comparison (handles symlinks like /tmp -> /private/tmp)
-            let main_repo_canonical = main_repo
-                .canonicalize()
-                .unwrap_or_else(|_| main_repo.clone());
-            let project_canonical = project_path
-                .canonicalize()
-                .unwrap_or_else(|_| project_path.to_path_buf());
+        match GitWorktree::find_main_repo(project_path) {
+            Err(_) => resolve = MountResolve::Degraded,
+            Ok(main_repo) => {
+                // Canonicalize paths for reliable comparison (handles symlinks like /tmp -> /private/tmp)
+                let main_repo_canonical = main_repo
+                    .canonicalize()
+                    .unwrap_or_else(|_| main_repo.clone());
+                let project_canonical = project_path
+                    .canonicalize()
+                    .unwrap_or_else(|_| project_path.to_path_buf());
 
-            // Check if project_path is a worktree (different from the main repo root).
-            // Mount enough of the filesystem so the worktree's relative gitdir reference
-            // resolves correctly inside the container.
-            if main_repo_canonical != project_canonical {
-                if project_canonical.starts_with(&main_repo_canonical) {
-                    // Worktree is inside the main repo (bare repo layout) --
-                    // mounting the main repo is sufficient.
-                    let name = main_repo_canonical
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_else(|| "workspace".to_string());
-                    let container_base = format!("/workspace/{}", name);
-                    let relative_worktree = project_canonical
-                        .strip_prefix(&main_repo_canonical)
-                        .map(|p| p.to_path_buf())
-                        .unwrap_or_default();
-                    let working_dir = if relative_worktree.as_os_str().is_empty() {
-                        container_base.clone()
-                    } else {
-                        format!("{}/{}", container_base, relative_worktree.display())
-                    };
+                // Check if project_path is a worktree (different from the main repo root).
+                // Mount enough of the filesystem so the worktree's relative gitdir reference
+                // resolves correctly inside the container.
+                if main_repo_canonical != project_canonical {
+                    if project_canonical.starts_with(&main_repo_canonical) {
+                        // Worktree is inside the main repo (bare repo layout) --
+                        // mounting the main repo is sufficient.
+                        let name = main_repo_canonical
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| "workspace".to_string());
+                        let container_base = format!("/workspace/{}", name);
+                        let relative_worktree = project_canonical
+                            .strip_prefix(&main_repo_canonical)
+                            .map(|p| p.to_path_buf())
+                            .unwrap_or_default();
+                        let working_dir = if relative_worktree.as_os_str().is_empty() {
+                            container_base.clone()
+                        } else {
+                            format!("{}/{}", container_base, relative_worktree.display())
+                        };
 
-                    return Ok((
-                        vec![VolumeMount {
-                            host_path: main_repo_canonical.to_string_lossy().to_string(),
-                            container_path: container_base,
-                            read_only: false,
-                        }],
-                        working_dir,
-                    ));
-                } else {
-                    // Worktree is a sibling of the main repo (non-bare layout).
-                    // Mount each separately under /workspace/, preserving their
-                    // relative path structure from their common ancestor. This
-                    // ensures the worktree's .git file (which contains a relative
-                    // gitdir path) resolves correctly inside the container.
-                    let common = common_ancestor(&main_repo_canonical, &project_canonical);
-                    let repo_rel = main_repo_canonical
-                        .strip_prefix(&common)
-                        .unwrap_or(&main_repo_canonical);
-                    let wt_rel = project_canonical
-                        .strip_prefix(&common)
-                        .unwrap_or(&project_canonical);
-
-                    let repo_container = format!("/workspace/{}", repo_rel.display());
-                    let wt_container = format!("/workspace/{}", wt_rel.display());
-
-                    return Ok((
-                        vec![
-                            VolumeMount {
+                        return Ok((
+                            vec![VolumeMount {
                                 host_path: main_repo_canonical.to_string_lossy().to_string(),
-                                container_path: repo_container,
+                                container_path: container_base,
                                 read_only: false,
-                            },
-                            VolumeMount {
-                                host_path: project_canonical.to_string_lossy().to_string(),
-                                container_path: wt_container.clone(),
-                                read_only: false,
-                            },
-                        ],
-                        wt_container,
-                    ));
+                            }],
+                            working_dir,
+                            MountResolve::Resolved,
+                        ));
+                    } else {
+                        // Worktree is a sibling of the main repo (non-bare layout).
+                        // Mount each separately under /workspace/, preserving their
+                        // relative path structure from their common ancestor. This
+                        // ensures the worktree's .git file (which contains a relative
+                        // gitdir path) resolves correctly inside the container.
+                        let common = common_ancestor(&main_repo_canonical, &project_canonical);
+                        let repo_rel = main_repo_canonical
+                            .strip_prefix(&common)
+                            .unwrap_or(&main_repo_canonical);
+                        let wt_rel = project_canonical
+                            .strip_prefix(&common)
+                            .unwrap_or(&project_canonical);
+
+                        let repo_container = format!("/workspace/{}", repo_rel.display());
+                        let wt_container = format!("/workspace/{}", wt_rel.display());
+
+                        return Ok((
+                            vec![
+                                VolumeMount {
+                                    host_path: main_repo_canonical.to_string_lossy().to_string(),
+                                    container_path: repo_container,
+                                    read_only: false,
+                                },
+                                VolumeMount {
+                                    host_path: project_canonical.to_string_lossy().to_string(),
+                                    container_path: wt_container.clone(),
+                                    read_only: false,
+                                },
+                            ],
+                            wt_container,
+                            MountResolve::Resolved,
+                        ));
+                    }
                 }
             }
         }
@@ -1163,6 +1195,7 @@ pub(crate) fn compute_volume_paths(
             read_only: false,
         }],
         workspace_path,
+        resolve,
     ))
 }
 
@@ -1658,17 +1691,6 @@ fn glob_roots(project_volumes: &[VolumeMount]) -> Vec<(String, String)> {
         .collect()
 }
 
-/// True when `project_path` presents as a git worktree whose linkage is broken.
-///
-/// [`compute_volume_paths`] resolves a worktree's mounts through
-/// `find_main_repo`; when that fails it falls through to `/workspace/{basename}`,
-/// a path the session's container never mounted (#2414). Every container path
-/// derived in that state is provisional, so a caller about to act destructively
-/// on the difference between the derived set and reality must not.
-fn worktree_linkage_broken(project_path: &Path) -> bool {
-    project_path.join(".git").exists() && GitWorktree::find_main_repo(project_path).is_err()
-}
-
 /// Produce a deterministic Docker volume name for a named volume_ignores mount.
 ///
 /// Uses the full session ID as a prefix so volumes can be enumerated on deletion.
@@ -1764,10 +1786,14 @@ pub(crate) fn build_container_config(
     // For multi-repo workspaces, mount the workspace dir and all main repos.
     // For bare repo worktrees, mount the entire bare repo and set working_dir to the worktree.
     // For sibling worktrees, mount the main repo and worktree as separate volumes.
-    let (project_volumes, workspace_path) = if let Some(ws_info) = workspace_info {
-        compute_workspace_volume_paths(project_path, ws_info)?
+    // A workspace resolve is always Resolved: compute_workspace_volume_paths derives
+    // its mounts from the stored `main_repo_path` of each repo and never consults
+    // `find_main_repo`, so it has no degraded fallback to report.
+    let (project_volumes, workspace_path, mount_resolve) = if let Some(ws_info) = workspace_info {
+        let (volumes, path) = compute_workspace_volume_paths(project_path, ws_info)?;
+        (volumes, path, MountResolve::Resolved)
     } else {
-        compute_volume_paths(project_path, project_path_str)?
+        compute_volume_paths_with_resolve(project_path, project_path_str)?
     };
 
     // Collect all paths that should receive volume_ignores: the workspace_path
@@ -2210,12 +2236,9 @@ pub(crate) fn build_container_config(
     // expanded against the host filesystem now (#2045): a point-in-time snapshot,
     // since Docker needs concrete mount paths when the container starts.
     let mut resolved_ignore_paths: Vec<String> = Vec::new();
-    let mut glob_matched_nothing = false;
     for ignore in &sandbox_config.volume_ignores {
         if has_glob_metachars(ignore) {
-            let matches = expand_glob_ignore(ignore, &glob_roots);
-            glob_matched_nothing |= matches.is_empty();
-            resolved_ignore_paths.extend(matches);
+            resolved_ignore_paths.extend(expand_glob_ignore(ignore, &glob_roots));
         } else {
             for base_path in &volume_ignore_bases {
                 resolved_ignore_paths.push(format!("{}/{}", base_path, ignore));
@@ -2240,11 +2263,7 @@ pub(crate) fn build_container_config(
         })
         .collect();
 
-    // A degraded mount resolve or a glob that matched nothing both leave the
-    // resolved set a floor rather than the whole truth, which is the difference
-    // between reclaiming a stranded volume and destroying a live cache.
-    let named_ignore_volumes_authoritative = !glob_matched_nothing
-        && !(workspace_info.is_none() && worktree_linkage_broken(project_path));
+    let named_ignore_volumes_authoritative = mount_resolve == MountResolve::Resolved;
 
     // Route by strategy: anonymous volumes are the default; named volumes fix VirtioFS on macOS.
     let (anonymous_volumes, named_ignore_volumes): (Vec<String>, Vec<NamedVolumeMount>) =
@@ -2605,14 +2624,14 @@ mod tests {
         assert_eq!(volumes[0].container_path, working_dir);
     }
 
+    /// The collapse to `/workspace/{basename}` is reported as `Degraded` rather than
+    /// left indistinguishable from the two resolves that land there legitimately.
     #[test]
-    fn worktree_linkage_broken_flags_only_the_degraded_resolve() {
+    fn compute_volume_paths_reports_the_collapsed_resolve_as_degraded() {
         let dir = TempDir::new().unwrap();
 
         // An orphaned worktree: a `.git` file whose gitdir points nowhere, the
-        // state a pruned admin entry leaves behind. compute_volume_paths collapses
-        // to /workspace/{basename} here (#2414), so the paths it derives are
-        // provisional and must not drive a deletion.
+        // state a pruned admin entry leaves behind (#2414).
         let orphaned = dir.path().join("myrepo-worktrees").join("contexec");
         std::fs::create_dir_all(&orphaned).unwrap();
         std::fs::write(
@@ -2620,16 +2639,27 @@ mod tests {
             "gitdir: ../../does-not-exist/.git/worktrees/contexec\n",
         )
         .unwrap();
-        assert!(worktree_linkage_broken(&orphaned));
 
-        // A plain directory has no linkage to break, and neither does a healthy
-        // repo; both resolve to /workspace/{basename} legitimately.
         let plain = dir.path().join("plain");
         std::fs::create_dir_all(&plain).unwrap();
-        assert!(!worktree_linkage_broken(&plain));
-
         let (_repo_dir, repo_path) = setup_regular_repo();
-        assert!(!worktree_linkage_broken(&repo_path));
+
+        for (case, path, expected) in [
+            ("an orphaned worktree", &orphaned, MountResolve::Degraded),
+            ("a plain directory", &plain, MountResolve::Resolved),
+            ("a healthy repo root", &repo_path, MountResolve::Resolved),
+        ] {
+            let (_volumes, workspace_path, resolve) =
+                compute_volume_paths_with_resolve(path, path.to_str().unwrap()).unwrap();
+            assert_eq!(resolve, expected, "{case}");
+            // All three land on the same shape of path, which is why the resolve
+            // has to be reported rather than inferred from the result.
+            assert_eq!(
+                workspace_path,
+                format!("/workspace/{}", path.file_name().unwrap().to_string_lossy()),
+                "{case}"
+            );
+        }
     }
 
     #[test]
@@ -4243,22 +4273,19 @@ volume_ignores = ["**/bin", "**/obj", "target"]
         );
     }
 
-    /// The named-volume reclaim (#3742) only runs against a resolve that establishes
-    /// the whole set. A literal entry always mounts, so it alone keeps the set
-    /// non-empty while a glob silently contributes nothing.
+    /// The named-volume reclaim (#3742) runs off the resolve the mounts came from,
+    /// carried on the config so the gate cannot re-derive a different answer.
     #[test]
     #[serial_test::serial]
-    fn named_ignore_volumes_are_authoritative_only_when_every_glob_matched() {
+    fn named_ignore_volumes_authoritative_tracks_the_mount_resolve() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
-        let build = |glob_dir_exists: bool| {
+        let build = |healthy_repo: bool| {
             let project_dir = TempDir::new().unwrap();
-            if glob_dir_exists {
-                fs::create_dir_all(project_dir.path().join("src/App/bin")).unwrap();
-            }
+            fs::create_dir_all(project_dir.path().join("src/App/bin")).unwrap();
             let config_dir = project_dir.path().join(".agent-of-empires");
             fs::create_dir_all(&config_dir).unwrap();
             fs::write(
@@ -4270,7 +4297,17 @@ volume_ignores_strategy = "named"
 "#,
             )
             .unwrap();
-            git2::Repository::init(project_dir.path()).unwrap();
+            if healthy_repo {
+                git2::Repository::init(project_dir.path()).unwrap();
+            } else {
+                // An orphaned worktree, whose collapsed resolve makes every derived
+                // path (the workdir included) provisional.
+                fs::write(
+                    project_dir.path().join(".git"),
+                    "gitdir: ../does-not-exist/.git/worktrees/x\n",
+                )
+                .unwrap();
+            }
 
             let sandbox_info = crate::session::instance::SandboxInfo {
                 enabled: true,
@@ -4294,17 +4331,17 @@ volume_ignores_strategy = "named"
             .unwrap()
         };
 
-        let matched = build(true);
-        assert!(matched.named_ignore_volumes_authoritative);
+        let healthy = build(true);
+        assert!(healthy.named_ignore_volumes_authoritative);
 
-        let unmatched = build(false);
+        let degraded = build(false);
         assert!(
-            !unmatched.named_ignore_volumes.is_empty(),
-            "the literal entry must still mount, so the empty-set guard cannot be what saves this case"
+            !degraded.named_ignore_volumes.is_empty(),
+            "the literal entry still mounts, so the empty-set guard cannot be what saves this case"
         );
         assert!(
-            !unmatched.named_ignore_volumes_authoritative,
-            "a glob that matched nothing leaves the set a floor, so it must not drive a deletion"
+            !degraded.named_ignore_volumes_authoritative,
+            "a collapsed resolve names volumes the session never had, so it must not drive a deletion"
         );
     }
 

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -6750,7 +6750,9 @@ volume_ignores = ["target"]
         );
 
         // Exactly the volume the reporter found orphaned, and not the main repo's,
-        // whose container path a worktree move leaves alone.
+        // whose container path a worktree move leaves alone. The literal suffix is
+        // the same `DefaultHasher` canary as in `containers::runtime_base`: a
+        // toolchain bump that changed it would orphan every existing named volume.
         assert_eq!(
             stranded,
             vec!["aoe-vi-sess1-workspace-otari-worktrees-905-target-31ddd0322290"]

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -194,11 +194,14 @@ impl Instance {
         let config = self.build_container_config()?;
         // Still the workdir the *previous* container was created with; the pin below
         // is what moves it forward.
-        let previous_workdir = self
-            .sandbox_info
-            .as_ref()
-            .and_then(|sandbox| sandbox.container_workdir.as_deref());
-        container.prune_stale_named_ignore_volumes(&self.id, &config, previous_workdir);
+        let stranded = container_config::stranded_named_ignore_volumes(
+            &config,
+            &self.id,
+            self.sandbox_info
+                .as_ref()
+                .and_then(|sandbox| sandbox.container_workdir.as_deref()),
+        );
+        container.remove_stale_named_ignore_volumes(&self.id, &stranded);
         let container_id = container.create(&config)?;
         self.identity_publisher_launched = config.identity_publisher_installed
             && identity_publisher_dependencies_available(&container)

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -192,7 +192,13 @@ impl Instance {
         // carries the values (leak-safe via the inherit path in run_create).
         self.ensure_before_start_env(true)?;
         let config = self.build_container_config()?;
-        container.prune_stale_named_ignore_volumes(&self.id, &config);
+        // Still the workdir the *previous* container was created with; the pin below
+        // is what moves it forward.
+        let previous_workdir = self
+            .sandbox_info
+            .as_ref()
+            .and_then(|sandbox| sandbox.container_workdir.as_deref());
+        container.prune_stale_named_ignore_volumes(&self.id, &config, previous_workdir);
         let container_id = container.create(&config)?;
         self.identity_publisher_launched = config.identity_publisher_installed
             && identity_publisher_dependencies_available(&container)

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -201,7 +201,7 @@ impl Instance {
                 .as_ref()
                 .and_then(|sandbox| sandbox.container_workdir.as_deref()),
         );
-        container.remove_stale_named_ignore_volumes(&self.id, &stranded);
+        container.remove_stranded_named_ignore_volumes(&self.id, &stranded);
         let container_id = container.create(&config)?;
         self.identity_publisher_launched = config.identity_publisher_installed
             && identity_publisher_dependencies_available(&container)

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -192,6 +192,7 @@ impl Instance {
         // carries the values (leak-safe via the inherit path in run_create).
         self.ensure_before_start_env(true)?;
         let config = self.build_container_config()?;
+        container.prune_stale_named_ignore_volumes(&self.id, &config);
         let container_id = container.create(&config)?;
         self.identity_publisher_launched = config.identity_publisher_installed
             && identity_publisher_dependencies_available(&container)

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -221,8 +221,11 @@ pub fn ensure_sandbox_container_released(session_id: &str, is_sandboxed: bool) -
 /// stopped container as-is, so without this the restarted container would
 /// still mount (and `cd` into) the old path. [`DockerContainer::discard`]
 /// forces a fresh `create` with the new path on next start while preserving
-/// the session's named ignore volumes (`target/`, `node_modules/`) so the
-/// recreated container re-attaches its build caches.
+/// the session's named ignore volumes (`target/`, `node_modules/`), so the
+/// recreated container re-attaches every cache the move did not move. A named
+/// volume's name encodes its container path, so the ones the move did strand
+/// are reclaimed at that create by
+/// [`DockerContainer::prune_stale_named_ignore_volumes`] (#3742).
 ///
 /// No-op for non-sandbox sessions, and commonly a no-op
 /// ([`Teardown::AlreadyGone`]) on the sandbox path too: the rename gate

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -222,9 +222,8 @@ pub fn ensure_sandbox_container_released(session_id: &str, is_sandboxed: bool) -
 /// still mount (and `cd` into) the old path. [`DockerContainer::discard`]
 /// forces a fresh `create` with the new path on next start while preserving
 /// the session's named ignore volumes (`target/`, `node_modules/`), so the
-/// recreated container re-attaches every cache the move did not move. The ones
-/// it did strand are reclaimed at that create by
-/// [`DockerContainer::prune_stale_named_ignore_volumes`] (#3742).
+/// recreated container re-attaches every cache the move did not move; see
+/// [`DockerContainer::remove_stale_named_ignore_volumes`] for the ones it did.
 ///
 /// No-op for non-sandbox sessions, and commonly a no-op
 /// ([`Teardown::AlreadyGone`]) on the sandbox path too: the rename gate

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -222,9 +222,8 @@ pub fn ensure_sandbox_container_released(session_id: &str, is_sandboxed: bool) -
 /// still mount (and `cd` into) the old path. [`DockerContainer::discard`]
 /// forces a fresh `create` with the new path on next start while preserving
 /// the session's named ignore volumes (`target/`, `node_modules/`), so the
-/// recreated container re-attaches every cache the move did not move. A named
-/// volume's name encodes its container path, so the ones the move did strand
-/// are reclaimed at that create by
+/// recreated container re-attaches every cache the move did not move. The ones
+/// it did strand are reclaimed at that create by
 /// [`DockerContainer::prune_stale_named_ignore_volumes`] (#3742).
 ///
 /// No-op for non-sandbox sessions, and commonly a no-op

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -223,7 +223,7 @@ pub fn ensure_sandbox_container_released(session_id: &str, is_sandboxed: bool) -
 /// forces a fresh `create` with the new path on next start while preserving
 /// the session's named ignore volumes (`target/`, `node_modules/`), so the
 /// recreated container re-attaches every cache the move did not move; see
-/// [`DockerContainer::remove_stale_named_ignore_volumes`] for the ones it did.
+/// [`DockerContainer::remove_stranded_named_ignore_volumes`] for the ones it did.
 ///
 /// No-op for non-sandbox sessions, and commonly a no-op
 /// ([`Teardown::AlreadyGone`]) on the sandbox path too: the rename gate


### PR DESCRIPTION
## Description

When you use a sandbox session on macOS with the "named" volume strategy, AoE keeps your build caches (`target/`, `node_modules/`, `.venv/`) inside Docker volumes instead of on disk, and it names each volume after the folder it belongs to. Moving a session's worktree changes that folder, so the next time the container starts it makes brand new empty volumes under the new names. The old ones were left behind with nothing to clean them up until the session was deleted, and Docker's usual `docker volume prune` skips them, so they were invisible while sitting on tens of gigabytes each. This change makes AoE throw away the leftovers at the moment it rebuilds the container, keeping only the volumes the new container actually uses, and only when it can prove which ones those are.

A named ignore volume is called `aoe-vi-{session_id}-{slug}-{hash}` over its container mount path (`container_config.rs`). The move path discards the container while preserving the session's volumes on the premise that they are re-attached on next start; that holds only for mounts whose container path did not move. In the reporter's case the main-repo `/workspace/otari/target` survives and the worktree's `/workspace/otari-worktrees/905/target` is orphaned on the spot. `deletion.rs` sweeps the whole `aoe-vi-{session_id}-` prefix correctly, but never runs for a session that is moved and later purged from the trash.

The fix names the volumes the move stranded and removes those, at the create that follows the move, when no container holds them.

### Naming the strand rather than inferring it

For each ignore path under the new `working_dir`, remap it onto the workdir the previous container was created with and compute the volume name it had there. That is exactly the set the move orphaned. A mount that kept its container path is never named, even when this run's config fails to resolve it, which is what a glob whose directory is absent from the host looks like. The runtime primitive takes an allowlist, so a volume the caller did not name cannot be reached from the reclaim at all.

The evidence of a move is `SandboxInfo::container_workdir`, already pinned at create for #2414, so there is no new persisted state and no migration. Nothing is removed unless it changed, and one further gate applies: `ContainerConfig::named_ignore_volumes_authoritative` is false when the mount resolve was degraded. `compute_volume_paths` falls through to `/workspace/{basename}` when `find_main_repo` fails, which the repo has a regression test for (`container_workdir_stays_pinned_when_worktree_linkage_breaks`, the #2414 fix), and there the workdir is provisional too, so the apparent move may be nothing but that failure. `compute_volume_paths_with_resolve` reports which branch it took rather than letting the gate re-derive it later, so a linkage repaired between the two reads cannot make a collapsed resolve look authoritative.

**What this deliberately does not reclaim.** A volume orphaned without a move: an edited `volume_ignores`, a switch back to `volume_ignores_strategy = "anonymous"`, an `extra_volumes` entry that shadows an ignore path, or a multi-repo attach, which clears the workdir pin the reclaim reads. Nor anything already orphaned: the pin advances at every create, so a session that has moved and restarted is out of reach, and the volumes in the issue belong to sessions that no longer exist. Upgrading does not shrink them.

**What it costs.** A move now loses the cache in both directions. Before this, moving A to B stranded A's volumes but left them intact, so moving back re-attached a warm cache; now they are gone at the B create and the return trip rebuilds cold. That is the price of reclaiming at all, and it is why the reclaim refuses to fire without proof of a move. Those keep today's behavior, so no user is worse off than before this PR. `docs/guides/sandbox.md` says so and gives the `docker volume ls` incantation to find them, and the multi-repo guide no longer claims an attach cleans up after itself. Reclaiming those safely needs each volume's container path recorded on `SandboxInfo` plus a migration; that is a separate change.

**Reclaim happens at the session's next start, not at the move.** Sweeping at move time needs the post-move volume name set, which means building a full container config at all nine `discard_sandbox_container_after_move` call sites.

### Why not the issue's first suggestion

#3742 offered two fixes, and this PR takes the second. The first, keying the volume name on session id plus mount role so a move keeps the same name, is the better end state: it removes the strand rather than collecting it, and it keeps the cache warm across a move instead of paying the cost above. It is not in this PR because there is no stable "role" to key on. The mount bases are themselves path-derived, so two ignore entries under different bases (`target/` in the main repo and in the worktree) collide on any role name short enough to be stable, and Docker cannot rename a volume, so every existing volume would need a migration to reach the new scheme.

That migration is worth doing, and it is also what a stable hash needs: `named_volume_for` uses `DefaultHasher`, which std documents as unspecified across releases. Two tests pin literal hashes as a canary for exactly that. Both belong in one follow-up.

The issue's secondary suggestion (a store-wide reconcile for `aoe-vi-*` volumes whose session id is absent from the session store, plus the swallowed failures in `remove_named_ignore_volumes`) is likewise a separate concern and is not in this PR.

Fixes #3742

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording <!-- N/A, no UI change -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: reaching the reclaim needs a live Docker daemon, a named-strategy sandbox session, a worktree move and a restart. `tests/e2e/sandbox.rs` does have the `#[ignore = "requires Docker daemon"]` convention for that, but no CI job runs those and no Docker was available to run one even once while writing this, so it would land unexecuted. Unit tests cover the decisions instead: `stranded_named_ignore_volumes` producing the reporter's own orphaned volume name for their layout, and producing it unchanged when the main repo's volume is missing from the config (the case the previous approach deleted); every branch that names nothing (unmoved workdir, no pin, degraded resolve); `selected_named_ignore_volumes` honoring the allowlist and never reaching a longer session id under the same prefix; `compute_volume_paths_with_resolve` reporting `Fallthrough` for every arrival at the collapsed `/workspace/{basename}`; and the flag end to end through `build_container_config`. What is left uncovered is the call at the create site.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Implementation and tests were written by Claude Opus 5 in back-and-forth with @njbrake; the scope calls above are his. The first draft removed anything the new config did not mount. Three independent review passes found successively narrower ways that deletes a live cache; commits 2 through 4 are those fixes.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCYiZhmr6riURz45y3eE9i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reclaims stranded named Docker ignore volumes after a recognized sandbox worktree move.
- Preserves active volumes and skips uncertain or unsupported cases.
- Adds safeguards, logging, unit tests, and documentation updates.

## Benefits

This reduces disk usage without removing valid volumes. Previously orphaned volumes and Docker end-to-end coverage remain future improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
