### PR TITLE
fix(sandbox): diagnose legacy mounts under declared agent config

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -301,6 +301,20 @@ agent's config and history under `sandbox-v2/<instance-id>` inside the agent's c
 the agent's usual config path, so credentials, hooks and conversation history
 belong to one session and `aoe` can resume the right conversation.
 
+**Upgrading wrappers with `agent_config_dir`:** older configurations manually
+mounted `<dir>/sandbox` through `sandbox.extra_volumes`. AoE now mounts
+`<dir>/sandbox-v2/<instance-id>` itself and supplies the agent's config-dir
+environment. The store migration does not rewrite wrappers or manual mounts.
+Remove manual agent-config mounts from `extra_volumes` and, inside the sandbox,
+let the wrapper preserve AoE's config-dir variables (for example,
+`CLAUDE_CONFIG_DIR`). Keep host-only account selection outside the sandbox.
+A wrapper that overwrites these variables can read the old store instead of
+the prepared one, without its seeded folder-trust record, even if the old
+mount uses a different container path. AoE warns once per container preparation
+when an extra-volume source is the declared config directory or a child of it;
+this signals a risk, not proof that the wrapper reads that mount. See
+[One CLI, two accounts](configuration.md#one-cli-two-accounts).
+
 Sessions created before this layout shared one agent store per agent (for
 example `~/.claude/sandbox`). Each one moves when you start it: AoE copies the
 shared store into that session's private directory, removes its stopped

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -201,7 +201,12 @@ wrapper points the CLI at another directory, set that host root in
 `session.agent_config_dir`. AoE stages a private per-session child and mounts it
 at the agent's canonical container config path. Remove any
 `sandbox.extra_volumes` entry for that path because it would shadow AoE's
-managed mount.
+managed mount; AoE warns once per container preparation when an extra-volume
+source is that directory or a child of it. Inside the sandbox the wrapper has
+to keep the config-dir variables AoE sets (`CLAUDE_CONFIG_DIR`, for example)
+rather than export its own, which points the agent at the pre-upgrade store
+and its missing folder-trust record, leaving the session on the folder-trust
+dialog. Host-only account selection stays outside the sandbox.
 
 To pre-trust worktrees for host sessions too, see `session.pre_trust_agent_folders`
 in the [configuration guide](configuration.md).
@@ -300,20 +305,6 @@ agent's config and history under `sandbox-v2/<instance-id>` inside the agent's c
 (for example `~/.claude/sandbox-v2/<id>`). The container mounts that copy at
 the agent's usual config path, so credentials, hooks and conversation history
 belong to one session and `aoe` can resume the right conversation.
-
-**Upgrading wrappers with `agent_config_dir`:** older configurations manually
-mounted `<dir>/sandbox` through `sandbox.extra_volumes`. AoE now mounts
-`<dir>/sandbox-v2/<instance-id>` itself and supplies the agent's config-dir
-environment. The store migration does not rewrite wrappers or manual mounts.
-Remove manual agent-config mounts from `extra_volumes` and, inside the sandbox,
-let the wrapper preserve AoE's config-dir variables (for example,
-`CLAUDE_CONFIG_DIR`). Keep host-only account selection outside the sandbox.
-A wrapper that overwrites these variables can read the old store instead of
-the prepared one, without its seeded folder-trust record, even if the old
-mount uses a different container path. AoE warns once per container preparation
-when an extra-volume source is the declared config directory or a child of it;
-this signals a risk, not proof that the wrapper reads that mount. See
-[One CLI, two accounts](configuration.md#one-cli-two-accounts).
 
 Sessions created before this layout shared one agent store per agent (for
 example `~/.claude/sandbox`). Each one moves when you start it: AoE copies the

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -138,6 +138,7 @@ impl Instance {
                 ),
             }
         }
+        self.warn_legacy_agent_config_mounts();
         let _transition_lock =
             if self.sandbox_store_generation < container_config::CURRENT_SANDBOX_STORE_GENERATION {
                 Some(crate::session::acquire_storage_shared_flock(
@@ -315,6 +316,35 @@ impl Instance {
         container_config::compute_volume_paths(Path::new(&self.project_path), &self.project_path)
             .map(|(_, wd)| wd)
             .unwrap_or_else(|_| "/workspace".to_string())
+    }
+
+    fn warn_legacy_agent_config_mounts(&self) {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let Ok(config) =
+            crate::session::config::profile_config::resolve_config(&self.effective_profile())
+        else {
+            return;
+        };
+        let Some(directory) = config.session.agent_config_dir_for(&self.tool, &home) else {
+            return;
+        };
+        if let Some(entry) = config.sandbox.extra_volumes.iter().find(|entry| {
+            entry
+                .split_once(':')
+                .is_some_and(|(source, _)| Path::new(source).starts_with(&directory))
+        }) {
+            tracing::warn!(
+                target: "session.profile",
+                agent = %self.tool,
+                agent_config_dir = %directory.display(),
+                extra_volume = %entry,
+                "sandbox.extra_volumes includes a source in the declared agent_config_dir tree; \
+                 manual agent-config mounts may bypass per-session isolation and staged folder trust. \
+                 Remove manual agent-config mounts and, inside the sandbox, preserve AoE-provided config-dir variables"
+            );
+        }
     }
 
     pub(super) fn build_container_config(&self) -> Result<crate::containers::ContainerConfig> {

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -542,6 +542,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    #[serial_test::serial(hook_base)]
     fn legacy_agent_config_mount_warns_once_for_selected_profile_and_agent() {
         use std::fs;
         use std::sync::Mutex;

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -539,4 +539,127 @@ mod tests {
         inst.sandbox_info.as_mut().unwrap().container_workdir = Some(pinned.clone());
         assert_eq!(inst.container_workdir(), pinned);
     }
+
+    #[test]
+    #[serial_test::serial]
+    fn legacy_agent_config_mount_warns_once_for_selected_profile_and_agent() {
+        use std::fs;
+        use std::sync::Mutex;
+
+        let home = tempfile::TempDir::new().unwrap();
+        let _app = crate::session::test_support::isolate_app_dir_at(home.path());
+        let (_hooks, _, _hook_dir) = crate::hooks::test_support::BaseGuard::ready();
+        let profile = "sandbox-store-diagnostic";
+        let _registry = crate::tmux::status_rules::ProfileRegistryGuard::take(profile);
+        let app_dir = crate::session::get_app_dir().unwrap();
+        fs::write(
+            app_dir.join("config.toml"),
+            r#"
+[session.custom_agents]
+claude-personal = "claude"
+[session.agent_detect_as]
+claude-personal = "claude"
+[session.agent_config_dir]
+claude-personal = "~/.claude-global"
+"#,
+        )
+        .unwrap();
+        let profile_path =
+            crate::session::config::profile_config::get_profile_config_path(profile).unwrap();
+        fs::create_dir_all(profile_path.parent().unwrap()).unwrap();
+        let declared = home.path().join("account");
+        let legacy = declared.join("sandbox");
+        fs::create_dir_all(&legacy).unwrap();
+        let legacy_json = r#"{"hasCompletedOnboarding":true}"#;
+        fs::write(legacy.join(".claude.json"), legacy_json).unwrap();
+        let source = declared.display();
+        let cases = [
+            (
+                "descendants",
+                "claude-personal",
+                vec![
+                    format!("{source}/sandbox:/root/legacy-account"),
+                    format!("{source}/templates:/templates:ro"),
+                ],
+                1,
+            ),
+            (
+                "root",
+                "claude-personal",
+                vec![format!("{source}:/account")],
+                1,
+            ),
+            (
+                "boundaries",
+                "claude-personal",
+                vec![
+                    format!("{source}-other:/root/.claude"),
+                    format!("/outside:{source}/sandbox"),
+                    format!("{source}/sandbox"),
+                ],
+                0,
+            ),
+            (
+                "other-agent",
+                "another-agent",
+                vec![format!("{source}/sandbox:/root/legacy-account")],
+                0,
+            ),
+        ];
+        let mut instance = Instance::new("diagnostic", home.path().to_str().unwrap());
+        instance.tool = "claude-personal".to_string();
+        instance.source_profile = profile.to_string();
+        instance.sandbox_info = Some(SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "diagnostic".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        });
+        for (case, declared_agent, entries, expected) in cases {
+            fs::write(
+                &profile_path,
+                format!(
+                    "[session.agent_config_dir]\n{declared_agent} = \"~/account\"\n[sandbox]\nextra_volumes = {entries:?}\n"
+                ),
+            )
+            .unwrap();
+            let log_path = home.path().join(format!("{case}.log"));
+            let subscriber = tracing_subscriber::fmt()
+                .with_max_level(tracing::Level::WARN)
+                .without_time()
+                .with_ansi(false)
+                .with_writer(Mutex::new(fs::File::create(&log_path).unwrap()))
+                .finish();
+            tracing::subscriber::with_default(subscriber, || {
+                instance.warn_legacy_agent_config_mounts();
+                if case == "descendants" {
+                    // Preparing the config again must not duplicate the diagnostic.
+                    for _ in 0..2 {
+                        instance.build_container_config().unwrap();
+                    }
+                }
+            });
+            let logs = fs::read_to_string(log_path).unwrap();
+            let warnings: Vec<_> = logs.lines().collect();
+            assert_eq!(warnings.len(), expected, "{case}: {logs}");
+            if expected == 1 {
+                let warning = warnings[0];
+                assert!(warning.contains("WARN") && warning.contains("session.profile"));
+                assert!(warning.contains("agent=claude-personal"), "{warning}");
+                assert!(
+                    warning.contains(&format!("agent_config_dir={source}")),
+                    "{warning}"
+                );
+                assert!(warning.contains(&entries[0]), "{warning}");
+            }
+        }
+        assert_eq!(
+            fs::read_to_string(legacy.join(".claude.json")).unwrap(),
+            legacy_json
+        );
+    }
 }

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -318,6 +318,8 @@ impl Instance {
             .unwrap_or_else(|_| "/workspace".to_string())
     }
 
+    /// Kept out of `build_container_config` so the diagnostic fires once per
+    /// preparation: a launch can build the config more than once.
     fn warn_legacy_agent_config_mounts(&self) {
         let Some(home) = dirs::home_dir() else {
             return;


### PR DESCRIPTION
## Description

Fixes #3775.

Add a diagnostic and an upgrade note for manual sandbox mounts retained after #3678. No compatibility behavior: mounts, environment variables, trust seeding, and persisted stores are unchanged.

### Root cause and evidence

#3678 moved a declared agent config store from `<dir>/sandbox` to `<dir>/sandbox-v2/<instance-id>`, mounted at the built-in config path. A wrapper's later `CLAUDE_CONFIG_DIR` export can select the old, separately mounted store instead of the one AoE prepared.

Reproduced locally on base `8876585e`, AoE 1.15.3, Linux, Docker 29.8.0, and sandbox-image Claude Code 2.1.258. The fixture used an isolated HOME, synthetic onboarding state, no real credentials, a declared account directory, and `<account>/sandbox:/root/legacy-account`. The wrapper exported `CLAUDE_CONFIG_DIR=/root/legacy-account`.

Observed:

```text
Yes, I trust this folder
WARN count: 0
managed trust: True
wrapper trust: None
```

Changing only the wrapper export to `/root/.claude` removed the folder-trust dialog. Restoring `/root/legacy-account` brought it back, without accepting trust or removing the manual mount. This isolates the selected config path, rather than missing trust seeding or a mount at the same destination.

The old `warn_unless_mounted` checked for a missing mount. It would have accepted this old recipe before the layout change. This PR adds a diagnostic for a retained manual recipe; it does not restore that old predicate.

Relevant source: `src/session/instance/container.rs:141,321-348`; existing store/seed behavior in `src/session/config/container_config.rs:1982-2013,2232-2267`.

### Fix

- Warn once per `get_container_for_instance` preparation when the first parsable extra-volume source equals or lies under the selected agent's declared config directory.
- Name the agent, declared directory, and manual volume. Describe a possible bypass of per-session isolation and staged folder trust, not a proven wrapper failure.
- Keep emission outside the config builder: Pi may build the config again while preparing its launch.
- Add the upgrade note to the existing **Per-session agent stores** section. Preserve AoE's config-dir variables inside the sandbox; retain host-only account selection outside it.

### Verification

The same full-binary warning assertion was run before and after the fix:

```text
Before: named warning count: 0
AssertionError: expected one named diagnostic, got 0
After:  named warning count: 1
```

The emitted WARN names `sandbox.extra_volumes`, `agent_config_dir`, the fixture agent, and the legacy mount. The unchanged wrapper still displays folder trust: this is diagnostic-only.

- `cargo test --lib legacy_agent_config_mount_warns_once_for_selected_profile_and_agent`: 1 passed.
- `cargo test --lib session::instance::container::tests`: 2 passed.
- `cargo test --lib session::config::container_config::tests`: 122 passed.
- `cargo test`: 6939 passed, 8 ignored.
- `cargo build`, `cargo clippy`, and `cargo fmt`: passed.
- Commit hooks also passed `cargo clippy -- -D warnings` and `cargo fmt -- --check`.
- Live Pi 0.84.4 sandbox launch with two suspect volumes: exactly one named warning. Its native session ID was not reported within the launch observation window; this check does not claim native resume works.

The permanent Rust regression covers multiple matching mounts, the root itself, component boundaries, source versus destination, malformed entries, the selected profile and agent, repeated config builds, and leaving the legacy JSON untouched. The red/green integration assertion used the actual binary; the newly added private helper is not claimed to compile on the pre-fix revision.

### Risks and limits

A read-only reference mount may be legitimate, so this is a warning, never a rejection. Path matching is lexical and component-based; it does not resolve symlink aliases or normalize `..`. The diagnostic examines declared configuration, not the wrapper's actual file reads or the container's effective mounts. Each explicit container preparation can warn again; there is no process-global or persisted suppression state, and no polling-loop emission. One additional profile configuration resolution is performed per preparation.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A: logging diagnostic only; no rendering change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the warning contract is covered by an isolated in-module Rust regression and actual Claude/Pi sandbox smoke checks. A permanent Docker/agent-dependent test would be more expensive and less deterministic.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Oh My Pi, `openai-codex/gpt-6-astra`, with analysis-only subagents for independent RCA and design review.

**Any Additional AI Details you'd like to share:**
One agent applied all code, test, and documentation changes. Reproduction and verification commands were executed locally. This PR is intentionally a draft; it has not been merged.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a one-time warning for manual sandbox mounts under a declared agent configuration directory.
- Added regression tests for matching, boundary, unrelated-agent, and duplicate-warning cases.
- Updated wrapper upgrade guidance to preserve AoE-managed config-directory variables and avoid outdated stores.

## Benefits

- Users can detect mounts that bypass per-session isolation or folder-trust state.
- Clear upgrade guidance helps prevent unexpected folder-trust prompts.

## Potential follow-up

- Monitor support reports for other upgrade patterns that may need documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->