### PR TITLE
fix(status): detect running turns across all omp composer shapes

### DIFF
--- a/src/tmux/detect/manifests/omp.toml
+++ b/src/tmux/detect/manifests/omp.toml
@@ -79,16 +79,37 @@ all = [
   { region = "bottom_non_empty_lines(8)", any = [
     { line_regex = ['(?i)^\s*(?:⎋|\x{f12b7}|esc)\s+\S'] },
     { line_regex = ['(?i)^\s*\S+\s+working(?:…|\.\.\.)'] },
-    { line_regex = ['(?i)[( ]esc to cancel[)]'] },
+    { line_regex = ['(?i)^\s*(?:[\x{2800}-\x{28FF}]|[-\\|/])\s+.*\(esc to cancel\)'] },
     { line_regex = ['(?i)^ {2}cancel\s+\S'] },
   ] },
 ]
 not = [
   { line_regex = ['^\s*(?:(?:╭[─-]*|\+[=-]*)\s*)?(?:\x{e0b6}\s+)?(?:⏱|\x{f017}|◷|◴|⌛)\s+'] },
   # A blocked panel keeps the composer and status row below it; the panel's
-  # own rules must win, so a live selector footer anywhere nearby silences
-  # this rule. Bordered rows only: the phrases alone are draftable prose.
-  { region = "bottom_non_empty_lines(12)", line_regex = ['(?i)^\s*[│|][^\n]*(?:up/down navigate|enter select|space toggle|enter submit|tab regions|current prompt to answer|esc cancel)'] },
+  # own rules must win, so a genuine live dialog silences this rule.
+  # Require the panel's option/cursor structure alongside footer hints so
+  # that quoted or draft footer phrases do not suppress active status.
+  # Live approve/deny panel
+  { region = "bottom_non_empty_lines(12)", all = [
+    { line_regex = ['(?i)^\s*[│|][^\n]*(?:up/down navigate|enter select|esc cancel)'] },
+    { line_regex = ['(?i)^\s*[│|]\s*(?:[\x{276F}\x{f054}>]\s*)?approve\s*[│|]?\s*$'] },
+    { line_regex = ['(?i)^\s*[│|]\s*(?:[\x{276F}\x{f054}>]\s*)?deny\s*[│|]?\s*$'] },
+  ] },
+  # Live plan panel
+  { region = "bottom_non_empty_lines(12)", all = [
+    { line_regex = ['(?i)^\s*[│|][^\n]*(?:tab regions|esc cancel)'] },
+    { line_regex = ['(?i)^\s*[│|]\s*(?:[\x{276F}\x{f054}>]\s*)?approve and execute'] },
+  ] },
+  # Live ask panel
+  { region = "bottom_non_empty_lines(12)", all = [
+    { line_regex = ['(?i)^\s*(?:╭[─-]*|\+[=-]*)\s*ask\b'] },
+    { line_regex = ['^\s*[│|].*[│|]\s*$'], contains_any = [
+      "enter select · n note",
+      "space toggle · enter ",
+      "enter submit · ↑/↓ scroll",
+      "current prompt to answer",
+    ] },
+  ] },
 ]
 
 # Presets without the pi segment expose one bottommost interrupt row.

--- a/src/tmux/detect/manifests/omp.toml
+++ b/src/tmux/detect/manifests/omp.toml
@@ -60,6 +60,37 @@ not = [
   { line_regex = ['^\s*(?:(?:╭[─-]*|\+[=-]*)\s*)?(?:\x{e0b6}\s+)?\p{Ll}\s+(?:0|[1-9]\d*)[smh]\s+\p{Ll}'] },
 ]
 
+# The status line's leading spinner and turn timer: live chrome drawn only
+# while a turn runs, parked at the bottom in every composer shape that keeps
+# a separate status row (claude, rule, pi, borderless, field, rail) and as
+# the band shape's own status row. Idle parks the same slot on the static
+# logo glyph (`π`) or a clock icon, neither of which is a braille frame.
+# Paired with an interrupt row or compaction indicator in the composer stack
+# so that stale historical timers without an active turn are not detected.
+[[rules]]
+id = "active_statusline"
+state = "running"
+priority = 960
+positional = true
+region = "bottom_non_empty_lines(3)"
+visible = true
+line_regex = ['^\s*(?:(?:╭[─-]*|\+[=-]*)\s*)?[\x{2800}-\x{28FF}]\s+(?:0|[1-9]\d*)[smh](?:\s|$)']
+all = [
+  { region = "bottom_non_empty_lines(8)", any = [
+    { line_regex = ['(?i)^\s*(?:⎋|\x{f12b7}|esc)\s+\S'] },
+    { line_regex = ['(?i)^\s*\S+\s+working(?:…|\.\.\.)'] },
+    { line_regex = ['(?i)[( ]esc to cancel[)]'] },
+    { line_regex = ['(?i)^ {2}cancel\s+\S'] },
+  ] },
+]
+not = [
+  { line_regex = ['^\s*(?:(?:╭[─-]*|\+[=-]*)\s*)?(?:\x{e0b6}\s+)?(?:⏱|\x{f017}|◷|◴|⌛)\s+'] },
+  # A blocked panel keeps the composer and status row below it; the panel's
+  # own rules must win, so a live selector footer anywhere nearby silences
+  # this rule. Bordered rows only: the phrases alone are draftable prose.
+  { region = "bottom_non_empty_lines(12)", line_regex = ['(?i)^\s*[│|][^\n]*(?:up/down navigate|enter select|space toggle|enter submit|tab regions|current prompt to answer|esc cancel)'] },
+]
+
 # Presets without the pi segment expose one bottommost interrupt row.
 [[rules]]
 id = "active_interrupt"

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -4324,6 +4324,73 @@ Final prose line.\n";
     }
 
     #[test]
+    fn test_detect_omp_status_running_on_active_statusline() {
+        // Composer shapes where the activity band is pushed above the prompt
+        // (claude, rule, pi, borderless, field, rail) or integrated into the
+        // band row park the live braille spinner in the bottom status line.
+        let cases = [
+            (
+                "claude shape with task band and separate statusline",
+                "  ⎋ Capturing live sessions\n\
+                 ───── ⚙ 1 · Review PR · ⏱ 28.6s ─\n\
+                 ❯\n\
+                 ───────────────────────────────────\n\
+                  ⠏ 28s · 🖥 linus · 🏃 Prewalk",
+            ),
+            (
+                "compaction on claude shape",
+                " ⠧ Auto server compaction… (esc to cancel)\n\
+                 ─ 👥 5 agents · Fix unresolved · ⏱ 9h12m ─\n\
+                 ❯\n\
+                 ───────────────────────────────────\n\
+                  ⠼ 16m · 🖥 linus",
+            ),
+            (
+                "rule shape",
+                "  ⎋ Running tests\n\
+                 ── ⚙ 1 · Test · ⏱ 4s ──\n\
+                 ❯\n\
+                  ⠦ 5s · 🖥 linus",
+            ),
+            (
+                "pi shape",
+                "  ⎋ Running tools\n\
+                 ───────────────────────────────────\n\
+                 Ask anything, edit files, run tools\n\
+                 ───────────────────────────────────\n\
+                  ⠧ 12s · 🖥 linus · gallery",
+            ),
+            (
+                "borderless shape",
+                "  ⎋ Working…\n\
+                 ❯ Ask anything\n\
+                  ⠙ 1m · 🖥 linus",
+            ),
+            (
+                "field shape",
+                "  ⎋ Working…\n\
+                 ▐ Ask anything ▌\n\
+                  ⠸ 3s · 🖥 linus",
+            ),
+            (
+                "rail shape",
+                "  ⎋ Working…\n\
+                 ▎ Ask anything\n\
+                  ⠴ 45s · 🖥 linus",
+            ),
+            (
+                "band shape",
+                "  ⎋ Working…\n\
+                  ⠦ 6s > ⬢ Sonnet > 🗺 Plan\n\
+                 ╰─ Ask anything ─╯",
+            ),
+        ];
+        for (name, pane) in cases {
+            assert_eq!(detect_omp_status(pane), Status::Running, "case: {name}");
+        }
+    }
+
+    #[test]
     fn test_detect_omp_status_active_brand_near_misses_idle() {
         let cases = [
             (
@@ -4390,6 +4457,14 @@ Final prose line.\n";
                 "decorated unicode clock-only first segment",
                 "  ⎋ Working…\n❯\n╭── ⏱ 5m ─╮\n╰─",
             ),
+            (
+                "stale band with parked pi footer",
+                "─ Continue Autonomous · ⏱ 2h4m ─\n❯\n───────────────────────────────────\n π · 🖥 linus",
+            ),
+            (
+                "parked claude shape at prompt",
+                "❯\n───────────────────────────────────\n π · 🖥 linus",
+            ),
         ];
         for (name, pane) in cases {
             assert_eq!(detect_omp_status(pane), Status::Idle, "case: {name}");
@@ -4415,6 +4490,11 @@ Final prose line.\n";
                 "lower active band wins",
                 format!("{approval}\n{band}\n╰─"),
                 Status::Running,
+            ),
+            (
+                "lower approval wins over active statusline",
+                format!("{approval}\n❯\n───────────────────────────────────\n ⠏ 28s · 🖥 linus"),
+                Status::Waiting,
             ),
         ];
         for (name, pane, expected) in cases {

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -4335,7 +4335,7 @@ Final prose line.\n";
                  ───── ⚙ 1 · Review PR · ⏱ 28.6s ─\n\
                  ❯\n\
                  ───────────────────────────────────\n\
-                  ⠏ 28s · 🖥 linus · 🏃 Prewalk",
+                  ⠏ 28s · 🖥 host · 🏃 Prewalk",
             ),
             (
                 "compaction on claude shape",
@@ -4343,14 +4343,14 @@ Final prose line.\n";
                  ─ 👥 5 agents · Fix unresolved · ⏱ 9h12m ─\n\
                  ❯\n\
                  ───────────────────────────────────\n\
-                  ⠼ 16m · 🖥 linus",
+                  ⠼ 16m · 🖥 host",
             ),
             (
                 "rule shape",
                 "  ⎋ Running tests\n\
                  ── ⚙ 1 · Test · ⏱ 4s ──\n\
                  ❯\n\
-                  ⠦ 5s · 🖥 linus",
+                  ⠦ 5s · 🖥 host",
             ),
             (
                 "pi shape",
@@ -4358,31 +4358,39 @@ Final prose line.\n";
                  ───────────────────────────────────\n\
                  Ask anything, edit files, run tools\n\
                  ───────────────────────────────────\n\
-                  ⠧ 12s · 🖥 linus · gallery",
+                  ⠧ 12s · 🖥 host · gallery",
             ),
             (
                 "borderless shape",
                 "  ⎋ Working…\n\
                  ❯ Ask anything\n\
-                  ⠙ 1m · 🖥 linus",
+                  ⠙ 1m · 🖥 host",
             ),
             (
                 "field shape",
                 "  ⎋ Working…\n\
                  ▐ Ask anything ▌\n\
-                  ⠸ 3s · 🖥 linus",
+                  ⠸ 3s · 🖥 host",
             ),
             (
                 "rail shape",
                 "  ⎋ Working…\n\
                  ▎ Ask anything\n\
-                  ⠴ 45s · 🖥 linus",
+                  ⠴ 45s · 🖥 host",
             ),
             (
                 "band shape",
                 "  ⎋ Working…\n\
                   ⠦ 6s > ⬢ Sonnet > 🗺 Plan\n\
                  ╰─ Ask anything ─╯",
+            ),
+            (
+                "active statusline with quoted selector hint is still running",
+                "  ⎋ Running tests\n\
+                 │ up/down navigate  enter select  esc cancel │\n\
+                 ❯\n\
+                 ───────────────────────────────────\n\
+                  ⠏ 28s · 🖥 host",
             ),
         ];
         for (name, pane) in cases {
@@ -4459,11 +4467,18 @@ Final prose line.\n";
             ),
             (
                 "stale band with parked pi footer",
-                "─ Continue Autonomous · ⏱ 2h4m ─\n❯\n───────────────────────────────────\n π · 🖥 linus",
+                "─ Continue Autonomous · ⏱ 2h4m ─\n❯\n───────────────────────────────────\n π · 🖥 host",
             ),
             (
                 "parked claude shape at prompt",
-                "❯\n───────────────────────────────────\n π · 🖥 linus",
+                "❯\n───────────────────────────────────\n π · 🖥 host",
+            ),
+            (
+                "stale parked spinner with prose mentioning esc to cancel",
+                "Some tool output: press (esc to cancel) to abort\n\
+                 ❯\n\
+                 ───────────────────────────────────\n\
+                  ⠏ 28s · 🖥 host",
             ),
         ];
         for (name, pane) in cases {
@@ -4493,7 +4508,7 @@ Final prose line.\n";
             ),
             (
                 "lower approval wins over active statusline",
-                format!("{approval}\n❯\n───────────────────────────────────\n ⠏ 28s · 🖥 linus"),
+                format!("{approval}\n❯\n───────────────────────────────────\n ⠏ 28s · 🖥 host"),
                 Status::Waiting,
             ),
         ];

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -4508,7 +4508,7 @@ Final prose line.\n";
             ),
             (
                 "lower approval wins over active statusline",
-                format!("{approval}\n❯\n───────────────────────────────────\n ⠏ 28s · 🖥 host"),
+                format!("⎋ Running tests\n{approval}\n❯\n───────────────────────────────────\n ⠏ 28s · 🖥 host"),
                 Status::Waiting,
             ),
         ];


### PR DESCRIPTION
## Description
Agent of Empires status detection for OMP (`omp.toml`) fails to detect active turns when OMP is configured with non-box composer shapes (e.g. `composer.shape = claude`, `rule`, `pi`, `borderless`, `field`, `rail`). Sessions stay reported as `Idle` even while actively executing tools or compaction.

In non-box composer shapes, OMP pushes the activity band above the input prompt (`position = 4`) and the interrupt hint (`⎋ <verb>`) above that (`position = 5+`), while parking a separate status line at the very bottom (`position = 1`):
```
  ⎋ Capturing live sessions
───── ⚙ 1 · Review PR · ⏱ 28.6s ─
❯
───────────────────────────────────
 ⠏ 28s · 🖥 host · 🏃 Prewalk
```

The existing `active_brand` rule required the activity band at `max_position = 2` and its interrupt row within `bottom_non_empty_lines(4)`. Furthermore, PR #3788's proposed `active_composer` rule only targeted Unicode box border delimiters (`╭─...╮`), which non-box shapes do not render.

### Solution
Add an `active_statusline` rule in `src/tmux/detect/manifests/omp.toml`:
1. Matches the leading live braille spinner and turn timer (`[\x{2800}-\x{28FF}] <timer>`) at the bottom of the pane (`region = "bottom_non_empty_lines(3)"`).
2. Gated with an `all` requirement on an interrupt row (`⎋`, `esc`, `working…`) or compaction hint (`(esc to cancel)`) within `bottom_non_empty_lines(8)` to ensure stale transcript timers do not trigger false-positive `Running` states when a session is idle.
3. Protected with `not` guards against clock glyphs and nearby bordered waiting/approval panels (`│ up/down navigate enter select esc cancel │`), ensuring `Waiting` states are never masked.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

Added unit regression tests in `src/tmux/status_detection.rs`:
- `test_detect_omp_status_running_on_active_statusline` covering all composer shapes (`claude`, `rule`, `pi`, `borderless`, `field`, `rail`, `band`) and auto server compaction.
- Near-miss idle tests (stale band with parked `π` footer, parked claude shape at prompt) and lowest-marker tests ensuring waiting dialogs win over spinning statuslines.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
Oh My Pi coding harness / gemini-3.8-flash

**Any Additional AI Details you'd like to share:**
AI was used to investigate the root cause across OMP composer layouts, design the manifest rule with positional arbitration and waiting guards, and add regression tests covering all composer shapes.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved OMP running-status detection across all composer shapes.
- Added active statusline detection for live spinners and turn timers.
- Reduced false positives from stale timers, waiting dialogs, approval panels, and quoted text.
- Added regression tests for composer shapes, auto-compaction, idle states, dialogs, and statusline edge cases.

## Benefits

OMP status detection now reports `Running` more reliably and avoids inactive or misleading UI indicators.

## Technical Notes

- Added the `active_statusline` rule.
- Restricted cancellation guards to rows with active spinner glyphs.
- Required panel-specific footer structures before suppressing active status.
- Updated test fixtures with neutral hostnames.

## Potential Enhancement

Add coverage for additional statusline layouts as the OMP interface evolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->