### PR TITLE
feat(web): reuse the searchable project picker for extra repos

### DIFF
--- a/web/src/components/session-wizard/__tests__/ExtraReposPicker.perRepoBase.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ExtraReposPicker.perRepoBase.test.tsx
@@ -14,6 +14,8 @@ const fetchBranches = vi.fn();
 
 vi.mock("../../../lib/api", () => ({
   fetchProjects: vi.fn().mockResolvedValue([]),
+  fetchSessions: vi.fn().mockResolvedValue({ sessions: [], workspace_ordering: [] }),
+  fetchRecentProjects: vi.fn().mockResolvedValue({ projects: [] }),
   fetchBranches: (...args: unknown[]) => fetchBranches(...args),
 }));
 

--- a/web/src/components/session-wizard/steps/ExtraReposPicker.tsx
+++ b/web/src/components/session-wizard/steps/ExtraReposPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import type { ProjectInfo } from "../../../lib/types";
-import { fetchBranches, fetchProjects, type BranchInfo } from "../../../lib/api";
+import { fetchBranches, type BranchInfo } from "../../../lib/api";
+import { ProjectSearchList } from "./ProjectSearchList";
+import { useProjectPicker } from "./projectPicker";
 
 interface Props {
   primaryPath: string;
@@ -95,16 +96,13 @@ export function ExtraReposPicker({
   onRepoBasesChange,
   basesEnabled,
 }: Props) {
-  const [projects, setProjects] = useState<ProjectInfo[]>([]);
-  const [loading, setLoading] = useState(true);
   const [freeText, setFreeText] = useState("");
 
-  useEffect(() => {
-    fetchProjects().then((p) => {
-      setProjects(p);
-      setLoading(false);
-    });
-  }, []);
+  // Hide the primary repo from the picker so users can't accidentally
+  // duplicate it (the builder rejects duplicate repo names).
+  const { loading, saved, recent, query, setQuery, filteredSaved, filteredRecent, hasAnyProjects } = useProjectPicker([
+    primaryPath,
+  ]);
 
   const setRepoBase = (path: string, base: string) => {
     const next = { ...repoBases };
@@ -112,10 +110,6 @@ export function ExtraReposPicker({
     else delete next[path];
     onRepoBasesChange(next);
   };
-
-  // Hide the primary repo from the picker so users can't accidentally
-  // duplicate it (the builder rejects duplicate repo names).
-  const pickable = projects.filter((p) => p.path !== primaryPath);
 
   const isSelected = (path: string) => selectedPaths.includes(path);
 
@@ -159,8 +153,9 @@ export function ExtraReposPicker({
       {selectedPaths.length > 0 && (
         <div className="flex flex-col gap-1.5 mb-3">
           {selectedPaths.map((path) => {
-            const known = projects.find((p) => p.path === path);
-            const label = known?.name || path.split("/").filter(Boolean).pop() || path;
+            const known = saved.find((p) => p.path === path);
+            const recentMatch = recent.find((r) => r.path === path);
+            const label = known?.name || recentMatch?.displayName || path.split("/").filter(Boolean).pop() || path;
             return (
               <div key={path} className="flex items-center gap-1.5">
                 <span
@@ -191,34 +186,29 @@ export function ExtraReposPicker({
         </div>
       )}
 
-      {!loading && pickable.length > 0 && (
+      {!loading && (saved.length > 0 || recent.length > 0) && (
         <div className="mb-3">
-          <p className="text-[10px] uppercase tracking-wider text-text-dim mb-1.5">Registered projects</p>
-          <div className="flex flex-wrap gap-1.5">
-            {pickable.map((p) => (
-              <button
-                key={p.path}
-                type="button"
-                onClick={() => toggle(p.path)}
-                className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] cursor-pointer transition-colors ${
-                  isSelected(p.path)
-                    ? "bg-brand-600/20 border border-brand-600/40 text-text-primary"
-                    : "bg-surface-900 border border-surface-700/40 text-text-secondary hover:border-surface-700"
-                }`}
-                title={p.path}
-              >
-                <span className="font-mono">{p.name}</span>
-                <span className="text-[9px] uppercase text-text-dim">{p.scope}</span>
-              </button>
-            ))}
-          </div>
+          <ProjectSearchList
+            query={query}
+            onQueryChange={setQuery}
+            filteredSaved={filteredSaved}
+            filteredRecent={filteredRecent}
+            isSelected={isSelected}
+            onSelect={toggle}
+          />
         </div>
       )}
 
-      {!loading && pickable.length === 0 && projects.length === 0 && (
+      {!loading && saved.length === 0 && recent.length === 0 && (
         <p className="text-[11px] text-text-dim mb-3">
-          No registered projects yet. Add one with{" "}
-          <code className="text-text-secondary">aoe project add &lt;path&gt;</code> or via the Projects page.
+          {hasAnyProjects ? (
+            "No other projects to add — the primary repo is the only one registered or recent."
+          ) : (
+            <>
+              No registered projects yet. Add one with{" "}
+              <code className="text-text-secondary">aoe project add &lt;path&gt;</code> or via the Projects page.
+            </>
+          )}
         </p>
       )}
 

--- a/web/src/components/session-wizard/steps/ProjectSearchList.tsx
+++ b/web/src/components/session-wizard/steps/ProjectSearchList.tsx
@@ -1,0 +1,121 @@
+import type { ProjectInfo } from "../../../lib/types";
+import type { RecentProject } from "./projectPicker";
+
+function timeAgo(ts: string | null): string {
+  if (!ts) return "";
+  const diff = Date.now() - new Date(ts).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+interface Props {
+  query: string;
+  onQueryChange: (query: string) => void;
+  filteredSaved: ProjectInfo[];
+  filteredRecent: RecentProject[];
+  isSelected: (path: string) => boolean;
+  onSelect: (path: string) => void;
+  /** Shown when a query matches nothing in either list. */
+  emptyMessage?: string;
+}
+
+/** Search box + saved/recent rows shared by the main Project step and the
+ *  extra-repos picker (#3743), so both offer the same searchable list
+ *  instead of two divergent UIs over the same underlying project data. */
+export function ProjectSearchList({
+  query,
+  onQueryChange,
+  filteredSaved,
+  filteredRecent,
+  isSelected,
+  onSelect,
+  emptyMessage = "No projects match that search.",
+}: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="Search projects by name or path"
+        aria-label="Search projects"
+        className="w-full px-3 py-2.5 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600"
+      />
+
+      {filteredSaved.length === 0 && filteredRecent.length === 0 && (
+        <p className="text-sm text-text-dim">{emptyMessage}</p>
+      )}
+
+      {filteredSaved.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim">Saved projects</p>
+          {filteredSaved.map((s) => (
+            <button
+              key={`saved:${s.scope}:${s.path}`}
+              type="button"
+              onClick={() => onSelect(s.path)}
+              title={s.path}
+              className={`flex items-center gap-3 px-3 py-2.5 rounded-md border transition-colors text-left cursor-pointer ${
+                isSelected(s.path)
+                  ? "border-brand-600 bg-surface-900"
+                  : "border-surface-700/40 bg-surface-900 hover:border-surface-700 hover:bg-surface-850"
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-text-primary truncate">{s.name}</span>
+                  <span className="text-[10px] font-mono text-text-dim shrink-0">{s.scope}</span>
+                </div>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="font-mono text-[11px] text-text-dim truncate">{s.path}</span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {filteredRecent.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          {filteredSaved.length > 0 && (
+            <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim">Recent</p>
+          )}
+          {filteredRecent.map((r) => (
+            <button
+              key={r.path}
+              type="button"
+              onClick={() => onSelect(r.path)}
+              title={r.path}
+              className={`flex items-center gap-3 px-3 py-2.5 rounded-md border transition-colors text-left cursor-pointer ${
+                isSelected(r.path)
+                  ? "border-brand-600 bg-surface-900"
+                  : "border-surface-700/40 bg-surface-900 hover:border-surface-700 hover:bg-surface-850"
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-text-primary truncate">{r.displayName}</span>
+                  <span className="text-[10px] font-mono text-text-dim shrink-0">{r.tool}</span>
+                </div>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="font-mono text-[11px] text-text-dim truncate">{r.path}</span>
+                </div>
+              </div>
+              <div className="flex flex-col items-end shrink-0 gap-0.5">
+                <span className="text-[10px] text-text-dim">{timeAgo(r.lastAccessedAt)}</span>
+                <span className="text-[10px] text-text-dim">
+                  {r.sessionCount} session{r.sessionCount !== 1 ? "s" : ""}
+                </span>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable react-refresh/only-export-components */
-import { useEffect, useMemo, useState } from "react";
-import { fetchSessions, fetchRecentProjects, fetchProjects, cloneRepo } from "../../../lib/api";
-import type { RecentProjectEntry } from "../../../lib/api";
-import type { AgentInfo, ClaudeSessionSummary, ProjectInfo, SessionResponse } from "../../../lib/types";
+import { useState } from "react";
+import { cloneRepo } from "../../../lib/api";
+import type { AgentInfo, ClaudeSessionSummary } from "../../../lib/types";
 import { DirectoryBrowser } from "../../DirectoryBrowser";
 import { ExtraReposPicker } from "./ExtraReposPicker";
 import { ClaudeSessionPicker } from "./ClaudeSessionPicker";
+import { ProjectSearchList } from "./ProjectSearchList";
+import { useProjectPicker } from "./projectPicker";
+
+export { collectRecentProjects, mergeRecentProjects, splitSavedAndRecent } from "./projectPicker";
 
 interface WizardData {
   path: string;
@@ -54,10 +57,6 @@ function Toggle({
 
 type Tab = "recent" | "browse" | "clone" | "import";
 
-/** How many recents render when the search box is empty. The search itself is
- *  not capped; see the filteredRecent memo. */
-const RECENT_CAP = 6;
-
 interface Props {
   data: WizardData;
   onChange: (field: string, value: unknown) => void;
@@ -67,113 +66,16 @@ interface Props {
   agents?: AgentInfo[];
 }
 
-interface RecentProject {
-  path: string;
-  displayName: string;
-  lastAccessedAt: string | null;
-  tool: string;
-  sessionCount: number;
-}
-
-export function collectRecentProjects(sessions: SessionResponse[]): RecentProject[] {
-  const map = new Map<string, RecentProject>();
-  for (const s of sessions) {
-    // Scratch sessions live in transient `<app_dir>/scratch/<id>/`
-    // directories that get deleted with the session (unless the user opts
-    // in to keeping the dir). They must not appear in the Recent list,
-    // where they would be re-selectable as a project.
-    if (s.scratch) continue;
-    // Multi-repo workspaces collapse to a single `main_repo_path` here, so
-    // picking one from Recent would start a plain single-repo session and
-    // silently drop the other repos. The project step cannot reconstruct a
-    // workspace from one path, so keep them out of the list entirely.
-    if (s.workspace_repos.length > 0) continue;
-    // Normalize the trailing slash before keying, mirroring the backend's
-    // dedup convention (`src/session/instance/tmux_session.rs` is_duplicate_session and
-    // `src/server/api/sessions/list.rs` workspace_id_for_session both
-    // `trim_end_matches('/')`). Without this, `/foo/bar` and `/foo/bar/`
-    // become two separate entries with split session counts. The `|| "/"`
-    // keeps the filesystem root from collapsing to an empty string.
-    const raw = s.main_repo_path || s.project_path;
-    if (!raw) continue;
-    const path = raw.replace(/\/+$/, "") || "/";
-    const existing = map.get(path);
-    const ts = s.last_accessed_at ?? s.created_at ?? null;
-    if (existing) {
-      existing.sessionCount++;
-      if ((ts ?? "") > (existing.lastAccessedAt ?? "")) {
-        existing.lastAccessedAt = ts;
-        existing.tool = s.tool;
-      }
-    } else {
-      map.set(path, {
-        path,
-        displayName: path.split("/").filter(Boolean).pop() || path,
-        lastAccessedAt: ts,
-        tool: s.tool,
-        sessionCount: 1,
-      });
-    }
-  }
-  return Array.from(map.values()).sort((a, b) => (b.lastAccessedAt ?? "").localeCompare(a.lastAccessedAt ?? ""));
-}
-
-// Fold the persisted recent-projects store (projects whose sessions are gone,
-// #2141) into the live session-derived list. Session-derived entries win on a
-// normalized-path collision, so an active project keeps its real session count
-// and freshness; persisted-only projects are appended with a zero count. The
-// merged list is sorted newest-first; the caller still slices to the visible
-// cap.
-export function mergeRecentProjects(sessionDerived: RecentProject[], persisted: RecentProjectEntry[]): RecentProject[] {
-  const byPath = new Map<string, RecentProject>();
-  for (const r of sessionDerived) byPath.set(r.path, r);
-  for (const p of persisted) {
-    const path = p.path.replace(/\/+$/, "") || "/";
-    if (byPath.has(path)) continue;
-    byPath.set(path, {
-      path,
-      displayName: p.display_name || path.split("/").filter(Boolean).pop() || path,
-      lastAccessedAt: p.last_used_at,
-      tool: p.tool,
-      sessionCount: 0,
-    });
-  }
-  return Array.from(byPath.values()).sort((a, b) => (b.lastAccessedAt ?? "").localeCompare(a.lastAccessedAt ?? ""));
-}
-
-/** Saved projects are a curated registry (#2140); recents are derived from
- *  live sessions and the persisted recent-projects store. A path can be in
- *  both. Drop it from recents so it renders once, in the Saved section.
- *  Path keys are normalized the same way the recents are (trailing slashes
- *  trimmed, root kept as "/") so `/foo/bar` and `/foo/bar/` match across the
- *  two sources. */
-export function splitSavedAndRecent(
-  saved: ProjectInfo[],
-  recent: RecentProject[],
-): { saved: ProjectInfo[]; recent: RecentProject[] } {
-  const norm = (p: string) => p.replace(/\/+$/, "") || "/";
-  const savedPaths = new Set(saved.map((s) => norm(s.path)));
-  return { saved, recent: recent.filter((r) => !savedPaths.has(norm(r.path))) };
-}
-
-function timeAgo(ts: string | null): string {
-  if (!ts) return "";
-  const diff = Date.now() - new Date(ts).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
 export function ProjectStep({ data, onChange, initialTab, agents = [] }: Props) {
-  const [recent, setRecent] = useState<RecentProject[]>([]);
-  const [saved, setSaved] = useState<ProjectInfo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<Tab>(initialTab ?? "recent");
-  const [query, setQuery] = useState("");
+  // `manualTab` is null until the user (or a select-and-jump action like
+  // Browse/Clone) picks a tab explicitly. Until then the active tab is
+  // derived: Recent while loading or when there is something to pick, Browse
+  // once loading settles with nothing saved or recent. This avoids an effect
+  // just to flip to Browse once the picker data arrives.
+  const [manualTab, setManualTab] = useState<Tab | null>(initialTab ?? null);
+  const { loading, query, setQuery, filteredSaved, filteredRecent, hasPicks } = useProjectPicker();
+  const activeTab: Tab = manualTab ?? (!loading && !hasPicks ? "browse" : "recent");
+  const setActiveTab = setManualTab;
 
   // Clone state
   const [cloneUrl, setCloneUrl] = useState("");
@@ -183,42 +85,6 @@ export function ProjectStep({ data, onChange, initialTab, agents = [] }: Props) 
   const [cloning, setCloning] = useState(false);
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
-
-  useEffect(() => {
-    Promise.all([fetchSessions(), fetchRecentProjects(), fetchProjects()]).then(
-      ([envelope, recentEnvelope, savedProjects]) => {
-        const sessionDerived = envelope ? collectRecentProjects(envelope.sessions) : [];
-        const merged = mergeRecentProjects(sessionDerived, recentEnvelope?.projects ?? []);
-        const split = splitSavedAndRecent(savedProjects, merged);
-        setSaved(split.saved);
-        setRecent(split.recent);
-        // Default to Browse only when there is nothing to pick from either
-        // source; a user with saved projects but no recents should still
-        // land on the Recent tab.
-        if (split.saved.length === 0 && split.recent.length === 0 && !initialTab) {
-          setActiveTab("browse");
-        }
-        setLoading(false);
-      },
-    );
-  }, [initialTab]);
-
-  // #3461: with no query, recents stay capped so the tab reads as a short
-  // "jump back in" list. A query searches the whole merged list instead, so a
-  // project sitting below the cap is still reachable by typing.
-  const filteredRecent = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return recent.slice(0, RECENT_CAP);
-    return recent.filter((r) => r.path.toLowerCase().includes(q) || r.displayName.toLowerCase().includes(q));
-  }, [recent, query]);
-
-  const filteredSaved = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return saved;
-    return saved.filter((s) => s.path.toLowerCase().includes(q) || s.name.toLowerCase().includes(q));
-  }, [saved, query]);
-
-  const hasPicks = recent.length > 0 || saved.length > 0;
 
   // A selected path that already shows up as a (border-highlighted) saved or
   // recent row needs no separate "Selected project" box; that would just
@@ -360,89 +226,19 @@ export function ProjectStep({ data, onChange, initialTab, agents = [] }: Props) 
           )}
 
           {/* Recent projects tab: saved (curated registry) on top, then
-              session-derived and persisted recents below. */}
+              session-derived and persisted recents below. #3461: type-to-filter
+              over the whole saved + recent list, so a project below the recent
+              cap is reachable without falling back to Browse. */}
           {!loading && activeTab === "recent" && hasPicks && (
-            <div className="flex flex-col gap-4">
-              {/* #3461: type-to-filter over the whole saved + recent list, so
-                  a project below RECENT_CAP is reachable without falling back
-                  to Browse. */}
-              <input
-                type="text"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search projects by name or path"
-                aria-label="Search projects"
-                className="w-full px-3 py-2.5 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600"
-              />
-
-              {filteredSaved.length === 0 && filteredRecent.length === 0 && (
-                <p className="text-sm text-text-dim">No projects match that search. Try the Browse tab.</p>
-              )}
-
-              {filteredSaved.length > 0 && (
-                <div className="flex flex-col gap-1.5">
-                  <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim">Saved projects</p>
-                  {filteredSaved.map((s) => (
-                    <button
-                      key={`saved:${s.scope}:${s.path}`}
-                      type="button"
-                      onClick={() => onChange("path", s.path)}
-                      className={`flex items-center gap-3 px-3 py-2.5 rounded-md border transition-colors text-left cursor-pointer ${
-                        data.path === s.path
-                          ? "border-brand-600 bg-surface-900"
-                          : "border-surface-700/40 bg-surface-900 hover:border-surface-700 hover:bg-surface-850"
-                      }`}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium text-text-primary truncate">{s.name}</span>
-                          <span className="text-[10px] font-mono text-text-dim shrink-0">{s.scope}</span>
-                        </div>
-                        <div className="flex items-center gap-2 mt-0.5">
-                          <span className="font-mono text-[11px] text-text-dim truncate">{s.path}</span>
-                        </div>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              )}
-
-              {filteredRecent.length > 0 && (
-                <div className="flex flex-col gap-1.5">
-                  {filteredSaved.length > 0 && (
-                    <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim">Recent</p>
-                  )}
-                  {filteredRecent.map((r) => (
-                    <button
-                      key={r.path}
-                      type="button"
-                      onClick={() => onChange("path", r.path)}
-                      className={`flex items-center gap-3 px-3 py-2.5 rounded-md border transition-colors text-left cursor-pointer ${
-                        data.path === r.path
-                          ? "border-brand-600 bg-surface-900"
-                          : "border-surface-700/40 bg-surface-900 hover:border-surface-700 hover:bg-surface-850"
-                      }`}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium text-text-primary truncate">{r.displayName}</span>
-                          <span className="text-[10px] font-mono text-text-dim shrink-0">{r.tool}</span>
-                        </div>
-                        <div className="flex items-center gap-2 mt-0.5">
-                          <span className="font-mono text-[11px] text-text-dim truncate">{r.path}</span>
-                        </div>
-                      </div>
-                      <div className="flex flex-col items-end shrink-0 gap-0.5">
-                        <span className="text-[10px] text-text-dim">{timeAgo(r.lastAccessedAt)}</span>
-                        <span className="text-[10px] text-text-dim">
-                          {r.sessionCount} session{r.sessionCount !== 1 ? "s" : ""}
-                        </span>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <ProjectSearchList
+              query={query}
+              onQueryChange={setQuery}
+              filteredSaved={filteredSaved}
+              filteredRecent={filteredRecent}
+              isSelected={(path) => data.path === path}
+              onSelect={(path) => onChange("path", path)}
+              emptyMessage="No projects match that search. Try the Browse tab."
+            />
           )}
 
           {/* Browse tab */}

--- a/web/src/components/session-wizard/steps/__tests__/ExtraReposPicker.test.tsx
+++ b/web/src/components/session-wizard/steps/__tests__/ExtraReposPicker.test.tsx
@@ -2,20 +2,25 @@
 //
 // Tests for ExtraReposPicker: the wizard step that lets the user attach
 // additional repos to a multi-repo session. Cover the loading -> loaded
-// transition, toggling registered projects, free-text add (including the
-// dedupe / primary-path guards), removal chips, and the resulting onChange
-// payloads.
+// transition, the shared search-over-saved-and-recent picker (#3743),
+// free-text add (including the dedupe / primary-path guards), removal
+// chips, and the resulting onChange payloads.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { ExtraReposPicker } from "../ExtraReposPicker";
 import type { ProjectInfo } from "../../../../lib/types";
+import type { RecentProjectEntry } from "../../../../lib/api";
 
 const fetchProjects = vi.fn();
+const fetchSessions = vi.fn();
+const fetchRecentProjects = vi.fn();
 const fetchBranches = vi.fn();
 vi.mock("../../../../lib/api", () => ({
   fetchProjects: () => fetchProjects(),
+  fetchSessions: () => fetchSessions(),
+  fetchRecentProjects: () => fetchRecentProjects(),
   fetchBranches: (...args: unknown[]) => fetchBranches(...args),
 }));
 
@@ -26,10 +31,9 @@ const PROJECTS: ProjectInfo[] = [
 ];
 
 // `basesEnabled` defaults to false so the per-repo base inputs (#3329) stay out
-// of the way of this file's concern, repo selection. Several assertions here
-// reach for the first `input[type="text"]`, which is the free-text path field.
-// The base fields have their own coverage in
-// `session-wizard/__tests__/ExtraReposPicker.perRepoBase.test.tsx`.
+// of the way of this file's concern, repo selection. The free-text path field
+// is looked up by placeholder, not position, because the shared search box
+// (#3743) also renders a text input above it.
 function setup(overrides?: { selectedPaths?: string[]; primaryPath?: string; basesEnabled?: boolean }) {
   const onChange = vi.fn();
   const onRepoBasesChange = vi.fn();
@@ -46,15 +50,23 @@ function setup(overrides?: { selectedPaths?: string[]; primaryPath?: string; bas
   return { ...utils, onChange, onRepoBasesChange };
 }
 
-function projectButton(container: HTMLElement, name: string): HTMLButtonElement | undefined {
-  return Array.from(container.querySelectorAll("button")).find(
-    (b) => b.querySelector(".font-mono")?.textContent === name,
-  ) as HTMLButtonElement | undefined;
+function projectRow(container: HTMLElement, name: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes(name)) as
+    | HTMLButtonElement
+    | undefined;
+}
+
+function freeTextInput(): HTMLInputElement {
+  return screen.getByPlaceholderText("/path/to/another/repo");
 }
 
 beforeEach(() => {
   fetchProjects.mockReset();
   fetchProjects.mockResolvedValue(PROJECTS);
+  fetchSessions.mockReset();
+  fetchSessions.mockResolvedValue({ sessions: [], workspace_ordering: [] });
+  fetchRecentProjects.mockReset();
+  fetchRecentProjects.mockResolvedValue({ projects: [] });
 });
 
 afterEach(() => {
@@ -62,13 +74,13 @@ afterEach(() => {
 });
 
 describe("ExtraReposPicker", () => {
-  it("hides the primary repo and lists the other registered projects once loaded", async () => {
+  it("hides the primary repo and lists the other saved projects once loaded", async () => {
     const { container } = setup();
-    await waitFor(() => expect(container.textContent).toContain("Registered projects"));
-    expect(projectButton(container, "alpha")).toBeTruthy();
-    expect(projectButton(container, "beta")).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain("Saved projects"));
+    expect(projectRow(container, "alpha")).toBeTruthy();
+    expect(projectRow(container, "beta")).toBeTruthy();
     // Primary is filtered out of the pickable list.
-    expect(projectButton(container, "primary")).toBeFalsy();
+    expect(projectRow(container, "primary")).toBeFalsy();
   });
 
   it("shows the none summary when nothing is selected", () => {
@@ -76,22 +88,17 @@ describe("ExtraReposPicker", () => {
     expect(container.textContent).toContain("none");
   });
 
-  it("selecting a registered project adds its path via onChange", async () => {
+  it("selecting a saved project adds its path via onChange", async () => {
     const { container, onChange } = setup({ selectedPaths: [] });
-    await waitFor(() => expect(projectButton(container, "alpha")).toBeTruthy());
-    fireEvent.click(projectButton(container, "alpha")!);
+    await waitFor(() => expect(projectRow(container, "alpha")).toBeTruthy());
+    fireEvent.click(projectRow(container, "alpha")!);
     expect(onChange).toHaveBeenCalledWith(["/repos/alpha"]);
   });
 
   it("clicking an already-selected project deselects it", async () => {
     const { container, onChange } = setup({ selectedPaths: ["/repos/alpha"] });
-    await waitFor(() => expect(projectButton(container, "alpha")).toBeTruthy());
-    // Click the registered-project toggle (title is the full path and it
-    // carries a scope label), not the chip's remove button.
-    const toggle = Array.from(container.querySelectorAll("button")).find(
-      (b) => b.getAttribute("title") === "/repos/alpha" && b.textContent?.includes("alpha"),
-    )!;
-    fireEvent.click(toggle);
+    await waitFor(() => expect(projectRow(container, "alpha")).toBeTruthy());
+    fireEvent.click(projectRow(container, "alpha")!);
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
@@ -116,18 +123,17 @@ describe("ExtraReposPicker", () => {
 
   it("Add button is disabled until the free-text input has content", async () => {
     const { container } = setup();
-    await waitFor(() => expect(container.textContent).toContain("Registered projects"));
+    await waitFor(() => expect(container.textContent).toContain("Saved projects"));
     const addBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.trim() === "Add")!;
     expect(addBtn.disabled).toBe(true);
-    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
-    fireEvent.change(input, { target: { value: "/new/repo" } });
+    fireEvent.change(freeTextInput(), { target: { value: "/new/repo" } });
     expect(addBtn.disabled).toBe(false);
   });
 
   it("free-text Add appends a trimmed path and clears the input", async () => {
     const { container, onChange } = setup({ selectedPaths: ["/repos/alpha"] });
-    await waitFor(() => expect(container.textContent).toContain("Registered projects"));
-    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    await waitFor(() => expect(container.textContent).toContain("Saved projects"));
+    const input = freeTextInput();
     fireEvent.change(input, { target: { value: "  /new/repo  " } });
     const addBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.trim() === "Add")!;
     fireEvent.click(addBtn);
@@ -137,8 +143,8 @@ describe("ExtraReposPicker", () => {
 
   it("Enter in the free-text input adds the path", async () => {
     const { container, onChange } = setup({ selectedPaths: [] });
-    await waitFor(() => expect(container.textContent).toContain("Registered projects"));
-    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    await waitFor(() => expect(container.textContent).toContain("Saved projects"));
+    const input = freeTextInput();
     fireEvent.change(input, { target: { value: "/typed/repo" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onChange).toHaveBeenCalledWith(["/typed/repo"]);
@@ -146,8 +152,8 @@ describe("ExtraReposPicker", () => {
 
   it("ignores a duplicate free-text path but still clears the input", async () => {
     const { container, onChange } = setup({ selectedPaths: ["/repos/alpha"] });
-    await waitFor(() => expect(container.textContent).toContain("Registered projects"));
-    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    await waitFor(() => expect(container.textContent).toContain("Saved projects"));
+    const input = freeTextInput();
     fireEvent.change(input, { target: { value: "/repos/alpha" } });
     const addBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.trim() === "Add")!;
     fireEvent.click(addBtn);
@@ -157,8 +163,8 @@ describe("ExtraReposPicker", () => {
 
   it("ignores a free-text path equal to the primary path", async () => {
     const { container, onChange } = setup({ primaryPath: "/repos/primary", selectedPaths: [] });
-    await waitFor(() => expect(container.textContent).toContain("Registered projects"));
-    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    await waitFor(() => expect(container.textContent).toContain("Saved projects"));
+    const input = freeTextInput();
     fireEvent.change(input, { target: { value: "/repos/primary" } });
     const addBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.trim() === "Add")!;
     fireEvent.click(addBtn);
@@ -166,10 +172,41 @@ describe("ExtraReposPicker", () => {
     expect(input.value).toBe("");
   });
 
-  it("shows the empty-projects hint when no projects are registered", async () => {
+  it("shows the empty-projects hint when there is nothing saved or recent", async () => {
     fetchProjects.mockResolvedValue([]);
     const { container } = setup();
     await waitFor(() => expect(container.textContent).toContain("No registered projects yet"));
     expect(container.textContent).toContain("aoe project add");
+  });
+
+  // A registered project can exist and still leave nothing pickable, when it
+  // *is* the primary repo (the only path useProjectPicker excludes). That's
+  // not the same as an empty registry, so the copy must say so.
+  it("shows a distinct hint when the only registered project is the primary repo", async () => {
+    fetchProjects.mockResolvedValue([{ name: "primary", path: "/repos/primary", scope: "global", pinned: false }]);
+    const { container } = setup({ primaryPath: "/repos/primary" });
+    await waitFor(() => expect(container.textContent).toContain("No other projects to add"));
+    expect(container.textContent).not.toContain("No registered projects yet");
+  });
+
+  // #3743: extra repos should be just as searchable as the main project step.
+  it("filters the saved list by name via the shared search box", async () => {
+    const { container } = setup();
+    await waitFor(() => expect(projectRow(container, "alpha")).toBeTruthy());
+    const search = screen.getByLabelText("Search projects");
+    fireEvent.change(search, { target: { value: "bet" } });
+    expect(projectRow(container, "beta")).toBeTruthy();
+    expect(projectRow(container, "alpha")).toBeFalsy();
+  });
+
+  it("lists recent projects alongside saved projects and can select one", async () => {
+    const recents: RecentProjectEntry[] = [
+      { path: "/repos/gamma", display_name: "gamma", tool: "claude", last_used_at: "2025-09-20T00:00:00+00:00" },
+    ];
+    fetchRecentProjects.mockResolvedValue({ projects: recents });
+    const { container, onChange } = setup();
+    await waitFor(() => expect(projectRow(container, "gamma")).toBeTruthy());
+    fireEvent.click(projectRow(container, "gamma")!);
+    expect(onChange).toHaveBeenCalledWith(["/repos/gamma"]);
   });
 });

--- a/web/src/components/session-wizard/steps/projectPicker.ts
+++ b/web/src/components/session-wizard/steps/projectPicker.ts
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchSessions, fetchRecentProjects, fetchProjects } from "../../../lib/api";
+import type { RecentProjectEntry } from "../../../lib/api";
+import type { ProjectInfo, SessionResponse } from "../../../lib/types";
+
+export interface RecentProject {
+  path: string;
+  displayName: string;
+  lastAccessedAt: string | null;
+  tool: string;
+  sessionCount: number;
+}
+
+/** How many recents render when the search box is empty. The search itself is
+ *  not capped; see `useProjectPicker`. */
+const RECENT_CAP = 6;
+
+function normalizePath(p: string): string {
+  return p.replace(/\/+$/, "") || "/";
+}
+
+export function collectRecentProjects(sessions: SessionResponse[]): RecentProject[] {
+  const map = new Map<string, RecentProject>();
+  for (const s of sessions) {
+    // Scratch sessions live in transient `<app_dir>/scratch/<id>/`
+    // directories that get deleted with the session (unless the user opts
+    // in to keeping the dir). They must not appear in the Recent list,
+    // where they would be re-selectable as a project.
+    if (s.scratch) continue;
+    // Multi-repo workspaces collapse to a single `main_repo_path` here, so
+    // picking one from Recent would start a plain single-repo session and
+    // silently drop the other repos. The project step cannot reconstruct a
+    // workspace from one path, so keep them out of the list entirely.
+    if (s.workspace_repos.length > 0) continue;
+    // Normalize the trailing slash before keying, mirroring the backend's
+    // dedup convention (`src/session/instance/tmux_session.rs` is_duplicate_session and
+    // `src/server/api/sessions/list.rs` workspace_id_for_session both
+    // `trim_end_matches('/')`). Without this, `/foo/bar` and `/foo/bar/`
+    // become two separate entries with split session counts. `normalizePath`
+    // keeps the filesystem root from collapsing to an empty string.
+    const raw = s.main_repo_path || s.project_path;
+    if (!raw) continue;
+    const path = normalizePath(raw);
+    const existing = map.get(path);
+    const ts = s.last_accessed_at ?? s.created_at ?? null;
+    if (existing) {
+      existing.sessionCount++;
+      if ((ts ?? "") > (existing.lastAccessedAt ?? "")) {
+        existing.lastAccessedAt = ts;
+        existing.tool = s.tool;
+      }
+    } else {
+      map.set(path, {
+        path,
+        displayName: path.split("/").filter(Boolean).pop() || path,
+        lastAccessedAt: ts,
+        tool: s.tool,
+        sessionCount: 1,
+      });
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => (b.lastAccessedAt ?? "").localeCompare(a.lastAccessedAt ?? ""));
+}
+
+// Fold the persisted recent-projects store (projects whose sessions are gone,
+// #2141) into the live session-derived list. Session-derived entries win on a
+// normalized-path collision, so an active project keeps its real session count
+// and freshness; persisted-only projects are appended with a zero count. The
+// merged list is sorted newest-first; the caller still slices to the visible
+// cap.
+export function mergeRecentProjects(sessionDerived: RecentProject[], persisted: RecentProjectEntry[]): RecentProject[] {
+  const byPath = new Map<string, RecentProject>();
+  for (const r of sessionDerived) byPath.set(r.path, r);
+  for (const p of persisted) {
+    const path = normalizePath(p.path);
+    if (byPath.has(path)) continue;
+    byPath.set(path, {
+      path,
+      displayName: p.display_name || path.split("/").filter(Boolean).pop() || path,
+      lastAccessedAt: p.last_used_at,
+      tool: p.tool,
+      sessionCount: 0,
+    });
+  }
+  return Array.from(byPath.values()).sort((a, b) => (b.lastAccessedAt ?? "").localeCompare(a.lastAccessedAt ?? ""));
+}
+
+/** Saved projects are a curated registry (#2140); recents are derived from
+ *  live sessions and the persisted recent-projects store. A path can be in
+ *  both. Drop it from recents so it renders once, in the Saved section.
+ *  Path keys are normalized the same way the recents are (trailing slashes
+ *  trimmed, root kept as "/") so `/foo/bar` and `/foo/bar/` match across the
+ *  two sources. */
+export function splitSavedAndRecent(
+  saved: ProjectInfo[],
+  recent: RecentProject[],
+): { saved: ProjectInfo[]; recent: RecentProject[] } {
+  const savedPaths = new Set(saved.map((s) => normalizePath(s.path)));
+  return { saved, recent: recent.filter((r) => !savedPaths.has(normalizePath(r.path))) };
+}
+
+/** Fetches and filters the saved + recent project lists shared by the main
+ *  Project step and the extra-repos picker (#3743), so both offer the same
+ *  search-over-saved-and-recent experience instead of two divergent UIs. */
+export function useProjectPicker(excludePaths: string[] = []) {
+  const [recent, setRecent] = useState<RecentProject[]>([]);
+  const [saved, setSaved] = useState<ProjectInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([fetchSessions(), fetchRecentProjects(), fetchProjects()]).then(
+      ([envelope, recentEnvelope, savedProjects]) => {
+        if (cancelled) return;
+        const sessionDerived = envelope ? collectRecentProjects(envelope.sessions) : [];
+        const merged = mergeRecentProjects(sessionDerived, recentEnvelope?.projects ?? []);
+        const split = splitSavedAndRecent(savedProjects, merged);
+        setSaved(split.saved);
+        setRecent(split.recent);
+        setLoading(false);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const excluded = useMemo(() => new Set(excludePaths.map(normalizePath)), [excludePaths]);
+  const visibleSaved = useMemo(() => saved.filter((s) => !excluded.has(normalizePath(s.path))), [saved, excluded]);
+  const visibleRecent = useMemo(() => recent.filter((r) => !excluded.has(normalizePath(r.path))), [recent, excluded]);
+
+  // #3461: with no query, recents stay capped so the list reads as a short
+  // "jump back in" list. A query searches the whole visible list instead, so
+  // a project sitting below the cap is still reachable by typing.
+  const filteredRecent = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return visibleRecent.slice(0, RECENT_CAP);
+    return visibleRecent.filter((r) => r.path.toLowerCase().includes(q) || r.displayName.toLowerCase().includes(q));
+  }, [visibleRecent, query]);
+
+  const filteredSaved = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return visibleSaved;
+    return visibleSaved.filter((s) => s.path.toLowerCase().includes(q) || s.name.toLowerCase().includes(q));
+  }, [visibleSaved, query]);
+
+  return {
+    loading,
+    saved: visibleSaved,
+    recent: visibleRecent,
+    query,
+    setQuery,
+    filteredSaved,
+    filteredRecent,
+    hasPicks: visibleSaved.length > 0 || visibleRecent.length > 0,
+    // Unfiltered, so a caller can tell "nothing registered at all" apart from
+    // "everything registered got excluded" (e.g. the only saved project is
+    // the primary repo in ExtraReposPicker).
+    hasAnyProjects: saved.length > 0 || recent.length > 0,
+  };
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -837,7 +837,9 @@
         "web/src/components/session-wizard/steps/Toggle.tsx",
         "web/src/components/session-wizard/steps/ExtraReposPicker.tsx",
         "web/src/components/session-wizard/steps/ProjectStep.tsx",
-        "web/src/components/session-wizard/steps/SessionStep.tsx"
+        "web/src/components/session-wizard/steps/SessionStep.tsx",
+        "web/src/components/session-wizard/steps/projectPicker.ts",
+        "web/src/components/session-wizard/steps/ProjectSearchList.tsx"
       ]
     },
     {
@@ -2963,7 +2965,9 @@
       "components": [
         "web/src/components/session-wizard/steps/ExtraReposPicker.tsx",
         "web/src/components/session-wizard/steps/ProjectStep.tsx",
-        "web/src/components/session-wizard/SessionWizard.tsx"
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/steps/projectPicker.ts",
+        "web/src/components/session-wizard/steps/ProjectSearchList.tsx"
       ]
     },
     {
@@ -3277,7 +3281,11 @@
       "kind": "mocked-playwright",
       "risk": "medium",
       "specs": ["tests/wizard-extra-repos.spec.ts"],
-      "components": ["web/src/components/session-wizard/steps/ExtraReposPicker.tsx"]
+      "components": [
+        "web/src/components/session-wizard/steps/ExtraReposPicker.tsx",
+        "web/src/components/session-wizard/steps/projectPicker.ts",
+        "web/src/components/session-wizard/steps/ProjectSearchList.tsx"
+      ]
     },
     {
       "id": "story.wizard-creating-banner",

--- a/web/tests/wizard-extra-repos.spec.ts
+++ b/web/tests/wizard-extra-repos.spec.ts
@@ -2,10 +2,11 @@ import { test, expect } from "./helpers/mockedTest";
 import { Page } from "@playwright/test";
 
 // Wizard Extra repos picker (#1219). Lives under the Project step once
-// a primary path is selected. Covers chip toggle on registered
-// projects, free-text path add via input + Enter / Add button, removal
-// via the X button on selected chips, and the primary-path filtering
-// rule that hides the selected project from the registered list.
+// a primary path is selected. Covers chip toggle on saved projects, the
+// shared search box over saved + recent projects (#3743), free-text path
+// add via input + Enter / Add button, removal via the X button on selected
+// chips, and the primary-path filtering rule that hides the selected
+// project from the picker.
 
 interface MockOptions {
   projects?: Array<{ name: string; path: string; scope: "global" | "profile" }>;
@@ -43,6 +44,7 @@ async function mockApis(page: Page, opts: MockOptions = {}) {
       ],
     }),
   );
+  await page.route("**/api/recent-projects", (r) => r.fulfill({ json: { projects: [] } }));
   await page.route("**/api/sessions", (r) =>
     r.fulfill({
       json: {
@@ -94,7 +96,7 @@ test.describe("Wizard extra repos picker (#1219)", () => {
     // projects list (#3461), so page-wide or wizard-wide button locators are
     // ambiguous.
     const picker = page.getByTestId("extra-repos-picker");
-    await expect(picker.getByText("Registered projects")).toBeVisible();
+    await expect(picker.getByText("Saved projects")).toBeVisible();
     // The primary entry (matching /tmp/example) is hidden from the picker
     // so users can't accidentally duplicate it.
     await expect(picker.getByRole("button").filter({ hasText: /^primary/ })).toHaveCount(0);
@@ -147,6 +149,20 @@ test.describe("Wizard extra repos picker (#1219)", () => {
     await expect(addBtn).toBeEnabled();
     await addBtn.click();
     await expect(page.getByText("1 selected")).toBeVisible();
+  });
+
+  // #3743: extra repos should be just as searchable as the main Project step.
+  test("the picker's own search box filters its saved-projects list", async ({ page }) => {
+    await mockApis(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openProjectStepWithPath(page);
+    const picker = page.getByTestId("extra-repos-picker");
+    // Scoped to the picker: the step's own Recent-tab search box (#3461)
+    // shares the same accessible name and is visible on the same screen.
+    await picker.getByLabel("Search projects").fill("shared");
+    await expect(picker.getByRole("button").filter({ hasText: /^shared-lib/ })).toBeVisible();
+    await expect(picker.getByRole("button").filter({ hasText: /^docs/ })).toHaveCount(0);
   });
 
   test("attempting to add the primary path as a free-text entry is a no-op", async ({ page }) => {


### PR DESCRIPTION
## Description

The extra-repos picker in the session wizard (`ExtraReposPicker.tsx`) offered only an unfiltered chip list of registered projects plus a free-text field, unlike the main Project step's search-over-saved-and-recent list (#3461, PR #3503). Two different UX levels for the same "pick a project path" task, and the weaker one is worse exactly when someone has many repos to choose from.

Extracted the saved/recent fetch+filter logic and its search UI into shared `web/src/components/session-wizard/steps/projectPicker.ts` (hook) and `ProjectSearchList.tsx` (presentational list), and reuse both from `ProjectStep.tsx` and `ExtraReposPicker.tsx`. Extra repos now get their own search box over saved + recent projects, in addition to the existing chip toggle, free-text add, per-repo base branch input, and primary-path exclusion, all of which are unchanged.

Also fixes a copy bug found in review: when the *only* registered project is the primary repo (so nothing is left to add as an extra repo), the picker previously showed "No registered projects yet" even though a project *is* registered — it's just excluded because it's the primary. `useProjectPicker` now also returns an unfiltered `hasAnyProjects`, so `ExtraReposPicker` can show an accurate "No other projects to add" message in that case.

Closes #3743.

![Extra repos picker with its own search box, filtering the saved-projects list while repo-beta is already selected](https://github.com/user-attachments/assets/dc51e607-2e3d-4298-a9f6-27b0108ed4a9)

## PR Type

- [x] New Feature
- [x] Refactor
- [ ] Bug Fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Also added/updated Vitest coverage for both `ProjectStep.tsx` (via the existing suite, now exercising the shared hook) and `ExtraReposPicker.tsx` (new search/recents cases, plus a case for the primary-only empty state).

Manually verified in a real browser: ran `cargo xtask dev`, registered two throwaway projects, and drove the wizard end to end (primary project selection -> extra-repos search box appears -> typing filters the saved list -> selecting toggles a chip -> free-text add still works). Screenshot above is from that session.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Sonnet 5), via the Claude Agent SDK

**Any Additional AI Details you'd like to share:**
Implementation, tests, and this PR description were produced end-to-end by Claude Code (agent session) from the linked issue, including the manual browser-driven verification pass (screenshot above), directed throughout by @cwrau (also the issue author).

- [x] I am an AI Agent filling out this form (check box if true)
