### PR TITLE
fix(vt): three review follow-ups on the VT grid live view (#3770-#3772)

### DIFF
--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -133,9 +133,10 @@ repaints in synchronized output (DEC 2026) is shown only between brackets,
 never mid-redraw.
 
 The channel needs tmux 3.4 or newer. A pane that cannot arm one, a pane
-whose grid could not be seeded, an older tmux, a split window, or a
-non-Unix host falls back to the polling path automatically; everything
-still works, with more latency and without the synchronized-output hold.
+whose grid could not be seeded, a grid still catching up with a resize,
+an older tmux, a split window, or a non-Unix host falls back to the
+polling path automatically; everything still works, with more latency
+and without the synchronized-output hold.
 The paired host and container shells always use the polling path.
 
 To rule the VT transport in or out while troubleshooting, toggle "VT

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -744,6 +744,11 @@ async fn handle_live_ws(
             let outcome: CaptureOutcome;
             #[cfg(unix)]
             let mut grid_frame = false;
+            // Set from the sample itself, not from a later hold check: only the
+            // sampler knows whether the payload it assembled is a half-drawn
+            // synchronized-output frame.
+            #[cfg(unix)]
+            let mut grid_incomplete = false;
             #[cfg(unix)]
             {
                 // The grid serves single-pane windows within its scrollback
@@ -771,7 +776,10 @@ async fn handle_live_ws(
                         })
                         .await
                         {
-                            Ok((content, cursor)) => CaptureOutcome::Frame(content, cursor),
+                            Ok(sample) => {
+                                grid_incomplete = sample.incomplete;
+                                CaptureOutcome::Frame(sample.content, sample.cursor)
+                            }
                             Err(_) => break,
                         }
                     }
@@ -1029,9 +1037,15 @@ async fn handle_live_ws(
                     // Mid-bracket grid (the app is inside a synchronized-output
                     // repaint, or a reseed just copied tmux's half-drawn cells):
                     // wait for the close, which wakes the loop. The hold expires
-                    // on its own if the app never closes the bracket.
+                    // on its own if the app never closes the bracket. A sample
+                    // that reports itself half-drawn is held whatever the hold
+                    // now says: it can have expired, or its bracket closed,
+                    // since the payload was assembled.
                     #[cfg(unix)]
-                    if grid_frame && capture_vt.as_ref().is_some_and(|ch| ch.sync_hold_active()) {
+                    if grid_frame
+                        && (grid_incomplete
+                            || capture_vt.as_ref().is_some_and(|ch| ch.sync_hold_active()))
+                    {
                         stats.sync_held += 1;
                         wait_for_next(
                             &capture_settings,

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -123,6 +123,11 @@ const GRID_CEILING_MS: u64 = 250;
 /// disagrees with the requested grid are withheld for this long, so the client
 /// sees one clean repaint instead of a clear, a half-draw, and a settle.
 const RESIZE_SETTLE_MS: u64 = 300;
+/// Gap between retries of a VT reseed a resize could not land. Each retry forks
+/// `capture-pane` and only runs while one is outstanding; several fit inside
+/// the settle window below, so an ordinary `Busy` (a chunk landed under the
+/// capture) is absorbed without the client ever leaving the grid.
+const GRID_RESYNC_RETRY: Duration = Duration::from_millis(120);
 /// A freshly armed channel seeded from `capture-pane`, which cannot tell
 /// whether the app was mid-repaint. Its first publish waits for output to
 /// arrive and go quiet for this long (a torn seed is completed by the rest of
@@ -275,6 +280,33 @@ struct LiveSettings {
     resize_settle_until_ms: AtomicU64,
 }
 
+impl LiveSettings {
+    fn new() -> Self {
+        Self {
+            window_lines: AtomicUsize::new(DEFAULT_WINDOW_LINES),
+            fast: AtomicBool::new(true),
+            screen_rows: AtomicU64::new(0),
+            screen_cols: AtomicU64::new(0),
+            is_owner: AtomicBool::new(false),
+            deflate: AtomicBool::new(false),
+            patch: AtomicBool::new(false),
+            force_full: AtomicBool::new(false),
+            resize_settle_until_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Withhold frames still at the old geometry after a resize this connection
+    /// drove as size owner, so the client sees one clean repaint. Whether the
+    /// VT parser caught up is tracked on the shared channel, not here: every
+    /// viewer of it has to stay off the grid until it does.
+    fn record_owner_resize(&self, owned: bool) {
+        if let Some(settle_until_ms) = resize_follow_up(owned, live_now_ms()) {
+            self.resize_settle_until_ms
+                .store(settle_until_ms, Ordering::Relaxed);
+        }
+    }
+}
+
 static LIVE_CLOCK: std::sync::LazyLock<Instant> = std::sync::LazyLock::new(Instant::now);
 
 fn live_now_ms() -> u64 {
@@ -285,6 +317,110 @@ fn live_now_ms() -> u64 {
 /// the window is open and the pane has not yet reached the requested grid.
 fn resize_settle_holds(now_ms: u64, until_ms: u64, want: (u16, u16), have: (u16, u16)) -> bool {
     now_ms < until_ms && want != have
+}
+
+/// When old-geometry frames stop being withheld after a resize this connection
+/// drove, or `None` when it did not own the resize and nothing moved.
+fn resize_follow_up(owned: bool, now_ms: u64) -> Option<u64> {
+    owned.then(|| now_ms + RESIZE_SETTLE_MS)
+}
+
+/// Whether a parser that has not caught up with the pane must take the grid out
+/// of service, rather than merely withhold its frames.
+///
+/// Inside the settle window the stale frames are already held (their geometry
+/// disagrees with the requested grid), and a reseed refused because a chunk
+/// landed under it usually succeeds on the next retry a few tens of ms later.
+/// Leaving the transport alone for that long spares the client a snapshot
+/// repaint it does not need; past it the fallback is the bounded way to keep
+/// showing the pane, and a viewer with no settle window of its own (it did not
+/// drive this resize) leaves the grid at once.
+fn resync_blocks_grid(resync_pending: bool, now_ms: u64, settle_until_ms: u64) -> bool {
+    resync_pending && now_ms >= settle_until_ms
+}
+
+/// Resize the pane as size owner and rebuild the VT grid to match.
+///
+/// The channel is told the new geometry BEFORE tmux is asked for it, so there
+/// is no window where the pane has resized and viewers are still free to
+/// publish the parser's old layout; an expectation whose resize turns out not
+/// to be ours is withdrawn. The resize stays marked in flight for as long as
+/// the guard lives, so another viewer probing the pane's size across it cannot
+/// mistake a not-yet-applied resize for one tmux refused. `Busy` (a chunk
+/// landed under the capture, common while an agent streams) and `Failed` leave
+/// the expectation standing, which is what keeps grid transport suspended until
+/// a retry lands.
+#[cfg(unix)]
+fn resize_and_reseed(
+    session: &crate::tmux::Session,
+    who: &str,
+    ch: Option<&crate::tmux::vt::VtChannel>,
+    cols: u16,
+    rows: u16,
+) -> bool {
+    let in_flight = ch.map(|ch| ch.begin_resize(cols, rows));
+    let owned = session.resize_window_if_owner(who, cols, rows);
+    match (owned, ch, in_flight) {
+        (true, Some(ch), _guard) => {
+            let deadline = crate::tmux::TmuxCommandDeadline::new();
+            ch.set_grid_size_with_deadline(cols, rows, &deadline);
+        }
+        (false, _, Some(guard)) => guard.abandon(),
+        _ => {}
+    }
+    owned
+}
+
+#[cfg(not(unix))]
+fn resize_and_reseed(session: &crate::tmux::Session, who: &str, cols: u16, rows: u16) -> bool {
+    session.resize_window_if_owner(who, cols, rows)
+}
+
+/// The VT grid renders a single-pane window within its scrollback depth, and
+/// only while the parser is known to describe the pane tmux currently has: a
+/// resize whose reseed has not landed leaves it a frame of a geometry that is
+/// gone, so the view falls back to `capture-pane` until the reseed catches up.
+#[cfg(unix)]
+fn grid_transport_eligible(
+    pane_count: Option<u16>,
+    window_lines: usize,
+    resync_pending: bool,
+) -> bool {
+    pane_count == Some(1) && window_lines <= crate::tmux::vt::SCROLLBACK_LINES && !resync_pending
+}
+
+/// Resolve a pending resize expectation while the grid is out of service.
+///
+/// Reconciling first is what ends it either way: tmux is asked for the pane's
+/// real size, which drops an expectation the pane never took and re-aims a real
+/// divergence at the geometry it does have. Every viewer does that much, since
+/// the snapshot fallback samples nothing and would otherwise leave the channel
+/// unread. The reseed after it is the size owner's fast path, and takes the
+/// cross-process lock into account: the local flag lags a steal by up to a
+/// heartbeat, and rebuilding the shared parser on a stale one would aim it at a
+/// geometry the new owner has already moved the pane away from.
+#[cfg(unix)]
+fn retry_pending_resync(
+    name: &str,
+    who: &str,
+    is_owner: bool,
+    ch: Option<&crate::tmux::vt::VtChannel>,
+    deadline: &crate::tmux::TmuxCommandDeadline,
+) {
+    let Some(ch) = ch else {
+        return;
+    };
+    if ch.pending_resync_target().is_none() {
+        return;
+    }
+    ch.reconcile_with_deadline(deadline);
+    let Some((cols, rows)) = ch.pending_resync_target() else {
+        return;
+    };
+    if !is_owner || !crate::tmux::Session::from_name(name).refresh_size_owner(who) {
+        return;
+    }
+    ch.set_grid_size_with_deadline(cols, rows, deadline);
 }
 
 /// Rewrite bare cursor-key sequences for an app in DECCKM (application
@@ -626,17 +762,7 @@ async fn handle_live_ws(
         }
     }
 
-    let settings = Arc::new(LiveSettings {
-        window_lines: AtomicUsize::new(DEFAULT_WINDOW_LINES),
-        fast: AtomicBool::new(true),
-        screen_rows: AtomicU64::new(0),
-        screen_cols: AtomicU64::new(0),
-        is_owner: AtomicBool::new(false),
-        deflate: AtomicBool::new(false),
-        patch: AtomicBool::new(false),
-        force_full: AtomicBool::new(false),
-        resize_settle_until_ms: AtomicU64::new(0),
-    });
+    let settings = Arc::new(LiveSettings::new());
     // Identifies this connection in the cross-process size-owner lock (shared
     // with the web PTY attach and the native TUI via tmux user options).
     let owner_id = format!(
@@ -731,10 +857,49 @@ async fn handle_live_ws(
         let mut deflater: Option<FrameDeflater> = None;
         let mut dead_probes: u32 = 0;
         let mut last_reassert = std::time::Instant::now() - REASSERT_MIN_INTERVAL;
+        #[cfg(unix)]
+        let mut last_grid_resync = Instant::now() - GRID_RESYNC_RETRY;
         let mut reassert_guard = ReassertGuard::new(STUCK_REASSERT_RETRY);
         let mut last_heartbeat = std::time::Instant::now() - SIZE_OWNER_HEARTBEAT;
         let mut last_reclaim = std::time::Instant::now() - SIZE_OWNER_HEARTBEAT;
         loop {
+            // The grid serves single-pane windows within its scrollback depth;
+            // a split window is composited from capture-pane.
+            #[cfg(unix)]
+            let live_grid = capture_vt.as_ref().filter(|ch| ch.is_alive()).cloned();
+            // A resize whose reseed did not land left the parser at the old
+            // geometry. Resolve it on a throttle, before this cycle's frame is
+            // timed; until it lands the frames come from capture-pane, which
+            // reads the resized pane itself.
+            #[cfg(unix)]
+            if last_grid_resync.elapsed() >= GRID_RESYNC_RETRY
+                && live_grid
+                    .as_ref()
+                    .is_some_and(|ch| ch.grid_resync_pending())
+            {
+                let name = capture_tmux.clone();
+                let who = capture_owner.clone();
+                let is_owner = capture_settings.is_owner.load(Ordering::Relaxed);
+                let ch = live_grid.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    let deadline = crate::tmux::TmuxCommandDeadline::new();
+                    retry_pending_resync(&name, &who, is_owner, ch.as_deref(), &deadline);
+                })
+                .await;
+                // Throttle from the end of the attempt: a reseed forks
+                // capture-pane and can take most of the interval.
+                last_grid_resync = Instant::now();
+            }
+            #[cfg(unix)]
+            let resync_pending = resync_blocks_grid(
+                live_grid
+                    .as_ref()
+                    .is_some_and(|ch| ch.grid_resync_pending()),
+                live_now_ms(),
+                capture_settings
+                    .resize_settle_until_ms
+                    .load(Ordering::Relaxed),
+            );
             let sample_started = std::time::Instant::now();
             let lines = capture_settings.window_lines.load(Ordering::Relaxed);
 
@@ -751,9 +916,6 @@ async fn handle_live_ws(
             let mut grid_incomplete = false;
             #[cfg(unix)]
             {
-                // The grid serves single-pane windows within its scrollback
-                // depth; a split window is composited from capture-pane.
-                let live_grid = capture_vt.as_ref().filter(|ch| ch.is_alive()).cloned();
                 if live_grid.is_some() && pane_count.1.elapsed() >= PANE_COUNT_PROBE_INTERVAL {
                     let name = capture_tmux.clone();
                     // Advance the probe clock even on failure, or a tmux that
@@ -765,10 +927,7 @@ async fn handle_live_ws(
                     pane_count = (probed.ok().flatten().or(pane_count.0), Instant::now());
                 }
                 outcome = match live_grid {
-                    Some(ch)
-                        if pane_count.0 == Some(1)
-                            && lines <= crate::tmux::vt::SCROLLBACK_LINES =>
-                    {
+                    Some(ch) if grid_transport_eligible(pane_count.0, lines, resync_pending) => {
                         grid_frame = true;
                         match tokio::task::spawn_blocking(move || {
                             let deadline = crate::tmux::TmuxCommandDeadline::new();
@@ -872,16 +1031,30 @@ async fn handle_live_ws(
                             last_reclaim = std::time::Instant::now();
                             let name = capture_tmux.clone();
                             let who = capture_owner.clone();
+                            #[cfg(unix)]
+                            let reclaim_vt = capture_vt.clone();
                             let claimed = tokio::task::spawn_blocking(move || {
                                 let session = crate::tmux::Session::from_name(&name);
-                                if session.claim_size_owner(&who, SIZE_OWNER_TTL) {
-                                    session.resize_window_if_owner(&who, cols, rows)
-                                } else {
-                                    false
+                                if !session.claim_size_owner(&who, SIZE_OWNER_TTL) {
+                                    return false;
                                 }
+                                #[cfg(unix)]
+                                let owned = resize_and_reseed(
+                                    &session,
+                                    &who,
+                                    reclaim_vt.as_deref(),
+                                    cols,
+                                    rows,
+                                );
+                                #[cfg(not(unix))]
+                                let owned = resize_and_reseed(&session, &who, cols, rows);
+                                owned
                             })
                             .await
                             .unwrap_or(false);
+                            // This resize moves the pane like any other the
+                            // owner drives, so it owes the same settle window.
+                            capture_settings.record_owner_resize(claimed);
                             if claimed {
                                 capture_settings.is_owner.store(true, Ordering::Relaxed);
                                 last_heartbeat = std::time::Instant::now();
@@ -947,26 +1120,23 @@ async fn handle_live_ws(
                                 #[cfg(unix)]
                                 let reassert_vt = capture_vt.clone();
                                 let still_owner = tokio::task::spawn_blocking(move || {
-                                    let owned = crate::tmux::Session::from_name(&name)
-                                        .resize_window_if_owner(&who, want_cols, want_rows);
+                                    let session = crate::tmux::Session::from_name(&name);
                                     #[cfg(unix)]
-                                    if owned {
-                                        if let Some(ch) = reassert_vt.as_ref() {
-                                            let deadline = crate::tmux::TmuxCommandDeadline::new();
-                                            ch.set_grid_size_with_deadline(
-                                                want_cols, want_rows, &deadline,
-                                            );
-                                        }
-                                    }
+                                    let owned = resize_and_reseed(
+                                        &session,
+                                        &who,
+                                        reassert_vt.as_deref(),
+                                        want_cols,
+                                        want_rows,
+                                    );
+                                    #[cfg(not(unix))]
+                                    let owned =
+                                        resize_and_reseed(&session, &who, want_cols, want_rows);
                                     owned
                                 })
                                 .await
                                 .unwrap_or(false);
-                                if still_owner {
-                                    capture_settings
-                                        .resize_settle_until_ms
-                                        .store(live_now_ms() + RESIZE_SETTLE_MS, Ordering::Relaxed);
-                                }
+                                capture_settings.record_owner_resize(still_owner);
                                 if !still_owner {
                                     capture_settings.is_owner.store(false, Ordering::Relaxed);
                                     let _ = capture_tx
@@ -1086,6 +1256,14 @@ async fn handle_live_ws(
                     #[cfg(unix)]
                     if announced_grid != Some(grid_frame) {
                         announced_grid = Some(grid_frame);
+                        // The two transports serialize the same screen from
+                        // different sources, and carry their own scrollback
+                        // depth with it. Patching across the switch would apply
+                        // rows (and a history shift) computed against the other
+                        // one's frame, which lands the cursor rows away from the
+                        // line it belongs on. Drop the baseline so the first
+                        // frame after a switch is a whole one.
+                        last_sent = None;
                         if capture_tx
                             .send(Message::Text(transport_json(grid_frame).into()))
                             .await
@@ -1290,25 +1468,24 @@ async fn handle_live_ws(
                                 let resize_vt = vt.clone();
                                 let owned = tokio::task::spawn_blocking(move || {
                                     let session = crate::tmux::Session::from_name(&name);
-                                    let owned = session.claim_size_owner(&who, SIZE_OWNER_TTL)
-                                        && session.resize_window_if_owner(&who, cols, rows);
-                                    #[cfg(unix)]
-                                    if owned {
-                                        if let Some(ch) = resize_vt.as_ref() {
-                                            let deadline = crate::tmux::TmuxCommandDeadline::new();
-                                            ch.set_grid_size_with_deadline(cols, rows, &deadline);
-                                        }
+                                    if !session.claim_size_owner(&who, SIZE_OWNER_TTL) {
+                                        return false;
                                     }
+                                    #[cfg(unix)]
+                                    let owned = resize_and_reseed(
+                                        &session,
+                                        &who,
+                                        resize_vt.as_deref(),
+                                        cols,
+                                        rows,
+                                    );
+                                    #[cfg(not(unix))]
+                                    let owned = resize_and_reseed(&session, &who, cols, rows);
                                     owned
                                 })
                                 .await
                                 .unwrap_or(false);
-                                if owned {
-                                    settings.resize_settle_until_ms.store(
-                                        live_now_ms() + RESIZE_SETTLE_MS,
-                                        Ordering::Relaxed,
-                                    );
-                                }
+                                settings.record_owner_resize(owned);
                                 settings.is_owner.store(owned, Ordering::Relaxed);
                                 let _ = out_tx
                                     .send(Message::Text(size_owner_json(owned).into()))
@@ -1360,32 +1537,29 @@ async fn handle_live_ws(
                                 let rows = settings.screen_rows.load(Ordering::Relaxed) as u16;
                                 #[cfg(unix)]
                                 let claim_vt = vt.clone();
-                                let owned = tokio::task::spawn_blocking(move || {
+                                let (owned, resized) = tokio::task::spawn_blocking(move || {
                                     let session = crate::tmux::Session::from_name(&name);
                                     if !session.steal_size_owner(&who) {
-                                        return false;
+                                        return (false, false);
                                     }
                                     if cols == 0 || rows == 0 {
-                                        return true;
+                                        return (true, false);
                                     }
-                                    let owned = session.resize_window_if_owner(&who, cols, rows);
                                     #[cfg(unix)]
-                                    if owned {
-                                        if let Some(ch) = claim_vt.as_ref() {
-                                            let deadline = crate::tmux::TmuxCommandDeadline::new();
-                                            ch.set_grid_size_with_deadline(cols, rows, &deadline);
-                                        }
-                                    }
-                                    owned
+                                    let owned = resize_and_reseed(
+                                        &session,
+                                        &who,
+                                        claim_vt.as_deref(),
+                                        cols,
+                                        rows,
+                                    );
+                                    #[cfg(not(unix))]
+                                    let owned = resize_and_reseed(&session, &who, cols, rows);
+                                    (owned, owned)
                                 })
                                 .await
-                                .unwrap_or(false);
-                                if owned && cols > 0 && rows > 0 {
-                                    settings.resize_settle_until_ms.store(
-                                        live_now_ms() + RESIZE_SETTLE_MS,
-                                        Ordering::Relaxed,
-                                    );
-                                }
+                                .unwrap_or((false, false));
+                                settings.record_owner_resize(resized);
                                 settings.is_owner.store(owned, Ordering::Relaxed);
                                 let _ = out_tx
                                     .send(Message::Text(size_owner_json(owned).into()))
@@ -2030,6 +2204,78 @@ mod tests {
         assert!(resize_settle_holds(100, 400, (80, 24), (120, 40)));
         assert!(!resize_settle_holds(100, 400, (80, 24), (80, 24)));
         assert!(!resize_settle_holds(500, 400, (80, 24), (120, 40)));
+    }
+
+    #[test]
+    fn a_resize_whose_reseed_missed_suspends_grid_transport_until_it_lands() {
+        // The settle window is armed by every resize this connection drives as
+        // size owner, and by nothing else.
+        assert_eq!(resize_follow_up(true, 100), Some(100 + RESIZE_SETTLE_MS));
+        assert_eq!(resize_follow_up(false, 100), None);
+
+        let settings = LiveSettings::new();
+        settings.record_owner_resize(true);
+        let settle_until = settings.resize_settle_until_ms.load(Ordering::Relaxed);
+        assert!(settle_until > 0);
+        settings.record_owner_resize(false);
+        assert_eq!(
+            settings.resize_settle_until_ms.load(Ordering::Relaxed),
+            settle_until,
+            "a resize this connection did not own arms nothing"
+        );
+
+        // Whether the parser reached the new geometry is the channel's state,
+        // not this connection's: a reseed that came back Busy or Failed has to
+        // hold every viewer of the shared grid off it, not just the one that
+        // drove the resize. The settle window expiring does not resume it.
+        assert!(!grid_transport_eligible(Some(1), 50, true));
+        assert!(!resize_settle_holds(
+            settle_until + 1,
+            settle_until,
+            (120, 40),
+            (120, 40)
+        ));
+        assert!(!grid_transport_eligible(Some(1), 50, true));
+        assert!(grid_transport_eligible(Some(1), 50, false));
+    }
+
+    #[test]
+    fn a_pending_reseed_withholds_frames_before_it_gives_up_the_grid() {
+        // Inside the settle window the stale frames are withheld anyway, so a
+        // reseed that lands on a retry never costs the client a transport flip.
+        assert!(!resync_blocks_grid(true, 100, 400));
+        assert!(grid_transport_eligible(
+            Some(1),
+            50,
+            resync_blocks_grid(true, 100, 400)
+        ));
+        // Past it the bounded snapshot fallback takes over.
+        assert!(resync_blocks_grid(true, 400, 400));
+        assert!(!grid_transport_eligible(
+            Some(1),
+            50,
+            resync_blocks_grid(true, 400, 400)
+        ));
+        // A viewer that did not drive the resize has no window of its own and
+        // leaves the grid at once: its parser is just as stale.
+        assert!(resync_blocks_grid(true, 100, 0));
+        // Nothing outstanding, nothing to gate.
+        assert!(!resync_blocks_grid(false, 100, 0));
+        assert!(!resync_blocks_grid(false, 100, 400));
+    }
+
+    #[test]
+    fn grid_transport_needs_a_single_pane_within_the_grids_scrollback() {
+        assert!(grid_transport_eligible(Some(1), 50, false));
+        // Unprobed or split windows are composited from capture-pane.
+        assert!(!grid_transport_eligible(None, 50, false));
+        assert!(!grid_transport_eligible(Some(2), 50, false));
+        // A window deeper than the grid keeps that history.
+        assert!(!grid_transport_eligible(
+            Some(1),
+            crate::tmux::vt::SCROLLBACK_LINES + 1,
+            false
+        ));
     }
 
     #[test]

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -325,20 +325,6 @@ fn resize_follow_up(owned: bool, now_ms: u64) -> Option<u64> {
     owned.then(|| now_ms + RESIZE_SETTLE_MS)
 }
 
-/// Whether a parser that has not caught up with the pane must take the grid out
-/// of service, rather than merely withhold its frames.
-///
-/// Inside the settle window the stale frames are already held (their geometry
-/// disagrees with the requested grid), and a reseed refused because a chunk
-/// landed under it usually succeeds on the next retry a few tens of ms later.
-/// Leaving the transport alone for that long spares the client a snapshot
-/// repaint it does not need; past it the fallback is the bounded way to keep
-/// showing the pane, and a viewer with no settle window of its own (it did not
-/// drive this resize) leaves the grid at once.
-fn resync_blocks_grid(resync_pending: bool, now_ms: u64, settle_until_ms: u64) -> bool {
-    resync_pending && now_ms >= settle_until_ms
-}
-
 /// Resize the pane as size owner and rebuild the VT grid to match.
 ///
 /// The channel is told the new geometry BEFORE tmux is asked for it, so there
@@ -376,17 +362,11 @@ fn resize_and_reseed(session: &crate::tmux::Session, who: &str, cols: u16, rows:
     session.resize_window_if_owner(who, cols, rows)
 }
 
-/// The VT grid renders a single-pane window within its scrollback depth, and
-/// only while the parser is known to describe the pane tmux currently has: a
-/// resize whose reseed has not landed leaves it a frame of a geometry that is
-/// gone, so the view falls back to `capture-pane` until the reseed catches up.
+/// The VT grid renders a single-pane window within its scrollback depth; a
+/// split window is composited from `capture-pane`.
 #[cfg(unix)]
-fn grid_transport_eligible(
-    pane_count: Option<u16>,
-    window_lines: usize,
-    resync_pending: bool,
-) -> bool {
-    pane_count == Some(1) && window_lines <= crate::tmux::vt::SCROLLBACK_LINES && !resync_pending
+fn grid_transport_eligible(pane_count: Option<u16>, window_lines: usize) -> bool {
+    pane_count == Some(1) && window_lines <= crate::tmux::vt::SCROLLBACK_LINES
 }
 
 /// Resolve a pending resize expectation while the grid is out of service.
@@ -890,16 +870,7 @@ async fn handle_live_ws(
                 // capture-pane and can take most of the interval.
                 last_grid_resync = Instant::now();
             }
-            #[cfg(unix)]
-            let resync_pending = resync_blocks_grid(
-                live_grid
-                    .as_ref()
-                    .is_some_and(|ch| ch.grid_resync_pending()),
-                live_now_ms(),
-                capture_settings
-                    .resize_settle_until_ms
-                    .load(Ordering::Relaxed),
-            );
+
             let sample_started = std::time::Instant::now();
             let lines = capture_settings.window_lines.load(Ordering::Relaxed);
 
@@ -927,7 +898,7 @@ async fn handle_live_ws(
                     pane_count = (probed.ok().flatten().or(pane_count.0), Instant::now());
                 }
                 outcome = match live_grid {
-                    Some(ch) if grid_transport_eligible(pane_count.0, lines, resync_pending) => {
+                    Some(ch) if grid_transport_eligible(pane_count.0, lines) => {
                         grid_frame = true;
                         match tokio::task::spawn_blocking(move || {
                             let deadline = crate::tmux::TmuxCommandDeadline::new();
@@ -1211,6 +1182,29 @@ async fn handle_live_ws(
                     // that reports itself half-drawn is held whatever the hold
                     // now says: it can have expired, or its bracket closed,
                     // since the payload was assembled.
+                    // The parser has not been rebuilt at the geometry the pane
+                    // was resized to, so its cells are laid out for a size the
+                    // pane no longer has. Withhold rather than switch transport:
+                    // the reseed lands in a frame or two, and flipping the
+                    // client between two serializations of the same screen for
+                    // that long costs it a repaint it does not need.
+                    #[cfg(unix)]
+                    if grid_frame
+                        && capture_vt
+                            .as_ref()
+                            .is_some_and(|ch| ch.grid_resync_pending())
+                    {
+                        stats.settle_held += 1;
+                        wait_for_next(
+                            &capture_settings,
+                            &capture_nudge,
+                            vt_rx.as_mut(),
+                            sample_started,
+                            grid_frame,
+                        )
+                        .await;
+                        continue;
+                    }
                     #[cfg(unix)]
                     if grid_frame
                         && (grid_incomplete
@@ -2207,7 +2201,7 @@ mod tests {
     }
 
     #[test]
-    fn a_resize_whose_reseed_missed_suspends_grid_transport_until_it_lands() {
+    fn a_resize_whose_reseed_missed_withholds_frames_until_it_lands() {
         // The settle window is armed by every resize this connection drives as
         // size owner, and by nothing else.
         assert_eq!(resize_follow_up(true, 100), Some(100 + RESIZE_SETTLE_MS));
@@ -2225,56 +2219,27 @@ mod tests {
         );
 
         // Whether the parser reached the new geometry is the channel's state,
-        // not this connection's: a reseed that came back Busy or Failed has to
-        // hold every viewer of the shared grid off it, not just the one that
-        // drove the resize. The settle window expiring does not resume it.
-        assert!(!grid_transport_eligible(Some(1), 50, true));
+        // not this connection's, and it withholds frames rather than moving the
+        // view to another transport: see `VtChannel::grid_resync_pending`. The
+        // settle window expiring does not republish the old grid either.
         assert!(!resize_settle_holds(
             settle_until + 1,
             settle_until,
             (120, 40),
             (120, 40)
         ));
-        assert!(!grid_transport_eligible(Some(1), 50, true));
-        assert!(grid_transport_eligible(Some(1), 50, false));
-    }
-
-    #[test]
-    fn a_pending_reseed_withholds_frames_before_it_gives_up_the_grid() {
-        // Inside the settle window the stale frames are withheld anyway, so a
-        // reseed that lands on a retry never costs the client a transport flip.
-        assert!(!resync_blocks_grid(true, 100, 400));
-        assert!(grid_transport_eligible(
-            Some(1),
-            50,
-            resync_blocks_grid(true, 100, 400)
-        ));
-        // Past it the bounded snapshot fallback takes over.
-        assert!(resync_blocks_grid(true, 400, 400));
-        assert!(!grid_transport_eligible(
-            Some(1),
-            50,
-            resync_blocks_grid(true, 400, 400)
-        ));
-        // A viewer that did not drive the resize has no window of its own and
-        // leaves the grid at once: its parser is just as stale.
-        assert!(resync_blocks_grid(true, 100, 0));
-        // Nothing outstanding, nothing to gate.
-        assert!(!resync_blocks_grid(false, 100, 0));
-        assert!(!resync_blocks_grid(false, 100, 400));
     }
 
     #[test]
     fn grid_transport_needs_a_single_pane_within_the_grids_scrollback() {
-        assert!(grid_transport_eligible(Some(1), 50, false));
+        assert!(grid_transport_eligible(Some(1), 50));
         // Unprobed or split windows are composited from capture-pane.
-        assert!(!grid_transport_eligible(None, 50, false));
-        assert!(!grid_transport_eligible(Some(2), 50, false));
+        assert!(!grid_transport_eligible(None, 50));
+        assert!(!grid_transport_eligible(Some(2), 50));
         // A window deeper than the grid keeps that history.
         assert!(!grid_transport_eligible(
             Some(1),
-            crate::tmux::vt::SCROLLBACK_LINES + 1,
-            false
+            crate::tmux::vt::SCROLLBACK_LINES + 1
         ));
     }
 

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -1587,6 +1587,37 @@ struct SampleCache {
     cursor: PaneCursor,
 }
 
+/// One [`VtChannel::sample`] result and whether it may be published.
+pub(crate) struct VtSample {
+    pub(crate) content: String,
+    pub(crate) cursor: Option<PaneCursor>,
+    /// True when `content` was serialized from a grid inside an unclosed
+    /// synchronized-output bracket, i.e. a half-drawn frame. Decided under the
+    /// same parser lock that assembled `content`, so a caller's publish
+    /// decision describes the state the payload came from; a later
+    /// [`VtChannel::sync_hold_active`] call can see an expired hold or an
+    /// entirely different bracket.
+    pub(crate) incomplete: bool,
+}
+
+impl VtSample {
+    fn whole(content: String, cursor: Option<PaneCursor>) -> Self {
+        Self {
+            content,
+            cursor,
+            incomplete: false,
+        }
+    }
+}
+
+/// One [`VtChannel::sample_rows_padded_with_deadline`] result: the visible grid
+/// as display rows, plus the same publishability [`VtSample`] carries.
+pub(crate) struct VtRowsSample {
+    pub(crate) rows: Vec<String>,
+    pub(crate) cursor: PaneCursor,
+    pub(crate) incomplete: bool,
+}
+
 impl VtChannel {
     /// Get the shared channel for `session`, arming a new one if none is live.
     /// Returns `None` if tmux is too old or the pane is gone or any tmux/socket
@@ -2023,7 +2054,7 @@ impl VtChannel {
     /// the TUI scroll and the web's virtual scroll spacer need real history
     /// here, not just the visible screen.
     #[cfg(test)]
-    pub(crate) fn sample(&self, max_lines: usize) -> (String, Option<PaneCursor>) {
+    pub(crate) fn sample(&self, max_lines: usize) -> VtSample {
         let deadline = crate::tmux::TmuxCommandDeadline::new();
         self.sample_with_deadline(max_lines, &deadline)
     }
@@ -2032,7 +2063,7 @@ impl VtChannel {
         &self,
         max_lines: usize,
         deadline: &crate::tmux::TmuxCommandDeadline,
-    ) -> (String, Option<PaneCursor>) {
+    ) -> VtSample {
         // Both fork tmux and take the parser lock themselves, so they run
         // before this sampler takes it.
         self.reconcile_grid(deadline);
@@ -2041,7 +2072,7 @@ impl VtChannel {
         let rows = self.rows.load(Ordering::Relaxed);
         let mut p = match self.parser.lock() {
             Ok(p) => p,
-            Err(_) => return (String::new(), None),
+            Err(_) => return VtSample::whole(String::new(), None),
         };
         // Read both under the parser lock, which is where the reader applies a
         // chunk and bumps the generation, and where it releases a bracket. The
@@ -2055,7 +2086,7 @@ impl VtChannel {
                 // Mid-bracket the grid is a half-drawn frame: serve the last
                 // complete one instead. The reader wakes viewers on close.
                 if same_window && (c.grid_gen == grid_gen || incomplete) {
-                    return (c.content.clone(), Some(c.cursor));
+                    return VtSample::whole(c.content.clone(), Some(c.cursor));
                 }
             }
         }
@@ -2077,7 +2108,11 @@ impl VtChannel {
                 });
             }
         }
-        (content, Some(cursor))
+        VtSample {
+            content,
+            cursor: Some(cursor),
+            incomplete,
+        }
     }
 
     /// Sample the VISIBLE grid as `want_rows` rows padded to `want_cols`
@@ -2096,7 +2131,7 @@ impl VtChannel {
         &self,
         want_cols: u16,
         want_rows: u16,
-    ) -> Option<(Vec<String>, PaneCursor)> {
+    ) -> Option<VtRowsSample> {
         let deadline = crate::tmux::TmuxCommandDeadline::new();
         self.sample_rows_padded_with_deadline(want_cols, want_rows, &deadline)
     }
@@ -2106,7 +2141,7 @@ impl VtChannel {
         want_cols: u16,
         want_rows: u16,
         deadline: &crate::tmux::TmuxCommandDeadline,
-    ) -> Option<(Vec<String>, PaneCursor)> {
+    ) -> Option<VtRowsSample> {
         self.reconcile_grid(deadline);
         self.refresh_owner_heartbeat(deadline);
         let cols = self.cols.load(Ordering::Relaxed);
@@ -2115,6 +2150,10 @@ impl VtChannel {
         let want_rows = want_rows.max(1);
 
         let p = self.parser.lock().ok()?;
+        // Read under the lock that renders these rows, like the scrollback
+        // sampler: a composite spliced from a half-drawn pane 0 tears the same
+        // way a whole-window frame does.
+        let incomplete = self.signals.frame_incomplete();
         let screen = p.screen();
         let readable_cols = cols.min(want_cols);
         let out = (0..want_rows)
@@ -2135,7 +2174,11 @@ impl VtChannel {
             .collect();
         let cursor = cursor_from_screen(screen, rows, cols);
         drop(p);
-        Some((out, cursor))
+        Some(VtRowsSample {
+            rows: out,
+            cursor,
+            incomplete,
+        })
     }
 
     /// A receiver that fires on every publishable grid change, OSC 52 write, and
@@ -3093,7 +3136,9 @@ mod tests {
             .process(b"hello\r\nworld\r\n\x1b[41mfilled");
 
         // Exact rectangle.
-        let (rows, cursor) = ch.sample_rows_padded(20, 4).expect("sample");
+        let sample = ch.sample_rows_padded(20, 4).expect("sample");
+        let (rows, cursor) = (sample.rows, sample.cursor);
+        assert!(!sample.incomplete, "no bracket open: publishable");
         assert_eq!(rows.len(), 4);
         for (i, r) in rows.iter().enumerate() {
             assert_eq!(
@@ -3108,7 +3153,7 @@ mod tests {
         assert!(cursor.position_reliable);
 
         // Narrower and shorter than the grid: truncate, never overflow.
-        let (rows, _) = ch.sample_rows_padded(6, 2).expect("sample");
+        let rows = ch.sample_rows_padded(6, 2).expect("sample").rows;
         assert_eq!(rows.len(), 2);
         for r in &rows {
             assert_eq!(crate::tmux::utils::strip_ansi(r).chars().count(), 6);
@@ -3117,7 +3162,7 @@ mod tests {
         // Taller than the grid (tmux says the pane grew before the grid caught
         // up): the extra rows are blank filler at the right width, not rows
         // borrowed from elsewhere.
-        let (rows, _) = ch.sample_rows_padded(10, 6).expect("sample");
+        let rows = ch.sample_rows_padded(10, 6).expect("sample").rows;
         assert_eq!(rows.len(), 6);
         for (i, r) in rows.iter().enumerate() {
             let plain = crate::tmux::utils::strip_ansi(r);
@@ -3126,6 +3171,15 @@ mod tests {
                 assert!(plain.trim().is_empty(), "row {i} should be filler: {r:?}");
             }
         }
+
+        // Mid-bracket the rows are a half-drawn repaint. A composite splices
+        // them into the window next to panes captured whole, so the sample says
+        // so and the preview keeps the frame it has.
+        ch.signals.begin_hold();
+        let held = ch.sample_rows_padded(20, 4).expect("sample");
+        assert!(held.incomplete, "mid-bracket rows are not publishable");
+        ch.signals.end_hold();
+        assert!(!ch.sample_rows_padded(20, 4).expect("sample").incomplete);
     }
 
     #[test]
@@ -3204,13 +3258,13 @@ mod tests {
 
         ch.parser.lock().unwrap().process(b"one");
         ch.grid_gen.fetch_add(1, Ordering::Relaxed);
-        let (first, _) = ch.sample(4);
+        let first = ch.sample(4).content;
         assert!(first.contains("one"), "fresh assembly:\n{first:?}");
 
         // Advance the parser WITHOUT bumping gen: the cache must still serve
         // the old frame (this is what makes an idle pane's cadence cheap).
         ch.parser.lock().unwrap().process(b" two");
-        let (cached, _) = ch.sample(4);
+        let cached = ch.sample(4).content;
         assert!(
             !cached.contains("two"),
             "same generation must serve the cached assembly:\n{cached:?}"
@@ -3218,14 +3272,14 @@ mod tests {
 
         // Bump gen (what the reader does per chunk): fresh assembly.
         ch.grid_gen.fetch_add(1, Ordering::Relaxed);
-        let (fresh, _) = ch.sample(4);
+        let fresh = ch.sample(4).content;
         assert!(
             fresh.contains("two"),
             "bumped generation must reassemble:\n{fresh:?}"
         );
 
         // A different window size also misses the cache.
-        let (wider, _) = ch.sample(3);
+        let wider = ch.sample(3).content;
         assert!(wider.contains("two"), "window change must reassemble");
     }
 
@@ -4240,25 +4294,65 @@ mod tests {
         ch.parser.lock().unwrap().process(b"before");
         ch.grid_gen.fetch_add(1, Ordering::Relaxed);
         let deadline = crate::tmux::TmuxCommandDeadline::new();
-        let (first, _) = ch.sample_with_deadline(4, &deadline);
+        let first = ch.sample_with_deadline(4, &deadline).content;
         assert!(first.contains("before"));
 
         // Output lands inside a bracket: the sample must not follow it yet.
         ch.signals.begin_hold();
         ch.parser.lock().unwrap().process(b"\r\x1b[Kafter");
         ch.grid_gen.fetch_add(1, Ordering::Relaxed);
-        let (held, _) = ch.sample_with_deadline(4, &deadline);
+        let held = ch.sample_with_deadline(4, &deadline).content;
         assert_eq!(
             held, first,
             "mid-bracket sample serves the last complete frame"
         );
 
         ch.signals.end_hold();
-        let (fresh, _) = ch.sample_with_deadline(4, &deadline);
+        let fresh = ch.sample_with_deadline(4, &deadline).content;
         assert!(
             fresh.contains("after"),
             "closing the bracket publishes the new frame"
         );
         assert!(!fresh.contains("before"));
+    }
+
+    #[test]
+    fn sample_reports_a_mid_bracket_cache_miss_as_incomplete() {
+        // The single-entry cache serves the last complete frame only for the
+        // window it was assembled for. A second viewer at a different window
+        // misses it and can only serialize the grid, which mid-bracket is half
+        // drawn: that payload must carry its own "do not publish", because the
+        // caller's later hold check can see an expired hold or a closed
+        // bracket and would publish the tear.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (ch, _alive) = dummy_channel("aoe-vt-partial-test", dir.path());
+        let deadline = crate::tmux::TmuxCommandDeadline::new();
+        ch.parser.lock().unwrap().process(b"whole");
+        ch.grid_gen.fetch_add(1, Ordering::Relaxed);
+        let cached = ch.sample_with_deadline(4, &deadline);
+        assert!(cached.content.contains("whole"));
+        assert!(!cached.incomplete);
+
+        // A repaint opens a bracket and only its first half has been applied.
+        ch.signals.begin_hold();
+        ch.parser.lock().unwrap().process(b"\r\x1b[Kpart");
+        ch.grid_gen.fetch_add(1, Ordering::Relaxed);
+
+        let hit = ch.sample_with_deadline(4, &deadline);
+        assert_eq!(hit.content, cached.content, "cache hit stays whole");
+        assert!(!hit.incomplete);
+
+        let miss = ch.sample_with_deadline(3, &deadline);
+        assert!(miss.content.contains("part"), "cache miss reassembles");
+        assert!(miss.incomplete, "a mid-bracket assembly is not publishable");
+
+        // The bracket closing after the sample does not make that payload
+        // publishable: completeness travels with it.
+        ch.signals.end_hold();
+        assert!(miss.incomplete);
+
+        let after = ch.sample_with_deadline(3, &deadline);
+        assert!(!after.incomplete, "a closed bracket publishes again");
+        assert!(after.content.contains("part"));
     }
 }

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -2424,6 +2424,11 @@ impl VtChannel {
     /// stays gated for as long as it takes a reseed to land rather than for a
     /// fixed window that a slow one could outlive.
     ///
+    /// This only ever resolves an expectation a resize declared; it never opens
+    /// one. Ordinary geometry drift is what the reseed below this call is for,
+    /// and gating the grid on it would put the channel into a retry loop over
+    /// something the same reconcile pass is already fixing.
+    ///
     /// `probe_seq` is [`Self::resize_seq`] read BEFORE the probe. Matching
     /// dimensions only retire an expectation when no resize overlapped it: one
     /// viewer's probe can read the pane before another viewer's resize lands
@@ -2431,6 +2436,9 @@ impl VtChannel {
     /// about the resize now in flight. Re-aiming is left unguarded because it
     /// keeps the gate up, which is the safe direction for a stale read.
     fn observe_pane_geometry(&self, pane: (u16, u16), probe_seq: u64) {
+        if self.resync_target.load(Ordering::Relaxed) == 0 {
+            return;
+        }
         if pane
             != (
                 self.cols.load(Ordering::Relaxed),
@@ -4838,9 +4846,15 @@ mod tests {
         ch.observe_pane_geometry(grid, ch.resize_seq());
         assert!(!ch.grid_resync_pending(), "an unmet request is dropped");
 
-        // A pane that disagrees is a real divergence: the expectation is re-aimed
-        // at tmux's own geometry and holds for as long as the reseed takes,
-        // however many attempts that is.
+        // With nothing outstanding, a probe opens no gate of its own: ordinary
+        // drift is the reseed's job, not this one's.
+        ch.observe_pane_geometry((132, 43), ch.resize_seq());
+        assert!(!ch.grid_resync_pending(), "reconcile opens no expectation");
+
+        // A pane that disagrees while one IS outstanding is a real divergence:
+        // it is re-aimed at tmux's own geometry and holds for as long as the
+        // reseed takes, however many attempts that is.
+        drop(ch.begin_resize(1, 1));
         ch.observe_pane_geometry((132, 43), ch.resize_seq());
         assert_eq!(ch.pending_resync_target(), Some((132, 43)));
         for _ in 0..10 {

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -215,11 +215,12 @@ impl SyncOutputScanner {
         }
     }
 
-    /// Scan one chunk; returns the last 2026 transition it contains
-    /// (`Some(true)` = bracket opened, `Some(false)` = closed).
-    fn feed(&mut self, chunk: &[u8]) -> Option<bool> {
+    /// Scan one chunk, appending its 2026 transitions to `out` in order
+    /// (`true` = bracket opened, `false` = closed). Order matters: one socket
+    /// read can carry the close of one repaint and the open of the next, and
+    /// each bracket needs its own hold lifetime.
+    fn feed(&mut self, chunk: &[u8], out: &mut Vec<bool>) {
         use SyncState::*;
-        let mut last = None;
         for &b in chunk {
             self.state = match (self.state, b) {
                 (Idle, 0x1b) => Esc,
@@ -235,7 +236,7 @@ impl SyncOutputScanner {
                 }
                 (Params, b'h' | b'l') => {
                     if self.params.split(|&c| c == b';').any(|p| p == b"2026") {
-                        last = Some(b == b'h');
+                        out.push(b == b'h');
                     }
                     Idle
                 }
@@ -243,7 +244,55 @@ impl SyncOutputScanner {
                 (Esc | Csi | Params, _) => Idle,
             };
         }
-        last
+    }
+}
+
+/// How one chunk's synchronized-output transitions move the hold around
+/// applying its bytes to the parser.
+///
+/// Opening is raised before the bytes land, so a sampler racing them serves
+/// the last complete frame; closing waits until they have landed, because the
+/// grid does not hold the finished frame before that. A chunk that closes one
+/// bracket and opens the next restarts the hold rather than letting the new
+/// bracket inherit the old one's age, which would let its first half-drawn
+/// grid outlive the abandon window immediately. That restart moves the bracket
+/// only: see [`ViewerSignals::restart_hold`] for why the incomplete run has to
+/// keep running across it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct SyncHoldPlan {
+    /// The chunk opens a bracket.
+    open: bool,
+    /// A close precedes that opener: the new bracket needs a fresh timestamp.
+    restart: bool,
+    /// The chunk ends outside any bracket.
+    close: bool,
+}
+
+impl SyncHoldPlan {
+    fn from_events(events: &[bool]) -> Self {
+        let last_open = events.iter().rposition(|&open| open);
+        Self {
+            open: last_open.is_some(),
+            restart: last_open.is_some_and(|i| events[..i].contains(&false)),
+            close: events.last() == Some(&false),
+        }
+    }
+
+    /// Applied before the chunk reaches the parser.
+    fn begin(&self, signals: &ViewerSignals) {
+        if self.restart {
+            signals.restart_hold();
+        } else if self.open {
+            signals.begin_hold();
+        }
+    }
+
+    /// Applied once the chunk has been applied to the parser, under the same
+    /// lock, so a sampler cannot see the release before the finished frame.
+    fn end(&self, signals: &ViewerSignals) {
+        if self.close {
+            signals.end_hold();
+        }
     }
 }
 
@@ -257,8 +306,16 @@ pub(crate) struct ViewerSignals {
     clipboard_latest: Mutex<Option<String>>,
     clipboard_seq: AtomicU64,
     /// Millis since `CHUNK_CLOCK` when the current 2026 bracket opened; 0 when
-    /// no bracket is open.
+    /// no bracket is open. Restarted per bracket, so each repaint gets its own
+    /// wakeup hold.
     sync_hold_since_ms: AtomicU64,
+    /// Millis since `CHUNK_CLOCK` when the grid last stopped holding a frame
+    /// the viewers could see whole; 0 while it holds one. Unlike the bracket
+    /// above this is NOT restarted by the next bracket, because a close the
+    /// same socket read reopens over is a frame no viewer ever got to sample:
+    /// refreshing here would let an app whose repaints straddle every read
+    /// extend the abandon window forever and freeze the view.
+    incomplete_since_ms: AtomicU64,
 }
 
 impl ViewerSignals {
@@ -268,6 +325,7 @@ impl ViewerSignals {
             clipboard_latest: Mutex::new(None),
             clipboard_seq: AtomicU64::new(0),
             sync_hold_since_ms: AtomicU64::new(0),
+            incomplete_since_ms: AtomicU64::new(0),
         }
     }
 
@@ -283,33 +341,75 @@ impl ViewerSignals {
     }
 
     fn begin_hold(&self) {
+        let now = chunk_now_ms().max(1);
         if self.sync_hold_since_ms.load(Ordering::Relaxed) == 0 {
-            self.sync_hold_since_ms
-                .store(chunk_now_ms().max(1), Ordering::Relaxed);
+            self.sync_hold_since_ms.store(now, Ordering::Relaxed);
+        }
+        if self.incomplete_since_ms.load(Ordering::Relaxed) == 0 {
+            self.incomplete_since_ms.store(now, Ordering::Relaxed);
         }
     }
 
+    /// A bracket closed with its bytes applied: the grid holds a whole frame
+    /// again, which ends both the wakeup hold and the incomplete run.
     fn end_hold(&self) {
         self.sync_hold_since_ms.store(0, Ordering::Relaxed);
+        self.incomplete_since_ms.store(0, Ordering::Relaxed);
+    }
+
+    /// Start the next bracket's hold when its opener shares a socket read with
+    /// the previous bracket's close. One store, so no sampler observes a gap
+    /// where the previous repaint's still half-drawn grid reads as whole.
+    ///
+    /// A run already under way deliberately keeps running: the frame that
+    /// closed mid-read was never in the grid on its own (this same read already
+    /// applied the next repaint's opening bytes over it), so counting it as
+    /// shown would let a continuously repainting app hold the view forever. A
+    /// read that opens, closes and reopens over a settled grid starts one,
+    /// because it too leaves a repaint half applied.
+    fn restart_hold(&self) {
+        let now = chunk_now_ms().max(1);
+        self.sync_hold_since_ms.store(now, Ordering::Relaxed);
+        if self.incomplete_since_ms.load(Ordering::Relaxed) == 0 {
+            self.incomplete_since_ms.store(now, Ordering::Relaxed);
+        }
     }
 
     /// True while a synchronized-output bracket is open and has not outlived
-    /// [`SYNC_HOLD_MAX_MS`]. Gates wakeups and publication.
+    /// [`SYNC_HOLD_MAX_MS`]. Gates wakeups and publication. Never outlives
+    /// [`Self::frame_incomplete`]: once the grid is publishable there is
+    /// nothing left to suppress wakeups for.
     pub(crate) fn hold_active(&self) -> bool {
-        self.open_within(chunk_now_ms(), SYNC_HOLD_MAX_MS)
+        let now = chunk_now_ms();
+        open_within(
+            self.sync_hold_since_ms.load(Ordering::Relaxed),
+            now,
+            SYNC_HOLD_MAX_MS,
+        ) && self.incomplete_within(now)
     }
 
     /// True while the grid holds a frame the app has not finished drawing, up
     /// to [`SYNC_BRACKET_ABANDON_MS`]. Outlives [`Self::hold_active`] so a slow
-    /// repaint is served from the last complete frame instead of torn.
+    /// repaint is served from the last complete frame instead of torn, and is
+    /// bounded from the START of the run of brackets none of which produced a
+    /// frame a viewer could sample, so tearing is the worst case and a frozen
+    /// view is never one.
     pub(crate) fn frame_incomplete(&self) -> bool {
-        self.open_within(chunk_now_ms(), SYNC_BRACKET_ABANDON_MS)
+        self.incomplete_within(chunk_now_ms())
     }
 
-    fn open_within(&self, now_ms: u64, window_ms: u64) -> bool {
-        let since = self.sync_hold_since_ms.load(Ordering::Relaxed);
-        since != 0 && now_ms.saturating_sub(since) < window_ms
+    fn incomplete_within(&self, now_ms: u64) -> bool {
+        open_within(
+            self.incomplete_since_ms.load(Ordering::Relaxed),
+            now_ms,
+            SYNC_BRACKET_ABANDON_MS,
+        )
     }
+}
+
+/// Whether a hold stamped at `since` (0 = none) is still inside `window_ms`.
+fn open_within(since: u64, now_ms: u64, window_ms: u64) -> bool {
+    since != 0 && now_ms.saturating_sub(since) < window_ms
 }
 
 /// `aoe __vt-pipe <socket>`: the bidirectional `pipe-pane -IO` forwarder. tmux
@@ -1393,22 +1493,18 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
     let mut buf = [0u8; 8192];
     let mut osc52 = Osc52Scanner::new();
     let mut sync = SyncOutputScanner::new();
+    let mut sync_events: Vec<bool> = Vec::new();
     while !ctx.stop.load(Ordering::Relaxed) {
         match conn.read(&mut buf) {
             Ok(0) => break,
             Ok(n) => {
-                // Track the app's synchronized-output bracket before anything
+                // Track the app's synchronized-output brackets before anything
                 // can publish this chunk: a frame is published when the
                 // bracket closes (or the hold expires), never in the middle.
-                let sync_event = sync.feed(&buf[..n]);
-                // Opening is raised before the grid is touched, so a sampler
-                // racing this chunk errs toward the last complete frame.
-                // Closing is raised below, under the parser lock, because the
-                // grid does not hold the finished frame until the chunk has
-                // been applied.
-                if sync_event == Some(true) {
-                    ctx.signals.begin_hold();
-                }
+                sync_events.clear();
+                sync.feed(&buf[..n], &mut sync_events);
+                let sync_plan = SyncHoldPlan::from_events(&sync_events);
+                sync_plan.begin(&ctx.signals);
                 // The vt100 parser below silently drops OSC 52, and in
                 // live-send no tmux client is attached for `set-clipboard`
                 // to forward to, so this tap is the ONLY path an agent's
@@ -1432,6 +1528,11 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
                 // Bytes received during the shorter pipe-connect window are
                 // already present in that later snapshot, so do not replay them.
                 if !ctx.seeded.load(Ordering::Acquire) {
+                    // These bytes never reach the parser, so a closing bracket
+                    // has nothing left to wait for: release it here or the
+                    // stale timestamp outlives the discarded repaint and the
+                    // next one inherits an already-expired hold.
+                    sync_plan.end(&ctx.signals);
                     ctx.settled_chunk_seq.store(seq + 1, Ordering::Release);
                     // OSC 52 remains independent of grid publication.
                     if copied.is_some() {
@@ -1461,15 +1562,13 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
                     );
                     // The finished frame is in the grid now, so the bracket can
                     // release; a sampler waiting on this lock sees a whole frame.
-                    if sync_event == Some(false) {
-                        ctx.signals.end_hold();
-                    }
+                    sync_plan.end(&ctx.signals);
                     // Publish settlement after parser, cursor, generation, and
                     // timing updates. Acquire readers use this completion fence.
                     ctx.settled_chunk_seq.store(seq + 1, Ordering::Release);
                     // Inside a synchronized-output bracket the grid is a
                     // half-drawn frame; viewers wake when it closes.
-                    if sync_event == Some(false) || !ctx.signals.hold_active() {
+                    if sync_plan.close || !ctx.signals.hold_active() {
                         ctx.notify_viewers();
                     }
                 }
@@ -4158,23 +4257,112 @@ mod tests {
     #[test]
     fn sync_output_scanner_tracks_2026_across_chunks_and_param_lists() {
         let mut sc = SyncOutputScanner::new();
-        assert_eq!(sc.feed(b"plain text \x1b[31m"), None);
+        let mut out = Vec::new();
+        let mut scan = |sc: &mut SyncOutputScanner, chunk: &[u8]| {
+            out.clear();
+            sc.feed(chunk, &mut out);
+            out.clone()
+        };
+        assert!(scan(&mut sc, b"plain text \x1b[31m").is_empty());
         // Split at every byte boundary of the opener.
         let opener = b"\x1b[?2026h";
         for (i, _) in opener.iter().enumerate().skip(1) {
             let mut split = SyncOutputScanner::new();
-            assert_eq!(split.feed(&opener[..i]), None);
-            assert_eq!(split.feed(&opener[i..]), Some(true), "split at {i}");
+            assert!(scan(&mut split, &opener[..i]).is_empty());
+            assert_eq!(scan(&mut split, &opener[i..]), vec![true], "split at {i}");
         }
-        assert_eq!(sc.feed(b"\x1b[?2026h"), Some(true));
+        assert_eq!(scan(&mut sc, b"\x1b[?2026h"), vec![true]);
         // 2026 inside a parameter list, closing.
-        assert_eq!(sc.feed(b"\x1b[?25;2026l"), Some(false));
+        assert_eq!(scan(&mut sc, b"\x1b[?25;2026l"), vec![false]);
         // Other private modes are not the bracket.
-        assert_eq!(sc.feed(b"\x1b[?1049h\x1b[?25l"), None);
+        assert!(scan(&mut sc, b"\x1b[?1049h\x1b[?25l").is_empty());
         // A non-private CSI with 2026 is not the bracket either.
-        assert_eq!(sc.feed(b"\x1b[2026h"), None);
-        // Last transition in a chunk wins.
-        assert_eq!(sc.feed(b"\x1b[?2026h frame \x1b[?2026l"), Some(false));
+        assert!(scan(&mut sc, b"\x1b[2026h").is_empty());
+        // Every transition in a chunk is reported, in order: one socket read
+        // can carry the end of one repaint and the start of the next.
+        assert_eq!(
+            scan(&mut sc, b"\x1b[?2026h frame \x1b[?2026l"),
+            vec![true, false]
+        );
+        assert_eq!(
+            scan(&mut sc, b"tail \x1b[?2026l head \x1b[?2026h"),
+            vec![false, true]
+        );
+    }
+
+    #[test]
+    fn sync_hold_plan_gives_each_bracket_its_own_lifetime() {
+        // (transitions in one chunk, plan)
+        for (events, want) in [
+            (
+                &[][..],
+                SyncHoldPlan {
+                    open: false,
+                    restart: false,
+                    close: false,
+                },
+            ),
+            (
+                &[true][..],
+                SyncHoldPlan {
+                    open: true,
+                    restart: false,
+                    close: false,
+                },
+            ),
+            (
+                &[false][..],
+                SyncHoldPlan {
+                    open: false,
+                    restart: false,
+                    close: true,
+                },
+            ),
+            // A whole repaint in one read: hold across the apply, release after.
+            (
+                &[true, false][..],
+                SyncHoldPlan {
+                    open: true,
+                    restart: false,
+                    close: true,
+                },
+            ),
+            // Back-to-back brackets: the new one must not inherit the old age.
+            (
+                &[false, true][..],
+                SyncHoldPlan {
+                    open: true,
+                    restart: true,
+                    close: false,
+                },
+            ),
+            (
+                &[false, true, false, true][..],
+                SyncHoldPlan {
+                    open: true,
+                    restart: true,
+                    close: false,
+                },
+            ),
+        ] {
+            assert_eq!(SyncHoldPlan::from_events(events), want, "{events:?}");
+        }
+
+        // The restart is what refreshes the timestamp: a bare re-open keeps
+        // the running bracket's age (its abandon window must stay bounded),
+        // while a close-then-open starts a new one.
+        let signals = ViewerSignals::new();
+        let stale = u64::MAX;
+        signals.sync_hold_since_ms.store(stale, Ordering::Relaxed);
+        SyncHoldPlan::from_events(&[true]).begin(&signals);
+        assert_eq!(signals.sync_hold_since_ms.load(Ordering::Relaxed), stale);
+        SyncHoldPlan::from_events(&[false, true]).begin(&signals);
+        let fresh = signals.sync_hold_since_ms.load(Ordering::Relaxed);
+        assert_ne!(fresh, stale, "a new bracket gets a new timestamp");
+        // The restart is one store: the previous repaint's tail bytes have not
+        // been applied yet, so a hold released even briefly here would let a
+        // sampler cache that half-drawn grid as a whole frame.
+        assert_ne!(fresh, 0, "and the hold is never dropped between them");
     }
 
     #[test]
@@ -4204,17 +4392,78 @@ mod tests {
             // Past this the app is stuck and its partial screen is all there is.
             (SYNC_BRACKET_ABANDON_MS, false, false),
         ] {
+            let now = since + elapsed;
             assert_eq!(
-                signals.open_within(since + elapsed, SYNC_HOLD_MAX_MS),
+                open_within(since, now, SYNC_HOLD_MAX_MS) && signals.incomplete_within(now),
                 hold,
                 "hold at {elapsed}ms"
             );
             assert_eq!(
-                signals.open_within(since + elapsed, SYNC_BRACKET_ABANDON_MS),
+                signals.incomplete_within(now),
                 incomplete,
                 "incomplete at {elapsed}ms"
             );
         }
+    }
+
+    #[test]
+    fn repeated_close_open_reads_cannot_freeze_the_view() {
+        // A full-screen agent repainting continuously delivers
+        // `tail(A) close(A) open(B) head(B)` in one socket read, over and over.
+        // Each read restarts the bracket hold, and none of them ever ends one:
+        // if that also refreshed the incomplete run, the sampler would serve
+        // its last complete frame forever and the view would freeze. The run is
+        // therefore stamped once and left alone, so the abandon window still
+        // expires and publication resumes (torn at worst, never frozen).
+        let signals = ViewerSignals::new();
+        signals.begin_hold();
+        let run_started = signals.incomplete_since_ms.load(Ordering::Relaxed);
+        let mut bracket = signals.sync_hold_since_ms.load(Ordering::Relaxed);
+        for read in 1..=50 {
+            SyncHoldPlan::from_events(&[false, true]).begin(&signals);
+            let next = signals.sync_hold_since_ms.load(Ordering::Relaxed);
+            assert!(next >= bracket, "read {read}: bracket hold moves forward");
+            bracket = next;
+            assert_eq!(
+                signals.incomplete_since_ms.load(Ordering::Relaxed),
+                run_started,
+                "read {read}: an unsampled close does not extend the abandon window"
+            );
+        }
+        assert!(
+            !signals.incomplete_within(run_started + SYNC_BRACKET_ABANDON_MS),
+            "the run still expires, so frames publish again"
+        );
+
+        // A read that ends outside a bracket is a frame the viewers can sample:
+        // it ends the run, and the next repaint gets a whole fresh hold.
+        SyncHoldPlan::from_events(&[false]).end(&signals);
+        assert_eq!(signals.incomplete_since_ms.load(Ordering::Relaxed), 0);
+        assert!(!signals.frame_incomplete());
+        signals.begin_hold();
+        assert!(signals.frame_incomplete());
+        assert!(signals.hold_active());
+    }
+
+    #[test]
+    fn a_restart_over_a_settled_grid_starts_the_incomplete_run() {
+        // One read can open a bracket, close it and open the next over a grid
+        // that was not mid-repaint when the read arrived. That still takes the
+        // restart path, and it still leaves the second repaint half applied, so
+        // it has to START the run rather than only move the bracket: with no
+        // run the grid reads as publishable and the tear goes out.
+        let signals = ViewerSignals::new();
+        assert_eq!(signals.incomplete_since_ms.load(Ordering::Relaxed), 0);
+        let plan = SyncHoldPlan::from_events(&[true, false, true]);
+        assert!(plan.restart, "the last opener follows a close");
+        assert!(!plan.close, "and the read ends inside the new bracket");
+        plan.begin(&signals);
+        assert!(
+            signals.frame_incomplete(),
+            "the half-applied repaint is held"
+        );
+        assert!(signals.hold_active());
+        assert_ne!(signals.incomplete_since_ms.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -4281,6 +4530,63 @@ mod tests {
             "viewers wake when the frame completes"
         );
         assert_eq!(*wakeup.0.lock().unwrap(), 1);
+
+        stop.store(true, Ordering::Relaxed);
+        drop(conn);
+        let _ = reader.join();
+    }
+
+    #[test]
+    fn reader_releases_a_bracket_closed_before_the_grid_is_seeded() {
+        use std::io::Write;
+
+        // Reads that arrive before the seed are discarded: the snapshot taken
+        // later already contains them. A bracket opened and closed inside that
+        // window must still end, or its timestamp survives into the seeded
+        // grid and the next repaint is born already past its abandon window.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("s.sock");
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let stop = Arc::new(AtomicBool::new(false));
+        let settled = Arc::new(AtomicU64::new(0));
+        let signals = Arc::new(ViewerSignals::new());
+        let ctx = ReaderCtx {
+            parser: Arc::new(Mutex::new(vt100::Parser::new(24, 80, 0))),
+            stop: stop.clone(),
+            seeded: Arc::new(AtomicBool::new(false)),
+            stream: Arc::new(Mutex::new(None)),
+            app_cursor: Arc::new(AtomicBool::new(false)),
+            alive: Arc::new(AtomicBool::new(false)),
+            wakeup: Arc::new(Mutex::new(None)),
+            clipboard: Arc::new(Mutex::new(None)),
+            chunk_seq: Arc::new(AtomicU64::new(0)),
+            settled_chunk_seq: settled.clone(),
+            last_chunk_ms: Arc::new(AtomicU64::new(0)),
+            prev_gap_ms: Arc::new(AtomicU64::new(u64::MAX)),
+            grid_gen: Arc::new(AtomicU64::new(0)),
+            signals: signals.clone(),
+        };
+        let reader = std::thread::spawn(move || run_reader(listener, ctx));
+        let mut conn = UnixStream::connect(&sock).expect("connect");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let await_chunk = |seq: u64| {
+            while settled.load(Ordering::Acquire) < seq {
+                assert!(
+                    Instant::now() < deadline,
+                    "reader never consumed chunk {seq}"
+                );
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        };
+
+        conn.write_all(b"\x1b[?2026h\x1b[2JPART-A").expect("write");
+        await_chunk(1);
+        assert!(signals.hold_active(), "pre-seed opener still holds");
+
+        conn.write_all(b"PART-B\x1b[?2026l").expect("write");
+        await_chunk(2);
+        assert!(!signals.hold_active(), "pre-seed close releases the hold");
+        assert!(!signals.frame_incomplete());
 
         stop.store(true, Ordering::Relaxed);
         drop(conn);

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -1673,6 +1673,23 @@ pub(crate) struct VtChannel {
     /// so `sample` refreshes at a fraction of `VT_OWNER_TTL` instead of
     /// forking `set-option` every call.
     last_owner_hb: Mutex<Instant>,
+    /// Geometry the parser still has to be rebuilt at, packed by [`pack_size`];
+    /// 0 when its grid describes the pane. tmux reflows on resize while
+    /// `pipe-pane` carries no reflow redraw, so between the pane changing size
+    /// and the reseed landing the grid renders a layout the pane no longer has.
+    /// A reseed that comes back `Busy` or `Failed` leaves it that way, and the
+    /// channel is shared: this belongs here, not in one viewer's state, or the
+    /// viewers that did not drive the resize keep publishing the stale grid.
+    resync_target: AtomicU64,
+    /// Seqlock over pane resizes: odd while one is in flight, and bumped again
+    /// when it finishes. A geometry probe that straddles a resize describes
+    /// either side of it, so it cannot be trusted to retire the expectation
+    /// that resize declared (see [`VtChannel::observe_pane_geometry`]).
+    resize_seq: AtomicU64,
+}
+
+fn pack_size(cols: u16, rows: u16) -> u64 {
+    ((cols as u64) << 16) | rows as u64
 }
 
 /// One cached [`VtChannel::sample`] assembly, valid while the grid
@@ -1706,6 +1723,28 @@ impl VtSample {
             cursor,
             incomplete: false,
         }
+    }
+}
+
+/// A pane resize in progress. Holding one marks [`VtChannel::resize_seq`] odd,
+/// so a geometry probe overlapping it knows not to retire the expectation the
+/// resize declared; dropping it closes the window.
+pub(crate) struct ResizeInFlight<'a> {
+    channel: &'a VtChannel,
+    token: u64,
+}
+
+impl ResizeInFlight<'_> {
+    /// The resize never ran (this caller turned out not to own the pane size):
+    /// withdraw its expectation, unless a newer one has replaced it.
+    pub(crate) fn abandon(self) {
+        self.channel.abandon_expected_grid(self.token);
+    }
+}
+
+impl Drop for ResizeInFlight<'_> {
+    fn drop(&mut self) {
+        self.channel.resize_seq.fetch_add(1, Ordering::Release);
     }
 }
 
@@ -1997,6 +2036,8 @@ impl VtChannel {
             last_size_check: Mutex::new(Instant::now()),
             pending_drift: Mutex::new(None),
             last_owner_hb: Mutex::new(Instant::now()),
+            resync_target: AtomicU64::new(0),
+            resize_seq: AtomicU64::new(0),
         })
     }
 
@@ -2043,6 +2084,9 @@ impl VtChannel {
         }
         *guard = Instant::now();
         drop(guard);
+        // Before the probe: a resize that starts or finishes while it is in
+        // flight makes what it read obsolete.
+        let probe_seq = self.resize_seq();
         let Some((c, r, cx, cy)) = pane_size_cursor(&self.target, deadline) else {
             return;
         };
@@ -2063,6 +2107,9 @@ impl VtChannel {
         // a generation from before that chunk.
         let grid_gen = self.grid_gen.load(Ordering::Relaxed);
         drop(p);
+        // tmux has just told us the pane's real size, which is what any
+        // outstanding resize expectation was a guess at.
+        self.observe_pane_geometry((c, r), probe_seq);
         let pending = self.pending_drift.lock().ok().and_then(|guard| *guard);
         match reconcile_step((c, r, cx, cy), (gc, gr, gcx, gcy), pending, grid_gen) {
             GridReconcile::InSync => self.clear_drift(),
@@ -2325,6 +2372,7 @@ impl VtChannel {
         {
             return VtRefreshResult::Refreshed;
         }
+        self.expect_grid_size(cols, rows);
         let result = self.reseed(cols, rows, false, deadline);
         if refresh_commits_geometry(result) {
             self.cols.store(cols, Ordering::Relaxed);
@@ -2332,6 +2380,120 @@ impl VtChannel {
             self.signals.bump_changed();
         }
         result
+    }
+
+    /// Declare the geometry the pane is being resized to, before the resize
+    /// runs. [`Self::grid_resync_pending`] holds every viewer off the grid from
+    /// this moment until the parser is rebuilt at it, so no one can publish a
+    /// frame laid out for the size the pane just left.
+    fn expect_grid_size(&self, cols: u16, rows: u16) -> u64 {
+        let target = pack_size(cols, rows);
+        self.resync_target.store(target, Ordering::Relaxed);
+        target
+    }
+
+    /// Open the window in which the pane's size is changing: declare the
+    /// geometry it is moving to and mark a resize in flight until the returned
+    /// guard drops. Callers that resize the pane must go through this, so a
+    /// concurrent geometry probe can tell that what it read may already be
+    /// obsolete.
+    pub(crate) fn begin_resize(&self, cols: u16, rows: u16) -> ResizeInFlight<'_> {
+        self.resize_seq.fetch_add(1, Ordering::Release);
+        let token = self.expect_grid_size(cols, rows);
+        ResizeInFlight {
+            channel: self,
+            token,
+        }
+    }
+
+    /// The resize seqlock, for a caller that is about to read the pane's
+    /// geometry and will hand the value back to [`Self::observe_pane_geometry`].
+    pub(crate) fn resize_seq(&self) -> u64 {
+        self.resize_seq.load(Ordering::Acquire)
+    }
+
+    /// Resolve any outstanding expectation against the geometry tmux just
+    /// reported for the pane, which is the only authority on whether the grid
+    /// is actually behind.
+    ///
+    /// A pane that already matches the grid owes nothing: the resize the
+    /// expectation described never took effect (tmux can refuse or clamp one),
+    /// and holding viewers off a grid that does describe the pane would strand
+    /// them on `capture-pane` over a request that is never coming. A real
+    /// divergence re-aims the expectation at tmux's own geometry instead, so it
+    /// stays gated for as long as it takes a reseed to land rather than for a
+    /// fixed window that a slow one could outlive.
+    ///
+    /// `probe_seq` is [`Self::resize_seq`] read BEFORE the probe. Matching
+    /// dimensions only retire an expectation when no resize overlapped it: one
+    /// viewer's probe can read the pane before another viewer's resize lands
+    /// and come back to a grid that still agrees with it, which says nothing
+    /// about the resize now in flight. Re-aiming is left unguarded because it
+    /// keeps the gate up, which is the safe direction for a stale read.
+    fn observe_pane_geometry(&self, pane: (u16, u16), probe_seq: u64) {
+        if pane
+            != (
+                self.cols.load(Ordering::Relaxed),
+                self.rows.load(Ordering::Relaxed),
+            )
+        {
+            self.expect_grid_size(pane.0, pane.1);
+            return;
+        }
+        if probe_seq % 2 == 0 && probe_seq == self.resize_seq() {
+            self.clear_resync_target();
+        }
+    }
+
+    /// Drop an expectation whose resize never happened (the caller turned out
+    /// not to own the pane size). Conditional, so a resize that another viewer
+    /// declared in the meantime is left standing.
+    fn abandon_expected_grid(&self, token: u64) {
+        let _ = self
+            .resync_target
+            .compare_exchange(token, 0, Ordering::Relaxed, Ordering::Relaxed);
+    }
+
+    fn clear_resync_target(&self) {
+        self.resync_target.store(0, Ordering::Relaxed);
+    }
+
+    /// True while the parser has not been rebuilt at the geometry the pane was
+    /// last resized to. Its grid still describes the old layout, so viewers
+    /// render from `capture-pane` (which reads the resized pane) until a reseed
+    /// lands, rather than publishing cells for a pane that is gone.
+    pub(crate) fn grid_resync_pending(&self) -> bool {
+        self.pending_resync_target().is_some()
+    }
+
+    /// The geometry still owed, for a caller that wants to drive the reseed
+    /// rather than wait for the periodic reconcile.
+    pub(crate) fn pending_resync_target(&self) -> Option<(u16, u16)> {
+        let target = self.resync_target.load(Ordering::Relaxed);
+        if target == 0 {
+            return None;
+        }
+        if target
+            == pack_size(
+                self.cols.load(Ordering::Relaxed),
+                self.rows.load(Ordering::Relaxed),
+            )
+        {
+            // Reached, by whichever path got there: reconcile, another viewer's
+            // resize, or this channel rearming.
+            self.clear_resync_target();
+            return None;
+        }
+        Some(((target >> 16) as u16, target as u16))
+    }
+
+    /// Re-read the pane and reconcile the grid with it from a caller that is
+    /// not sampling. The snapshot fallback a pending resize expectation forces
+    /// bypasses [`Self::sample_with_deadline`], so without this nothing would
+    /// re-read the pane while the grid is out of service and the expectation
+    /// could never resolve. Rate-limited inside, like every other caller.
+    pub(crate) fn reconcile_with_deadline(&self, deadline: &crate::tmux::TmuxCommandDeadline) {
+        self.reconcile_grid(deadline);
     }
 
     /// Time since this channel armed (and seeded from `capture-pane`).
@@ -3179,6 +3341,8 @@ mod tests {
             last_size_check: Mutex::new(Instant::now()),
             pending_drift: Mutex::new(None),
             last_owner_hb: Mutex::new(Instant::now()),
+            resync_target: AtomicU64::new(0),
+            resize_seq: AtomicU64::new(0),
         });
         (ch, alive)
     }
@@ -4620,6 +4784,121 @@ mod tests {
             "closing the bracket publishes the new frame"
         );
         assert!(!fresh.contains("before"));
+    }
+
+    #[test]
+    fn a_resize_holds_every_viewer_off_the_grid_until_the_parser_catches_up() {
+        // The expectation is declared before tmux resizes, so there is no
+        // window where the pane has moved and the parser's old layout is still
+        // publishable, and it lives on the shared channel: a viewer that did
+        // not drive the resize renders the same stale cells if it does not see
+        // it. Only reaching the geometry clears it, whichever path gets there.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (ch, _alive) = dummy_channel("aoe-vt-resync-test", dir.path());
+        assert!(!ch.grid_resync_pending(), "a settled grid owes nothing");
+
+        ch.expect_grid_size(40, 10);
+        assert!(ch.grid_resync_pending());
+        assert_eq!(ch.pending_resync_target(), Some((40, 10)));
+
+        // A reseed that comes back Busy or Failed leaves the stored geometry
+        // alone, so the expectation stands and the viewers stay on snapshots.
+        assert!(ch.grid_resync_pending());
+
+        // Committing the geometry is what clears it.
+        ch.cols.store(40, Ordering::Relaxed);
+        ch.rows.store(10, Ordering::Relaxed);
+        assert_eq!(ch.pending_resync_target(), None);
+        assert!(!ch.grid_resync_pending());
+
+        // A resize that turned out not to be ours withdraws its own
+        // expectation, and only its own: another viewer's newer one stands.
+        ch.begin_resize(80, 24).abandon();
+        assert!(!ch.grid_resync_pending());
+        let mine = ch.begin_resize(80, 24);
+        let theirs = ch.begin_resize(100, 30);
+        mine.abandon();
+        assert_eq!(
+            ch.pending_resync_target(),
+            Some((100, 30)),
+            "a superseded expectation must not clear the live one"
+        );
+        drop(theirs);
+
+        // tmux is the authority on whether the grid is behind, and reconcile
+        // hands its answer here. A pane that already matches the grid owes
+        // nothing: this expectation described a resize tmux refused or clamped,
+        // and honoring it would strand every viewer on capture-pane over a
+        // geometry that is never coming. Note this resolves the request without
+        // a reseed ever succeeding, so no failing retry can extend it.
+        let grid = (
+            ch.cols.load(Ordering::Relaxed),
+            ch.rows.load(Ordering::Relaxed),
+        );
+        ch.observe_pane_geometry(grid, ch.resize_seq());
+        assert!(!ch.grid_resync_pending(), "an unmet request is dropped");
+
+        // A pane that disagrees is a real divergence: the expectation is re-aimed
+        // at tmux's own geometry and holds for as long as the reseed takes,
+        // however many attempts that is.
+        ch.observe_pane_geometry((132, 43), ch.resize_seq());
+        assert_eq!(ch.pending_resync_target(), Some((132, 43)));
+        for _ in 0..10 {
+            // Every failed reseed re-declares the same target; none of them
+            // may quietly retire it while the pane still disagrees.
+            ch.expect_grid_size(132, 43);
+            assert!(ch.grid_resync_pending(), "a live divergence stays gated");
+        }
+        ch.cols.store(132, Ordering::Relaxed);
+        ch.rows.store(43, Ordering::Relaxed);
+        assert!(!ch.grid_resync_pending(), "landing the reseed ends it");
+    }
+
+    #[test]
+    fn a_geometry_probe_that_straddles_a_resize_cannot_retire_it() {
+        // Two viewers. The owner declares a resize, a follower reads the pane
+        // before tmux applies it, and the resize then lands while the reseed
+        // comes back Busy. The follower's probe now says the pane matches the
+        // grid, which was true when it was taken and is not any more: retiring
+        // the expectation on it would put the follower straight back on a grid
+        // laid out for the size the pane just left, with no settle window of
+        // its own and a second to wait before it could look again.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (ch, _alive) = dummy_channel("aoe-vt-resize-race", dir.path());
+        let settled = (
+            ch.cols.load(Ordering::Relaxed),
+            ch.rows.load(Ordering::Relaxed),
+        );
+
+        // Owner: resize to 100x30 declared, tmux has not applied it yet.
+        let in_flight = ch.begin_resize(100, 30);
+        // Follower: probe starts here and reads the pane's pre-resize size.
+        let probe_seq = ch.resize_seq();
+        // Owner: tmux applies the resize, the reseed fails, the window closes.
+        drop(in_flight);
+
+        ch.observe_pane_geometry(settled, probe_seq);
+        assert_eq!(
+            ch.pending_resync_target(),
+            Some((100, 30)),
+            "a probe that straddled the resize must not retire it"
+        );
+
+        // A probe taken wholly inside the window is no better.
+        let in_flight = ch.begin_resize(100, 30);
+        let probe_seq = ch.resize_seq();
+        ch.observe_pane_geometry(settled, probe_seq);
+        assert!(ch.grid_resync_pending(), "nor one taken mid-resize");
+        drop(in_flight);
+
+        // A probe with no resize anywhere near it is the case that may retire
+        // an expectation, and still does.
+        let probe_seq = ch.resize_seq();
+        ch.observe_pane_geometry(settled, probe_seq);
+        assert!(
+            !ch.grid_resync_pending(),
+            "a quiescent probe still resolves a request the pane never took"
+        );
     }
 
     #[test]

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1206,11 +1206,19 @@ fn capture_composited_over_grid(
     let Some(first) = layout.first_pane() else {
         return capture_composited(name, lines, forward_empty, deadline);
     };
-    let Some((rows, mut cursor)) =
+    let Some(sample) =
         channel.sample_rows_padded_with_deadline(first.width, first.height, deadline)
     else {
         return capture_composited(name, lines, forward_empty, deadline);
     };
+    if sample.incomplete {
+        // Pane 0 is mid-repaint. Splicing it beside panes captured whole tears
+        // the composite, and a `capture-pane` fallback would only fork to read
+        // the same half-drawn cells, so keep the frame the preview has until
+        // the bracket closes or is abandoned.
+        return (None, None);
+    }
+    let (rows, mut cursor) = (sample.rows, sample.cursor);
 
     // The sampled cursor stays pane relative after its rows are painted on
     // the window grid. Rebase only the frame dimensions and carry pane 0's
@@ -1636,9 +1644,16 @@ impl LiveCaptureWorker {
                                         &command_deadline,
                                     )
                                 } else {
-                                    let (content, cur) =
-                                        v.sample_with_deadline(lines, &command_deadline);
-                                    (Some(content), cur)
+                                    let sample = v.sample_with_deadline(lines, &command_deadline);
+                                    // A half-drawn synchronized-output frame is
+                                    // not published: the bracket closing (or
+                                    // abandoning) brings a whole one, and the
+                                    // preview keeps the last frame until then.
+                                    if sample.incomplete {
+                                        (None, None)
+                                    } else {
+                                        (Some(sample.content), sample.cursor)
+                                    }
                                 }
                             }
                             // No grid for pane 0, so every pane comes from the
@@ -1669,6 +1684,29 @@ impl LiveCaptureWorker {
                     let vt_timing = vt_source.as_ref().and_then(|v| v.chunk_timing());
                     #[cfg(not(unix))]
                     let vt_timing: Option<(u64, u64)> = None;
+                    // Recheck the target once for both publishes: a retarget
+                    // mid-fork means these bytes (and this cursor) belong to
+                    // the old pane and must not land under the new view.
+                    // `set_target` also clears the mailbox, but the fork may
+                    // have started before that switch.
+                    let still_current = target_cell.lock().ok().is_some_and(|g| *g == name)
+                        && generation_cell.load(Ordering::Relaxed) == generation_now;
+                    // Publish an agent clipboard write and wake the render loop
+                    // even if the frame dedups, fails, or is withheld as half
+                    // drawn: the read above already consumed it, and this tap is
+                    // the only path an agent's copy has to the host (#2420).
+                    if still_current {
+                        if let Some(text) = clipboard_now {
+                            if let Ok(mut guard) = clipboard_cell.lock() {
+                                *guard = Some(ClipboardFrame {
+                                    generation: generation_now,
+                                    target: name.clone(),
+                                    text,
+                                });
+                            }
+                            wake.notify_one();
+                        }
+                    }
                     if let Some(content) = capture {
                         // Skip unchanged frames (no point waking a re-parse).
                         // Empties are skipped too unless this pane forwards
@@ -1676,28 +1714,7 @@ impl LiveCaptureWorker {
                         // render loop, so an idle pane never repaints.
                         let changed = last_captured.as_deref() != Some(content.as_str());
 
-                        // Recheck the target once for both publishes: a retarget
-                        // mid-fork means these bytes (and this cursor) belong to
-                        // the old pane and must not land under the new view.
-                        // `set_target` also clears the mailbox, but the fork may
-                        // have started before that switch.
-                        let still_current = target_cell.lock().ok().is_some_and(|g| *g == name)
-                            && generation_cell.load(Ordering::Relaxed) == generation_now;
                         if still_current {
-                            // Publish an agent clipboard write and wake the
-                            // render loop even if the frame itself dedups: a
-                            // copy must reach the host clipboard promptly
-                            // whether or not the grid changed visibly.
-                            if let Some(text) = clipboard_now {
-                                if let Ok(mut guard) = clipboard_cell.lock() {
-                                    *guard = Some(ClipboardFrame {
-                                        generation: generation_now,
-                                        target: name.clone(),
-                                        text,
-                                    });
-                                }
-                                wake.notify_one();
-                            }
                             // A budget change alone (deeper scroll, viewport
                             // resize over a quiet pane) must republish even
                             // when the bytes are identical, or consumers


### PR DESCRIPTION
## Description

Three post-merge review follow-ups on #3762, one commit each. They share the VT
grid transport, so they land together.

**#3770, partial frames on a sample cache miss.** The sampler read
`frame_incomplete()` under the parser lock but reused its single complete-frame
cache only for a matching window; on a miss mid-bracket it serialized the
half-drawn grid, and the WebSocket decided publishability afterwards from
`sync_hold_active()` (expires at 200ms while a frame stays incomplete for 2s,
and can observe a bracket that closed after the sample). Both samplers now
return their publishability, decided under the lock that assembled the payload:
`VtSample` for the scrollback window, `VtRowsSample` for the composite rows.
The web loop holds such a sample whatever the hold says now; the TUI preview
skips it, whole-window and composited alike. Publishing an agent's OSC 52 copy
moved out of the frame block, since the read that fetches it is consuming and it
must reach the host clipboard whether or not this cycle has a frame.

**#3771, DEC 2026 transitions across seeding and back-to-back brackets.** The
scanner reported only the last transition per read, and the pre-seed branch
discarded a chunk before its closer could release the hold. `feed` now appends
transitions in order and `SyncHoldPlan` maps a chunk's transitions to the hold
moves around applying it. The bracket hold and the incomplete run are separate
deadlines: a close that the same read reopens over restarts the bracket, but not
the run, because that frame was never in the grid on its own for a viewer to
sample. Refreshing both would let an app whose repaints straddle every socket
read extend the abandon window forever and freeze the view.

**#3772, grid transport after a failed resize reseed.** Direct resize, ownership
takeover, drift re-assert and auto-reclaim (which the issue did not list,
because it never reseeded the grid at all) discarded `VtRefreshResult` and armed
the settle window on tmux ownership alone, so `Busy`/`Failed` republished the
old geometry once the window expired. The channel is now told the geometry
before tmux is asked for it and holds that expectation until the parser is
rebuilt at it. It lives on the channel because the parser is shared: a viewer
that did not drive the resize renders the same stale cells. Frames are withheld
while it stands rather than moved to another transport.

Whether the expectation is still owed is settled against tmux rather than a
clock. `reconcile_grid` re-reads the pane and either drops one the pane never
took (a resize tmux refused or clamped, which no reseed can satisfy) or re-aims
a real divergence at the geometry tmux does report; it never opens one, since
ordinary drift is what the reseed in that same pass is for. A probe that
straddles a resize cannot retire it, because what it read may describe either
side of it. The withhold stops the loop sampling, so the capture loop drives
that reconcile itself and the size owner re-drives the reseed on a throttle.

Nothing on the list turned out wrong, fixed, or in conflict.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Rust unit tests, no wall-clock sleeps for the timing cases:

- `sample_reports_a_mid_bracket_cache_miss_as_incomplete`: two viewers on
  different windows, and a bracket closing after the sample.
- `sample_rows_padded_renders_the_visible_grid_at_the_requested_rectangle`:
  extended for the composite path's mid-bracket case.
- `sync_hold_plan_gives_each_bracket_its_own_lifetime` and the extended scanner
  test: ordered transitions, close-then-open in one chunk, fresh timestamp with
  no released window between brackets.
- `repeated_close_open_reads_cannot_freeze_the_view`: fifty straddling reads
  never extend the abandon window, and a clean close still ends the run.
- `reader_releases_a_bracket_closed_before_the_grid_is_seeded`: the pre-seed
  close, through the real reader loop.
- `a_restart_over_a_settled_grid_starts_the_incomplete_run`: a read that opens,
  closes and reopens over a grid that was not mid-repaint.
- `a_resize_holds_every_viewer_off_the_grid_until_the_parser_catches_up`: the
  expectation declared before the resize, cleared only by reaching the geometry,
  withdrawn when the resize was not ours, dropped when tmux shows the pane never
  took it, held across ten failed reseeds while the pane really does differ, and
  never opened by reconcile on its own.
- `a_geometry_probe_that_straddles_a_resize_cannot_retire_it`: the two-viewer
  interleaving, plus the mid-resize and quiescent probes.
- `a_resize_whose_reseed_missed_withholds_frames_until_it_lands` and
  `grid_transport_needs_a_single_pane_within_the_grids_scrollback`: the settle
  window and transport eligibility.

Two assertions the issues asked for are not tested as written. The
sample/publish interleaving needs no barrier once publishability travels with
the payload, so the test asserts the flag survives the bracket closing instead.
The hold expiring while a frame stays incomplete is covered by
`viewer_signals_hold_opens_and_closes`, which injects the clock. The four resize
call sites are covered at the channel state they all record into, not
individually: they are inline in one long async block with no seam to drive them
from a test.

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: `live/live-grid-transport.spec.ts` already covers
  this flow end to end and is the spec that caught the transport regression in
  the previous push; it passes here along with the rest of the live suite.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the paths need a real agent repainting inside a
  synchronized-output bracket and a tmux resize racing a reseed, neither of
  which an e2e harness can stage deterministically.

`cargo fmt`, `cargo clippy --all-targets` and `cargo test` are clean, and each
commit builds and tests green on its own. The live Playwright suite is 160
passed / 2 failed locally: `triage-snooze` passes on re-run, and
`acp-view-switch` "switch to terminal resumes the claude conversation" fails the
same way on a clean `main` worktree here, so neither is from this branch.
On the live suite I measured this branch against `main` rather than eyeballing
one run, because an earlier revision of this work made
`live-size-owner-takeover` "ownership ping-pong" flaky: run together with
`live-grid-transport` and `mobile-live-no-flutter` it failed about 4 runs in 14
while `main` failed 0 in 26. It was the runtime transport switch, not a logic
error: the cursor overlay lands rows off its prompt when the view moves between
two serializations of the same screen. Withholding frames instead of switching
transports takes it to 1 in 14, which I cannot separate from `main` at that
sample size but have not proven to be zero either. The spec passes 6 of 6 on its
own; it only shows up under the three-spec load.
`acp::supervisor::tests::shutdown_and_wait_degrades_when_load_errs_without_peer`
and `process::worker_registry::tests::pid_source_for_falls_back_to_peer_pid_on_load_err`
also fail on `main` in my sandbox: both chmod a file to 0o000 and assert the
read fails, which uid 0 bypasses.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Issues read and fixed by the
model under my direction, then revised against this PR's review. I reviewed the
diff.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3770
Fixes #3771
Fixes #3772

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents incomplete VT frames from reaching viewers during synchronized output.
- Tracks DEC 2026 transitions across pre-seed reads and consecutive brackets.
- Suspends grid transport after resize until VT reseeding succeeds.
- Uses bounded `capture-pane` polling while the grid catches up.
- Adds documentation and Rust tests for sampling, synchronization, resize recovery, and transport eligibility.

## Benefits

Viewers no longer receive partial or stale frames after synchronized updates or geometry changes. Live view recovery is more reliable when VT reseeding is delayed or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->