### PR TITLE
fix(tui): refresh storage during live send

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -852,6 +852,7 @@ impl App {
         let mut last_metrics_sample = std::time::Instant::now();
         let mut last_daemon_status_refresh = std::time::Instant::now();
         let mut last_disk_refresh = std::time::Instant::now();
+        let mut full_heartbeat_deferred = false;
         let mut last_spinner_redraw = std::time::Instant::now();
         let mut last_heartbeat = std::time::Instant::now();
         let mut last_presence_refresh = std::time::Instant::now();
@@ -1951,20 +1952,9 @@ impl App {
                 needs_full_refresh = true;
             }
 
-            // Disk reload: heartbeat (defense-in-depth) plus the
-            // file-watch-driven kick. Both gate on `live_send.is_none()`
-            // so reloads never interrupt a paste-in-progress; the dirty
-            // flag stays latched (Acquire pairs with the forwarder/adapter
-            // Release) until the next eligible tick. The watcher is scoped
-            // to `sessions.json` / `groups.json`, so the watcher path calls
-            // `reload_storage_only` (storage + profile rediscovery only);
-            // the heartbeat path calls full `reload()` to refresh the
-            // status-hook config cache and mouse-capture toggle.
-            //
-            // Config kick runs before the storage-mirror block:
-            // `refresh_from_config` invalidates profile-derived state that
-            // the block reads. Same `live_idle` gate; recomputing
-            // `tool_hotkey_cache` mid live-send disrupts input.
+            // Full/config reloads stay deferred during live-send to preserve input
+            // policy and mouse-capture state. Storage-only reloads preserve the live
+            // target unless it drifts, in which case normal teardown restores sizing.
             let live_idle = self.home.live_send.is_none();
             let config_kick = take_config_refresh_kick(live_idle, &self.home.config_watch.dirty);
             if config_kick {
@@ -1978,22 +1968,19 @@ impl App {
             }
 
             let heartbeat_due = last_disk_refresh.elapsed() >= DISK_REFRESH_INTERVAL;
-            // Only consume the dirty latch when we're eligible to act on
-            // it (`live_idle`). When live-send is on, the latch must
-            // persist for the next eligible tick so a watcher kick that
-            // arrived during live-send is not silently lost.
-            let dirty = if live_idle {
-                self.home
-                    .disk_watch
-                    .dirty
-                    .swap(false, std::sync::atomic::Ordering::Acquire)
-            } else {
-                false
-            };
-            let refresh_decision = decide_disk_refresh(live_idle, heartbeat_due, dirty);
+            // Consume watcher notifications in every mode. The decision below routes
+            // live-send ticks to the storage-only reload.
+            let dirty = self
+                .home
+                .disk_watch
+                .dirty
+                .swap(false, std::sync::atomic::Ordering::Acquire);
+            let refresh_plan =
+                plan_disk_refresh(live_idle, heartbeat_due, dirty, full_heartbeat_deferred);
+            full_heartbeat_deferred = refresh_plan.full_heartbeat_deferred;
 
-            match refresh_decision {
-                DiskRefreshDecision::Heartbeat => {
+            match refresh_plan.decision {
+                DiskRefreshDecision::FullHeartbeat => {
                     let reload_result = self.home.reload();
                     let reload_ok = reload_result.is_ok();
                     handle_tick_reload_storage(reload_result, &mut self.home.reload_failure_state);
@@ -2011,9 +1998,12 @@ impl App {
                     refresh_needed = true;
                     needs_full_refresh = true;
                 }
-                DiskRefreshDecision::Watcher => {
+                DiskRefreshDecision::StorageOnly => {
                     let reload_result = self.home.reload_storage_only();
                     handle_tick_reload_storage(reload_result, &mut self.home.reload_failure_state);
+                    if heartbeat_due {
+                        last_disk_refresh = std::time::Instant::now();
+                    }
                     refresh_needed = true;
                     needs_full_refresh = true;
                 }
@@ -2768,30 +2758,55 @@ fn poll_update_receiver(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DiskRefreshDecision {
-    Heartbeat,
-    Watcher,
+    FullHeartbeat,
+    StorageOnly,
     None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DiskRefreshPlan {
+    decision: DiskRefreshDecision,
+    full_heartbeat_deferred: bool,
 }
 
 fn take_config_refresh_kick(live_idle: bool, config_dirty: &std::sync::atomic::AtomicBool) -> bool {
     live_idle && config_dirty.swap(false, std::sync::atomic::Ordering::Acquire)
 }
 
-/// Pure refresh-policy decision. Inputs are plain values so this helper
-/// is side-effect free; callers are responsible for actually consuming
-/// the watcher latch (`AtomicBool::swap`) before invoking it. Keeping
-/// decision and mutation separate lets the unit tests below be
-/// table-driven without owning an atomic.
+/// Pure refresh-policy decision. Storage-only refreshes remain eligible during
+/// live-send, both for watcher notifications and as the periodic fallback. The
+/// full heartbeat reload requires an idle live-send state.
 fn decide_disk_refresh(live_idle: bool, heartbeat_due: bool, dirty: bool) -> DiskRefreshDecision {
-    if !live_idle {
-        return DiskRefreshDecision::None;
-    }
-    if heartbeat_due {
-        DiskRefreshDecision::Heartbeat
-    } else if dirty {
-        DiskRefreshDecision::Watcher
+    if live_idle && heartbeat_due {
+        DiskRefreshDecision::FullHeartbeat
+    } else if heartbeat_due || dirty {
+        DiskRefreshDecision::StorageOnly
     } else {
         DiskRefreshDecision::None
+    }
+}
+
+/// Preserve an overdue full heartbeat across storage-only timer resets, so it
+/// runs on the first idle tick after live-send exits.
+fn plan_disk_refresh(
+    live_idle: bool,
+    heartbeat_due: bool,
+    dirty: bool,
+    full_heartbeat_deferred: bool,
+) -> DiskRefreshPlan {
+    let decision = decide_disk_refresh(
+        live_idle,
+        heartbeat_due || (live_idle && full_heartbeat_deferred),
+        dirty,
+    );
+    let full_heartbeat_deferred = match decision {
+        DiskRefreshDecision::FullHeartbeat => false,
+        DiskRefreshDecision::StorageOnly if !live_idle && heartbeat_due => true,
+        _ => full_heartbeat_deferred,
+    };
+    DiskRefreshPlan {
+        decision,
+        full_heartbeat_deferred,
     }
 }
 
@@ -4527,17 +4542,17 @@ mod tests {
     fn heartbeat_wins_when_both_disk_paths_are_ready() {
         assert_eq!(
             decide_disk_refresh(true, true, true),
-            DiskRefreshDecision::Heartbeat,
+            DiskRefreshDecision::FullHeartbeat,
             "when live-idle and both heartbeat and watcher are ready, the full reload wins"
         );
         assert_eq!(
             decide_disk_refresh(true, true, false),
-            DiskRefreshDecision::Heartbeat,
+            DiskRefreshDecision::FullHeartbeat,
             "heartbeat fires even without a watcher kick"
         );
         assert_eq!(
             decide_disk_refresh(true, false, true),
-            DiskRefreshDecision::Watcher,
+            DiskRefreshDecision::StorageOnly,
             "watcher kick alone fires the storage-only path"
         );
         assert_eq!(
@@ -4548,38 +4563,51 @@ mod tests {
     }
 
     #[test]
-    fn live_send_blocks_every_decision_branch() {
-        // The pure helper must return None for every (heartbeat_due,
-        // dirty) combination when live-send is on. Latch preservation is
-        // the caller's responsibility (see
-        // `caller_gating_preserves_dirty_latch_during_live_send`).
+    fn live_send_uses_storage_only_for_watcher_and_heartbeat() {
+        assert_eq!(
+            decide_disk_refresh(false, false, false),
+            DiskRefreshDecision::None,
+            "live-send with no refresh input must remain idle"
+        );
+        assert_eq!(
+            decide_disk_refresh(false, true, false),
+            DiskRefreshDecision::StorageOnly,
+            "live-send must use a storage-only heartbeat fallback"
+        );
         for &heartbeat in &[false, true] {
-            for &dirty in &[false, true] {
-                assert_eq!(
-                    decide_disk_refresh(false, heartbeat, dirty),
-                    DiskRefreshDecision::None,
-                    "live_send must block refresh (heartbeat={heartbeat}, dirty={dirty})"
-                );
-            }
+            assert_eq!(
+                decide_disk_refresh(false, heartbeat, true),
+                DiskRefreshDecision::StorageOnly,
+                "live-send must allow the storage-only watcher path (heartbeat={heartbeat})"
+            );
         }
     }
 
     #[test]
-    fn caller_gating_preserves_dirty_latch_during_live_send() {
-        // Mirrors the gating logic in the tick loop: only consume the
-        // latch when live_idle is true. A watcher kick that arrived
-        // during live-send must remain observable on the next eligible
-        // tick.
+    fn full_heartbeat_deferred_during_live_send_runs_on_exit() {
+        let live_plan = plan_disk_refresh(false, true, false, false);
+        assert_eq!(live_plan.decision, DiskRefreshDecision::StorageOnly);
+        assert!(live_plan.full_heartbeat_deferred);
+
+        let idle_plan = plan_disk_refresh(true, false, false, live_plan.full_heartbeat_deferred);
+        assert_eq!(idle_plan.decision, DiskRefreshDecision::FullHeartbeat);
+        assert!(!idle_plan.full_heartbeat_deferred);
+    }
+
+    #[test]
+    fn caller_consumes_dirty_latch_during_live_send() {
         let dirty_atomic = std::sync::atomic::AtomicBool::new(true);
-        let live_idle = false;
-        let _dirty = if live_idle {
-            dirty_atomic.swap(false, std::sync::atomic::Ordering::Acquire)
-        } else {
-            false
-        };
+        let dirty = dirty_atomic.swap(false, std::sync::atomic::Ordering::Acquire);
+
+        assert!(dirty, "live-send must consume the watcher kick");
         assert!(
-            dirty_atomic.load(std::sync::atomic::Ordering::Acquire),
-            "live_send tick must NOT consume the dirty latch; it must persist for the next tick"
+            !dirty_atomic.load(std::sync::atomic::Ordering::Acquire),
+            "a consumed watcher kick must not remain latched"
+        );
+        assert_eq!(
+            decide_disk_refresh(false, true, dirty),
+            DiskRefreshDecision::StorageOnly,
+            "the consumed kick must choose storage-only refresh while the full heartbeat remains deferred"
         );
     }
 
@@ -4609,7 +4637,7 @@ mod tests {
         let disk_decision = decide_disk_refresh(true, true, dirty);
 
         assert!(config_kick, "config refresh must be scheduled first");
-        assert_eq!(disk_decision, DiskRefreshDecision::Heartbeat);
+        assert_eq!(disk_decision, DiskRefreshDecision::FullHeartbeat);
         assert!(!config_dirty.load(std::sync::atomic::Ordering::Acquire));
         assert!(!disk_dirty.load(std::sync::atomic::Ordering::Acquire));
     }

--- a/src/tui/home/file_watch_tests.rs
+++ b/src/tui/home/file_watch_tests.rs
@@ -310,6 +310,220 @@ async fn reload_storage_only_keeps_disk_watch_scoped_in_single_profile_mode() {
     );
 }
 
+#[tokio::test]
+#[serial]
+async fn reload_storage_only_preserves_live_send_state_while_adding_peer_row() {
+    let temp = TempDir::new().expect("tempdir");
+    let _home = isolate_home(temp.path());
+
+    let live = FileWatchService::new().expect("live svc");
+    let writer = Storage::new("live-refresh", live.clone()).expect("writer");
+    let mut active = Instance::new("active-live", "/tmp/active-live");
+    active.source_profile = "live-refresh".to_string();
+    let active_id = active.id.clone();
+    writer
+        .update(|instances, _groups| {
+            instances.push(active);
+            Ok(())
+        })
+        .expect("seed active row");
+
+    let mut view = HomeView::new(
+        Some("live-refresh".to_string()),
+        crate::tmux::AvailableTools::with_tools(&["claude"]),
+        live.clone(),
+    )
+    .expect("HomeView::new");
+    view.cursor = view
+        .flat_items
+        .iter()
+        .position(
+            |item| matches!(item, crate::session::Item::Session { id, .. } if id == &active_id),
+        )
+        .expect("active row in flat items");
+    view.update_selected();
+
+    let tmux_name = crate::tmux::Session::resolve_name(&active_id, "active-live");
+    view.live_send = Some(super::live_send::LiveSendState {
+        session_id: active_id.clone(),
+        title: "active-live".to_string(),
+        tmux_name: tmux_name.clone(),
+        target: super::live_send::LiveSendTarget::Agent,
+        exit_chords: super::live_send::parse_chord_list(super::live_send::DEFAULT_EXIT_CHORD),
+        leader: None,
+    });
+    view.pending_paste = Some("queued paste".to_string());
+    view.preview_capture_target = Some(tmux_name.clone());
+    view.live_send_last_resize = Some((100, 30));
+    view.trashed_section_collapsed = true;
+    view.search_active = true;
+    view.search_query = tui_input::Input::new("peer-added".to_string());
+
+    writer
+        .update(|instances, _groups| {
+            instances
+                .iter_mut()
+                .find(|inst| inst.id == active_id)
+                .expect("active row on disk")
+                .trash();
+            let mut peer = Instance::new("peer-added", "/tmp/peer-added");
+            peer.source_profile = "live-refresh".to_string();
+            instances.push(peer);
+            Ok(())
+        })
+        .expect("peer write");
+
+    view.reload_storage_only().expect("storage-only reload");
+
+    assert!(view
+        .instances
+        .values()
+        .any(|inst| inst.title == "peer-added"));
+    assert!(
+        view.get_instance(&active_id)
+            .is_some_and(Instance::is_trashed),
+        "storage mirror must consume the active row mutation"
+    );
+    assert!(
+        !view.flat_items.iter().any(
+            |item| matches!(item, crate::session::Item::Session { id, .. } if id == &active_id)
+        ),
+        "precondition: the active row moved under the collapsed trash shelf"
+    );
+    assert_eq!(view.selected_session.as_deref(), Some(active_id.as_str()));
+    assert_eq!(view.pending_paste.as_deref(), Some("queued paste"));
+    assert_eq!(
+        view.preview_capture_target.as_deref(),
+        Some(tmux_name.as_str())
+    );
+    assert_eq!(view.live_send_last_resize, Some((100, 30)));
+    assert_eq!(
+        view.displayed_pane_tmux_name().as_deref(),
+        Some(tmux_name.as_str()),
+        "preview capture must stay pinned to the live-send pane"
+    );
+    let peer_index = view
+        .flat_items
+        .iter()
+        .position(|item| {
+            matches!(item, crate::session::Item::Session { id, .. }
+                if view.get_instance(id).is_some_and(|inst| inst.title == "peer-added"))
+        })
+        .expect("peer row remains visible");
+    assert!(
+        view.search_matches.contains(&peer_index),
+        "reload must still refresh search matches without moving live selection"
+    );
+    assert!(
+        !view.is_sidebar_item_selected(&view.flat_items[peer_index], peer_index),
+        "cursor fallback must not visibly retarget selection during live-send"
+    );
+    let state = view.live_send.as_ref().expect("live-send remains active");
+    assert_eq!(state.session_id, active_id);
+    assert_eq!(state.title, "active-live");
+    assert_eq!(state.tmux_name, tmux_name);
+    assert_eq!(state.target, super::live_send::LiveSendTarget::Agent);
+}
+
+#[tokio::test]
+#[serial]
+async fn reload_storage_only_ends_live_send_when_active_row_is_removed() {
+    let temp = TempDir::new().expect("tempdir");
+    let _home = isolate_home(temp.path());
+
+    let live = FileWatchService::new().expect("live svc");
+    let writer = Storage::new("live-refresh", live.clone()).expect("writer");
+    let active = Instance::new("active-live", "/tmp/active-live");
+    let active_id = active.id.clone();
+    let peer = Instance::new("peer", "/tmp/peer");
+    let peer_id = peer.id.clone();
+    writer
+        .update(|instances, _groups| {
+            instances.extend([active, peer]);
+            Ok(())
+        })
+        .expect("seed rows");
+
+    let mut view = HomeView::new(
+        Some("live-refresh".to_string()),
+        crate::tmux::AvailableTools::with_tools(&["claude"]),
+        live,
+    )
+    .expect("HomeView::new");
+    view.cursor = view
+        .flat_items
+        .iter()
+        .position(
+            |item| matches!(item, crate::session::Item::Session { id, .. } if id == &active_id),
+        )
+        .expect("active row in flat items");
+    view.update_selected();
+    view.live_send = Some(super::live_send::LiveSendState {
+        session_id: active_id.clone(),
+        title: "active-live".to_string(),
+        tmux_name: "aoe_test_removed_live_refresh".to_string(),
+        target: super::live_send::LiveSendTarget::Agent,
+        exit_chords: super::live_send::parse_chord_list(super::live_send::DEFAULT_EXIT_CHORD),
+        leader: None,
+    });
+
+    writer
+        .update(|instances, _groups| {
+            instances.retain(|instance| instance.id != active_id);
+            Ok(())
+        })
+        .expect("remove active row");
+
+    view.reload_storage_only().expect("storage-only reload");
+
+    assert!(view.get_instance(&active_id).is_none());
+    assert!(
+        view.live_send.is_none(),
+        "deleted target must end live-send"
+    );
+    assert_eq!(
+        view.info_dialog.as_ref().map(|dialog| dialog.title()),
+        Some("Live send ended")
+    );
+    assert_eq!(view.selected_session.as_deref(), Some(peer_id.as_str()));
+}
+
+#[tokio::test]
+#[serial]
+async fn reload_failure_dialog_waits_until_live_send_exits() {
+    let temp = TempDir::new().expect("tempdir");
+    let _home = isolate_home(temp.path());
+
+    let live = FileWatchService::new().expect("live svc");
+    let mut view = HomeView::new(
+        Some("live-failure".to_string()),
+        crate::tmux::AvailableTools::with_tools(&["claude"]),
+        live,
+    )
+    .expect("HomeView::new");
+    view.live_send = Some(super::live_send::LiveSendState {
+        session_id: "active".to_string(),
+        title: "active".to_string(),
+        tmux_name: "aoe_test_live_failure".to_string(),
+        target: super::live_send::LiveSendTarget::Agent,
+        exit_chords: super::live_send::parse_chord_list(super::live_send::DEFAULT_EXIT_CHORD),
+        leader: None,
+    });
+    view.reload_failure_state
+        .record_storage(&Err::<(), _>(anyhow::anyhow!("disk unreadable")));
+
+    assert!(!view.try_present_reload_failure_dialog());
+    assert!(view.info_dialog.is_none());
+    assert!(view.reload_failure_state.has_unacknowledged_failure());
+
+    view.live_send = None;
+    assert!(view.try_present_reload_failure_dialog());
+    assert_eq!(
+        view.info_dialog.as_ref().map(|dialog| dialog.title()),
+        Some("Reload Failed")
+    );
+}
+
 /// Locks the single-profile-mode scoping invariant for
 /// `rewire_after_profile_delete`. In `aoe --profile X` mode
 /// `can_delete_selected` requires `!p.is_active`, so the deleted

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -4281,6 +4281,13 @@ impl HomeView {
                 }
             }
         }
+        if self.flat_items.is_empty() {
+            self.cursor = 0;
+            self.selected_session = None;
+            self.selected_group = None;
+            self.selected_group_profile = None;
+            return;
+        }
         self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
         self.update_selected();
     }
@@ -6280,9 +6287,7 @@ impl HomeView {
                 return;
             }
         }
-        if let Some(reason) = self.live_send_drift_reason(&state) {
-            self.exit_live_send_and_restore_sizing(&state);
-            self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
+        if self.end_live_send_on_drift(&state) {
             return;
         }
         // Ctrl+C reaching this point is forwarded to the agent rather than
@@ -6364,6 +6369,7 @@ impl HomeView {
         if let Some(id) = &live_session_id {
             self.clear_preview_pane_sync(id);
         }
+        self.reseat_cursor_after_rebuild();
         // Preview selections also work outside live mode now, but a
         // live-mode highlight pins to the live-resized pane coords,
         // and exiting reflows the preview back to its normal size.
@@ -6420,6 +6426,15 @@ impl HomeView {
         None
     }
 
+    pub(super) fn end_live_send_on_drift(&mut self, state: &live_send::LiveSendState) -> bool {
+        let Some(reason) = self.live_send_drift_reason(state) else {
+            return false;
+        };
+        self.exit_live_send_and_restore_sizing(state);
+        self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
+        true
+    }
+
     /// Poll the live-send worker's lock-loss flag (set off-thread when
     /// another surface takes the size-owner lock) and exit live mode when
     /// it trips, mirroring the web live view's demote-on-heartbeat. Called
@@ -6447,9 +6462,7 @@ impl HomeView {
         // A dead or renamed session also fails the worker's ownership
         // refresh; prefer the accurate drift message over blaming a
         // takeover that never happened.
-        if let Some(reason) = self.live_send_drift_reason(&state) {
-            self.exit_live_send_and_restore_sizing(&state);
-            self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
+        if self.end_live_send_on_drift(&state) {
             return true;
         }
         // Name the thief where the owner id makes it unambiguous. The web

--- a/src/tui/home/lifecycle.rs
+++ b/src/tui/home/lifecycle.rs
@@ -580,8 +580,8 @@ impl HomeView {
 
     /// Storage-only reload: profile rediscovery + per-profile load + tree
     /// rebuild + cursor restore. Skips the status-hook config-cache refresh,
-    /// which is driven by the full `reload()` path. Used by the watcher-
-    /// driven tick.
+    /// which is driven by the full `reload()` path. Used by watcher and
+    /// live-send heartbeat ticks.
     pub(in crate::tui) fn reload_storage_only(&mut self) -> anyhow::Result<()> {
         use crate::session::list_profiles;
 
@@ -752,14 +752,29 @@ impl HomeView {
             self.cursor = self.flat_items.len() - 1;
         }
 
+        // Storage rebuilds and search re-scoring must not move the live-send
+        // selection. Teardown reconciles it with the latest projection.
+        let preserve_live_selection = self.live_send.as_ref().is_some_and(|state| {
+            prev_selected_session.as_deref() == Some(state.session_id.as_str())
+        });
+
         if self.search_active && !self.search_query.value().is_empty() {
-            self.update_search();
+            if preserve_live_selection {
+                self.refresh_search_matches();
+            } else {
+                self.update_search();
+            }
         } else if !self.search_matches.is_empty() {
             // Recalculate match indices without moving the cursor
             self.refresh_search_matches();
         }
 
-        self.update_selected();
+        if !preserve_live_selection {
+            self.update_selected();
+        }
+        if let Some(state) = self.live_send.clone() {
+            self.end_live_send_on_drift(&state);
+        }
         Ok(())
     }
 
@@ -832,13 +847,11 @@ impl HomeView {
     ///   recorded for the same acknowledged burst). The ack latch
     ///   stays in place; the user is not re-notified for the same
     ///   ongoing burst.
-    /// * No-op: nothing failing, body unchanged, or an unrelated
-    ///   dialog (a `Watcher Warning` from `rewire_after_profile_delete`,
-    ///   or a profile create/delete `Error`) occupies the slot. In
-    ///   the foreign-dialog case the ack latch stays armed so the
-    ///   next tick can present once the foreign dialog is dismissed.
+    /// * No-op: live-send active, nothing failing, body unchanged, or an
+    ///   unrelated dialog occupies the slot. While live or another dialog is
+    ///   open, the ack latch stays armed so a later tick can present it.
     pub(in crate::tui) fn try_present_reload_failure_dialog(&mut self) -> bool {
-        if !self.reload_failure_state.has_any_failure() {
+        if self.live_send.is_some() || !self.reload_failure_state.has_any_failure() {
             return false;
         }
         let title = RELOAD_FAILED_TITLE;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2954,7 +2954,8 @@ impl HomeView {
                 .and_then(|id| self.get_instance(id))
                 .is_some_and(|inst| inst.is_trashed());
 
-        let selected_stopped = !selected_archived
+        let selected_stopped = !live_send_active
+            && !selected_archived
             && !selected_trashed
             && matches!(self.view_mode, ViewMode::Structured)
             && self
@@ -2971,7 +2972,8 @@ impl HomeView {
         // pane forever, so short-circuit to an explanatory placeholder
         // instead. Only in the Structured (agent output) view; Terminal
         // and Tool views show their own, independently-live panes.
-        let selected_structured = !selected_archived
+        let selected_structured = !live_send_active
+            && !selected_archived
             && !selected_trashed
             && matches!(self.view_mode, ViewMode::Structured)
             && self

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1368,7 +1368,7 @@ impl HomeView {
             .enumerate()
         {
             let abs_idx = i + scroll.scroll_offset;
-            let is_selected = abs_idx == self.cursor;
+            let is_selected = self.is_sidebar_item_selected(item, abs_idx);
             let is_hovered = !is_selected && Some(abs_idx) == hover_idx;
             let is_match =
                 !self.search_matches.is_empty() && self.search_matches.contains(&abs_idx);
@@ -1443,7 +1443,7 @@ impl HomeView {
                 .enumerate()
             {
                 let abs_idx = list_len + sscroll.scroll_offset + i;
-                let is_selected = abs_idx == self.cursor;
+                let is_selected = self.is_sidebar_item_selected(item, abs_idx);
                 let is_hovered = !is_selected && Some(abs_idx) == hover_idx;
                 let is_match =
                     !self.search_matches.is_empty() && self.search_matches.contains(&abs_idx);
@@ -2025,11 +2025,24 @@ impl HomeView {
         }
     }
 
+    pub(super) fn is_sidebar_item_selected(&self, item: &Item, index: usize) -> bool {
+        // A reload can hide the live row while the cursor falls onto a peer.
+        match (&self.live_send, &self.selected_session, item) {
+            (Some(_), Some(selected), Item::Session { id, .. }) => id == selected,
+            (Some(_), Some(_), _) => false,
+            _ => index == self.cursor,
+        }
+    }
+
     /// tmux session name backing the pane the preview currently shows, as a
     /// function of the selected session and view mode (and, for Terminal,
-    /// the host/container sub-mode). `None` when nothing is selected. Drives
+    /// the host/container sub-mode). Live-send pins the pane captured at entry,
+    /// independent of storage-driven selection changes. Drives
     /// `sync_preview_capture_worker`.
     pub(super) fn displayed_pane_tmux_name(&self) -> Option<String> {
+        if let Some(state) = &self.live_send {
+            return Some(state.tmux_name.clone());
+        }
         let id = self.selected_session.as_ref()?;
         let inst = self.get_instance(id)?;
         let name = match &self.view_mode {
@@ -2914,11 +2927,13 @@ impl HomeView {
         // live to capture. Short-circuit every view mode to a calm "Archived"
         // placeholder instead of forking captures that come back empty and
         // surface as "No output available".
-        let selected_archived = self
-            .selected_session
-            .as_ref()
-            .and_then(|id| self.get_instance(id))
-            .is_some_and(|inst| inst.is_archived());
+        let live_send_active = self.live_send.is_some();
+        let selected_archived = !live_send_active
+            && self
+                .selected_session
+                .as_ref()
+                .and_then(|id| self.get_instance(id))
+                .is_some_and(|inst| inst.is_archived());
 
         // A session whose pane is simply gone (killed, exited, server reboot)
         // with no diagnostic detail carries the generic gone-error. Present
@@ -2932,11 +2947,12 @@ impl HomeView {
         // must not hide that pane's output there.
         // A trashed session's pane was also killed (on trash). Same calm
         // placeholder treatment as archived, with a restore hint.
-        let selected_trashed = self
-            .selected_session
-            .as_ref()
-            .and_then(|id| self.get_instance(id))
-            .is_some_and(|inst| inst.is_trashed());
+        let selected_trashed = !live_send_active
+            && self
+                .selected_session
+                .as_ref()
+                .and_then(|id| self.get_instance(id))
+                .is_some_and(|inst| inst.is_trashed());
 
         let selected_stopped = !selected_archived
             && !selected_trashed
@@ -3082,11 +3098,12 @@ impl HomeView {
         match self.view_mode {
             ViewMode::Structured => {
                 // Check if selected session is being created (show hook progress)
-                let is_creating = self
-                    .selected_session
-                    .as_ref()
-                    .and_then(|id| self.get_instance(id))
-                    .is_some_and(|inst| inst.status == Status::Creating);
+                let is_creating = !live_send_active
+                    && self
+                        .selected_session
+                        .as_ref()
+                        .and_then(|id| self.get_instance(id))
+                        .is_some_and(|inst| inst.status == Status::Creating);
 
                 if is_creating {
                     self.render_creating_preview(frame, inner, theme);

--- a/src/tui/home/tests/preview_drag_select.rs
+++ b/src/tui/home/tests/preview_drag_select.rs
@@ -703,25 +703,45 @@ fn full_render_pipeline_captures_copy_text_after_finalize() {
     // Drives the actual render path: render seeds the text-view
     // snapshot, the drag handlers map against it, and
     // paint_preview_selection captures the selected lines from the
-    // parsed cache into `preview_copy_text` for the app loop to drain.
+    // parsed cache into preview_copy_text for the app loop to drain.
     use crate::tui::styles::load_theme;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
-    let mut env = create_test_env_empty();
+    let mut env = create_test_env_with_sessions(1);
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).unwrap();
     let theme = load_theme("empire");
+    let session_id = env
+        .view
+        .selected_session
+        .clone()
+        .expect("fixture must select its session");
+    let title = env
+        .view
+        .get_instance(&session_id)
+        .expect("selected instance")
+        .title
+        .clone();
+    let tmux_name = env
+        .view
+        .displayed_pane_tmux_name()
+        .expect("selected pane target");
+    env.view.live_send = Some(LiveSendState {
+        session_id: session_id.clone(),
+        title,
+        tmux_name: tmux_name.clone(),
+        target: crate::tui::home::live_send::LiveSendTarget::Agent,
+        exit_chords: Vec::new(),
+        leader: None,
+    });
 
-    // Stub the preview cache so render_preview has known content to
-    // paint and to back the copy.
     env.view.preview_cache.content = "alpha beta gamma\nsecond line\nthird line\n".to_string();
     env.view.preview_cache.dimensions = (80, 24);
     env.view.preview_cache.captured_lines = 3;
-    env.view.preview_cache.session_id = Some("fake-id".to_string());
+    env.view.preview_cache.session_id = Some(session_id);
+    env.view.preview_cache.capture_target = Some(tmux_name);
 
-    // First render seeds preview_text_view + paints content. We need
-    // that before the drag handlers can map the cursor.
     terminal
         .draw(|f| {
             let area = f.area();
@@ -736,32 +756,20 @@ fn full_render_pipeline_captures_copy_text_after_finalize() {
         "render should have parsed scrollback into the text view"
     );
 
-    // Install live-send so handle_drag_start claims the preview click.
-    env.view.live_send = Some(LiveSendState {
-        session_id: "fake-id".to_string(),
-        title: "fake".to_string(),
-        tmux_name: "aoe_test_full_pipeline".to_string(),
-        target: crate::tui::home::live_send::LiveSendTarget::Agent,
-        exit_chords: Vec::new(),
-        leader: None,
-    });
-
-    // Find a row in the output pane that actually carries text.
     let initial_buf = terminal.backend().buffer().clone();
-    let mut content_row = None;
+    let mut content_cell = None;
     for r in pane.y..pane.bottom() {
         let mut row_text = String::new();
         for c in pane.x..pane.right() {
             row_text.push_str(initial_buf[(c, r)].symbol());
         }
-        if row_text.trim().chars().any(|ch| ch.is_alphabetic()) {
-            content_row = Some(r);
+        if let Some(offset) = row_text.find("alpha") {
+            content_cell = Some((pane.x + offset as u16, r));
             break;
         }
     }
-    let row = content_row.expect("preview must paint some text");
-    let start_col = pane.x;
-    let end_col = pane.right() - 1;
+    let (start_col, row) = content_cell.expect("preview must paint seeded cache text");
+    let end_col = start_col + "alpha".len() as u16 - 1;
     assert!(env.view.handle_drag_start(start_col, row));
     assert!(env.view.handle_drag_move(end_col, row));
     assert!(env.view.handle_drag_end());
@@ -770,9 +778,6 @@ fn full_render_pipeline_captures_copy_text_after_finalize() {
         "drag_end should arm a pending capture"
     );
 
-    // The render that paints the finalized highlight is where the
-    // capture happens: it reads the selected lines from the parsed
-    // cache and stashes the string for the app loop to drain.
     terminal
         .draw(|f| {
             let area = f.area();
@@ -788,8 +793,5 @@ fn full_render_pipeline_captures_copy_text_after_finalize() {
         .view
         .take_preview_copy_text()
         .expect("render should have captured selection text");
-    assert!(
-        copied.contains("alpha"),
-        "captured text should include the first content row; got {copied:?}"
-    );
+    assert_eq!(copied, "alpha");
 }

--- a/tests/e2e/filewatch_tui_reload.rs
+++ b/tests/e2e/filewatch_tui_reload.rs
@@ -1,13 +1,10 @@
-//! e2e: peer-process write to `sessions.json` propagates to the TUI within
-//! sub-tick budget (1.5 s, well under the 5 s heartbeat). Validates the
-//! kernel-watcher path end-to-end through the production binary.
+//! e2e: peer-process writes to `sessions.json` propagate to the TUI through
+//! both the kernel-watcher path and the five-second storage heartbeat fallback.
 //!
-//! The test launches the TUI under tmux, then performs a `Storage::update`
-//! against the same profile dir from outside the TUI process (mimicking a
-//! peer CLI invocation). With the subscription wired in `HomeView::new`,
-//! the dirty flag flips, the tick consumes it, `reload_storage_only` runs,
-//! and the new session row lands on screen within the harness's 1.5 s
-//! timeout.
+//! The watcher case must land within 1.5 seconds. The fallback case creates a
+//! previously unknown profile while live-send is active, so no disk watch can
+//! already cover it; the periodic storage-only reload must discover it without
+//! running the deferred full heartbeat.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -45,4 +42,92 @@ fn peer_storage_update_reflects_within_sub_tick_budget() {
         .expect("peer write to sessions.json");
 
     h.wait_for_timeout(title, Duration::from_millis(1_500));
+}
+
+#[test]
+#[serial]
+fn peer_cli_add_reflects_during_live_send_without_changing_target() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("filewatch_live_send_reload");
+    let bin = h.install_path_command("claude");
+    std::fs::write(bin.join("claude"), "#!/bin/sh\ncat > live-send-input\n")
+        .expect("write interactive claude");
+
+    let active_project = h.project_path();
+    let active = h.run_cli(&[
+        "add",
+        active_project.to_str().expect("utf8 active project"),
+        "-t",
+        "active-live",
+        "-c",
+        "claude",
+    ]);
+    assert!(
+        active.status.success(),
+        "initial aoe add failed: {}",
+        String::from_utf8_lossy(&active.stderr)
+    );
+
+    h.spawn_tui();
+    h.wait_for("active-live");
+    h.send_keys("Tab");
+    h.wait_for_timeout("LIVE →  active-live", Duration::from_secs(10));
+
+    let peer_project = h.home_path().join("peer-project");
+    std::fs::create_dir_all(&peer_project).expect("create peer project");
+    let peer = h.run_cli(&[
+        "add",
+        peer_project.to_str().expect("utf8 peer project"),
+        "-t",
+        "peer-added",
+        "-c",
+        "claude",
+    ]);
+    assert!(
+        peer.status.success(),
+        "peer aoe add failed: {}",
+        String::from_utf8_lossy(&peer.stderr)
+    );
+
+    h.wait_for_timeout("peer-added", Duration::from_millis(1_500));
+    h.assert_screen_contains("LIVE →  active-live");
+    let _home = HomeGuard::new(h.home_path());
+    let late_storage =
+        Storage::new("late-live-profile", FileWatchService::noop()).expect("late profile storage");
+    late_storage
+        .update(|instances, _groups| {
+            let mut inst = Instance::new("late-profile-added", "/tmp/late-profile-added");
+            inst.source_profile = "late-live-profile".to_string();
+            instances.push(inst);
+            Ok(())
+        })
+        .expect("peer write in previously unwatched profile");
+    h.wait_for_timeout("late-profile-added", Duration::from_secs(7));
+    h.assert_screen_contains("LIVE →  active-live");
+    h.type_text("routed-after-refresh");
+    h.send_keys("Enter");
+
+    let active_input = active_project.join("live-send-input");
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let routed = loop {
+        if let Ok(contents) = std::fs::read_to_string(&active_input) {
+            if contents.contains("routed-after-refresh") {
+                break contents;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "live-send input did not reach the original session"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    assert!(routed.contains("routed-after-refresh"));
+    let peer_input = peer_project.join("live-send-input");
+    assert!(
+        std::fs::read_to_string(peer_input)
+            .map(|contents| !contents.contains("routed-after-refresh"))
+            .unwrap_or(true),
+        "storage refresh must not reroute input to the peer-added session"
+    );
 }


### PR DESCRIPTION
## Description

Fixes #3631.

Allow the TUI storage mirror to consume `sessions.json` and `groups.json` changes while live-send remains active. Watcher notifications trigger the storage-only reload immediately, and the five-second heartbeat uses the same storage-only path during live-send so newly created or temporarily unwatched profiles are still discovered. Full heartbeat and config reloads remain deferred; an overdue full heartbeat is latched across live-send storage refreshes and runs on the first eligible tick after live-send exits.

The live-send target, logical selection, paste buffer, capture worker, input worker, and pane sizing remain pinned while the storage projection rebuilds. If an external mutation hides the active row under a collapsed shelf, the sidebar does not visibly select a peer row. If the refreshed storage removes or renames the active target, the existing drift path ends live-send immediately, reports the reason, and reconciles selection, including an empty sidebar. Reload failures stay latched but their modal is deferred until live-send exits, so input and paste routing are not intercepted.

Regression coverage includes an external `aoe add` becoming visible within the watcher budget, a previously unwatched profile appearing through the periodic fallback, an active row moving to trash without retargeting selection or capture, active-row removal ending live-send, deferred full-heartbeat catch-up, deferred reload-failure presentation, rendered preview text matching copied text, and input remaining routed to the original live pane.

Validation:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --lib tui::app::tests` (41 passed)
- `cargo test --lib tui::home::file_watch_tests` (37 passed)
- `cargo test --lib tui::home::tests::live_send_mode` (35 passed)
- `cargo test --lib tui::home::tests::preview_drag_select` (31 passed)
- `cargo test --features e2e-tests --test e2e filewatch_tui_reload` (2 passed)

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The changed behavior has deterministic TUI E2E coverage. No visual styling changed, so no screenshot or recording was added.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

OpenAI Codex GPT-5.6 Sol via Oh My Pi.

**Any Additional AI Details you'd like to share:**

The agent reproduced the issue against the full TUI binary, ran independent fresh code and design reviews from the current base-to-head diff, incorporated every GitHub review and general comment, corrected every validated finding, and reran the targeted unit, lifecycle, E2E, full-suite, format, and lint checks listed above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not our AI :)

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the TUI sidebar during live-send when external sessions or groups change.
- Added watcher and periodic storage refreshes without interrupting live-send.
- Preserved the active session, selection, input routing, preview state, capture target, and pane sizing.
- Deferred full reloads and reload-error dialogs until live-send ends.
- Ended live-send and repaired selection when the active session changed or was removed.
- Added regression and end-to-end tests for refresh behavior, selection, input routing, deferred reloads, and preview capture.

## Benefits

The sidebar stays current during live-send. External changes appear promptly, while disruptive updates remain safely deferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->