### PR TITLE
fix(session): open anchored stores through symlinked ancestors on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,13 @@ on:
   # No branch filter: a stacked PR targets its parent branch rather than main,
   # and a base filter would leave every PR but the bottom of the stack with no
   # checks at all.
+  #
+  # `labeled` is listed so adding `ci-macos` starts a run that can see the
+  # label; the default types alone would leave the macOS job waiting for the
+  # next push. It re-runs the workflow on any label, which is rare enough to
+  # cost less than a macOS regression reaching main.
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,6 +220,14 @@ jobs:
     # job can move to its own workflow with a `push` + `schedule` trigger and
     # drop the per-step conditions.
     #
+    # To run it on a pull request, add the `ci-macos` label. Every step below
+    # is gated on `not a PR, or that label`, so labelling runs this job for
+    # real and the required context reports a pass either way. Reach for it
+    # whenever a change touches `src/process/macos.rs`, a `target_os` cfg, or
+    # anything filesystem-shaped: macOS resolves `/tmp` and the per-user temp
+    # root through symlinks and its `mode_t` is 16 bits, and both have already
+    # reached main unnoticed because this suite does not run here by default.
+    #
     # Both cargo invocations share one feature set so the crate compiles once.
     # `e2e-tests` is an empty feature whose only consumer is `required-features`
     # on the `[[test]] name = "e2e"` target, so adding it to the --lib --bins
@@ -249,7 +257,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-macos')
         with:
           # These jobs run repository-controlled build/test code after checkout
           # and never push, so the job token must not linger in .git/config
@@ -257,28 +265,28 @@ jobs:
           # release.yml.
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-macos')
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-macos')
         with:
           cache-bin: "true"
           save-if: true
       - name: Install tmux
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-macos')
         run: brew install tmux
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-macos')
         with:
           node-version: '22'
       - name: Cargo test (macOS, lib + bins)
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-macos')
         run: cargo test --features web,e2e-tests --lib --bins
       - name: Cargo test (macOS, acp live-daemon e2e)
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-macos')
         run: cargo test --features web,e2e-tests --test e2e -- acp_ --test-threads=1 --nocapture
       - name: Skipped on pull requests
-        if: github.event_name == 'pull_request'
-        run: echo "macOS runs post-merge on main; see the comment on this job."
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci-macos')
+        run: echo "macOS runs post-merge on main. Add the 'ci-macos' label to run it here."
 
   vitest:
     name: Vitest

--- a/src/session/anchored_fs.rs
+++ b/src/session/anchored_fs.rs
@@ -19,37 +19,49 @@ pub(crate) struct AnchoredDir {
 }
 
 impl AnchoredDir {
+    /// Anchor at `path`, whose ancestors are resolved the way any other
+    /// caller resolves them and whose own leaf may not be a symlink.
+    ///
+    /// Walking the ancestors with `O_NOFOLLOW` defended nothing: a hostile
+    /// `/var` is not a threat this type can answer, while macOS reaches both
+    /// `/tmp` and the per-user temp root through a symlink, so the walk
+    /// refused every anchored read on that platform. The leaf keeps
+    /// `O_NOFOLLOW` because it is the swap an attacker controls, and so does
+    /// every component below it, which is the escape this type exists to stop.
     pub(crate) fn open(path: &Path) -> Result<Self> {
         let root = path.to_path_buf();
-        let mut fd = open(
-            if path.is_absolute() {
-                Path::new("/")
-            } else {
-                Path::new(".")
-            },
-            OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC | OFlag::O_RDONLY,
-            Mode::empty(),
-        )?;
         for component in path.components() {
-            match component {
-                Component::RootDir | Component::CurDir => {}
-                Component::Normal(value) => {
-                    fd = openat(
-                        &fd,
-                        value,
-                        OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC | OFlag::O_RDONLY,
-                        Mode::empty(),
-                    )
-                    .with_context(|| {
-                        format!("opening anchored directory component {}", root.display())
-                    })?;
-                }
-                _ => bail!(
+            if !matches!(
+                component,
+                Component::RootDir | Component::CurDir | Component::Normal(_)
+            ) {
+                bail!(
                     "anchored root contains a non-normal component: {}",
                     path.display()
-                ),
+                );
             }
         }
+        let resolving = OFlag::O_DIRECTORY | OFlag::O_CLOEXEC | OFlag::O_RDONLY;
+        let (Some(parent), Some(leaf)) = (path.parent(), path.file_name()) else {
+            // A bare root such as `/` or `.` has no leaf to guard.
+            let fd = open(path, resolving, Mode::empty())
+                .with_context(|| format!("opening anchored root {}", root.display()))?;
+            return Ok(Self { root, fd });
+        };
+        let parent = if parent.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            parent
+        };
+        let parent_fd = open(parent, resolving, Mode::empty())
+            .with_context(|| format!("opening anchored root parent {}", parent.display()))?;
+        let fd = openat(
+            &parent_fd,
+            leaf,
+            resolving | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        )
+        .with_context(|| format!("opening anchored root {}", root.display()))?;
         Ok(Self { root, fd })
     }
 
@@ -270,8 +282,49 @@ fn normal_components(path: &Path) -> Result<Vec<std::ffi::OsString>> {
 mod tests {
     use super::*;
 
-    #[test]
+    /// A symlinked ancestor of the anchor is normal on macOS, where `/tmp`
+    /// and the per-user temp root under `/var` both resolve through one, and
+    /// it says nothing about whether the store below the anchor is safe.
+    /// Refusing it made every anchored read fail there.
     #[cfg(unix)]
+    #[test]
+    fn opens_through_a_symlinked_ancestor() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("real");
+        std::fs::create_dir_all(real.join("store")).unwrap();
+        std::fs::write(real.join("store/id"), b"anchored").unwrap();
+        symlink(&real, temp.path().join("via-link")).unwrap();
+
+        let anchored = AnchoredDir::open(&temp.path().join("via-link/store"))
+            .expect("an anchor reached through a symlinked ancestor must open");
+        assert_eq!(
+            anchored
+                .read_regular(Path::new("id"), 64)
+                .unwrap()
+                .as_deref(),
+            Some(&b"anchored"[..])
+        );
+    }
+
+    /// The anchor's own leaf still may not be a symlink: that is the swap an
+    /// attacker controls, unlike the system directories above it.
+    #[cfg(unix)]
+    #[test]
+    fn refuses_a_symlinked_anchor_leaf() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        symlink(&real, temp.path().join("leaf-link")).unwrap();
+
+        assert!(AnchoredDir::open(&temp.path().join("leaf-link")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn refuses_symlink_components_and_bounds_reads() {
         use std::os::unix::fs::symlink;
         let temp = tempfile::tempdir().unwrap();

--- a/src/session/capture/mod.rs
+++ b/src/session/capture/mod.rs
@@ -1394,8 +1394,19 @@ fn read_hermes_sessions_from_sqlite(
 ) -> Result<HermesSessionScan> {
     use rusqlite::{Connection, OpenFlags};
 
+    // `SQLITE_OPEN_NOFOLLOW` refuses a symlink anywhere in the path, not just
+    // at the leaf, and macOS reaches both `/tmp` and the per-user temp root
+    // through one. Resolve the directory first so the flag guards the database
+    // file itself, which is the swap that matters; the directory was already
+    // opened under `AnchoredDir`, whose own leaf is `O_NOFOLLOW`.
+    let resolved = match (db_path.parent(), db_path.file_name()) {
+        (Some(parent), Some(leaf)) => std::fs::canonicalize(parent)
+            .map(|parent| parent.join(leaf))
+            .unwrap_or_else(|_| db_path.to_path_buf()),
+        _ => db_path.to_path_buf(),
+    };
     let conn = Connection::open_with_flags(
-        db_path,
+        &resolved,
         OpenFlags::SQLITE_OPEN_READ_ONLY
             | OpenFlags::SQLITE_OPEN_NO_MUTEX
             | OpenFlags::SQLITE_OPEN_NOFOLLOW,


### PR DESCRIPTION
## Description

`Cargo Test (macos)` fails on `main` with 23 failures across capture, migration v027, the sandbox pollers and `anchored_fs` itself. One root cause, plus a second instance of the same mistake a layer down.

**`AnchoredDir::open` walked the anchor root's own ancestors with `O_NOFOLLOW`.** Any ancestor that is a symlink aborts the open with `ENOTDIR`. macOS reaches both `/tmp` and the per-user temp root under `/var` through exactly such a symlink, so every anchored read failed there. Refusing those ancestors bought nothing, since a hostile `/var` is not a threat this type can answer. The anchor's own leaf keeps `O_NOFOLLOW`, because that is the swap an attacker controls, and so does every component below it, which is the escape the type exists to prevent.

**`SQLITE_OPEN_NOFOLLOW` refuses a symlink anywhere in the path, not only at the leaf.** The sandboxed Hermes poller failed for the same reason. Its directory is resolved first so the flag guards the database file itself; that directory was already opened through `AnchoredDir`, whose leaf is `O_NOFOLLOW`.

Both fixes preserve every symlink refusal: `refuses_symlink_components_and_bounds_reads`, `refuses_a_symlinked_anchor_leaf` and `sandbox_hermes_poller_refuses_symlink_fifo_and_excess_rows` all still pass.

**Why this reached `main`.** The macOS steps are skipped on pull requests to save runner minutes, so a macOS-only regression only surfaces after a merge. Two did today: a `mode_t` width difference that broke the build (#3750) and this. Every step is now gated on "not a pull request, or the `ci-macos` label", so the suite can be run on a PR on demand. The required context still reports a pass when the label is absent, so the merge box is unaffected. This PR carries the label, so `Cargo Test (macos)` below is a real run.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
  - `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib --bins`: 6597 passed.
  - All 23 of the macOS failures pass under a symlinked `TMPDIR`, which reproduces the platform condition on Linux. Verified per test, by name.
- [x] Documentation was updated where necessary
  - The workflow comment documents the label and when to reach for it.
- [ ] For UI changes: included screenshot or recording
  - No UI changes.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

`opens_through_a_symlinked_ancestor` and `refuses_a_symlinked_anchor_leaf` build the anchor behind a symlinked ancestor, so the platform condition is now reproducible on any unix and this class of break no longer needs a Mac to catch.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any Additional AI Details you'd like to share:**

The root cause was reproduced on Linux before the fix was written, by pointing an anchor at a symlinked ancestor and getting the identical `ENOTDIR` that macOS CI reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZgLCCADgHXfvUasSGcApg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed macOS failures when temporary paths contain symlinked directories.
- Preserved protection against symlinked anchor leaves, descendants, and database files.
- Added tests for valid symlinked ancestors and rejected symlinked leaves.
- Updated Hermes database path handling before opening SQLite.
- Enabled on-demand macOS CI for pull requests labeled `ci-macos`, including label changes.

## Benefits

- Temporary directories resolve correctly on macOS.
- Symlink safety remains enforced where it matters.
- The changes pass all existing tests and the previously failing macOS cases.

## Potential enhancement

- Monitor labeled macOS CI usage and expand coverage if additional platform-specific path cases appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->