### PR TITLE
perf(migrations): move a sandbox store when its session starts, not on every boot

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -163,7 +163,7 @@ Run without arguments to launch the TUI dashboard.
 * `acp` — Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...)
 * `uninstall` — Uninstall Agent of Empires
 * `update` — Update aoe to the latest release
-* `migrate` — Run pending data migrations now, showing progress. Startup reports a pending sandbox store move without performing it, and a session moves its own store when it starts, so use this to move every eligible store at once. Trashed and archived sessions are skipped; they move when started, restored or unarchived
+* `migrate` — Run pending data migrations now, showing progress. A sandboxed session moves its own agent store when it starts; use this to move every eligible store at once instead. Trashed and archived sessions are skipped; they move when started, restored or unarchived
 * `completion` — Generate shell completions
 
 ###### **Options:**
@@ -1839,7 +1839,7 @@ Update aoe to the latest release
 
 ## `aoe migrate`
 
-Run pending data migrations now, showing progress. Startup reports a pending sandbox store move without performing it, and a session moves its own store when it starts, so use this to move every eligible store at once. Trashed and archived sessions are skipped; they move when started, restored or unarchived
+Run pending data migrations now, showing progress. A sandboxed session moves its own agent store when it starts; use this to move every eligible store at once instead. Trashed and archived sessions are skipped; they move when started, restored or unarchived
 
 **Usage:** `aoe migrate`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -163,7 +163,7 @@ Run without arguments to launch the TUI dashboard.
 * `acp` — Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...)
 * `uninstall` — Uninstall Agent of Empires
 * `update` — Update aoe to the latest release
-* `migrate` — Run pending data migrations now, showing progress. Startup runs them too; use this after deferring one with AOE_DEFER_SANDBOX_MIGRATION=1
+* `migrate` — Run pending data migrations now, showing progress. Startup reports a pending sandbox store move without performing it, and a session moves its own store when it starts, so use this to move every eligible store at once. Trashed and archived sessions are skipped; they move when started, restored or unarchived
 * `completion` — Generate shell completions
 
 ###### **Options:**
@@ -1839,7 +1839,7 @@ Update aoe to the latest release
 
 ## `aoe migrate`
 
-Run pending data migrations now, showing progress. Startup runs them too; use this after deferring one with AOE_DEFER_SANDBOX_MIGRATION=1
+Run pending data migrations now, showing progress. Startup reports a pending sandbox store move without performing it, and a session moves its own store when it starts, so use this to move every eligible store at once. Trashed and archived sessions are skipped; they move when started, restored or unarchived
 
 **Usage:** `aoe migrate`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -163,7 +163,7 @@ Run without arguments to launch the TUI dashboard.
 * `acp` — Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...)
 * `uninstall` — Uninstall Agent of Empires
 * `update` — Update aoe to the latest release
-* `migrate` — Run pending data migrations now, showing progress. A sandboxed session moves its own agent store when it starts; use this to move every eligible store at once instead. Trashed and archived sessions are skipped; they move when started, restored or unarchived
+* `migrate` — Run pending data migrations now, showing progress. A sandboxed session moves its own agent store when it starts; use this to move every eligible store at once instead. Trashed and archived sessions are skipped; each moves when it is started, or restore or unarchive it and run this again
 * `completion` — Generate shell completions
 
 ###### **Options:**
@@ -1839,7 +1839,7 @@ Update aoe to the latest release
 
 ## `aoe migrate`
 
-Run pending data migrations now, showing progress. A sandboxed session moves its own agent store when it starts; use this to move every eligible store at once instead. Trashed and archived sessions are skipped; they move when started, restored or unarchived
+Run pending data migrations now, showing progress. A sandboxed session moves its own agent store when it starts; use this to move every eligible store at once instead. Trashed and archived sessions are skipped; each moves when it is started, or restore or unarchive it and run this again
 
 **Usage:** `aoe migrate`
 

--- a/docs/development/adding-a-migration.md
+++ b/docs/development/adding-a-migration.md
@@ -5,6 +5,13 @@ Breaking changes to stored data (file locations, config schema) go through
 tracks state; `migrations::run_migrations()` runs pending ones in order on
 startup and bumps the version.
 
+A migration whose work is large and per-session may leave rows pending rather
+than doing all of it at startup. v027 is the example: it stamps the version at
+first upgrade, then moves each session's store when that session next needs a
+container, with `aoe migrate` as the bulk path. If you write one of these, the
+startup pass must be cheap and the deferred work must have a trigger a user
+reaches without knowing it exists.
+
 To add one:
 
 1. Create `src/migrations/vNNN_description.rs` with a `pub fn run() -> anyhow::Result<()>`.

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -302,22 +302,25 @@ the agent's usual config path, so credentials, hooks and conversation history
 belong to one session and `aoe` can resume the right conversation.
 
 Sessions created before this layout shared one agent store per agent (for
-example `~/.claude/sandbox`). The first `aoe` start after upgrading moves them:
-it copies the shared store into a private directory for every sandboxed session,
-removes each session's stopped container so the next launch mounts the copy,
-and deletes the shared store once every session that used it has moved (the
-private copies are the data from then on). Startup prints what it is copying
-and how long it has been running. A large store copied for many sessions can take minutes; a
-session whose container is still running is skipped and moved on a later start,
-after it stops.
+example `~/.claude/sandbox`). Each one moves when you start it: AoE copies the
+shared store into that session's private directory, removes its stopped
+container so the next launch mounts the copy, and deletes the shared store once
+every session that used it has moved (the private copies are the data from then
+on). A large store takes a while, so the first start of a session is slower
+than usual. A session whose container is still running is skipped and moved on
+a later start, after it stops. Trashed and archived sessions stay on the shared
+store until they are restored.
 
-To start without waiting, quit and set `AOE_DEFER_SANDBOX_MIGRATION=1` for that
-launch. Sessions then keep using the shared store, and the move is retried on
-the next start without the variable, or on demand with:
+To move every pending session at once instead of paying for each at its next
+start:
 
 ```bash
 aoe migrate
 ```
+
+`AOE_DEFER_SANDBOX_MIGRATION=1` skips the move for that launch, so the session
+starts on the shared store; the move is retried on a later start without the
+variable, or with `aoe migrate`.
 
 ## Worktrees and Sandboxing
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -309,7 +309,8 @@ every session that used it has moved (the private copies are the data from then
 on). A large store takes a while, so the first start of a session is slower
 than usual. A session whose container is still running is skipped and moved on
 a later start, after it stops. Trashed and archived sessions stay on the shared
-store until they are restored, unarchived, or started directly.
+store. Starting one moves it; restoring or unarchiving alone does not, so run
+`aoe migrate` afterwards if you want it moved before its next start.
 
 To move every eligible session at once instead of paying for each at its next
 start:

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -309,18 +309,22 @@ every session that used it has moved (the private copies are the data from then
 on). A large store takes a while, so the first start of a session is slower
 than usual. A session whose container is still running is skipped and moved on
 a later start, after it stops. Trashed and archived sessions stay on the shared
-store until they are restored.
+store until they are restored, unarchived, or started directly.
 
-To move every pending session at once instead of paying for each at its next
+To move every eligible session at once instead of paying for each at its next
 start:
 
 ```bash
 aoe migrate
 ```
 
-`AOE_DEFER_SANDBOX_MIGRATION=1` skips the move for that launch, so the session
-starts on the shared store; the move is retried on a later start without the
-variable, or with `aoe migrate`.
+This skips trashed and archived sessions, which keep their shared store until
+one of them is started or brought back.
+
+`AOE_DEFER_SANDBOX_MIGRATION=1` skips the move for that launch. A session whose
+container is still running carries on unaffected, on the shared store. One
+whose container is stopped cannot start until its store has moved, so drop the
+variable or run `aoe migrate` before launching it.
 
 ## Worktrees and Sandboxing
 

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -236,7 +236,8 @@ pub enum Commands {
     /// Run pending data migrations now, showing progress. A sandboxed session
     /// moves its own agent store when it starts; use this to move every
     /// eligible store at once instead. Trashed and archived sessions are
-    /// skipped; they move when started, restored or unarchived.
+    /// skipped; each moves when it is started, or restore or unarchive it
+    /// and run this again.
     Migrate,
 
     /// Generate shell completions

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -233,11 +233,10 @@ pub enum Commands {
     /// Update aoe to the latest release
     Update(UpdateArgs),
 
-    /// Run pending data migrations now, showing progress. Startup reports a
-    /// pending sandbox store move without performing it, and a session moves
-    /// its own store when it starts, so use this to move every eligible store
-    /// at once. Trashed and archived sessions are skipped; they move when
-    /// started, restored or unarchived.
+    /// Run pending data migrations now, showing progress. A sandboxed session
+    /// moves its own agent store when it starts; use this to move every
+    /// eligible store at once instead. Trashed and archived sessions are
+    /// skipped; they move when started, restored or unarchived.
     Migrate,
 
     /// Generate shell completions

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -233,8 +233,11 @@ pub enum Commands {
     /// Update aoe to the latest release
     Update(UpdateArgs),
 
-    /// Run pending data migrations now, showing progress. Startup runs them
-    /// too; use this after deferring one with AOE_DEFER_SANDBOX_MIGRATION=1.
+    /// Run pending data migrations now, showing progress. Startup reports a
+    /// pending sandbox store move without performing it, and a session moves
+    /// its own store when it starts, so use this to move every eligible store
+    /// at once. Trashed and archived sessions are skipped; they move when
+    /// started, restored or unarchived.
     Migrate,
 
     /// Generate shell completions

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -236,9 +236,12 @@ pub fn run_migrations() -> Result<()> {
 }
 
 /// Run all pending migrations, sending [`progress::Event`]s to `reporter` so a
-/// long one (store copies, container probes) reads as work, not a hang. A
-/// still-pending sandbox store move is retried too; it reports only the work
-/// it actually does (copies and their outcome), not what stays pending.
+/// long one (store copies, container probes) reads as work, not a hang.
+///
+/// A still-pending sandbox store move is *not* retried here: v027's rows move
+/// when their session next needs a container, or all at once under
+/// [`run_migrations_announced`] for `aoe migrate`. This path only advances the
+/// schema version and reports the migrations it actually runs.
 pub fn run_migrations_with(reporter: Option<progress::Reporter>) -> Result<()> {
     run_migrations_inner(reporter, false)
 }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -202,6 +202,19 @@ pub fn has_pending_migrations() -> bool {
 }
 
 /// Run all pending migrations silently. Call this early in app startup.
+/// Move this session's sandbox store into the private layout, if it is still
+/// on the shared one. Called from the launch path so the copy is paid by the
+/// session being started rather than by every pending row on any `aoe` start.
+///
+/// A failure here is reported by the caller and does not block the launch:
+/// a row that did not move stays on its shared store and is retried.
+pub fn migrate_sandbox_store_for(id: &str) -> Result<()> {
+    if get_current_version() < 27 {
+        return Ok(());
+    }
+    v027_isolate_sandbox_stores::migrate_instance(id)
+}
+
 pub fn run_migrations() -> Result<()> {
     run_migrations_with(None)
 }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -207,10 +207,13 @@ pub fn has_pending_migrations() -> bool {
 /// the session that needs it rather than by every pending row on any `aoe`
 /// start.
 ///
-/// `reporter` must be supplied by any caller a user is waiting on. Without an
-/// installed reporter every `progress::step` and `notice` is a no-op
-/// ([`progress`]), and a multi-minute store copy on the launch path would run
-/// with nothing on screen: the hang #3757 removed from boot, moved to attach.
+/// `reporter` is how a caller with a screen narrates the copy. Nothing passes
+/// one yet: [`migrate_sandbox_store_for`] installs `tracing_reporter`, which
+/// reaches the log and, under `ProcessContext::Tui`, only the log
+/// (`logging.rs` forces a file sink there). So a large store still copies with
+/// nothing drawn, which is #3757's boot hang relocated to attach rather than
+/// removed. This parameter exists so the TUI and CLI launch paths can close
+/// that; until one does, the gap is real and the log is the only trail.
 ///
 /// A failure here is reported by the caller and does not block the launch:
 /// a row that did not move stays on its shared store and is retried.

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -203,16 +203,32 @@ pub fn has_pending_migrations() -> bool {
 
 /// Run all pending migrations silently. Call this early in app startup.
 /// Move this session's sandbox store into the private layout, if it is still
-/// on the shared one. Called from the launch path so the copy is paid by the
-/// session being started rather than by every pending row on any `aoe` start.
+/// on the shared one. Called from the container path so the copy is paid by
+/// the session that needs it rather than by every pending row on any `aoe`
+/// start.
+///
+/// `reporter` must be supplied by any caller a user is waiting on. Without an
+/// installed reporter every `progress::step` and `notice` is a no-op
+/// ([`progress`]), and a multi-minute store copy on the launch path would run
+/// with nothing on screen: the hang #3757 removed from boot, moved to attach.
 ///
 /// A failure here is reported by the caller and does not block the launch:
 /// a row that did not move stays on its shared store and is retried.
-pub fn migrate_sandbox_store_for(id: &str) -> Result<()> {
+pub fn migrate_sandbox_store_for_with(
+    id: &str,
+    reporter: Option<progress::Reporter>,
+) -> Result<()> {
     if get_current_version() < 27 {
         return Ok(());
     }
+    let _installed = progress::install(reporter);
     v027_isolate_sandbox_stores::migrate_instance(id)
+}
+
+/// [`migrate_sandbox_store_for_with`] using the process-wide default reporter,
+/// so the copy narrates itself wherever one is configured.
+pub fn migrate_sandbox_store_for(id: &str) -> Result<()> {
+    migrate_sandbox_store_for_with(id, Some(progress::tracing_reporter()))
 }
 
 pub fn run_migrations() -> Result<()> {

--- a/src/migrations/progress.rs
+++ b/src/migrations/progress.rs
@@ -33,6 +33,29 @@ pub enum Event {
 
 pub type Reporter = Arc<dyn Fn(Event) + Send + Sync>;
 
+/// A reporter for callers with no screen of their own: the store move on the
+/// container path runs while a user waits, so it must leave a trail even when
+/// nothing installed a renderer. `Progress` is dropped, being the per-100-file
+/// refinement, and everything else is logged once.
+pub fn tracing_reporter() -> Reporter {
+    Arc::new(|event| match event {
+        Event::Started { version, name, .. } => {
+            tracing::info!(target: "migrations", version, name, "running migration");
+        }
+        Event::Step(message) => tracing::info!(target: "migrations", "{message}"),
+        Event::Notice(message) => tracing::warn!(target: "migrations", "{message}"),
+        Event::Finished { version, elapsed } => {
+            tracing::info!(
+                target: "migrations",
+                version,
+                duration_ms = elapsed.as_millis() as u64,
+                "migration completed"
+            );
+        }
+        Event::Progress(_) => {}
+    })
+}
+
 static REPORTER: RwLock<Option<Reporter>> = RwLock::new(None);
 
 /// Installs `reporter` until the returned guard drops.

--- a/src/migrations/progress.rs
+++ b/src/migrations/progress.rs
@@ -58,17 +58,24 @@ pub fn tracing_reporter() -> Reporter {
 
 static REPORTER: RwLock<Option<Reporter>> = RwLock::new(None);
 
-/// Installs `reporter` until the returned guard drops.
+/// Installs `reporter` until the returned guard drops, which puts back
+/// whatever was installed before. The store-move path installs its own
+/// reporter from a session launch, so an install can now nest inside or race
+/// one from `run_migrations`; restoring `None` would silence that caller for
+/// the rest of its run.
 pub(super) fn install(reporter: Option<Reporter>) -> ReporterGuard {
-    *REPORTER.write().unwrap_or_else(|e| e.into_inner()) = reporter;
-    ReporterGuard
+    let previous = std::mem::replace(
+        &mut *REPORTER.write().unwrap_or_else(|e| e.into_inner()),
+        reporter,
+    );
+    ReporterGuard(previous)
 }
 
-pub(super) struct ReporterGuard;
+pub(super) struct ReporterGuard(Option<Reporter>);
 
 impl Drop for ReporterGuard {
     fn drop(&mut self) {
-        *REPORTER.write().unwrap_or_else(|e| e.into_inner()) = None;
+        *REPORTER.write().unwrap_or_else(|e| e.into_inner()) = self.0.take();
     }
 }
 

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -435,10 +435,12 @@ fn run_in(
                 }
                 continue;
             }
+            // A parked row does not defer retirement globally: it becomes a
+            // `Hold` target, and `all_ready` refuses to retire any root that
+            // carries one. Setting the pass-wide flag here would block every
+            // unrelated root too, so no store on a machine with a single
+            // archived session would ever be reclaimed.
             let parked = row_is_parked(row) && only != Some(id.as_str());
-            if parked {
-                defer_source_retirement = true;
-            }
             let Some(tool) = row.get("tool").and_then(Value::as_str) else {
                 defer_source_retirement = true;
                 continue;
@@ -595,9 +597,10 @@ fn run_in(
             if selected.contains(shared) {
                 continue;
             }
-            // Another session's cohort: it still holds its shared source, so
-            // nothing may retire underneath it this pass.
-            defer_source_retirement = true;
+            // Another session's cohort: it still holds its shared source.
+            // Demoting its members to `Hold` is what protects it, through
+            // `all_ready`; the pass-wide flag would also strand the cohort
+            // this pass just emptied.
             for target in cohort.iter_mut() {
                 target.disposition = Disposition::Hold;
             }
@@ -611,6 +614,17 @@ fn run_in(
         .filter(|target| target.disposition == Disposition::Move)
         .map(|target| (target.registry, target.row))
         .collect();
+    // Reporting only. `affected_rows` excludes held rows by construction, so
+    // without this the completion notice subtracts them from nothing and tells
+    // a user the transition finished while parked sessions are still on the
+    // shared store.
+    let held_row_count = cohorts
+        .values()
+        .flatten()
+        .filter(|target| target.disposition == Disposition::Hold)
+        .map(|target| (target.registry, target.row))
+        .collect::<BTreeSet<_>>()
+        .len();
     if announce && defer_stores && !affected_rows.is_empty() {
         progress::notice(format!(
             "{DEFER_ENV} is set: {} sandboxed session(s) keep their shared agent store for now; \
@@ -787,8 +801,8 @@ fn run_in(
             // Copying its store is the cost this skip exists to avoid.
             if target.disposition == Disposition::Hold {
                 // Held members are asked about by the fold above but publish
-                // nothing, and their source stays put.
-                defer_source_retirement = true;
+                // nothing. Their root is protected by `all_ready`, which
+                // requires every member to be `Move` and ready.
                 continue;
             }
             copied_targets += 1;
@@ -799,7 +813,7 @@ fn run_in(
                     "Isolating agent stores for {} sandboxed session(s): each gets its own copy of the \
                      shared agent store under sandbox-v2/. Large stores take a while. To start without \
                      waiting, quit and run with {DEFER_ENV}=1; finish later with `aoe migrate`.",
-                    affected_rows.len()
+                    total_targets
                 ));
             }
             progress::step(format!(
@@ -880,12 +894,12 @@ fn run_in(
         // included: a held row still reads this source, so retiring it would
         // leave that session with no store to open.
         //
-        // The `Move` clause is deliberately redundant. A held target never
-        // reaches `affected_rows`, so it can never be in `ready_rows`, and
-        // `defer_source_retirement` is set for it besides. It is written here
-        // anyway because this is the line that decides to delete a store, and
-        // it should say what it requires rather than inherit it from two
-        // places several hundred lines up.
+        // The `Move` clause is the mechanism, not a restatement. It is what
+        // keeps a root alive for a held member, per root. The pass-wide
+        // `defer_source_retirement` below stays for the rows that never
+        // produce a target at all (no id, no tool, no agent), whose root
+        // cannot be known; routing an ordinary parked row through it instead
+        // would block every unrelated root on the machine.
         let all_ready = !related.is_empty()
             && related.iter().all(|target| {
                 target.disposition == Disposition::Move
@@ -933,12 +947,17 @@ fn run_in(
     let done = ready_rows.len();
     if !affected_rows.is_empty() && (announce || done > 0) {
         let left = affected_rows.len().saturating_sub(done);
-        progress::notice(if left == 0 {
-            format!("{done} sandboxed session(s) now use private agent stores.")
-        } else {
-            format!(
+        progress::notice(match (left, held_row_count) {
+            (0, 0) => format!("{done} sandboxed session(s) now use private agent stores."),
+            (0, held) => format!(
+                "{done} sandboxed session(s) now use private agent stores. {held} trashed or archived session(s) stay on the shared store; each moves when it is started, or restore or unarchive it and run `aoe migrate`."
+            ),
+            (left, 0) => format!(
                 "{done} sandboxed session(s) moved to private agent stores, {left} still pending; the move resumes on a later start or with `aoe migrate`."
-            )
+            ),
+            (left, held) => format!(
+                "{done} sandboxed session(s) moved to private agent stores, {left} still pending and {held} trashed or archived; the move resumes on a later start or with `aoe migrate`."
+            ),
         });
     }
     if pending.is_empty() {
@@ -2306,6 +2325,87 @@ gemini = "{}"
 
     /// Clearing `trashed_at` makes the row eligible again, and the start that
     /// follows the restore moves its store.
+    /// Retirement is per root. A parked row holds its own root and nothing
+    /// else: every test above asserts a source *survives*, so nothing caught
+    /// a pass-wide flag suppressing retirement everywhere, which left the
+    /// transition unable to finish on any machine with one archived session.
+    #[test]
+    #[serial_test::serial]
+    fn an_unrelated_parked_row_does_not_hold_a_ready_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let gemini = home.join(".gemini/sandbox");
+        fs::create_dir_all(&gemini).unwrap();
+        fs::write(gemini.join("data"), b"g").unwrap();
+        let claude = home.join(".claude/sandbox");
+        fs::create_dir_all(&claude).unwrap();
+        fs::write(claude.join("data"), b"c").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true}},
+            {"id":"3333333333333333","tool":"claude","sandbox_info":{"enabled":true},
+             "archived_at":"2026-09-05T00:00:00Z"}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+
+        assert_eq!(
+            fs::read(home.join(".gemini/sandbox-v2/1111111111111111/data")).unwrap(),
+            b"g"
+        );
+        assert!(
+            !gemini.exists(),
+            "the gemini root had no held member and must be retired"
+        );
+        assert!(
+            claude.exists(),
+            "the claude root carries a parked member and must survive"
+        );
+    }
+
+    /// The scoped counterpart: a launch that empties its own cohort retires
+    /// that root, while the cohort it held keeps its own.
+    #[test]
+    #[serial_test::serial]
+    fn a_scoped_pass_retires_the_root_it_emptied() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let gemini = home.join(".gemini/sandbox");
+        fs::create_dir_all(&gemini).unwrap();
+        fs::write(gemini.join("data"), b"g").unwrap();
+        let claude = home.join(".claude/sandbox");
+        fs::create_dir_all(&claude).unwrap();
+        fs::write(claude.join("data"), b"c").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true}},
+            {"id":"3333333333333333","tool":"claude","sandbox_info":{"enabled":true}}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+
+        run_in_only(&app, &home, &|_| Ok(false), "1111111111111111").unwrap();
+
+        assert!(
+            !gemini.exists(),
+            "the scoped cohort moved in full and its root must be retired"
+        );
+        assert!(
+            claude.exists(),
+            "the cohort this pass held must keep its source"
+        );
+    }
+
     #[test]
     #[serial_test::serial]
     fn a_restored_row_migrates_on_its_next_pass() {

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -157,6 +157,25 @@ fn reap_migrated_container(id: &str) -> Result<bool> {
     }
 }
 
+/// What this pass may do with one row's store.
+///
+/// Every sandboxed row becomes a `Target` whatever its disposition, because
+/// the liveness gate reasons over whole cohorts: a member missing from its
+/// cohort is a member the gate never asks about, and its peers' store is then
+/// published while that session is still writing to it. Three reviews of this
+/// migration found that same defect three times, each from a different filter
+/// applied before cohorts were assembled. Eligibility is therefore a property
+/// of the target and never a filter on the rows that build one.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Disposition {
+    /// Copy and publish this store once the cohort is quiescent.
+    Move,
+    /// Leave this row on the shared store: it is parked, or this pass was
+    /// scoped to a different cohort. It is still a cohort member, so it is
+    /// still asked about, and it still holds its source against retirement.
+    Hold,
+}
+
 #[derive(Clone)]
 struct Target {
     registry: usize,
@@ -165,6 +184,7 @@ struct Target {
     shared: PathBuf,
     private: PathBuf,
     cleanup_root: PathBuf,
+    disposition: Disposition,
 }
 
 struct Registry {
@@ -194,8 +214,10 @@ pub(crate) fn reconcile_pending(announce: bool) -> Result<()> {
 }
 
 /// Move the store of one session, for the start that is about to launch it.
-/// Every other pending row is left alone, so a machine with many parked or
-/// idle sessions pays for the one it is opening instead of all of them.
+/// The cohort sharing that session's store moves with it, since the cohort is
+/// the unit the liveness gate reasons about; every other cohort is left alone,
+/// so a machine with many parked or idle sessions does not pay for all of them
+/// on one launch.
 pub(crate) fn migrate_instance(id: &str) -> Result<()> {
     reconcile_scoped(false, Some(id))
 }
@@ -322,6 +344,8 @@ fn run_in(
     }
     let mut targets = Vec::new();
     let mut affected_rows = BTreeSet::new();
+    // Rows this pass will not copy but must still count as cohort members,
+    // so the liveness fold below asks about them before publishing a store.
     let mut known_sources = BTreeSet::new();
     let mut cleanup_roots = BTreeSet::new();
     let mut needs_registry_write = false;
@@ -411,9 +435,9 @@ fn run_in(
                 }
                 continue;
             }
-            if row_is_parked(row) && only != Some(id.as_str()) {
+            let parked = row_is_parked(row) && only != Some(id.as_str());
+            if parked {
                 defer_source_retirement = true;
-                continue;
             }
             let Some(tool) = row.get("tool").and_then(Value::as_str) else {
                 defer_source_retirement = true;
@@ -504,7 +528,10 @@ fn run_in(
                     Some(source.clone())
                 }
             }));
-            if stored_plans.is_none() {
+            // A parked row is carried only as a cohort member; it publishes
+            // nothing this pass, so it gets neither the drift checkpoint nor
+            // the pending stamp.
+            if stored_plans.is_none() && !parked {
                 set_transition_paths(row, &plans);
                 needs_registry_write = true;
             }
@@ -515,11 +542,18 @@ fn run_in(
                 continue;
             }
             let pending_generation = if old_private { 0 } else { 1 };
-            if generation != u64::from(pending_generation) {
+            if !parked && generation != u64::from(pending_generation) {
                 set_generation(row, pending_generation);
                 needs_registry_write = true;
             }
-            affected_rows.insert((registry_index, row_index));
+            if !parked {
+                affected_rows.insert((registry_index, row_index));
+            }
+            let disposition = if parked {
+                Disposition::Hold
+            } else {
+                Disposition::Move
+            };
             targets.extend(plans.into_iter().map(|(shared, private)| {
                 let cleanup_root = if old_private {
                     shared.parent().unwrap_or(&shared).to_path_buf()
@@ -530,6 +564,7 @@ fn run_in(
                     registry: registry_index,
                     row: row_index,
                     id: id.clone(),
+                    disposition,
                     shared,
                     private,
                     cleanup_root,
@@ -545,29 +580,37 @@ fn run_in(
             .or_default()
             .push(target);
     }
-    // Scope by cohort, never by row. A cohort is every session sharing one
-    // legacy store, and the liveness gate below asks about all of them before
-    // any copy: a store a peer is still writing to must not be published.
-    // Dropping the peers from the cohort instead would leave that fold asking
-    // only about the session being started, and copy the store mid-write.
-    let mut scoped_out_rows: BTreeSet<(usize, usize)> = BTreeSet::new();
+    // Scoping demotes; it never removes. A cohort not named by this pass keeps
+    // every member and every member keeps its place in the liveness fold, so
+    // the gate still asks about sessions this pass will not touch. Dropping
+    // them instead is what let an earlier revision copy a store out from under
+    // a live peer.
     if let Some(wanted) = only {
         let selected: BTreeSet<PathBuf> = cohorts
             .iter()
             .filter(|(_, cohort)| cohort.iter().any(|target| target.id == wanted))
             .map(|(shared, _)| shared.clone())
             .collect();
-        cohorts.retain(|shared, cohort| {
-            let keep = selected.contains(shared);
-            if !keep {
-                // Another session's cohort. It still holds its shared source,
-                // so nothing may retire underneath it this pass.
-                defer_source_retirement = true;
-                scoped_out_rows.extend(cohort.iter().map(|t| (t.registry, t.row)));
+        for (shared, cohort) in cohorts.iter_mut() {
+            if selected.contains(shared) {
+                continue;
             }
-            keep
-        });
+            // Another session's cohort: it still holds its shared source, so
+            // nothing may retire underneath it this pass.
+            defer_source_retirement = true;
+            for target in cohort.iter_mut() {
+                target.disposition = Disposition::Hold;
+            }
+        }
     }
+    // The rows this pass will actually publish. Derived from the targets, so a
+    // row cannot be marked ready without a target that says it may move.
+    let movable_rows: BTreeSet<(usize, usize)> = cohorts
+        .values()
+        .flatten()
+        .filter(|target| target.disposition == Disposition::Move)
+        .map(|target| (target.registry, target.row))
+        .collect();
     if announce && defer_stores && !affected_rows.is_empty() {
         progress::notice(format!(
             "{DEFER_ENV} is set: {} sandboxed session(s) keep their shared agent store for now; \
@@ -598,10 +641,14 @@ fn run_in(
         sync_parent(&journal)?;
     }
 
-    let mut ready_rows = affected_rows.clone();
-    for key in &scoped_out_rows {
-        ready_rows.remove(key);
-    }
+    // Intersect rather than subtract: a row is publishable only if a target
+    // says so, so no future filter can leave a row stamped current whose store
+    // was never copied.
+    let mut ready_rows: BTreeSet<(usize, usize)> = affected_rows
+        .iter()
+        .filter(|key| movable_rows.contains(key))
+        .copied()
+        .collect();
     let mut pending = Vec::new();
     let mut blocked_roots = BTreeSet::new();
     let mut orphan_blocked_roots = BTreeSet::new();
@@ -709,7 +756,11 @@ fn run_in(
         }
     }
 
-    let total_targets: usize = cohorts.values().map(Vec::len).sum();
+    let total_targets: usize = cohorts
+        .values()
+        .flatten()
+        .filter(|target| target.disposition == Disposition::Move)
+        .count();
     let mut copied_targets = 0usize;
     for (shared, cohort) in &cohorts {
         let ids: BTreeSet<&str> = cohort.iter().map(|target| target.id.as_str()).collect();
@@ -732,6 +783,14 @@ fn run_in(
             continue;
         }
         for target in cohort {
+            // A parked row is here only so the fold above could ask about it.
+            // Copying its store is the cost this skip exists to avoid.
+            if target.disposition == Disposition::Hold {
+                // Held members are asked about by the fold above but publish
+                // nothing, and their source stays put.
+                defer_source_retirement = true;
+                continue;
+            }
             copied_targets += 1;
             if copied_targets == 1 {
                 // Said once, right before the first copy: this is the part
@@ -817,10 +876,21 @@ fn run_in(
             .flatten()
             .filter(|target| &target.cleanup_root == root)
             .collect();
+        // Every member under this root must have published, held members
+        // included: a held row still reads this source, so retiring it would
+        // leave that session with no store to open.
+        //
+        // The `Move` clause is deliberately redundant. A held target never
+        // reaches `affected_rows`, so it can never be in `ready_rows`, and
+        // `defer_source_retirement` is set for it besides. It is written here
+        // anyway because this is the line that decides to delete a store, and
+        // it should say what it requires rather than inherit it from two
+        // places several hundred lines up.
         let all_ready = !related.is_empty()
-            && related
-                .iter()
-                .all(|target| ready_rows.contains(&(target.registry, target.row)));
+            && related.iter().all(|target| {
+                target.disposition == Disposition::Move
+                    && ready_rows.contains(&(target.registry, target.row))
+            });
         if !defer_source_retirement && !blocked_roots.contains(root) && all_ready {
             progress::step(format!("retiring shared agent store {}", root.display()));
             retire_legacy(root)?;
@@ -2418,6 +2488,117 @@ gemini = "{}"
         assert!(
             legacy.exists(),
             "the still-parked peer must keep the shared source"
+        );
+    }
+
+    /// A parked row is skipped for copying, not for the liveness question.
+    /// `archive` does not stop the container, and `aoe send` starts an
+    /// archived session without unparking it, so a parked peer can be writing
+    /// the shared store while an unparked peer is started. Dropping it from
+    /// the cohort would publish that store mid-write, at generation 2.
+    #[test]
+    #[serial_test::serial]
+    fn a_live_parked_peer_blocks_its_cohort() {
+        for scoped in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+            let app = crate::session::get_app_dir().unwrap();
+            let home = dirs::home_dir().unwrap();
+            let legacy = home.join(".gemini/sandbox");
+            fs::create_dir_all(&legacy).unwrap();
+            fs::write(legacy.join("data"), b"data").unwrap();
+            let rows = serde_json::json!([
+                {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true}},
+                {"id":"2222222222222222","tool":"gemini","sandbox_info":{"enabled":true},
+                 "archived_at":"2026-09-05T00:00:00Z"}
+            ]);
+            fs::write(
+                app.join("sessions.json"),
+                serde_json::to_vec(&rows).unwrap(),
+            )
+            .unwrap();
+
+            let live_peer = |id: &str| Ok(id == "2222222222222222");
+            if scoped {
+                run_in_only(&app, &home, &live_peer, "1111111111111111").unwrap();
+            } else {
+                run_in(&app, &home, &live_peer).unwrap();
+            }
+
+            assert!(
+                !home.join(".gemini/sandbox-v2/1111111111111111").exists(),
+                "scoped={scoped}: a live archived peer must block the copy"
+            );
+            let rows: Value =
+                serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+            assert_ne!(
+                rows[0]["sandbox_store_generation"], 2,
+                "scoped={scoped}: a blocked row must not be stamped current"
+            );
+            assert!(
+                legacy.exists(),
+                "scoped={scoped}: the shared source must survive"
+            );
+
+            // Once the parked peer stops, the same pass moves the unparked row
+            // and still leaves the parked one on the shared store.
+            if scoped {
+                run_in_only(&app, &home, &|_| Ok(false), "1111111111111111").unwrap();
+            } else {
+                run_in(&app, &home, &|_| Ok(false)).unwrap();
+            }
+            assert_eq!(
+                fs::read(home.join(".gemini/sandbox-v2/1111111111111111/data")).unwrap(),
+                b"data",
+                "scoped={scoped}: the unparked row must move once the peer stops"
+            );
+            assert!(
+                !home.join(".gemini/sandbox-v2/2222222222222222").exists(),
+                "scoped={scoped}: the parked peer must not be copied"
+            );
+            assert!(
+                legacy.exists(),
+                "scoped={scoped}: the parked peer still holds the shared source"
+            );
+        }
+    }
+
+    /// A scoped pass must not retire a cleanup root a scoped-out cohort still
+    /// lives under. Codex sessions each own a child of one shared root, so
+    /// dropping `defer_source_retirement` in the cohort filter would quarantine
+    /// and delete every other codex session's store.
+    #[test]
+    #[serial_test::serial]
+    fn a_scoped_pass_holds_the_root_a_scoped_out_cohort_lives_under() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let root = home.join(".codex/sandbox");
+        fs::create_dir_all(root.join("1111111111111111")).unwrap();
+        fs::write(root.join("1111111111111111/data"), b"one").unwrap();
+        fs::create_dir_all(root.join("2222222222222222")).unwrap();
+        fs::write(root.join("2222222222222222/data"), b"two").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"codex","sandbox_info":{"enabled":true}},
+            {"id":"2222222222222222","tool":"codex","sandbox_info":{"enabled":true}}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+
+        run_in_only(&app, &home, &|_| Ok(false), "1111111111111111").unwrap();
+
+        assert_eq!(
+            fs::read(root.join("2222222222222222/data")).unwrap(),
+            b"two",
+            "a scoped-out cohort's shared store must survive the pass"
+        );
+        assert_eq!(
+            fs::read(home.join(".codex/sandbox-v2/1111111111111111/data")).unwrap(),
+            b"one"
         );
     }
 

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -410,10 +410,6 @@ fn run_in(
                 defer_source_retirement = true;
                 continue;
             }
-            if only.is_some_and(|wanted| wanted != id) {
-                defer_source_retirement = true;
-                continue;
-            }
             let Some(tool) = row.get("tool").and_then(Value::as_str) else {
                 defer_source_retirement = true;
                 continue;
@@ -544,6 +540,29 @@ fn run_in(
             .or_default()
             .push(target);
     }
+    // Scope by cohort, never by row. A cohort is every session sharing one
+    // legacy store, and the liveness gate below asks about all of them before
+    // any copy: a store a peer is still writing to must not be published.
+    // Dropping the peers from the cohort instead would leave that fold asking
+    // only about the session being started, and copy the store mid-write.
+    let mut scoped_out_rows: BTreeSet<(usize, usize)> = BTreeSet::new();
+    if let Some(wanted) = only {
+        let selected: BTreeSet<PathBuf> = cohorts
+            .iter()
+            .filter(|(_, cohort)| cohort.iter().any(|target| target.id == wanted))
+            .map(|(shared, _)| shared.clone())
+            .collect();
+        cohorts.retain(|shared, cohort| {
+            let keep = selected.contains(shared);
+            if !keep {
+                // Another session's cohort. It still holds its shared source,
+                // so nothing may retire underneath it this pass.
+                defer_source_retirement = true;
+                scoped_out_rows.extend(cohort.iter().map(|t| (t.registry, t.row)));
+            }
+            keep
+        });
+    }
     if announce && defer_stores && !affected_rows.is_empty() {
         progress::notice(format!(
             "{DEFER_ENV} is set: {} sandboxed session(s) keep their shared agent store for now; \
@@ -575,6 +594,9 @@ fn run_in(
     }
 
     let mut ready_rows = affected_rows.clone();
+    for key in &scoped_out_rows {
+        ready_rows.remove(key);
+    }
     let mut pending = Vec::new();
     let mut blocked_roots = BTreeSet::new();
     let mut orphan_blocked_roots = BTreeSet::new();
@@ -2247,11 +2269,15 @@ gemini = "{}"
         );
     }
 
-    /// A scoped pass moves the session being started and leaves every other
-    /// pending row where it is, so one launch does not pay for all of them.
+    /// The regression the cohort scoping exists for: a scoped pass must still
+    /// ask about every session sharing the store, not just the one being
+    /// started. Scoping by row instead drops the peers from the cohort, the
+    /// liveness fold then only sees the named session, and the store is copied
+    /// while a live peer is still writing to it. The copy becomes
+    /// authoritative at generation 2, so the loss is silent.
     #[test]
     #[serial_test::serial]
-    fn a_scoped_pass_moves_only_the_named_instance() {
+    fn a_scoped_pass_refuses_a_store_a_live_peer_is_writing() {
         let temp = tempfile::tempdir().unwrap();
         let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
         let app = crate::session::get_app_dir().unwrap();
@@ -2269,6 +2295,62 @@ gemini = "{}"
         )
         .unwrap();
 
+        // Start 1111 while its cohort peer 2222 is live.
+        run_in_only(
+            &app,
+            &home,
+            &|id| Ok(id == "2222222222222222"),
+            "1111111111111111",
+        )
+        .unwrap();
+
+        assert!(
+            !home.join(".gemini/sandbox-v2/1111111111111111").exists(),
+            "a live cohort peer must block the scoped copy"
+        );
+        let rows: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_ne!(
+            rows[0]["sandbox_store_generation"], 2,
+            "a blocked row must not be stamped current"
+        );
+        assert!(legacy.exists(), "the shared source must survive");
+
+        // Once the peer stops, the same scoped pass moves it.
+        run_in_only(&app, &home, &|_| Ok(false), "1111111111111111").unwrap();
+        assert_eq!(
+            fs::read(home.join(".gemini/sandbox-v2/1111111111111111/data")).unwrap(),
+            b"data"
+        );
+    }
+
+    /// A scoped pass moves the named session's whole cohort, since the cohort
+    /// is the unit the liveness gate reasons about, and leaves every other
+    /// agent's cohort alone. That is what stops one launch paying for every
+    /// pending store on the machine.
+    #[test]
+    #[serial_test::serial]
+    fn a_scoped_pass_moves_only_the_named_cohort() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let legacy = home.join(".gemini/sandbox");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("data"), b"data").unwrap();
+        let other = home.join(".claude/sandbox");
+        fs::create_dir_all(&other).unwrap();
+        fs::write(other.join("data"), b"other").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true}},
+            {"id":"3333333333333333","tool":"claude","sandbox_info":{"enabled":true}}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+
         run_in_only(&app, &home, &|_| Ok(false), "1111111111111111").unwrap();
 
         assert_eq!(
@@ -2276,12 +2358,12 @@ gemini = "{}"
             b"data"
         );
         assert!(
-            !home.join(".gemini/sandbox-v2/2222222222222222").exists(),
-            "an unnamed row must not be moved by a scoped pass"
+            !home.join(".claude/sandbox-v2/3333333333333333").exists(),
+            "another agent's cohort must not be moved by a scoped pass"
         );
         assert!(
-            legacy.exists(),
-            "the unmoved row still needs the shared source"
+            other.exists(),
+            "the untouched cohort still needs its shared source"
         );
     }
 

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -182,6 +182,7 @@ pub fn run() -> Result<()> {
         &reap_migrated_container,
         defer_requested(),
         true,
+        None,
     )
 }
 
@@ -189,6 +190,20 @@ pub fn run() -> Result<()> {
 /// every startup until no pre-v2 row remains, then becomes a cheap read.
 /// `announce` narrates pending rows (see [`ANNOUNCE`]).
 pub(crate) fn reconcile_pending(announce: bool) -> Result<()> {
+    reconcile_scoped(announce, None)
+}
+
+/// Move the store of one session, for the start that is about to launch it.
+/// Every other pending row is left alone, so a machine with many parked or
+/// idle sessions pays for the one it is opening instead of all of them.
+pub(crate) fn migrate_instance(id: &str) -> Result<()> {
+    reconcile_scoped(false, Some(id))
+}
+
+/// `only` scopes the move to a single instance; `announce` both narrates and
+/// selects the bulk path, so a bare `aoe` start reports what is pending
+/// without copying while `aoe migrate` moves everything eligible.
+fn reconcile_scoped(announce: bool, only: Option<&str>) -> Result<()> {
     let app_dir = crate::session::get_app_dir()?;
     if !transition_may_be_pending(&app_dir)? {
         return Ok(());
@@ -206,8 +221,9 @@ pub(crate) fn reconcile_pending(announce: bool) -> Result<()> {
         &home,
         &batched_running_probe(announce),
         &reap_migrated_container,
-        defer_requested(),
+        defer_requested() || (!announce && only.is_none()),
         announce,
+        only,
     )?;
     progress::report(progress::Event::Finished {
         version: 27,
@@ -244,6 +260,21 @@ fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
     Ok(false)
 }
 
+/// Whether a row is parked: trashed or archived. Such a session is not going
+/// to be started, and a trashed one is usually deleted within
+/// `trash_retention_days`, so copying its store buys nothing and costs a full
+/// store per row. Parked rows keep their shared store and migrate on the start
+/// that follows a restore or unarchive.
+///
+/// A parked row still blocks retirement of the shared source it reads, via
+/// `defer_source_retirement`: retiring underneath it would leave a restored
+/// session with no store to open.
+fn row_is_parked(row: &Value) -> bool {
+    ["trashed_at", "archived_at"]
+        .iter()
+        .any(|key| row.get(key).is_some_and(|value| !value.is_null()))
+}
+
 /// `defer_stores` leaves every cohort on its shared store this pass (see
 /// [`DEFER_ENV`]); rows stay pending as they do behind a live container.
 /// `announce` narrates deferrals and pending rows: the schema migration and
@@ -255,6 +286,7 @@ fn run_in(
     reap: &ReapProbe<'_>,
     defer_stores: bool,
     announce: bool,
+    only: Option<&str>,
 ) -> Result<()> {
     progress::step("reading session registries");
     fs::create_dir_all(app_dir)?;
@@ -372,6 +404,14 @@ fn run_in(
                 if clear_transition_metadata(row) {
                     needs_registry_write = true;
                 }
+                continue;
+            }
+            if row_is_parked(row) {
+                defer_source_retirement = true;
+                continue;
+            }
+            if only.is_some_and(|wanted| wanted != id) {
+                defer_source_retirement = true;
                 continue;
             }
             let Some(tool) = row.get("tool").and_then(Value::as_str) else {
@@ -1393,7 +1433,24 @@ mod tests {
     /// the glob import keeps these tests hermetic: they assert the migration's
     /// own logic and must not depend on a container runtime being installed.
     fn run_in(app_dir: &Path, home: &Path, is_running: &RunningProbe<'_>) -> Result<()> {
-        super::run_in(app_dir, home, is_running, &|_| Ok(true), false, true)
+        super::run_in(app_dir, home, is_running, &|_| Ok(true), false, true, None)
+    }
+
+    fn run_in_only(
+        app_dir: &Path,
+        home: &Path,
+        is_running: &RunningProbe<'_>,
+        only: &str,
+    ) -> Result<()> {
+        super::run_in(
+            app_dir,
+            home,
+            is_running,
+            &|_| Ok(true),
+            false,
+            true,
+            Some(only),
+        )
     }
 
     fn row(id: &str) -> String {
@@ -1446,7 +1503,16 @@ mod tests {
 
         // The answers the production probes give when the runtime is
         // unreachable: liveness cannot be disproved, and nothing is reaped.
-        super::run_in(&app, &home, &|_| Ok(true), &|_| Ok(false), false, true).unwrap();
+        super::run_in(
+            &app,
+            &home,
+            &|_| Ok(true),
+            &|_| Ok(false),
+            false,
+            true,
+            None,
+        )
+        .unwrap();
         let deferred: Value =
             serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
         assert_eq!(
@@ -1459,7 +1525,16 @@ mod tests {
         );
         assert!(transition_may_be_pending(&app).unwrap());
 
-        super::run_in(&app, &home, &|_| Ok(false), &|_| Ok(true), false, true).unwrap();
+        super::run_in(
+            &app,
+            &home,
+            &|_| Ok(false),
+            &|_| Ok(true),
+            false,
+            true,
+            None,
+        )
+        .unwrap();
         let committed: Value =
             serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
         assert_eq!(committed[0]["sandbox_store_generation"], 2);
@@ -1503,6 +1578,7 @@ mod tests {
             &|_| panic!("a deferred pass must not reap containers"),
             true,
             true,
+            None,
         )
         .unwrap();
         drop(guard);
@@ -2078,6 +2154,149 @@ gemini = "{}"
 
         assert_eq!(fs::read(victim.join("keep")).unwrap(), b"keep");
         assert!(!app.join(JOURNAL).exists());
+    }
+
+    /// A trashed or archived row must not have its store copied, and must not
+    /// let the shared source be retired: a restore would otherwise open a
+    /// session whose store had been moved out from under it.
+    #[test]
+    #[serial_test::serial]
+    fn parked_rows_are_not_copied_and_hold_the_shared_source() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let legacy = home.join(".gemini/sandbox");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("data"), b"data").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true},
+             "trashed_at":"2026-09-05T00:00:00Z"},
+            {"id":"2222222222222222","tool":"gemini","sandbox_info":{"enabled":true},
+             "archived_at":"2026-09-05T00:00:00Z"},
+            {"id":"3333333333333333","tool":"gemini","sandbox_info":{"enabled":true}}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+
+        let rows: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert!(
+            rows[0].get("sandbox_store_generation").is_none(),
+            "trashed row moved"
+        );
+        assert!(
+            rows[1].get("sandbox_store_generation").is_none(),
+            "archived row moved"
+        );
+        assert_eq!(rows[2]["sandbox_store_generation"], 2);
+        for id in ["1111111111111111", "2222222222222222"] {
+            assert!(
+                !home.join(".gemini/sandbox-v2").join(id).exists(),
+                "parked row {id} must not get a private store"
+            );
+        }
+        assert!(
+            legacy.exists(),
+            "a parked row must protect the shared source it still reads"
+        );
+    }
+
+    /// Clearing `trashed_at` makes the row eligible again, and the start that
+    /// follows the restore moves its store.
+    #[test]
+    #[serial_test::serial]
+    fn a_restored_row_migrates_on_its_next_pass() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let legacy = home.join(".gemini/sandbox");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("data"), b"data").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true},
+             "trashed_at":"2026-09-05T00:00:00Z"}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+        assert!(legacy.exists());
+
+        let restored = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true}}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&restored).unwrap(),
+        )
+        .unwrap();
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+
+        assert_eq!(
+            fs::read(home.join(".gemini/sandbox-v2/1111111111111111/data")).unwrap(),
+            b"data"
+        );
+    }
+
+    /// A scoped pass moves the session being started and leaves every other
+    /// pending row where it is, so one launch does not pay for all of them.
+    #[test]
+    #[serial_test::serial]
+    fn a_scoped_pass_moves_only_the_named_instance() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let legacy = home.join(".gemini/sandbox");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("data"), b"data").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true}},
+            {"id":"2222222222222222","tool":"gemini","sandbox_info":{"enabled":true}}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+
+        run_in_only(&app, &home, &|_| Ok(false), "1111111111111111").unwrap();
+
+        assert_eq!(
+            fs::read(home.join(".gemini/sandbox-v2/1111111111111111/data")).unwrap(),
+            b"data"
+        );
+        assert!(
+            !home.join(".gemini/sandbox-v2/2222222222222222").exists(),
+            "an unnamed row must not be moved by a scoped pass"
+        );
+        assert!(
+            legacy.exists(),
+            "the unmoved row still needs the shared source"
+        );
+    }
+
+    #[test]
+    fn row_is_parked_reads_both_fields_and_ignores_nulls() {
+        assert!(!row_is_parked(&serde_json::json!({"id":"a"})));
+        assert!(!row_is_parked(
+            &serde_json::json!({"trashed_at":null,"archived_at":null})
+        ));
+        assert!(row_is_parked(
+            &serde_json::json!({"trashed_at":"2026-09-05T00:00:00Z"})
+        ));
+        assert!(row_is_parked(
+            &serde_json::json!({"archived_at":"2026-09-05T00:00:00Z"})
+        ));
     }
 
     #[test]

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -269,6 +269,11 @@ fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
 /// A parked row still blocks retirement of the shared source it reads, via
 /// `defer_source_retirement`: retiring underneath it would leave a restored
 /// session with no store to open.
+///
+/// A pass scoped to the parked row itself ignores this: `aoe send`, `aoe
+/// session start` and the HTTP start/send handlers all launch a trashed or
+/// archived session without unparking it first, and skipping it there leaves
+/// it on a shared store no later pass will move, so the launch bails forever.
 fn row_is_parked(row: &Value) -> bool {
     ["trashed_at", "archived_at"]
         .iter()
@@ -406,7 +411,7 @@ fn run_in(
                 }
                 continue;
             }
-            if row_is_parked(row) {
+            if row_is_parked(row) && only != Some(id.as_str()) {
                 defer_source_retirement = true;
                 continue;
             }
@@ -2364,6 +2369,55 @@ gemini = "{}"
         assert!(
             other.exists(),
             "the untouched cohort still needs its shared source"
+        );
+        let rows: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_eq!(rows[0]["sandbox_store_generation"], 2);
+        // The scoped-out row must not be stamped current: its store was never
+        // copied, and generation 2 would point the session at a private store
+        // that does not exist.
+        assert_ne!(rows[1]["sandbox_store_generation"], 2);
+    }
+
+    /// A parked row is skipped by the bulk passes, but `aoe send` / `aoe
+    /// session start` / the HTTP handlers start a trashed or archived session
+    /// without unparking it. The pass scoped to that session must move it, or
+    /// nothing ever will and its launch bails on the pending transition.
+    #[test]
+    #[serial_test::serial]
+    fn a_scoped_pass_moves_the_parked_row_it_names() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let legacy = home.join(".gemini/sandbox");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("data"), b"data").unwrap();
+        let rows = serde_json::json!([
+            {"id":"1111111111111111","tool":"gemini","sandbox_info":{"enabled":true},
+             "archived_at":"2026-09-05T00:00:00Z"},
+            {"id":"2222222222222222","tool":"gemini","sandbox_info":{"enabled":true},
+             "trashed_at":"2026-09-05T00:00:00Z"}
+        ]);
+        fs::write(
+            app.join("sessions.json"),
+            serde_json::to_vec(&rows).unwrap(),
+        )
+        .unwrap();
+
+        run_in_only(&app, &home, &|_| Ok(false), "1111111111111111").unwrap();
+
+        assert_eq!(
+            fs::read(home.join(".gemini/sandbox-v2/1111111111111111/data")).unwrap(),
+            b"data"
+        );
+        let rows: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_eq!(rows[0]["sandbox_store_generation"], 2);
+        assert_ne!(rows[1]["sandbox_store_generation"], 2);
+        assert!(
+            legacy.exists(),
+            "the still-parked peer must keep the shared source"
         );
     }
 

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -91,6 +91,22 @@ impl Instance {
             .image
             .clone();
         let container = DockerContainer::new(&self.id, &image);
+        // Charge the sandbox store move to the session that needs it, at the
+        // one chokepoint every entry point shares: tmux launches, ACP
+        // structured sessions and a bare container terminal all arrive here.
+        // It must stay above the shared flock below, which `run_in` takes
+        // exclusively. A failure leaves the row on its shared store for a
+        // later attempt rather than blocking the launch.
+        if self.sandbox_store_generation < container_config::CURRENT_SANDBOX_STORE_GENERATION {
+            match crate::migrations::migrate_sandbox_store_for(&self.id) {
+                Ok(()) => self.reconcile_from_disk(),
+                Err(error) => tracing::warn!(
+                    session_id = %self.id,
+                    %error,
+                    "sandbox store move deferred; session continues on its shared store"
+                ),
+            }
+        }
         let _transition_lock =
             if self.sandbox_store_generation < container_config::CURRENT_SANDBOX_STORE_GENERATION {
                 Some(crate::session::acquire_storage_shared_flock(

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -97,7 +97,16 @@ impl Instance {
         // It must stay above the shared flock below, which `run_in` takes
         // exclusively. A failure leaves the row on its shared store for a
         // later attempt rather than blocking the launch.
-        if self.sandbox_store_generation < container_config::CURRENT_SANDBOX_STORE_GENERATION {
+        //
+        // A running container is the one case worth skipping outright: its
+        // cohort cannot move while it is up, so the pass is guaranteed to
+        // refuse, and it is not free. `run_in` takes the v027 lock and every
+        // registry's storage lock exclusively, and `Storage::update` waits on
+        // the first of those, so attaching to a live legacy session would
+        // stall writes in every AoE process to reach a foregone conclusion.
+        if self.sandbox_store_generation < container_config::CURRENT_SANDBOX_STORE_GENERATION
+            && !container.is_running()?
+        {
             match crate::migrations::migrate_sandbox_store_for(&self.id) {
                 Ok(()) => self.reconcile_from_disk(),
                 Err(error) => tracing::warn!(

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -172,7 +172,7 @@ impl Instance {
 
         if self.sandbox_store_generation < container_config::CURRENT_SANDBOX_STORE_GENERATION {
             anyhow::bail!(
-                "sandbox store transition is pending for {}; stop all legacy sandbox peers and restart AoE before relaunching it",
+                "sandbox store transition is pending for {}; stop the other sandboxed sessions sharing this agent's store, then relaunch it or run `aoe migrate`",
                 self.id
             );
         }

--- a/src/session/instance/start.rs
+++ b/src/session/instance/start.rs
@@ -90,16 +90,6 @@ impl Instance {
         if self.is_structured() {
             return Ok(LaunchSidOutcome::Skipped);
         }
-        // The sandbox store move is charged to the session that needs it. A
-        // failure leaves the row on its shared store for a later attempt; it
-        // must not stop the launch.
-        if let Err(error) = crate::migrations::migrate_sandbox_store_for(&self.id) {
-            tracing::warn!(
-                session_id = %self.id,
-                %error,
-                "sandbox store move deferred; session starts on its shared store"
-            );
-        }
         let profile = self.effective_profile();
         let storage = crate::session::storage::Storage::new(&profile, self.resolve_file_watch())
             .context("failed to open lifecycle lock storage")?;

--- a/src/session/instance/start.rs
+++ b/src/session/instance/start.rs
@@ -90,6 +90,16 @@ impl Instance {
         if self.is_structured() {
             return Ok(LaunchSidOutcome::Skipped);
         }
+        // The sandbox store move is charged to the session that needs it. A
+        // failure leaves the row on its shared store for a later attempt; it
+        // must not stop the launch.
+        if let Err(error) = crate::migrations::migrate_sandbox_store_for(&self.id) {
+            tracing::warn!(
+                session_id = %self.id,
+                %error,
+                "sandbox store move deferred; session starts on its shared store"
+            );
+        }
         let profile = self.effective_profile();
         let storage = crate::session::storage::Storage::new(&profile, self.resolve_file_watch())
             .context("failed to open lifecycle lock storage")?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -229,9 +229,11 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
 
     // Run pending migrations with a spinner that names the migration, its
     // current step and the elapsed time, and keeps the notices a migration
-    // emits (what is being moved, how to defer it) on screen. Unconditional:
-    // a deferred sandbox store move runs from the schema-current path too, and
-    // the spinner draws nothing until a migration reports it has started.
+    // emits (what is being moved, how to defer it) on screen. Unconditional
+    // because the spinner draws nothing until a migration reports it has
+    // started, so the schema-current path costs nothing. Note this covers the
+    // startup pass only: v027's store move now runs from the container path,
+    // which has no reporter installed and so draws nothing here.
     {
         const SPINNER_FRAMES: &[char] = &['◐', '◓', '◑', '◒'];
         let console = std::sync::Arc::new(std::sync::Mutex::new(


### PR DESCRIPTION
## Description

v027 copies each agent's shared store once per sandboxed row on any `aoe` start. The cost is `rows × files_per_store`. On the machine this came from: 46 rows across 5 profiles, an 8,555-file / 252 MB codex store, so roughly 400k file operations, measured at **252 MB/min**.

Most of that work is discarded. Of those 46 rows, **21 were trashed and 8 archived**, and a trashed row is normally deleted within `trash_retention_days`.

**Skip parked rows.** A row carrying `trashed_at` or `archived_at` keeps its shared store and moves on the start that follows a restore or unarchive. It still sets `defer_source_retirement`, so the source it reads is not retired underneath it; a restored session would otherwise open with its store already moved away. `snoozed_until` is deliberately excluded, being a self-clearing temporary archive.

**Scope the move by cohort.** A cohort is every session sharing one legacy store, and it is the unit the liveness gate reasons about. `run_in` takes an optional instance id and selects cohorts *after* assembly, so the gate still asks about every peer before any copy. Scoping by row instead left the fold asking only about the session being started, which copied a store a live peer was still writing to.

**Trigger at `get_container_for_instance`.** The chokepoint every entry point shares: tmux launches, ACP structured sessions, and a bare container terminal all arrive there. It sits above the shared transition flock that function takes. This mirrors #3754, which put its per-session volume reclaim at the same place.

A bare `aoe` start now reports what is pending without copying (reusing `defer_stores`). `aoe migrate` is unchanged as the bulk path, as is the schema migration. A failed move is logged and leaves the row on its shared store; it never blocks the launch.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behaviour is migration internals reached through the container path, and the failure modes are ordering and liveness rather than rendering or a subcommand surface. Five unit tests in `v027_isolate_sandbox_stores` cover them directly, including the live-peer regression, which an e2e test could not observe without a second running sandboxed session on the same agent.

Tests added:

- `a_scoped_pass_refuses_a_store_a_live_peer_is_writing` — the regression the cohort scoping exists for; asserts no copy, no generation stamp, source intact, then that the same pass succeeds once the peer stops
- `parked_rows_are_not_copied_and_hold_the_shared_source`
- `a_restored_row_migrates_on_its_next_pass`
- `a_scoped_pass_moves_only_the_named_cohort`
- `row_is_parked_reads_both_fields_and_ignores_nulls`

`cargo test --lib migrations::` 167 passed, `--lib session::instance` 378 passed, `cargo fmt --check` and `cargo clippy --all-targets` clean (the one `items after a test module` warning is pre-existing in `src/process/macos.rs`).

## Known trade-off

On a machine with several pending cohorts the shared source is retired later than before, and with a permanently archived row it is not retired until that row is restored or `aoe migrate` runs. Disk usage stays at shared-plus-private for longer instead of spiking and dropping. That is the cost of not copying stores nobody has asked for.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Written and reworked with Claude Opus 5. The first commit was reviewed by a separate Claude Opus 5 agent with no shared context, which found the live-peer torn-copy path, the structured/ACP bypass, and the missing progress reporter; the second commit is that rework, and the review also contributed the `docs/guides/sandbox.md` correction.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TM1yRz6ioAsAxsybNKXa9x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Deferred sandbox store migration until a session needs its container.
- Added support for session-specific and bulk migration paths.
- Protected shared stores from removal while eligible sessions still depend on them.
- Skipped archived and trashed sessions during bulk migration, while allowing migration when those sessions start.
- Added failure handling that logs migration issues without blocking session launches.
- Updated migration documentation and CLI references.
- Added coverage for scoped migration, parked sessions, live peers, progress reporting, and store cleanup.

## Benefits

This reduces startup work and avoids unnecessary store copies. Sessions migrate only when needed, while shared-store safety and recovery through `aoe migrate` remain available.

## Potential enhancement

Further user-facing diagnostics could make deferred or failed migrations easier to identify and resolve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->