### PR TITLE
fix: restore the lib-test build and make load-Err fixtures root-safe

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -5441,11 +5441,10 @@ cursor-acp-bridge = "agent acp"
             std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
         }
         let session_id = "sw-err-2102";
-        // Force load() -> Err by writing a real record file and stripping
-        // read permission: path.exists() stays true, but std::fs::read
-        // fails with PermissionDenied. (Corrupt JSON is coerced to
-        // Ok(None) by load itself, so it can't drive the Err arm.)
-        use std::os::unix::fs::PermissionsExt;
+        // Force load() -> Err by replacing the record file with a directory:
+        // path.exists() stays true, but std::fs::read fails for every user,
+        // root included. (Corrupt JSON is coerced to Ok(None) by load itself,
+        // so it can't drive the Err arm.)
         let socket_path = crate::process::worker_registry::socket_path_for(session_id).unwrap();
         let record = crate::process::worker_registry::WorkerRecord::new(
             session_id.into(),
@@ -5462,7 +5461,8 @@ cursor-acp-bridge = "agent acp"
         );
         crate::process::worker_registry::save(&record).unwrap();
         let record_path = crate::process::worker_registry::record_path(session_id).unwrap();
-        std::fs::set_permissions(&record_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        std::fs::remove_file(&record_path).unwrap();
+        std::fs::create_dir(&record_path).unwrap();
         assert!(
             crate::process::worker_registry::load(session_id).is_err(),
             "fixture must force load() to return Err"

--- a/src/process/worker_registry.rs
+++ b/src/process/worker_registry.rs
@@ -1275,7 +1275,6 @@ mod tests {
     #[serial]
     fn pid_source_for_falls_back_to_control_socket_on_load_err() {
         with_temp_home(|| {
-            use std::os::unix::fs::PermissionsExt;
             let session_id = "sess-load-err";
             let rec = WorkerRecord::new(
                 session_id.into(),
@@ -1292,7 +1291,10 @@ mod tests {
             );
             save(&rec).unwrap();
             let rec_path = record_path(session_id).unwrap();
-            std::fs::set_permissions(&rec_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+            // Force load() -> Err: a directory keeps path.exists() true while
+            // std::fs::read fails for every user, root included.
+            std::fs::remove_file(&rec_path).unwrap();
+            std::fs::create_dir(&rec_path).unwrap();
             assert!(
                 load(session_id).is_err(),
                 "fixture must force load() to return Err"

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -5181,6 +5181,7 @@ mod tests {
             alive: Arc::new(AtomicBool::new(false)),
             wakeup: Arc::new(Mutex::new(None)),
             clipboard: Arc::new(Mutex::new(None)),
+            links: Arc::new(LinkTable::default()),
             chunk_seq: Arc::new(AtomicU64::new(0)),
             settled_chunk_seq: settled.clone(),
             last_chunk_ms: Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
## Description

`main` does not compile under `cargo test`: #3749 added `ReaderCtx::links`, #3778 added a test that builds a `ReaderCtx`, and the two merged two minutes apart, so neither PR's CI saw the other. Adds the missing field.

Also makes the two `load() -> Err` fixtures root-safe. They forced the error with `chmod 0o000` on the record file, which does not stop a root reader, so both fail in any container that runs tests as root. A directory at the record path keeps `path.exists()` true while `std::fs::read` fails for every user.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --all-targets`, `cargo test` (6784 + 287 pass, 0 fail), and `cargo check --features web --all-targets` are clean.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any Additional AI Details you'd like to share:**

Diagnosed from a local `cargo check --all-targets` and a full test run; the CI queue on main had no completed runs to read.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhXfhqm4KaMPBRujncyqc4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restored `cargo test` compilation by adding the missing `ReaderCtx::links` test field.
- Updated two error fixtures to use directories, so they fail reliably when tests run as root.
- Removed the unused permissions import.
- Formatting, Clippy, tests, and web-feature checks pass.

These changes make the tests more reliable across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->