### PR TITLE
fix: honor Codex hooks feature opt-out

### DIFF
--- a/docs/development/adding-agents.md
+++ b/docs/development/adding-agents.md
@@ -92,7 +92,9 @@ Cursor uses version 1 `.cursor/hooks.json`, with direct command entries under `h
 
 ### Codex (`hooks.json`)
 
-The generic JSON payload above, written to `hooks.json` in Codex's config dir rather than to a settings file: set `hook_config: Some(AgentHookConfig { settings_rel_path: ".codex/hooks.json", format: HookFormat::CodexJson, ... })`. `codex_hooks_json_path_in()` resolves `CODEX_HOME` (else `~/.codex`) and the generic `install_hooks()` writes it. Codex status weighs the hook write against its manifest rules by declared priority, so a prompt on screen outranks a `running` write.
+The generic JSON payload above is written to `hooks.json` in Codex's config directory rather than to a settings file. Set `hook_config: Some(AgentHookConfig { settings_rel_path: ".codex/hooks.json", format: HookFormat::CodexJson, ... })`. `codex_hooks_json_path_in()` resolves `CODEX_HOME` or falls back to `~/.codex`. `install_codex_json_hooks()` checks the adjacent `config.toml` feature opt-out before delegating to the generic JSON installer. Empty-event cleanup still removes existing AoE entries while preserving user hooks when the Codex feature is disabled.
+
+Host configuration links are supported. Sandbox installation refuses linked or unreadable configuration files without following them; only a genuinely absent configuration retains the default opt-in behavior.
 
 Codex's separate `config.toml` stores `[hooks.state]` trust data and `[features].hooks = false`; its mutations are serialized with `config.toml.lock` and committed by atomic replacement. `install_codex_hooks_with_preserved_state()` / `uninstall_codex_hooks()` exist only for the v015/v017/v018 migrations that repair or strip hooks AoE once wrote there. Do not point `settings_rel_path` at `config.toml`.
 

--- a/docs/development/adding-agents.md
+++ b/docs/development/adding-agents.md
@@ -92,7 +92,7 @@ Cursor uses version 1 `.cursor/hooks.json`, with direct command entries under `h
 
 ### Codex (`hooks.json`)
 
-The generic JSON payload above is written to `hooks.json` in Codex's config directory rather than to a settings file. Set `hook_config: Some(AgentHookConfig { settings_rel_path: ".codex/hooks.json", format: HookFormat::CodexJson, ... })`. `codex_hooks_json_path_in()` resolves `CODEX_HOME` or falls back to `~/.codex`. `install_codex_json_hooks()` checks the adjacent `config.toml` feature opt-out before delegating to the generic JSON installer. Empty-event cleanup still removes existing AoE entries while preserving user hooks when the Codex feature is disabled.
+The generic JSON payload above is written to `hooks.json` in Codex's config directory rather than to a settings file. Set `hook_config: Some(AgentHookConfig { settings_rel_path: ".codex/hooks.json", format: HookFormat::CodexJson, ... })`. `codex_hooks_json_path_in()` resolves `CODEX_HOME` or falls back to `~/.codex`. `install_codex_json_hooks()` checks the adjacent `config.toml` feature opt-out before delegating to the generic JSON installer. Empty-event cleanup still removes existing AoE entries while preserving user hooks when the Codex feature is disabled. Codex status weighs the hook write against its manifest rules by declared priority, so a prompt on screen outranks a `running` write.
 
 Host configuration links are supported. Sandbox installation refuses linked or unreadable configuration files without following them; only a genuinely absent configuration retains the default opt-in behavior.
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -758,6 +758,48 @@ pub fn install_hooks(
     })
 }
 
+/// Install Codex JSON hooks unless the adjacent config explicitly disables them.
+/// Empty events remove AoE hooks regardless of the feature flag, preserving user hooks.
+/// Host config links are followed; sandbox config must be absent or safely readable
+/// without following links. Invalid or unreadable config aborts non-empty installation.
+pub(crate) fn install_codex_json_hooks(
+    hooks_path: &Path,
+    events: impl AsRef<[crate::agents::ResolvedHookEvent]>,
+    target: HookInstallTarget,
+) -> Result<()> {
+    let events = events.as_ref();
+    if events.is_empty() {
+        return install_hooks(hooks_path, events, target);
+    }
+
+    let config_path = hooks_path.with_file_name("config.toml");
+    let config = match target {
+        HookInstallTarget::Host => read_codex_config(&config_path, SymlinkPolicy::Follow)?,
+        HookInstallTarget::Sandbox => match std::fs::symlink_metadata(&config_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                toml_edit::DocumentMut::new()
+            }
+            Err(error) => return Err(error).context("Inspecting sandbox Codex config"),
+            Ok(_) => {
+                // Never maps unsafe or unreadable entries to absence; do not opt in on that result.
+                let content = SymlinkPolicy::Never.read(&config_path)?.with_context(|| {
+                    format!(
+                        "Cannot safely read sandbox Codex config {}",
+                        config_path.display()
+                    )
+                })?;
+                content
+                    .parse::<toml_edit::DocumentMut>()
+                    .with_context(|| format!("Failed to parse {}", config_path.display()))?
+            }
+        },
+    };
+    if codex_hooks_feature_is_disabled(&config, &config_path) {
+        return Ok(());
+    }
+    install_hooks(hooks_path, events, target)
+}
+
 pub(super) const CODEX_HOOK_EVENT_NAMES: &[&str] = &[
     "SessionStart",
     "UserPromptSubmit",
@@ -2746,6 +2788,45 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
         assert_eq!(content["apiKey"], "test-key");
         assert_eq!(content["model"], "opus");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_json_config_links_are_host_only() {
+        let tmp = TempDir::new().unwrap();
+        let config = tmp.path().join("config.toml");
+        let hooks = tmp.path().join("hooks.json");
+        let linked = tmp.path().join("linked.toml");
+        std::fs::write(&linked, "[features]\nhooks = true\n").unwrap();
+        std::os::unix::fs::symlink(&linked, &config).unwrap();
+
+        assert!(
+            install_codex_json_hooks(&hooks, codex_events(), HookInstallTarget::Sandbox).is_err()
+        );
+        assert!(!hooks.exists());
+        install_codex_json_hooks(&hooks, codex_events(), HookInstallTarget::Host).unwrap();
+        let installed = std::fs::read_to_string(&hooks).unwrap();
+        assert!(installed.contains("aoe-hooks"));
+        assert!(std::fs::symlink_metadata(&config)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(
+            install_codex_json_hooks(&hooks, codex_events(), HookInstallTarget::Sandbox).is_err()
+        );
+        assert_eq!(std::fs::read_to_string(&hooks).unwrap(), installed);
+
+        std::fs::remove_file(&linked).unwrap();
+        assert!(
+            install_codex_json_hooks(&hooks, codex_events(), HookInstallTarget::Sandbox).is_err()
+        );
+        assert_eq!(std::fs::read_to_string(&hooks).unwrap(), installed);
+        std::fs::remove_file(&config).unwrap();
+        std::fs::remove_file(&hooks).unwrap();
+        install_codex_json_hooks(&hooks, codex_events(), HookInstallTarget::Sandbox).unwrap();
+        assert!(std::fs::read_to_string(&hooks)
+            .unwrap()
+            .contains("aoe-hooks"));
     }
 
     #[test]

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1340,7 +1340,7 @@ fn refresh_codex_sandbox_hooks(
             return;
         }
     };
-    if let Err(e) = crate::hooks::install_hooks(
+    if let Err(e) = crate::hooks::install_codex_json_hooks(
         &hooks_path,
         &events,
         crate::hooks::HookInstallTarget::Sandbox,
@@ -2167,8 +2167,14 @@ pub(crate) fn build_container_config(
                         });
                 if let Some(settings_file) = settings_file {
                     let result = match hook_cfg.format {
-                        crate::agents::HookFormat::CodexJson
-                        | crate::agents::HookFormat::JsonSettings => crate::hooks::install_hooks(
+                        crate::agents::HookFormat::CodexJson => {
+                            crate::hooks::install_codex_json_hooks(
+                                &settings_file,
+                                &events,
+                                crate::hooks::HookInstallTarget::Sandbox,
+                            )
+                        }
+                        crate::agents::HookFormat::JsonSettings => crate::hooks::install_hooks(
                             &settings_file,
                             &events,
                             crate::hooks::HookInstallTarget::Sandbox,
@@ -5961,6 +5967,33 @@ trusted_hash = "keep"
         );
         assert!(hooks_text.contains("aoe-hooks"));
         crate::hooks::cleanup_hook_status_dir(instance_id);
+    }
+
+    #[test]
+    fn test_refresh_codex_sandbox_hooks_honors_codex_feature_opt_out() {
+        let temp = TempDir::new().unwrap();
+        let profile_config = crate::session::config::Config::default();
+        let mount = AGENT_CONFIG_MOUNTS
+            .iter()
+            .find(|mount| mount.tool_name == "codex")
+            .unwrap();
+
+        let writes = [
+            ("hooks-off", "[features]\nhooks = false\n"),
+            ("legacy-hooks-off", "[features]\ncodex_hooks = false\n"),
+            ("hooks-on", "[features]\nhooks = true\n"),
+        ]
+        .map(|(case, config)| {
+            let sandbox_dir = temp.path().join(case);
+            fs::create_dir_all(&sandbox_dir).unwrap();
+            fs::write(sandbox_dir.join("config.toml"), config).unwrap();
+
+            refresh_codex_sandbox_hooks(mount, &sandbox_dir, &profile_config);
+
+            sandbox_dir.join("hooks.json").exists()
+        });
+
+        assert_eq!(writes, [false, false, true]);
     }
 
     #[test]

--- a/src/session/instance/hooks.rs
+++ b/src/session/instance/hooks.rs
@@ -557,7 +557,7 @@ impl Instance {
         };
         let hooks_path =
             generic_host_config_path_for(&self.tool, hook_cfg, &home, session_cfg, &environment);
-        match crate::hooks::install_hooks(
+        match crate::hooks::install_codex_json_hooks(
             &hooks_path,
             events,
             crate::hooks::HookInstallTarget::Host,
@@ -822,6 +822,41 @@ mod tests {
         assert!(hooks.contains("aoe-hooks"));
         assert!(!profile_codex_home.join("hooks.json").exists());
         assert!(!tmp.path().join(".codex").join("hooks.json").exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_codex_host_hook_install_honors_codex_feature_opt_out() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _codex_home_guard = EnvGuard::unset(&["CODEX_HOME"]);
+        let _home_guard = EnvGuard::set(&[("HOME", tmp.path())]);
+        let profile_config = crate::session::config::Config::default();
+        let agent = crate::agents::get_agent("codex").unwrap();
+        let events = crate::agents::resolved_hook_events(agent, &profile_config).unwrap();
+
+        let writes = [
+            ("hooks-off", "[features]\nhooks = false\n"),
+            ("legacy-hooks-off", "[features]\ncodex_hooks = false\n"),
+            ("hooks-on", "[features]\nhooks = true\n"),
+        ]
+        .map(|(case, config)| {
+            let codex_home = tmp.path().join(case);
+            std::fs::create_dir_all(&codex_home).unwrap();
+            std::fs::write(codex_home.join("config.toml"), config).unwrap();
+
+            let mut inst = Instance::new(case, "/tmp/test");
+            inst.tool = "codex".to_string();
+            inst.detect_as = "codex".to_string();
+            inst.pending_host_env = vec![(
+                "CODEX_HOME".to_string(),
+                codex_home.to_string_lossy().into_owned(),
+            )];
+            inst.install_codex_host_hooks(&profile_config.session, &events);
+
+            codex_home.join("hooks.json").exists()
+        });
+
+        assert_eq!(writes, [false, false, true]);
     }
 
     #[test]
@@ -1189,6 +1224,49 @@ agent_status_hooks = false
         inst.ensure_disclosed_host_hook_path(crate::agents::get_agent("gemini"))
             .unwrap();
         inst.install_agent_status_hooks(crate::agents::get_agent("gemini"));
+
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("printf foreign"));
+        assert!(!content.contains("aoe-hooks"));
+        assert!(!inst.identity_publisher_launched);
+    }
+    #[test]
+    #[serial_test::serial]
+    fn disabling_status_hooks_removes_stale_codex_entries_while_codex_hooks_are_disabled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _app = crate::session::test_support::isolate_app_dir_at(&tmp.path().join("app"));
+        let _codex_home_guard = EnvGuard::unset(&["CODEX_HOME"]);
+        let _home_guard = EnvGuard::set(&[("HOME", tmp.path())]);
+        acknowledge_hooks();
+
+        let mut inst = Instance::new("codex", "/tmp/test");
+        inst.tool = "codex".to_string();
+        inst.detect_as = "codex".to_string();
+        inst.install_agent_status_hooks(crate::agents::get_agent("codex"));
+        let path = tmp.path().join(".codex/hooks.json");
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        settings["hooks"]["ForeignEvent"] = serde_json::json!([{
+            "hooks": [{"type": "command", "command": "printf foreign"}]
+        }]);
+        std::fs::write(&path, serde_json::to_vec_pretty(&settings).unwrap()).unwrap();
+        std::fs::write(
+            tmp.path().join(".codex/config.toml"),
+            "[features]\nhooks = false\n",
+        )
+        .unwrap();
+
+        let profile = "cleanup-disabled-codex-hooks";
+        let profile_dir = crate::session::get_profile_dir(profile).unwrap();
+        std::fs::write(
+            profile_dir.join("config.toml"),
+            "[session]\nagent_status_hooks = false\n",
+        )
+        .unwrap();
+        inst.source_profile = profile.to_string();
+        inst.ensure_disclosed_host_hook_path(crate::agents::get_agent("codex"))
+            .unwrap();
+        inst.install_agent_status_hooks(crate::agents::get_agent("codex"));
 
         let content = std::fs::read_to_string(path).unwrap();
         assert!(content.contains("printf foreign"));


### PR DESCRIPTION
## Description

Fixes #3674.

Honor Codex's `[features].hooks = false` opt-out, including the deprecated `codex_hooks = false` alias, before AoE writes `hooks.json` on host and sandbox paths. The Codex JSON writer now owns the single feature decision and is used by host installation, sandbox refresh, and initial sandbox setup.

A live Codex CLI 0.151.0 probe confirmed that Codex itself skips configured `hooks.json` commands while the feature is disabled; enabling the feature with the same hook fixture fired both `SessionStart` and `UserPromptSubmit`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: deterministic in-module regression tests directly exercise both live on-disk writers; no binary or container runtime is needed

## Verification

- `cargo test codex_feature_opt_out -- --nocapture` (red before fix, 2 passed after fix)
- `cargo test --lib rewrite_hook_strings -- --nocapture` (22 passed)
- Three existing Codex disabled-feature migration cases run individually with `--exact`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` (6940 passed, 8 ignored)

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** OpenAI Codex (GPT-5.6-sol) through Oh My Pi

**Any Additional AI Details you'd like to share:**

The AI agent read the issue and repository instructions, performed the isolated live Codex probe, implemented the fix, and ran the listed verification. The contributor will review the draft before marking it ready.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Respect Codex hook opt-out settings during host and sandbox installation.
- Support both `[features].hooks = false` and deprecated `codex_hooks = false`.
- Remove stale AoE hooks while preserving user hooks.
- Add regression tests for configuration handling and symlink safety.
- Update Codex hook documentation.

This prevents AoE from writing `hooks.json` when Codex hooks are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->