### PR TITLE
feat(migrations): show progress and a way to defer the sandbox store move

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -120,6 +120,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe acp switch-agent`↴](#aoe-acp-switch-agent)
 * [`aoe uninstall`↴](#aoe-uninstall)
 * [`aoe update`↴](#aoe-update)
+* [`aoe migrate`↴](#aoe-migrate)
 * [`aoe completion`↴](#aoe-completion)
 
 ## `aoe`
@@ -162,6 +163,7 @@ Run without arguments to launch the TUI dashboard.
 * `acp` — Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...)
 * `uninstall` — Uninstall Agent of Empires
 * `update` — Update aoe to the latest release
+* `migrate` — Run pending data migrations now, showing progress. Startup runs them too; use this after deferring one with AOE_DEFER_SANDBOX_MIGRATION=1
 * `completion` — Generate shell completions
 
 ###### **Options:**
@@ -1832,6 +1834,14 @@ Update aoe to the latest release
 * `-y`, `--yes` — Skip confirmation prompt
 * `--check` — Print update status and exit (no install)
 * `--dry-run` — Detect install method and print what would happen, no download
+
+
+
+## `aoe migrate`
+
+Run pending data migrations now, showing progress. Startup runs them too; use this after deferring one with AOE_DEFER_SANDBOX_MIGRATION=1
+
+**Usage:** `aoe migrate`
 
 
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -61,6 +61,7 @@ settings save on `config.toml`.
 | `AGENT_OF_EMPIRES_PROFILE` | Default profile to use |
 | `AGENT_OF_EMPIRES_DEBUG` | Enable debug logging to `debug.log` in app data dir (`1` to enable). Legacy alias for `AOE_LOG_LEVEL=debug`. |
 | `AOE_LOG_LEVEL` | File log level: `trace`, `debug`, `info`, `warn`, `error`. |
+| `AOE_DEFER_SANDBOX_MIGRATION` | Start without moving sandboxed sessions' agent stores; the move is retried on a later start or with `aoe migrate`. See [Per-session agent stores](sandbox.md#per-session-agent-stores). |
 
 ## Theme
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -289,15 +289,15 @@ aoe add --sandbox-image my-sandbox:latest .
 
 ## Per-session agent stores
 
-Each sandboxed session gets its own copy of the agent's config store on the
-host, under `sandbox-v2/<instance-id>` inside the agent's config directory
+Each sandboxed session gets its own agent store on the host: a copy of the
+agent's config and history under `sandbox-v2/<instance-id>` inside the agent's config directory
 (for example `~/.claude/sandbox-v2/<id>`). The container mounts that copy at
 the agent's usual config path, so credentials, hooks and conversation history
 belong to one session and `aoe` can resume the right conversation.
 
-Sessions created before this layout shared one store per agent (for example
-`~/.claude/sandbox`). The first `aoe` start after upgrading moves them: it
-copies the shared store into a private directory for every sandboxed session,
+Sessions created before this layout shared one agent store per agent (for
+example `~/.claude/sandbox`). The first `aoe` start after upgrading moves them:
+it copies the shared store into a private directory for every sandboxed session,
 removes each session's stopped container so the next launch mounts the copy,
 and deletes the shared store once every session that used it has moved (the
 private copies are the data from then on). Startup prints what it is copying

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -287,6 +287,32 @@ aoe add --sandbox-image my-sandbox:latest .
 > Building a custom image and using structured view? Install the agent's ACP
 > adapter in the image too, or the handshake fails.
 
+## Per-session agent stores
+
+Each sandboxed session gets its own copy of the agent's config store on the
+host, under `sandbox-v2/<instance-id>` inside the agent's config directory
+(for example `~/.claude/sandbox-v2/<id>`). The container mounts that copy at
+the agent's usual config path, so credentials, hooks and conversation history
+belong to one session and `aoe` can resume the right conversation.
+
+Sessions created before this layout shared one store per agent (for example
+`~/.claude/sandbox`). The first `aoe` start after upgrading moves them: it
+copies the shared store into a private directory for every sandboxed session,
+removes each session's stopped container so the next launch mounts the copy,
+and deletes the shared store once every session that used it has moved (the
+private copies are the data from then on). Startup prints what it is copying
+and how long it has been running. A large store copied for many sessions can take minutes; a
+session whose container is still running is skipped and moved on a later start,
+after it stops.
+
+To start without waiting, quit and set `AOE_DEFER_SANDBOX_MIGRATION=1` for that
+launch. Sessions then keep using the shared store, and the move is retried on
+the next start without the variable, or on demand with:
+
+```bash
+aoe migrate
+```
+
 ## Worktrees and Sandboxing
 
 Git worktrees need the bare repo pattern so the container can reach the repo's git directory. See [Worktrees](worktrees.md#bare-repos).

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -233,6 +233,10 @@ pub enum Commands {
     /// Update aoe to the latest release
     Update(UpdateArgs),
 
+    /// Run pending data migrations now, showing progress. Startup runs them
+    /// too; use this after deferring one with AOE_DEFER_SANDBOX_MIGRATION=1.
+    Migrate,
+
     /// Generate shell completions
     Completion {
         /// Shell to generate completions for
@@ -278,6 +282,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "acp",
     "uninstall",
     "update",
+    "migrate",
     "completion",
 ];
 
@@ -328,6 +333,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::ExtractSessionId(_) => return None,
         Commands::Uninstall(_) => "uninstall",
         Commands::Update(_) => "update",
+        Commands::Migrate => "migrate",
         Commands::Completion { .. } => "completion",
     })
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,9 +1,9 @@
 //! `aoe migrate`: run pending data migrations now, with progress on stderr.
 //!
 //! Every `aoe` command runs pending migrations before it starts; this command
-//! exists so a user who deferred a long one (see
-//! [`crate::migrations::v027_isolate_sandbox_stores::DEFER_ENV`]) can finish
-//! it when convenient and watch it happen.
+//! exists so a user who deferred a long one (see `DEFER_ENV` in
+//! `crate::migrations::v027_isolate_sandbox_stores`) can finish it when
+//! convenient and watch it happen.
 
 use std::io::{IsTerminal, Write};
 use std::sync::{Arc, Mutex};
@@ -11,71 +11,246 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 
-use crate::migrations::progress::{ConsoleProgress, Event, Reporter};
+use crate::migrations::progress::{fit_width, ConsoleProgress, Event, Reporter};
 
 /// How long a migration may run before a CLI command mentions it. Quick
 /// migrations stay silent; anything slower gets its name and steps.
 const QUIET_FOR: Duration = Duration::from_millis(1500);
 
-/// A reporter that writes migration progress to stderr. Notices always print.
-/// The migration's name and steps print once it has run for [`QUIET_FOR`] (or
-/// once a notice makes the context necessary); on a TTY the status line is
-/// redrawn in place with per-file progress, on a pipe steps print as lines.
-pub fn stderr_reporter() -> Reporter {
-    let tty = std::io::stderr().is_terminal();
-    let state = Arc::new(Mutex::new((
-        ConsoleProgress::default(),
-        None::<Instant>,
-        false,
-    )));
-    Arc::new(move |event: Event| {
-        let mut guard = state.lock().unwrap_or_else(|e| e.into_inner());
-        let (console, started, shown) = &mut *guard;
+/// Columns assumed when the terminal width is unknown.
+const FALLBACK_WIDTH: usize = 80;
+
+const PREFIX: &str = "aoe: ";
+
+/// Renders migration events into stderr writes. Notices always print. The
+/// migration's name and steps print once it has run for `QUIET_FOR` (or once
+/// a notice makes the context necessary). On a TTY the status line is redrawn
+/// in place and clamped to the terminal width; on a pipe each new step prints
+/// as its own line and per-file progress is dropped.
+struct StderrRenderer {
+    console: ConsoleProgress,
+    started: Option<Instant>,
+    shown: bool,
+    tty: bool,
+}
+
+impl StderrRenderer {
+    fn new(tty: bool) -> Self {
+        Self {
+            console: ConsoleProgress::default(),
+            started: None,
+            shown: false,
+            tty,
+        }
+    }
+
+    /// The bytes to write for `event`, observed at `now` on a `width`-column
+    /// terminal.
+    fn render(&mut self, event: Event, now: Instant, width: usize) -> String {
         match &event {
             Event::Started { .. } => {
-                *started = Some(Instant::now());
-                *shown = false;
+                self.started = Some(now);
+                self.shown = false;
             }
-            Event::Finished { .. } => *started = None,
+            Event::Finished { .. } => self.started = None,
             _ => {}
         }
         let discrete = !matches!(event, Event::Progress(_));
         let notice = matches!(event, Event::Notice(_));
-        console.apply(event);
-        let slow = started.is_some_and(|at| at.elapsed() >= QUIET_FOR);
+        self.console.apply(event);
+        let slow = self
+            .started
+            .is_some_and(|at| now.duration_since(at) >= QUIET_FOR);
+        let newly_shown = !self.shown && (notice || slow);
         if notice || slow {
-            *shown = true;
+            self.shown = true;
         }
-        let lines = console.take_lines();
-        if !*shown && lines.is_empty() {
+        let lines = self.console.take_lines();
+        if !self.shown && lines.is_empty() {
+            return String::new();
+        }
+        let mut out = String::new();
+        if self.tty {
+            out.push_str("\r\x1b[2K");
+        }
+        for line in lines {
+            out.push_str(PREFIX);
+            out.push_str(&line);
+            out.push('\n');
+        }
+        if let Some(status) = self.console.status_line() {
+            if self.tty {
+                out.push_str(&fit_width(
+                    &format!("{PREFIX}{status}"),
+                    width.max(FALLBACK_WIDTH.min(width)),
+                ));
+            } else if !notice && (discrete || newly_shown) {
+                // A pipe gets each new step once; the first line after the
+                // quiet period also goes out even when a progress tick is
+                // what crossed it, so a slow copy is never silent. A notice
+                // stands alone; the status follows with the next step.
+                out.push_str(PREFIX);
+                out.push_str(&status);
+                out.push('\n');
+            }
+        }
+        out
+    }
+}
+
+pub fn stderr_reporter() -> Reporter {
+    let tty = std::io::stderr().is_terminal();
+    let renderer = Arc::new(Mutex::new(StderrRenderer::new(tty)));
+    Arc::new(move |event: Event| {
+        let width = crate::terminal::get_size().map_or(FALLBACK_WIDTH, |(w, _)| w as usize);
+        let out =
+            renderer
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .render(event, Instant::now(), width);
+        if out.is_empty() {
             return;
         }
         let mut err = std::io::stderr().lock();
-        if tty {
-            let _ = write!(err, "\r\x1b[2K");
-        }
-        for line in lines {
-            let _ = writeln!(err, "aoe: {line}");
-        }
-        if let Some(status) = console.status_line() {
-            if tty {
-                let _ = write!(err, "aoe: {status}");
-            } else if discrete && !notice {
-                let _ = writeln!(err, "aoe: {status}");
-            }
-        }
+        let _ = err.write_all(out.as_bytes());
         let _ = err.flush();
     })
 }
 
 pub fn run() -> Result<()> {
     if !crate::migrations::has_pending_migrations() {
-        eprintln!("aoe: data schema is current; checking for deferred sandbox store moves");
+        eprintln!("{PREFIX}data schema is current; retrying any deferred migration work");
     }
     crate::migrations::run_migrations_announced(Some(stderr_reporter()))?;
     if std::io::stderr().is_terminal() {
         eprint!("\r\x1b[2K");
     }
-    eprintln!("aoe: migrations complete");
+    eprintln!("{PREFIX}migrations complete");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn started() -> Event {
+        Event::Started {
+            version: 27,
+            name: "isolate_sandbox_stores",
+            position: 1,
+            total: 1,
+        }
+    }
+
+    #[test]
+    fn a_quick_migration_stays_silent_on_a_pipe() {
+        let mut r = StderrRenderer::new(false);
+        let t0 = Instant::now();
+        assert_eq!(r.render(started(), t0, 80), "");
+        assert_eq!(
+            r.render(Event::Step("reading session registries".into()), t0, 80),
+            ""
+        );
+        assert_eq!(
+            r.render(
+                Event::Finished {
+                    version: 27,
+                    elapsed: Duration::from_millis(300),
+                },
+                t0,
+                80,
+            ),
+            ""
+        );
+    }
+
+    #[test]
+    fn a_slow_migration_prints_its_first_status_even_from_a_progress_tick() {
+        let mut r = StderrRenderer::new(false);
+        let t0 = Instant::now();
+        r.render(started(), t0, 80);
+        r.render(Event::Step("copying agent store 1/2".into()), t0, 80);
+        // Still inside the quiet period: nothing.
+        assert_eq!(
+            r.render(
+                Event::Progress("100 files, 5 MB".into()),
+                t0 + Duration::from_millis(500),
+                80
+            ),
+            ""
+        );
+        // The tick that crosses the quiet period prints the status once.
+        let out = r.render(
+            Event::Progress("200 files, 11 MB".into()),
+            t0 + QUIET_FOR,
+            80,
+        );
+        assert!(out.starts_with(
+            "aoe: Data migration v27 (isolate_sandbox_stores): copying agent store 1/2, 200 files"
+        ));
+        assert!(out.ends_with('\n'));
+        // Later ticks stay quiet on a pipe; a new step prints.
+        assert_eq!(
+            r.render(
+                Event::Progress("300 files, 17 MB".into()),
+                t0 + QUIET_FOR,
+                80
+            ),
+            ""
+        );
+        let out = r.render(
+            Event::Step("retiring shared agent store".into()),
+            t0 + QUIET_FOR,
+            80,
+        );
+        assert_eq!(out.matches('\n').count(), 1);
+        assert!(out.contains("retiring shared agent store"));
+    }
+
+    #[test]
+    fn a_notice_prints_at_once_and_reveals_the_context() {
+        let mut r = StderrRenderer::new(false);
+        let t0 = Instant::now();
+        r.render(started(), t0, 80);
+        r.render(Event::Step("reading session registries".into()), t0, 80);
+        let out = r.render(
+            Event::Notice("AOE_DEFER_SANDBOX_MIGRATION is set".into()),
+            t0,
+            80,
+        );
+        assert_eq!(out, "aoe: AOE_DEFER_SANDBOX_MIGRATION is set\n");
+        // Context is now shown: the next step prints as a line.
+        let out = r.render(
+            Event::Step("checking which sandbox containers are running".into()),
+            t0,
+            80,
+        );
+        assert_eq!(out, "aoe: Data migration v27 (isolate_sandbox_stores): checking which sandbox containers are running (0.0s)\n");
+    }
+
+    #[test]
+    fn a_tty_redraws_one_clamped_status_line() {
+        let mut r = StderrRenderer::new(true);
+        let t0 = Instant::now();
+        r.render(started(), t0, 40);
+        let step = "copying agent store 1/2: /home/u/.gemini/sandbox -> /home/u/.gemini/sandbox-v2/0123456789abcdef";
+        let out = r.render(Event::Step(step.into()), t0 + QUIET_FOR, 40);
+        assert!(out.starts_with("\r\x1b[2K"));
+        let status = out.trim_start_matches("\r\x1b[2K");
+        assert_eq!(status.chars().count(), 40, "{status:?}");
+        assert!(!status.contains('\n'));
+        // A finished migration leaves its summary line and clears the status.
+        let out = r.render(
+            Event::Finished {
+                version: 27,
+                elapsed: Duration::from_millis(2500),
+            },
+            t0 + QUIET_FOR,
+            40,
+        );
+        assert_eq!(
+            out,
+            "\r\x1b[2Kaoe: Data migration v27 (isolate_sandbox_stores) done in 2.5s\n"
+        );
+    }
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,81 @@
+//! `aoe migrate`: run pending data migrations now, with progress on stderr.
+//!
+//! Every `aoe` command runs pending migrations before it starts; this command
+//! exists so a user who deferred a long one (see
+//! [`crate::migrations::v027_isolate_sandbox_stores::DEFER_ENV`]) can finish
+//! it when convenient and watch it happen.
+
+use std::io::{IsTerminal, Write};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+
+use crate::migrations::progress::{ConsoleProgress, Event, Reporter};
+
+/// How long a migration may run before a CLI command mentions it. Quick
+/// migrations stay silent; anything slower gets its name and steps.
+const QUIET_FOR: Duration = Duration::from_millis(1500);
+
+/// A reporter that writes migration progress to stderr. Notices always print.
+/// The migration's name and steps print once it has run for [`QUIET_FOR`] (or
+/// once a notice makes the context necessary); on a TTY the status line is
+/// redrawn in place with per-file progress, on a pipe steps print as lines.
+pub fn stderr_reporter() -> Reporter {
+    let tty = std::io::stderr().is_terminal();
+    let state = Arc::new(Mutex::new((
+        ConsoleProgress::default(),
+        None::<Instant>,
+        false,
+    )));
+    Arc::new(move |event: Event| {
+        let mut guard = state.lock().unwrap_or_else(|e| e.into_inner());
+        let (console, started, shown) = &mut *guard;
+        match &event {
+            Event::Started { .. } => {
+                *started = Some(Instant::now());
+                *shown = false;
+            }
+            Event::Finished { .. } => *started = None,
+            _ => {}
+        }
+        let discrete = !matches!(event, Event::Progress(_));
+        let notice = matches!(event, Event::Notice(_));
+        console.apply(event);
+        let slow = started.is_some_and(|at| at.elapsed() >= QUIET_FOR);
+        if notice || slow {
+            *shown = true;
+        }
+        let lines = console.take_lines();
+        if !*shown && lines.is_empty() {
+            return;
+        }
+        let mut err = std::io::stderr().lock();
+        if tty {
+            let _ = write!(err, "\r\x1b[2K");
+        }
+        for line in lines {
+            let _ = writeln!(err, "aoe: {line}");
+        }
+        if let Some(status) = console.status_line() {
+            if tty {
+                let _ = write!(err, "aoe: {status}");
+            } else if discrete && !notice {
+                let _ = writeln!(err, "aoe: {status}");
+            }
+        }
+        let _ = err.flush();
+    })
+}
+
+pub fn run() -> Result<()> {
+    if !crate::migrations::has_pending_migrations() {
+        eprintln!("aoe: data schema is current; checking for deferred sandbox store moves");
+    }
+    crate::migrations::run_migrations_announced(Some(stderr_reporter()))?;
+    if std::io::stderr().is_terminal() {
+        eprint!("\r\x1b[2K");
+    }
+    eprintln!("aoe: migrations complete");
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@ pub mod list;
 pub mod log_level;
 pub mod logs;
 pub mod mcp;
+pub mod migrate;
 pub mod output;
 pub mod plugin;
 pub mod profile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,6 +383,7 @@ async fn run(
         Some(Commands::Skill { command }) => return cli::skill::run(command),
         Some(Commands::Uninstall(args)) => return cli::uninstall::run(args).await,
         Some(Commands::Update(args)) => return cli::update::run(args).await,
+        Some(Commands::Migrate) => return cli::migrate::run(),
         // Pure redirect; needs no app data, so it must short-circuit before
         // config/migration prework that can fail in constrained environments.
         Some(Commands::Stop { .. }) => return cli::killall::stop_trap(),
@@ -392,9 +393,11 @@ async fn run(
     let profile_explicit = cli.profile.is_some();
     let profile = cli.profile.unwrap_or_default();
 
-    // TUI mode handles migrations with a spinner; CLI runs them silently
+    // TUI mode handles migrations with a spinner. CLI commands report progress
+    // on stderr only when a migration actually does work, so a quick command
+    // stays quiet and a long store move never looks like a hang.
     if cli.command.is_some() {
-        migrations::run_migrations()?;
+        migrations::run_migrations_with(Some(cli::migrate::stderr_reporter()))?;
     }
 
     // Surface config diagnostics on stderr for user-visible CLI commands

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -208,7 +208,8 @@ pub fn run_migrations() -> Result<()> {
 
 /// Run all pending migrations, sending [`progress::Event`]s to `reporter` so a
 /// long one (store copies, container probes) reads as work, not a hang. A
-/// still-pending sandbox store move is retried quietly.
+/// still-pending sandbox store move is retried too; it reports only the work
+/// it actually does (copies and their outcome), not what stays pending.
 pub fn run_migrations_with(reporter: Option<progress::Reporter>) -> Result<()> {
     run_migrations_inner(reporter, false)
 }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -8,6 +8,7 @@
 //! 2. Implement the migration function
 //! 3. Add it to the `MIGRATIONS` array below
 
+pub mod progress;
 mod v001_xdg_linux;
 mod v002_seed_sandbox_from_volumes;
 mod v003_yolo_mode_config;
@@ -200,8 +201,26 @@ pub fn has_pending_migrations() -> bool {
     get_current_version() < CURRENT_VERSION
 }
 
-/// Run all pending migrations. Call this early in app startup.
+/// Run all pending migrations silently. Call this early in app startup.
 pub fn run_migrations() -> Result<()> {
+    run_migrations_with(None)
+}
+
+/// Run all pending migrations, sending [`progress::Event`]s to `reporter` so a
+/// long one (store copies, container probes) reads as work, not a hang. A
+/// still-pending sandbox store move is retried quietly.
+pub fn run_migrations_with(reporter: Option<progress::Reporter>) -> Result<()> {
+    run_migrations_inner(reporter, false)
+}
+
+/// [`run_migrations_with`] for an explicit `aoe migrate`: a pending sandbox
+/// store move also narrates what is still pending and why.
+pub fn run_migrations_announced(reporter: Option<progress::Reporter>) -> Result<()> {
+    run_migrations_inner(reporter, true)
+}
+
+fn run_migrations_inner(reporter: Option<progress::Reporter>, announce: bool) -> Result<()> {
+    let _installed = progress::install(reporter);
     let current = get_current_version();
     debug!("Current schema version: {}", current);
 
@@ -211,28 +230,40 @@ pub fn run_migrations() -> Result<()> {
         );
     }
     if current == CURRENT_VERSION {
-        return v027_isolate_sandbox_stores::reconcile_pending();
+        return v027_isolate_sandbox_stores::reconcile_pending(announce);
     }
 
-    for migration in MIGRATIONS {
-        if migration.version > current {
-            let start = std::time::Instant::now();
-            info!(
-                target: "migrations",
-                version = migration.version,
-                name = migration.name,
-                "running migration"
-            );
-            (migration.run)()?;
-            set_version(migration.version)?;
-            info!(
-                target: "migrations",
-                version = migration.version,
-                name = migration.name,
-                duration_ms = start.elapsed().as_millis() as u64,
-                "migration completed"
-            );
-        }
+    let pending: Vec<&Migration> = MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version > current)
+        .collect();
+    for (index, migration) in pending.iter().enumerate() {
+        let start = std::time::Instant::now();
+        info!(
+            target: "migrations",
+            version = migration.version,
+            name = migration.name,
+            "running migration"
+        );
+        progress::report(progress::Event::Started {
+            version: migration.version,
+            name: migration.name,
+            position: index + 1,
+            total: pending.len(),
+        });
+        (migration.run)()?;
+        set_version(migration.version)?;
+        progress::report(progress::Event::Finished {
+            version: migration.version,
+            elapsed: start.elapsed(),
+        });
+        info!(
+            target: "migrations",
+            version = migration.version,
+            name = migration.name,
+            duration_ms = start.elapsed().as_millis() as u64,
+            "migration completed"
+        );
     }
 
     Ok(())

--- a/src/migrations/progress.rs
+++ b/src/migrations/progress.rs
@@ -3,8 +3,8 @@
 //! A migration can run for minutes (copying agent stores, probing a container
 //! runtime). With nothing but a spinner the user cannot tell work from a hang.
 //! The runner installs a reporter for the duration of a run and migrations
-//! call [`step`], [`progress`] and [`notice`] from wherever the work happens;
-//! with no reporter installed every call is a no-op.
+//! call `step`, `progress` and `notice` from wherever the work happens; with
+//! no reporter installed every call is a no-op.
 
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -152,14 +152,38 @@ pub fn format_elapsed(elapsed: Duration) -> String {
 }
 
 pub fn format_bytes(bytes: u64) -> String {
-    const MB: u64 = 1024 * 1024;
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
     if bytes >= 10 * MB {
         format!("{} MB", bytes / MB)
     } else if bytes >= MB {
         format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
     } else {
-        format!("{} KB", bytes / 1024)
+        format!("{bytes} B")
     }
+}
+
+/// Clamp `line` to `width` columns by eliding its middle, so a status line
+/// redrawn in place with `\r` + erase-line never wraps onto rows the erase
+/// cannot reach. Paths make these lines long; keeping both ends keeps the
+/// counts and the elapsed time readable.
+pub fn fit_width(line: &str, width: usize) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    if width == 0 || chars.len() <= width {
+        return line.to_string();
+    }
+    if width < 8 {
+        return chars[..width].iter().collect();
+    }
+    let keep = width - 1;
+    let head = keep / 2;
+    let tail = keep - head;
+    let mut out: String = chars[..head].iter().collect();
+    out.push('\u{2026}');
+    out.extend(chars[chars.len() - tail..].iter());
+    out
 }
 
 #[cfg(test)]
@@ -167,7 +191,10 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
+    // The reporter is process-global; a concurrent migration test would
+    // interleave its events into this sequence.
     #[test]
+    #[serial_test::serial]
     fn reporter_receives_events_only_while_installed() {
         let seen = Arc::new(Mutex::new(Vec::new()));
         {
@@ -245,8 +272,23 @@ mod tests {
         assert_eq!(format_elapsed(Duration::from_millis(1500)), "1.5s");
         assert_eq!(format_elapsed(Duration::from_secs(42)), "42s");
         assert_eq!(format_elapsed(Duration::from_secs(125)), "2m05s");
+        assert_eq!(format_bytes(500), "500 B");
         assert_eq!(format_bytes(512 * 1024), "512 KB");
         assert_eq!(format_bytes(3 * 1024 * 1024 / 2), "1.5 MB");
         assert_eq!(format_bytes(40 * 1024 * 1024), "40 MB");
+    }
+
+    #[test]
+    fn fit_width_elides_the_middle_and_keeps_both_ends() {
+        assert_eq!(fit_width("short", 80), "short");
+        assert_eq!(fit_width("short", 0), "short");
+        let long =
+            "copying store 1/2: /home/u/.gemini/sandbox -> /home/u/.gemini/sandbox-v2/abc (0.4s)";
+        let fitted = fit_width(long, 40);
+        assert_eq!(fitted.chars().count(), 40);
+        assert!(fitted.starts_with("copying store 1/2: "));
+        assert!(fitted.ends_with(" (0.4s)"));
+        assert!(fitted.contains('\u{2026}'));
+        assert_eq!(fit_width("abcdefghij", 5), "abcde");
     }
 }

--- a/src/migrations/progress.rs
+++ b/src/migrations/progress.rs
@@ -1,0 +1,252 @@
+//! Progress events for startup data migrations.
+//!
+//! A migration can run for minutes (copying agent stores, probing a container
+//! runtime). With nothing but a spinner the user cannot tell work from a hang.
+//! The runner installs a reporter for the duration of a run and migrations
+//! call [`step`], [`progress`] and [`notice`] from wherever the work happens;
+//! with no reporter installed every call is a no-op.
+
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// A migration begins. `position` and `total` count this run's pending set.
+    Started {
+        version: u32,
+        name: &'static str,
+        position: usize,
+        total: usize,
+    },
+    /// A discrete phase of the current migration, replacing the previous one.
+    Step(String),
+    /// A frequent refinement of the current step (bytes copied so far). Line
+    /// renderers without in-place updates drop these.
+    Progress(String),
+    /// A line worth keeping on screen: a deferral, something skipped, a hint.
+    Notice(String),
+    Finished {
+        version: u32,
+        elapsed: Duration,
+    },
+}
+
+pub type Reporter = Arc<dyn Fn(Event) + Send + Sync>;
+
+static REPORTER: RwLock<Option<Reporter>> = RwLock::new(None);
+
+/// Installs `reporter` until the returned guard drops.
+pub(super) fn install(reporter: Option<Reporter>) -> ReporterGuard {
+    *REPORTER.write().unwrap_or_else(|e| e.into_inner()) = reporter;
+    ReporterGuard
+}
+
+pub(super) struct ReporterGuard;
+
+impl Drop for ReporterGuard {
+    fn drop(&mut self) {
+        *REPORTER.write().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+}
+
+pub(crate) fn report(event: Event) {
+    let reporter = REPORTER.read().unwrap_or_else(|e| e.into_inner()).clone();
+    if let Some(reporter) = reporter {
+        reporter(event);
+    }
+}
+
+pub(crate) fn step(message: impl Into<String>) {
+    report(Event::Step(message.into()));
+}
+
+pub(crate) fn progress(message: impl Into<String>) {
+    report(Event::Progress(message.into()));
+}
+
+pub(crate) fn notice(message: impl Into<String>) {
+    report(Event::Notice(message.into()));
+}
+
+/// Renders events into one status line plus a queue of lines to keep, for a
+/// terminal that redraws the status line in place (the TUI boot spinner, a CLI
+/// on a TTY).
+#[derive(Default)]
+pub struct ConsoleProgress {
+    label: String,
+    step: String,
+    detail: String,
+    started: Option<Instant>,
+    lines: Vec<String>,
+}
+
+impl ConsoleProgress {
+    pub fn apply(&mut self, event: Event) {
+        match event {
+            Event::Started {
+                version,
+                name,
+                position,
+                total,
+            } => {
+                self.label = if total > 1 {
+                    format!("Data migration {position}/{total} (v{version} {name})")
+                } else {
+                    format!("Data migration v{version} ({name})")
+                };
+                self.step.clear();
+                self.detail.clear();
+                self.started = Some(Instant::now());
+            }
+            Event::Step(step) => {
+                self.step = step;
+                self.detail.clear();
+            }
+            Event::Progress(detail) => self.detail = detail,
+            Event::Notice(line) => self.lines.push(line),
+            Event::Finished { elapsed, .. } => {
+                // Sub-second migrations are not worth a line.
+                if elapsed >= Duration::from_secs(1) {
+                    self.lines.push(format!(
+                        "{} done in {}",
+                        self.label,
+                        format_elapsed(elapsed)
+                    ));
+                }
+                self.started = None;
+            }
+        }
+    }
+
+    /// The current activity, or `None` when no migration is running.
+    pub fn status_line(&self) -> Option<String> {
+        let started = self.started?;
+        let mut line = self.label.clone();
+        if !self.step.is_empty() {
+            line.push_str(": ");
+            line.push_str(&self.step);
+        }
+        if !self.detail.is_empty() {
+            line.push_str(", ");
+            line.push_str(&self.detail);
+        }
+        line.push_str(&format!(" ({})", format_elapsed(started.elapsed())));
+        Some(line)
+    }
+
+    /// Lines queued since the last call, oldest first.
+    pub fn take_lines(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.lines)
+    }
+}
+
+pub fn format_elapsed(elapsed: Duration) -> String {
+    let secs = elapsed.as_secs();
+    if secs >= 60 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else if secs >= 10 {
+        format!("{secs}s")
+    } else {
+        format!("{:.1}s", elapsed.as_secs_f64())
+    }
+}
+
+pub fn format_bytes(bytes: u64) -> String {
+    const MB: u64 = 1024 * 1024;
+    if bytes >= 10 * MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else {
+        format!("{} KB", bytes / 1024)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn reporter_receives_events_only_while_installed() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        {
+            let sink = seen.clone();
+            let _guard = install(Some(Arc::new(move |event| {
+                sink.lock().unwrap().push(event)
+            })));
+            step("planning");
+            progress("3 files");
+            notice("deferred");
+        }
+        step("after uninstall");
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                Event::Step("planning".into()),
+                Event::Progress("3 files".into()),
+                Event::Notice("deferred".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn console_progress_builds_a_status_line_and_keeps_notices() {
+        let mut console = ConsoleProgress::default();
+        assert_eq!(console.status_line(), None);
+        console.apply(Event::Started {
+            version: 27,
+            name: "isolate_sandbox_stores",
+            position: 1,
+            total: 1,
+        });
+        console.apply(Event::Step("copying store 1/2".into()));
+        console.apply(Event::Progress("120 files, 4.0 MB".into()));
+        let line = console.status_line().unwrap();
+        assert!(line.starts_with(
+            "Data migration v27 (isolate_sandbox_stores): copying store 1/2, 120 files, 4.0 MB ("
+        ));
+        // A new step drops the stale detail.
+        console.apply(Event::Step("retiring legacy store".into()));
+        assert!(!console.status_line().unwrap().contains("120 files"));
+        console.apply(Event::Notice(
+            "session abc is running; its store moves after it stops".into(),
+        ));
+        console.apply(Event::Finished {
+            version: 27,
+            elapsed: Duration::from_millis(2500),
+        });
+        assert_eq!(console.status_line(), None);
+        let lines = console.take_lines();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("session abc"));
+        assert!(lines[1].ends_with("done in 2.5s"));
+        assert!(console.take_lines().is_empty());
+        // Instant finishes stay quiet; a multi-migration run numbers its label.
+        console.apply(Event::Started {
+            version: 26,
+            name: "x",
+            position: 2,
+            total: 3,
+        });
+        assert!(console
+            .status_line()
+            .unwrap()
+            .starts_with("Data migration 2/3 (v26 x)"));
+        console.apply(Event::Finished {
+            version: 26,
+            elapsed: Duration::from_millis(20),
+        });
+        assert!(console.take_lines().is_empty());
+    }
+
+    #[test]
+    fn formatting_helpers_pick_readable_units() {
+        assert_eq!(format_elapsed(Duration::from_millis(1500)), "1.5s");
+        assert_eq!(format_elapsed(Duration::from_secs(42)), "42s");
+        assert_eq!(format_elapsed(Duration::from_secs(125)), "2m05s");
+        assert_eq!(format_bytes(512 * 1024), "512 KB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 / 2), "1.5 MB");
+        assert_eq!(format_bytes(40 * 1024 * 1024), "40 MB");
+    }
+}

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -6,14 +6,75 @@
 //! journal, and the legacy quarantine exist only while that bounded transition
 //! is pending; the committed state keeps only `sandbox-v2/<instance>`.
 
+use super::progress;
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 const JOURNAL: &str = ".v027-sandbox-transition.json";
 pub(crate) const LOCK: &str = ".v027-sandbox-transition.lock";
+/// Set to any non-empty value to start without moving stores: every sandboxed
+/// session stays on its shared store and is retried on a later start (or with
+/// `aoe migrate`). The schema version still advances, so this is a deferral,
+/// not a downgrade.
+pub const DEFER_ENV: &str = "AOE_DEFER_SANDBOX_MIGRATION";
+
+fn defer_requested() -> bool {
+    std::env::var_os(DEFER_ENV).is_some_and(|value| !value.is_empty())
+}
+
+/// Whether this pass narrates deferrals and pending rows. The schema migration
+/// and `aoe migrate` do; the per-startup reconcile stays quiet unless it moves
+/// a store, so a machine whose runtime is down is not told the same thing on
+/// every command.
+static ANNOUNCE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// The runtime-unavailable notice is worth one line per pass, not one per row.
+static RUNTIME_NOTICED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Files and bytes copied by the store copy in flight, for the progress line.
+static COPY_FILES: AtomicU64 = AtomicU64::new(0);
+static COPY_BYTES: AtomicU64 = AtomicU64::new(0);
+static COPY_LABEL: Mutex<String> = Mutex::new(String::new());
+
+fn begin_copy_progress(label: String) {
+    COPY_FILES.store(0, Ordering::Relaxed);
+    COPY_BYTES.store(0, Ordering::Relaxed);
+    *COPY_LABEL.lock().unwrap_or_else(|e| e.into_inner()) = label;
+}
+
+/// One regular file copied. Reports every 100 files so a large store shows
+/// movement without flooding the reporter.
+fn copied_file(bytes: u64) {
+    let files = COPY_FILES.fetch_add(1, Ordering::Relaxed) + 1;
+    let total = COPY_BYTES.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    if files % 100 == 0 {
+        progress::progress(format!("{files} files, {}", progress::format_bytes(total)));
+    }
+}
+
+/// One liveness probe per session inspects a container each; a machine with
+/// many sandboxed sessions paid for a subprocess per row. Ask the runtime for
+/// every sandbox container once and answer from that; a session it did not
+/// list (or a runtime that returned nothing) still gets the per-row probe, so
+/// an unreachable runtime keeps reading as live.
+fn batched_running_probe() -> impl Fn(&str) -> Result<bool> {
+    let batch: std::sync::OnceLock<std::collections::HashMap<String, bool>> =
+        std::sync::OnceLock::new();
+    move |id: &str| {
+        let states = batch.get_or_init(|| {
+            progress::step("checking which sandbox containers are running");
+            crate::containers::batch_container_health()
+        });
+        match states.get(&crate::containers::DockerContainer::generate_name(id)) {
+            Some(running) => Ok(*running),
+            None => migrated_container_is_running(id),
+        }
+    }
+}
 
 /// Reports whether a migrated row's container is live. See
 /// [`migrated_container_is_running`] for what an unreachable runtime answers.
@@ -58,6 +119,11 @@ fn migrated_container_is_running(id: &str) -> Result<bool> {
         Ok(running) => Ok(running),
         Err(error) if runtime_cannot_answer(&error) => {
             tracing::warn!("v027 treating {id} as live: container runtime unavailable ({error})");
+            if ANNOUNCE.load(Ordering::Relaxed) && !RUNTIME_NOTICED.swap(true, Ordering::Relaxed) {
+                progress::notice(format!(
+                    "container runtime unavailable ({error}); sandboxed sessions keep their shared store until their containers can be checked"
+                ));
+            }
             Ok(true)
         }
         Err(error) => Err(error.into()),
@@ -108,25 +174,42 @@ pub fn run() -> Result<()> {
     run_in(
         &app_dir,
         &home,
-        &migrated_container_is_running,
+        &batched_running_probe(),
         &reap_migrated_container,
+        defer_requested(),
+        true,
     )
 }
 
 /// Retry cohorts that were live during the schema migration. This is called on
 /// every startup until no pre-v2 row remains, then becomes a cheap read.
-pub(crate) fn reconcile_pending() -> Result<()> {
+/// `announce` narrates pending rows (see [`ANNOUNCE`]).
+pub(crate) fn reconcile_pending(announce: bool) -> Result<()> {
     let app_dir = crate::session::get_app_dir()?;
     if !transition_may_be_pending(&app_dir)? {
         return Ok(());
     }
     let home = dirs::home_dir().context("home directory unavailable for sandbox migration")?;
+    let start = std::time::Instant::now();
+    progress::report(progress::Event::Started {
+        version: 27,
+        name: "isolate_sandbox_stores",
+        position: 1,
+        total: 1,
+    });
     run_in(
         &app_dir,
         &home,
-        &migrated_container_is_running,
+        &batched_running_probe(),
         &reap_migrated_container,
-    )
+        defer_requested(),
+        announce,
+    )?;
+    progress::report(progress::Event::Finished {
+        version: 27,
+        elapsed: start.elapsed(),
+    });
+    Ok(())
 }
 
 fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
@@ -157,12 +240,19 @@ fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
     Ok(false)
 }
 
+/// `defer_stores` leaves every cohort on its shared store this pass (see
+/// [`DEFER_ENV`]); rows stay pending exactly as they do behind a live container.
 fn run_in(
     app_dir: &Path,
     home: &Path,
     is_running: &RunningProbe<'_>,
     reap: &ReapProbe<'_>,
+    defer_stores: bool,
+    announce: bool,
 ) -> Result<()> {
+    ANNOUNCE.store(announce, Ordering::Relaxed);
+    RUNTIME_NOTICED.store(false, Ordering::Relaxed);
+    progress::step("reading session registries");
     fs::create_dir_all(app_dir)?;
     let _lock = crate::session::acquire_storage_flock(app_dir, LOCK)?;
     let registry_paths = registry_paths(app_dir)?;
@@ -410,6 +500,13 @@ fn run_in(
             .or_default()
             .push(target);
     }
+    if announce && defer_stores && !affected_rows.is_empty() {
+        progress::notice(format!(
+            "{DEFER_ENV} is set: {} sandboxed session(s) keep their shared agent store for now; \
+             the move is retried on a later start or with `aoe migrate`.",
+            affected_rows.len()
+        ));
+    }
     if !needs_registry_write
         && cohorts.is_empty()
         && known_sources.iter().all(|source| !source.exists())
@@ -508,7 +605,11 @@ fn run_in(
             let id = orphan.to_string_lossy();
             let source = root.join(orphan);
             let metadata = fs::symlink_metadata(&source)?;
-            if metadata.file_type().is_symlink() || !metadata.is_dir() || is_running(&id)? {
+            if defer_stores
+                || metadata.file_type().is_symlink()
+                || !metadata.is_dir()
+                || is_running(&id)?
+            {
                 tracing::warn!(
                     "v027 preserving ambiguous or live orphan store: {}",
                     source.display()
@@ -517,6 +618,7 @@ fn run_in(
                 orphan_blocked_roots.insert(root.clone());
                 continue;
             }
+            progress::step(format!("copying unregistered store {}", source.display()));
             publish_store(
                 &source,
                 &destination_parent.join(orphan),
@@ -536,20 +638,45 @@ fn run_in(
         }
     }
 
+    let total_targets: usize = cohorts.values().map(Vec::len).sum();
+    let mut copied_targets = 0usize;
     for (shared, cohort) in &cohorts {
         let ids: BTreeSet<&str> = cohort.iter().map(|target| target.id.as_str()).collect();
-        let live = ids.iter().try_fold(false, |live, id| {
-            is_running(id).map(|running| live || running)
-        })?;
+        let live = defer_stores
+            || ids.iter().try_fold(false, |live, id| {
+                is_running(id).map(|running| live || running)
+            })?;
         if live {
             for target in cohort {
                 ready_rows.remove(&(target.registry, target.row));
                 blocked_roots.insert(target.cleanup_root.clone());
             }
+            if announce && !defer_stores {
+                progress::notice(format!(
+                    "session(s) {} running or unverified; their store moves after they stop",
+                    ids.iter().copied().collect::<Vec<_>>().join(", ")
+                ));
+            }
             pending.push(shared.to_string_lossy().into_owned());
             continue;
         }
         for target in cohort {
+            copied_targets += 1;
+            if copied_targets == 1 {
+                // Said once, right before the first copy: this is the part
+                // that can take minutes, and the one a user may want to skip.
+                progress::notice(format!(
+                    "Isolating agent stores for {} sandboxed session(s): each gets its own copy of the \
+                     shared store under sandbox-v2/. Large stores take a while. To start without waiting, \
+                     quit and run with {DEFER_ENV}=1; finish later with `aoe migrate`.",
+                    affected_rows.len()
+                ));
+            }
+            progress::step(format!(
+                "copying store {copied_targets}/{total_targets}: {} -> {}",
+                shared.display(),
+                target.private.display()
+            ));
             let excluded = excluded_by_root
                 .get(&target.cleanup_root)
                 .context("missing cleanup-root exclusions")?;
@@ -591,6 +718,12 @@ fn run_in(
         }
     }
     let mut deferred_rows = BTreeSet::new();
+    if !ready_ids.is_empty() {
+        progress::step(format!(
+            "removing {} stopped sandbox container(s) so they relaunch on the new store",
+            ready_ids.len()
+        ));
+    }
     for (id, keys) in &ready_ids {
         if !reap(id)? {
             deferred_rows.extend(keys.iter().copied());
@@ -618,6 +751,7 @@ fn run_in(
                 .iter()
                 .all(|target| ready_rows.contains(&(target.registry, target.row)));
         if !defer_source_retirement && !blocked_roots.contains(root) && all_ready {
+            progress::step(format!("retiring legacy store {}", root.display()));
             retire_legacy(root)?;
         } else {
             pending.push(root.to_string_lossy().into_owned());
@@ -655,6 +789,17 @@ fn run_in(
         sync_parent(&registry.path)?;
     }
 
+    let done = ready_rows.len();
+    if !affected_rows.is_empty() && (announce || done > 0) {
+        let left = affected_rows.len().saturating_sub(done);
+        progress::notice(if left == 0 {
+            format!("{done} sandboxed session(s) now use private agent stores.")
+        } else {
+            format!(
+                "{done} sandboxed session(s) moved, {left} still pending; the move resumes on a later start or with `aoe migrate`."
+            )
+        });
+    }
     if pending.is_empty() {
         match fs::remove_file(&journal) {
             Ok(()) => {}
@@ -874,6 +1019,7 @@ fn publish_store(
         return Ok(());
     }
     fs::create_dir(&stage)?;
+    begin_copy_progress(source.display().to_string());
     copy_tree_no_links(
         source,
         &stage,
@@ -1066,7 +1212,8 @@ fn copy_tree_from_fd(
                 options.create_new(true);
             }
             let mut output = options.open(&target)?;
-            std::io::copy(&mut input, &mut output)?;
+            let bytes = std::io::copy(&mut input, &mut output)?;
+            copied_file(bytes);
             output.set_permissions(fs::Permissions::from_mode(opened.st_mode as u32))?;
             futimens(
                 &output,
@@ -1144,7 +1291,7 @@ fn copy_tree_no_links(
                 Err(error) => return Err(error.into()),
             };
             if should_copy {
-                fs::copy(entry.path(), &target)?;
+                copied_file(fs::copy(entry.path(), &target)?);
                 fs::set_permissions(&target, metadata.permissions())?;
                 fs::File::open(&target)?.sync_all()?;
             }
@@ -1242,7 +1389,7 @@ mod tests {
     /// the glob import keeps these tests hermetic: they assert the migration's
     /// own logic and must not depend on a container runtime being installed.
     fn run_in(app_dir: &Path, home: &Path, is_running: &RunningProbe<'_>) -> Result<()> {
-        super::run_in(app_dir, home, is_running, &|_| Ok(true))
+        super::run_in(app_dir, home, is_running, &|_| Ok(true), false, true)
     }
 
     fn row(id: &str) -> String {
@@ -1295,7 +1442,7 @@ mod tests {
 
         // The answers the production probes give when the runtime is
         // unreachable: liveness cannot be disproved, and nothing is reaped.
-        super::run_in(&app, &home, &|_| Ok(true), &|_| Ok(false)).unwrap();
+        super::run_in(&app, &home, &|_| Ok(true), &|_| Ok(false), false, true).unwrap();
         let deferred: Value =
             serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
         assert_eq!(
@@ -1308,7 +1455,7 @@ mod tests {
         );
         assert!(transition_may_be_pending(&app).unwrap());
 
-        super::run_in(&app, &home, &|_| Ok(false), &|_| Ok(true)).unwrap();
+        super::run_in(&app, &home, &|_| Ok(false), &|_| Ok(true), false, true).unwrap();
         let committed: Value =
             serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
         assert_eq!(committed[0]["sandbox_store_generation"], 2);
@@ -1318,6 +1465,79 @@ mod tests {
         );
         assert!(!home.join(".gemini/sandbox").exists());
         assert!(!transition_may_be_pending(&app).unwrap());
+    }
+
+    /// `AOE_DEFER_SANDBOX_MIGRATION` must behave exactly like a live cohort: no
+    /// copy, no reap, the row pending, and a later undeferred pass finishing
+    /// the move. It also has to say so, since a silent deferral would look
+    /// like a migration that did nothing.
+    #[test]
+    #[serial_test::serial]
+    fn deferral_leaves_stores_pending_and_reports_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        fs::create_dir_all(&app).unwrap();
+        fs::create_dir_all(home.join(".gemini/sandbox/history")).unwrap();
+        fs::write(home.join(".gemini/sandbox/history/id.json"), b"legacy").unwrap();
+        fs::write(app.join("sessions.json"), format!("[{}]", row("one"))).unwrap();
+
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = events.clone();
+        let guard = progress::install(Some(std::sync::Arc::new(move |event| {
+            sink.lock().unwrap().push(event)
+        })));
+        let probed = std::cell::Cell::new(false);
+        super::run_in(
+            &app,
+            &home,
+            &|_| {
+                probed.set(true);
+                Ok(false)
+            },
+            &|_| panic!("a deferred pass must not reap containers"),
+            true,
+            true,
+        )
+        .unwrap();
+        drop(guard);
+        assert!(!probed.get(), "deferral skips the container probe");
+        let pending: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_eq!(pending[0]["sandbox_store_generation"], 1);
+        assert!(!home.join(".gemini/sandbox-v2").exists());
+        assert!(home.join(".gemini/sandbox").is_dir());
+        assert!(app.join(JOURNAL).is_file());
+        let notices: Vec<String> = events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match event {
+                progress::Event::Notice(line) => Some(line.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            notices
+                .iter()
+                .any(|line| line.contains(DEFER_ENV) && line.contains("1 sandboxed session")),
+            "deferral is announced: {notices:?}"
+        );
+        assert!(
+            notices.iter().any(|line| line.contains("1 still pending")),
+            "summary counts the pending row: {notices:?}"
+        );
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+        let committed: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_eq!(committed[0]["sandbox_store_generation"], 2);
+        assert_eq!(
+            fs::read(home.join(".gemini/sandbox-v2/one/history/id.json")).unwrap(),
+            b"legacy"
+        );
+        assert!(!app.join(JOURNAL).exists());
     }
 
     #[test]

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -13,7 +13,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
 
 const JOURNAL: &str = ".v027-sandbox-transition.json";
 pub(crate) const LOCK: &str = ".v027-sandbox-transition.lock";
@@ -24,26 +23,20 @@ pub(crate) const LOCK: &str = ".v027-sandbox-transition.lock";
 pub const DEFER_ENV: &str = "AOE_DEFER_SANDBOX_MIGRATION";
 
 fn defer_requested() -> bool {
-    std::env::var_os(DEFER_ENV).is_some_and(|value| !value.is_empty())
+    defer_requested_by(std::env::var_os(DEFER_ENV).as_deref())
 }
 
-/// Whether this pass narrates deferrals and pending rows. The schema migration
-/// and `aoe migrate` do; the per-startup reconcile stays quiet unless it moves
-/// a store, so a machine whose runtime is down is not told the same thing on
-/// every command.
-static ANNOUNCE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-/// The runtime-unavailable notice is worth one line per pass, not one per row.
-static RUNTIME_NOTICED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+fn defer_requested_by(value: Option<&std::ffi::OsStr>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
+}
 
 /// Files and bytes copied by the store copy in flight, for the progress line.
 static COPY_FILES: AtomicU64 = AtomicU64::new(0);
 static COPY_BYTES: AtomicU64 = AtomicU64::new(0);
-static COPY_LABEL: Mutex<String> = Mutex::new(String::new());
 
-fn begin_copy_progress(label: String) {
+fn begin_copy_progress() {
     COPY_FILES.store(0, Ordering::Relaxed);
     COPY_BYTES.store(0, Ordering::Relaxed);
-    *COPY_LABEL.lock().unwrap_or_else(|e| e.into_inner()) = label;
 }
 
 /// One regular file copied. Reports every 100 files so a large store shows
@@ -61,23 +54,57 @@ fn copied_file(bytes: u64) {
 /// every sandbox container once and answer from that; a session it did not
 /// list (or a runtime that returned nothing) still gets the per-row probe, so
 /// an unreachable runtime keeps reading as live.
-fn batched_running_probe() -> impl Fn(&str) -> Result<bool> {
+///
+/// The snapshot is taken at the first probe and reused for the pass, so a
+/// container started mid-pass reads as stopped for later cohorts. That is
+/// contained: `reap_migrated_container` removes without force, so a container
+/// that came alive fails the removal and the transition, rather than losing
+/// its store underneath a running agent.
+///
+/// `announce` lets the fallback probe say once, per pass, that the runtime
+/// could not be asked; the per-startup reconcile passes `false` so a machine
+/// whose runtime is down is not told the same thing on every command.
+fn batched_running_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
     let batch: std::sync::OnceLock<std::collections::HashMap<String, bool>> =
         std::sync::OnceLock::new();
+    let runtime_noticed = std::cell::Cell::new(false);
     move |id: &str| {
         let states = batch.get_or_init(|| {
             progress::step("checking which sandbox containers are running");
             crate::containers::batch_container_health()
         });
-        match states.get(&crate::containers::DockerContainer::generate_name(id)) {
-            Some(running) => Ok(*running),
-            None => migrated_container_is_running(id),
+        if let Some(running) = states.get(&crate::containers::DockerContainer::generate_name(id)) {
+            return Ok(*running);
         }
+        let (running, unanswered) = probe_container_running(id)?;
+        if unanswered && announce && !runtime_noticed.replace(true) {
+            progress::notice(
+                "container runtime unavailable; sandboxed sessions keep their shared agent store until their containers can be checked",
+            );
+        }
+        Ok(running)
+    }
+}
+
+/// Whether a migrated row's container is live, so its store must be left
+/// alone this pass, plus whether that answer is the fail-closed substitute for
+/// a runtime that could not be asked. Publishing a store and retiring its
+/// legacy source while a container AoE cannot see may still be writing to it
+/// is the one outcome this migration must never produce, so an unknown answer
+/// takes the arm that copies nothing.
+fn probe_container_running(id: &str) -> Result<(bool, bool)> {
+    match crate::containers::DockerContainer::from_session_id(id).is_running() {
+        Ok(running) => Ok((running, false)),
+        Err(error) if runtime_cannot_answer(&error) => {
+            tracing::warn!("v027 treating {id} as live: container runtime unavailable ({error})");
+            Ok((true, true))
+        }
+        Err(error) => Err(error.into()),
     }
 }
 
 /// Reports whether a migrated row's container is live. See
-/// [`migrated_container_is_running`] for what an unreachable runtime answers.
+/// [`probe_container_running`] for what an unreachable runtime answers.
 type RunningProbe<'a> = dyn Fn(&str) -> Result<bool> + 'a;
 
 /// Reaps the stopped container of a row whose store has moved. `Ok(false)`
@@ -105,29 +132,6 @@ fn runtime_cannot_answer(error: &crate::containers::error::DockerError) -> bool 
             | DockerError::PermissionDenied
             | DockerError::InspectFailed(_)
     )
-}
-
-/// Whether a migrated row's container is live, so its store must be left
-/// alone this pass.
-///
-/// A runtime that cannot answer reports live. Publishing a store and retiring
-/// its legacy source while a container AoE cannot see may still be writing to
-/// it is the one outcome this migration must never produce, so an unknown
-/// answer takes the arm that copies nothing.
-fn migrated_container_is_running(id: &str) -> Result<bool> {
-    match crate::containers::DockerContainer::from_session_id(id).is_running() {
-        Ok(running) => Ok(running),
-        Err(error) if runtime_cannot_answer(&error) => {
-            tracing::warn!("v027 treating {id} as live: container runtime unavailable ({error})");
-            if ANNOUNCE.load(Ordering::Relaxed) && !RUNTIME_NOTICED.swap(true, Ordering::Relaxed) {
-                progress::notice(format!(
-                    "container runtime unavailable ({error}); sandboxed sessions keep their shared store until their containers can be checked"
-                ));
-            }
-            Ok(true)
-        }
-        Err(error) => Err(error.into()),
-    }
 }
 
 /// Remove the stopped container of a row whose store has moved, so its next
@@ -174,7 +178,7 @@ pub fn run() -> Result<()> {
     run_in(
         &app_dir,
         &home,
-        &batched_running_probe(),
+        &batched_running_probe(true),
         &reap_migrated_container,
         defer_requested(),
         true,
@@ -200,7 +204,7 @@ pub(crate) fn reconcile_pending(announce: bool) -> Result<()> {
     run_in(
         &app_dir,
         &home,
-        &batched_running_probe(),
+        &batched_running_probe(announce),
         &reap_migrated_container,
         defer_requested(),
         announce,
@@ -241,7 +245,9 @@ fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
 }
 
 /// `defer_stores` leaves every cohort on its shared store this pass (see
-/// [`DEFER_ENV`]); rows stay pending exactly as they do behind a live container.
+/// [`DEFER_ENV`]); rows stay pending as they do behind a live container.
+/// `announce` narrates deferrals and pending rows: the schema migration and
+/// `aoe migrate` do, the per-startup reconcile reports only stores it moves.
 fn run_in(
     app_dir: &Path,
     home: &Path,
@@ -250,8 +256,6 @@ fn run_in(
     defer_stores: bool,
     announce: bool,
 ) -> Result<()> {
-    ANNOUNCE.store(announce, Ordering::Relaxed);
-    RUNTIME_NOTICED.store(false, Ordering::Relaxed);
     progress::step("reading session registries");
     fs::create_dir_all(app_dir)?;
     let _lock = crate::session::acquire_storage_flock(app_dir, LOCK)?;
@@ -653,7 +657,7 @@ fn run_in(
             }
             if announce && !defer_stores {
                 progress::notice(format!(
-                    "session(s) {} running or unverified; their store moves after they stop",
+                    "session(s) {} running or unverified; their agent store moves after they stop",
                     ids.iter().copied().collect::<Vec<_>>().join(", ")
                 ));
             }
@@ -667,13 +671,13 @@ fn run_in(
                 // that can take minutes, and the one a user may want to skip.
                 progress::notice(format!(
                     "Isolating agent stores for {} sandboxed session(s): each gets its own copy of the \
-                     shared store under sandbox-v2/. Large stores take a while. To start without waiting, \
-                     quit and run with {DEFER_ENV}=1; finish later with `aoe migrate`.",
+                     shared agent store under sandbox-v2/. Large stores take a while. To start without \
+                     waiting, quit and run with {DEFER_ENV}=1; finish later with `aoe migrate`.",
                     affected_rows.len()
                 ));
             }
             progress::step(format!(
-                "copying store {copied_targets}/{total_targets}: {} -> {}",
+                "copying agent store {copied_targets}/{total_targets}: {} -> {}",
                 shared.display(),
                 target.private.display()
             ));
@@ -751,7 +755,7 @@ fn run_in(
                 .iter()
                 .all(|target| ready_rows.contains(&(target.registry, target.row)));
         if !defer_source_retirement && !blocked_roots.contains(root) && all_ready {
-            progress::step(format!("retiring legacy store {}", root.display()));
+            progress::step(format!("retiring shared agent store {}", root.display()));
             retire_legacy(root)?;
         } else {
             pending.push(root.to_string_lossy().into_owned());
@@ -796,7 +800,7 @@ fn run_in(
             format!("{done} sandboxed session(s) now use private agent stores.")
         } else {
             format!(
-                "{done} sandboxed session(s) moved, {left} still pending; the move resumes on a later start or with `aoe migrate`."
+                "{done} sandboxed session(s) moved to private agent stores, {left} still pending; the move resumes on a later start or with `aoe migrate`."
             )
         });
     }
@@ -1019,7 +1023,7 @@ fn publish_store(
         return Ok(());
     }
     fs::create_dir(&stage)?;
-    begin_copy_progress(source.display().to_string());
+    begin_copy_progress();
     copy_tree_no_links(
         source,
         &stage,
@@ -1538,6 +1542,46 @@ mod tests {
             b"legacy"
         );
         assert!(!app.join(JOURNAL).exists());
+    }
+
+    /// The documented recipe end to end: `AOE_DEFER_SANDBOX_MIGRATION=1` on a
+    /// pre-v27 install commits the schema version (so the next start reaches
+    /// the reconcile path) while the store stays put and the row stays pending.
+    #[test]
+    #[serial_test::serial]
+    fn deferring_through_the_runner_advances_the_schema_and_keeps_the_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        fs::create_dir_all(&app).unwrap();
+        fs::create_dir_all(home.join(".gemini/sandbox/history")).unwrap();
+        fs::write(home.join(".gemini/sandbox/history/id.json"), b"legacy").unwrap();
+        fs::write(app.join("sessions.json"), format!("[{}]", row("one"))).unwrap();
+        fs::write(app.join(".schema_version"), b"26").unwrap();
+
+        assert!(!defer_requested_by(None));
+        assert!(!defer_requested_by(Some(std::ffi::OsStr::new(""))));
+        assert!(defer_requested_by(Some(std::ffi::OsStr::new("1"))));
+
+        std::env::set_var(DEFER_ENV, "1");
+        let result = super::super::run_migrations_announced(None);
+        std::env::remove_var(DEFER_ENV);
+        result.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(app.join(".schema_version"))
+                .unwrap()
+                .trim(),
+            "27"
+        );
+        assert!(!super::super::has_pending_migrations());
+        assert!(transition_may_be_pending(&app).unwrap());
+        assert!(home.join(".gemini/sandbox").is_dir());
+        assert!(!home.join(".gemini/sandbox-v2").exists());
+        let pending: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_eq!(pending[0]["sandbox_store_generation"], 1);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -229,8 +229,10 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
 
     // Run pending migrations with a spinner that names the migration, its
     // current step and the elapsed time, and keeps the notices a migration
-    // emits (what is being moved, how to defer it) on screen.
-    if migrations::has_pending_migrations() {
+    // emits (what is being moved, how to defer it) on screen. Unconditional:
+    // a deferred sandbox store move runs from the schema-current path too, and
+    // the spinner draws nothing until a migration reports it has started.
+    {
         const SPINNER_FRAMES: &[char] = &['◐', '◓', '◑', '◒'];
         let console = std::sync::Arc::new(std::sync::Mutex::new(
             migrations::progress::ConsoleProgress::default(),
@@ -255,10 +257,13 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
                 println!("  {line}");
             }
             if let Some(status) = console.status_line() {
-                print!(
+                // One row only: the erase above cannot reach a wrapped line.
+                let width = crate::terminal::get_size().map_or(80, |(w, _)| w as usize);
+                let line = format!(
                     "  {} {status}",
                     SPINNER_FRAMES[frame % SPINNER_FRAMES.len()]
                 );
+                print!("{}", migrations::progress::fit_width(&line, width));
             }
             let _ = io::stdout().flush();
         };
@@ -281,8 +286,6 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
                 }
             }
         }
-    } else {
-        tokio::task::spawn_blocking(migrations::run_migrations).await??;
     }
 
     // Check for tmux

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -227,24 +227,56 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
         return remote_home::run_standalone(endpoint).await;
     }
 
-    // Run pending migrations with a spinner so users see progress
+    // Run pending migrations with a spinner that names the migration, its
+    // current step and the elapsed time, and keeps the notices a migration
+    // emits (what is being moved, how to defer it) on screen.
     if migrations::has_pending_migrations() {
         const SPINNER_FRAMES: &[char] = &['◐', '◓', '◑', '◒'];
-        let migration_handle = tokio::task::spawn_blocking(migrations::run_migrations);
+        let console = std::sync::Arc::new(std::sync::Mutex::new(
+            migrations::progress::ConsoleProgress::default(),
+        ));
+        let reporter: migrations::progress::Reporter = {
+            let console = console.clone();
+            std::sync::Arc::new(move |event| {
+                console
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .apply(event);
+            })
+        };
+        let migration_handle =
+            tokio::task::spawn_blocking(move || migrations::run_migrations_with(Some(reporter)));
         tokio::pin!(migration_handle);
         let mut tick = tokio::time::interval(std::time::Duration::from_millis(120));
         let mut frame = 0usize;
+        let draw = |frame: usize, console: &mut migrations::progress::ConsoleProgress| {
+            print!("\r\x1b[2K");
+            for line in console.take_lines() {
+                println!("  {line}");
+            }
+            if let Some(status) = console.status_line() {
+                print!(
+                    "  {} {status}",
+                    SPINNER_FRAMES[frame % SPINNER_FRAMES.len()]
+                );
+            }
+            let _ = io::stdout().flush();
+        };
         loop {
             tokio::select! {
                 result = &mut migration_handle => {
+                    let mut console = console.lock().unwrap_or_else(|e| e.into_inner());
                     print!("\r\x1b[2K");
+                    for line in console.take_lines() {
+                        println!("  {line}");
+                    }
                     let _ = io::stdout().flush();
+                    drop(console);
                     result??;
                     break;
                 }
                 _ = tick.tick() => {
-                    print!("\r  {} Running data migrations...", SPINNER_FRAMES[frame % SPINNER_FRAMES.len()]);
-                    let _ = io::stdout().flush();
+                    draw(frame, &mut console.lock().unwrap_or_else(|e| e.into_inner()));
                     frame += 1;
                 }
             }

--- a/web/tests/helpers/isolatedEnv.test.ts
+++ b/web/tests/helpers/isolatedEnv.test.ts
@@ -31,6 +31,7 @@ const NON_SUFFIX_HOST_STATE: Record<string, string> = {
   AOE_CITYHALL_BUNDLE_TOKEN: "host-bundle-token",
   AOE_CITYHALL_BUNDLE_URL: "https://host.invalid/bundle",
   AOE_CITYHALL_MODE: "1",
+  AOE_DEFER_SANDBOX_MIGRATION: "1",
   AOE_DAEMON_TOKEN: "host-token",
   AOE_DAEMON_URL: "http://a-real-daemon.internal:8080",
   AOE_GITHUB_CLONE_BASE: `file://${HOST}/plugins`,

--- a/web/tests/helpers/isolatedEnv.ts
+++ b/web/tests/helpers/isolatedEnv.ts
@@ -59,6 +59,9 @@ export const HOST_STATE_VARS = new Set([
   "AOE_ACP_AGENT_ENV", // the daemon -> runner env carrier, decoded into agents
   "AOE_ACP_NODE", // an arbitrary host Node executable for the ACP runner
   "AOE_CITYHALL_MODE", // serves the daemon as a client of a host CityHall
+  // Defers the sandbox store migration; a host shell exporting it would make
+  // every live spec skip v027 and run against the pre-migration layout.
+  "AOE_DEFER_SANDBOX_MIGRATION",
   // `apply_cityhall_bundle` runs on the boot path: a host URL is fetched and
   // applied as config, and a first boot that cannot reach it aborts the
   // daemon outright.


### PR DESCRIPTION
## Description

Migration v027 copies each agent's shared sandbox store once per sandboxed session and probes a container per row. Behind the boot spinner that looked like a hang, with no way to start without waiting.

- Boot spinner and CLI commands now name the migration, its current step (container check, copying store k/n with file and byte counts, retiring the legacy store) and elapsed time, and keep the migration's notices on screen.
- v027 says what it copies, how to skip it, and which sessions stay pending and why. Quick migrations stay silent.
- `AOE_DEFER_SANDBOX_MIGRATION=1` starts without moving stores; rows stay pending like they do behind a live container.
- `aoe migrate` runs pending migrations on demand with progress.
- One batched `docker ps` replaces a `docker inspect` per session.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (two chmod-based tests fail only when run as root)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the deferral path, the notices, and the progress renderer are covered by unit tests in `migrations::progress` and `v027`; the terminal output was checked by hand against a fake container runtime on a pseudo-TTY and a pipe.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5.1 (Claude Code)

**Any Additional AI Details you'd like to share:** Implemented and verified via discussion with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR was drafted by Claude Fable 5.1 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01He5usTXecgyWa1WrD87j6Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added migration progress reporting to the boot spinner and CLI.
- Added the `aoe migrate` command for on-demand migration.
- Added deferred sandbox-store migration with `AOE_DEFER_SANDBOX_MIGRATION=1`.
- Added notices for deferred work, store copying, skipped sessions, and migration results.
- Improved container checks with one batched runtime query.
- Updated documentation, environment handling, and tests.

## Benefits

Users can monitor migration progress, defer store migration when needed, and complete pending work later without blocking startup.

## Potential follow-up

Add more validation for interrupted migrations and additional runtime environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->