### PR TITLE
fix(sandbox): reclaim per-session agent stores that no session owns

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -67,6 +67,8 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe project list`↴](#aoe-project-list)
 * [`aoe project add`↴](#aoe-project-add)
 * [`aoe project remove`↴](#aoe-project-remove)
+* [`aoe sandbox`↴](#aoe-sandbox)
+* [`aoe sandbox reclaim`↴](#aoe-sandbox-reclaim)
 * [`aoe worktree`↴](#aoe-worktree)
 * [`aoe worktree list`↴](#aoe-worktree-list)
 * [`aoe worktree info`↴](#aoe-worktree-info)
@@ -149,6 +151,7 @@ Run without arguments to launch the TUI dashboard.
 * `plugin` — Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `profile` — Manage profiles (separate workspaces)
 * `project` — Manage the project registry used by multi-repo session pickers
+* `sandbox` — Inspect and reclaim per-session sandbox agent stores
 * `worktree` — Manage git worktrees for parallel development
 * `tmux` — tmux integration utilities
 * `sounds` — Manage sound effects for agent state transitions
@@ -1103,6 +1106,30 @@ Remove a project from the registry
 
   Possible values: `global`, `profile`
 
+
+
+
+## `aoe sandbox`
+
+Inspect and reclaim per-session sandbox agent stores
+
+**Usage:** `aoe sandbox <COMMAND>`
+
+###### **Subcommands:**
+
+* `reclaim` — Report per-session agent stores whose session no longer exists in any profile, and how much disk they hold. Reports only unless `--delete` is given: each store holds a copy of that agent's credentials
+
+
+
+## `aoe sandbox reclaim`
+
+Report per-session agent stores whose session no longer exists in any profile, and how much disk they hold. Reports only unless `--delete` is given: each store holds a copy of that agent's credentials
+
+**Usage:** `aoe sandbox reclaim [OPTIONS]`
+
+###### **Options:**
+
+* `--delete` — Remove the reported stores instead of only naming them
 
 
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -354,9 +354,14 @@ aoe sandbox reclaim --delete   # remove it
 ```
 
 The report is the default because a store holds a copy of the agent's
-credentials. A store whose container is still running is kept, as is one when
-the container runtime cannot be asked, and the pass refuses to run while a
-store move is in flight.
+credentials. A store is kept when its container is still running under any
+installed runtime, when a runtime cannot be asked, or when it was written to in
+the last fifteen minutes, since a store is seeded before the session that owns
+it is recorded. The pass refuses to run while a store move is in flight.
+
+A session still on the shared legacy store has no private store of its own, so
+deleting it removes its container but leaves that shared store to the
+migration.
 
 ## Worktrees and Sandboxing
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -356,7 +356,7 @@ aoe sandbox reclaim --delete   # remove it
 The report is the default because a store holds a copy of the agent's
 credentials. A store whose container is still running is kept, as is one when
 the container runtime cannot be asked, and the pass refuses to run while a
-store move is still pending.
+store move is in flight.
 
 ## Worktrees and Sandboxing
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -342,6 +342,22 @@ container is still running carries on unaffected, on the shared store. One
 whose container is stopped cannot start until its store has moved, so drop the
 variable or run `aoe migrate` before launching it.
 
+### Reclaiming stores
+
+Permanently deleting a sandboxed session removes its store along with its
+container. Stores stranded before that (or by a delete that kept the container)
+are found by their instance id resolving in no profile:
+
+```bash
+aoe sandbox reclaim            # report what would go, and how much it frees
+aoe sandbox reclaim --delete   # remove it
+```
+
+The report is the default because a store holds a copy of the agent's
+credentials. A store whose container is still running is kept, as is one when
+the container runtime cannot be asked, and the pass refuses to run while a
+store move is still pending.
+
 ## Worktrees and Sandboxing
 
 Git worktrees need the bare repo pattern so the container can reach the repo's git directory. See [Worktrees](worktrees.md#bare-repos).

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -354,10 +354,12 @@ aoe sandbox reclaim --delete   # remove it
 ```
 
 The report is the default because a store holds a copy of the agent's
-credentials. A store is kept when its container is still running under any
-installed runtime, when a runtime cannot be asked, or when it was written to in
-the last fifteen minutes, since a store is seeded before the session that owns
-it is recorded. The pass refuses to run while a store move is in flight.
+credentials. A store is removed only when no container for it exists under any
+installed runtime: a stopped container can be started again, and nothing a
+reclaim can hold would stop it. A store is also kept when a runtime cannot be
+asked, and when it was written to in the last fifteen minutes, since a store is
+seeded before the session that owns it is recorded. The pass refuses to run
+while a store move is in flight.
 
 A session still on the shared legacy store has no private store of its own, so
 deleting it removes its container but leaves that shared store to the

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -22,6 +22,7 @@ use super::profile::ProfileCommands;
 use super::project::ProjectCommands;
 use super::ps::PsArgs;
 use super::remove::RemoveArgs;
+use super::sandbox::SandboxCommands;
 use super::send::SendArgs;
 use super::serve::ServeArgs;
 use super::session::SessionCommands;
@@ -152,6 +153,12 @@ pub enum Commands {
         command: ProjectCommands,
     },
 
+    /// Inspect and reclaim per-session sandbox agent stores
+    Sandbox {
+        #[command(subcommand)]
+        command: SandboxCommands,
+    },
+
     /// Manage git worktrees for parallel development
     Worktree {
         #[command(subcommand)]
@@ -275,6 +282,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "plugin",
     "profile",
     "project",
+    "sandbox",
     "worktree",
     "tmux",
     "sounds",
@@ -323,6 +331,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Plugin { .. } => "plugin",
         Commands::Profile { .. } => "profile",
         Commands::Project { .. } => "project",
+        Commands::Sandbox { .. } => "sandbox",
         Commands::Worktree { .. } => "worktree",
         Commands::Tmux { .. } => "tmux",
         Commands::Sounds { .. } => "sounds",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub mod profile;
 pub mod project;
 pub mod ps;
 pub mod remove;
+pub mod sandbox;
 pub mod send;
 pub mod serve;
 pub mod session;

--- a/src/cli/sandbox.rs
+++ b/src/cli/sandbox.rs
@@ -1,0 +1,84 @@
+//! `aoe sandbox`: inspect and reclaim the per-session agent stores that
+//! sandboxed sessions mount as their agent's config directory.
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+use crate::migrations::progress::format_bytes;
+use crate::session::sandbox_store_reclaim as reclaim;
+
+#[derive(Subcommand)]
+pub enum SandboxCommands {
+    /// Report per-session agent stores whose session no longer exists in any
+    /// profile, and how much disk they hold. Reports only unless `--delete`
+    /// is given: each store holds a copy of that agent's credentials.
+    Reclaim(ReclaimArgs),
+}
+
+#[derive(Args)]
+pub struct ReclaimArgs {
+    /// Remove the reported stores instead of only naming them.
+    #[arg(long)]
+    pub delete: bool,
+}
+
+pub fn run(command: SandboxCommands) -> Result<()> {
+    match command {
+        SandboxCommands::Reclaim(args) => run_reclaim(args),
+    }
+}
+
+fn run_reclaim(args: ReclaimArgs) -> Result<()> {
+    if !args.delete {
+        let plan = reclaim::report()?;
+        print_plan(&plan);
+        if !plan.orphans.is_empty() {
+            println!("\nRun `aoe sandbox reclaim --delete` to remove them.");
+        }
+        return Ok(());
+    }
+
+    let outcome = reclaim::reclaim()?;
+    print_plan(&outcome.plan);
+    println!();
+    if outcome.removed.is_empty() {
+        println!("Removed nothing.");
+    } else {
+        println!(
+            "Removed {} store(s), freeing {}.",
+            outcome.removed.len(),
+            format_bytes(outcome.freed())
+        );
+    }
+    for (path, reason) in &outcome.failures {
+        eprintln!("aoe: kept {}: {reason}", path.display());
+    }
+    Ok(())
+}
+
+fn print_plan(plan: &reclaim::Plan) {
+    println!(
+        "Scanned {} store root(s) against {} session(s) across all profiles.",
+        plan.roots.len(),
+        plan.owners
+    );
+    for (path, reason) in &plan.preserved {
+        println!("  preserved  {}  ({})", path.display(), reason.label());
+    }
+    if plan.orphans.is_empty() {
+        println!("No orphaned agent stores.");
+        return;
+    }
+    for orphan in &plan.orphans {
+        println!(
+            "  orphan     {}  ({})",
+            orphan.path.display(),
+            format_bytes(orphan.bytes)
+        );
+    }
+    println!(
+        "{} orphaned store(s), {} total.",
+        plan.orphans.len(),
+        format_bytes(plan.bytes())
+    );
+}

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -28,6 +28,10 @@ pub fn runtime_binary() -> &'static str {
     }
 }
 
+/// Name prefix every aoe sandbox container carries. Also the filter a batch
+/// listing passes to the runtime, so the two cannot drift.
+pub const SANDBOX_NAME_PREFIX: &str = "aoe-sandbox-";
+
 pub fn get_container_runtime() -> ContainerRuntime {
     if let Ok(cfg) = Config::load() {
         match cfg.sandbox.container_runtime {
@@ -44,7 +48,7 @@ pub fn get_container_runtime() -> ContainerRuntime {
 /// Returns a map of container name -> is_running.
 pub fn batch_container_health() -> HashMap<String, bool> {
     let start = std::time::Instant::now();
-    let map = get_container_runtime().batch_running_states("aoe-sandbox-");
+    let map = get_container_runtime().batch_running_states(SANDBOX_NAME_PREFIX);
     tracing::debug!(
         target: "containers.runtime",
         count = map.len(),
@@ -59,7 +63,7 @@ pub fn batch_container_health() -> HashMap<String, bool> {
 /// name means.
 pub fn batch_container_states() -> HashMap<String, ContainerState> {
     let start = std::time::Instant::now();
-    let map = get_container_runtime().batch_container_states("aoe-sandbox-");
+    let map = get_container_runtime().batch_container_states(SANDBOX_NAME_PREFIX);
     tracing::debug!(
         target: "containers.runtime",
         count = map.len(),
@@ -74,7 +78,7 @@ pub fn batch_container_states() -> HashMap<String, ContainerState> {
 /// usable sample for is absent rather than zeroed.
 pub fn batch_container_stats() -> stats::StatsMap {
     let start = std::time::Instant::now();
-    let map = get_container_runtime().batch_stats("aoe-sandbox-");
+    let map = get_container_runtime().batch_stats(SANDBOX_NAME_PREFIX);
     tracing::debug!(
         target: "containers.runtime",
         count = map.len(),
@@ -157,7 +161,7 @@ impl DockerContainer {
     }
 
     pub fn generate_name(session_id: &str) -> String {
-        format!("aoe-sandbox-{}", truncate_id(session_id, 8))
+        format!("{SANDBOX_NAME_PREFIX}{}", truncate_id(session_id, 8))
     }
 
     pub fn from_session_id(session_id: &str) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,6 +465,9 @@ async fn run(
         Some(Commands::Cityhall { command }) => cli::cityhall::run(command),
         Some(Commands::Serve(args)) => cli::serve::run(&profile, args).await,
         Some(Commands::Url(args)) => cli::url::run(args),
+        // After the migration prework: a pending store transition is finished
+        // by then, so the pass is not refused for work `aoe` was about to do.
+        Some(Commands::Sandbox { command }) => cli::sandbox::run(command),
         Some(Commands::Acp { command }) => cli::acp::run(command).await,
         Some(Commands::AcpRunner(args)) => agent_of_empires::process::runner::run(*args).await,
         None => {

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -339,7 +339,7 @@ fn reconcile_scoped(
     Ok(())
 }
 
-pub(crate) fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
+fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
     if app_dir.join(JOURNAL).exists() {
         return Ok(true);
     }
@@ -361,6 +361,30 @@ pub(crate) fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
                     )
                     || transition_paths(row).ok().flatten().is_some())
         }) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Whether a row's store move is published but not yet finished, so its
+/// private store is being written.
+///
+/// Narrower than [`transition_may_be_pending`], which also answers yes for a
+/// row merely still on the shared store and for a journal naming a legacy root
+/// not yet retired. A parked row holds both of those for as long as it stays
+/// archived or trashed, so neither ever goes back to `false` and neither can
+/// gate a user-facing command. Both describe the legacy `sandbox` root, which
+/// no reclaim pass reads.
+pub(crate) fn transition_in_flight(app_dir: &Path) -> Result<bool> {
+    for registry in load_registries(app_dir)? {
+        let Some(rows) = registry.value.as_array() else {
+            continue;
+        };
+        if rows
+            .iter()
+            .any(|row| transition_paths(row).ok().flatten().is_some())
+        {
             return Ok(true);
         }
     }
@@ -1527,7 +1551,7 @@ fn load_registries(app_dir: &Path) -> Result<Vec<Registry>> {
     load_registry_paths(registry_paths(app_dir)?)
 }
 
-fn profile_for_registry(app_dir: &Path, path: &Path) -> String {
+pub(crate) fn profile_for_registry(app_dir: &Path, path: &Path) -> String {
     path.strip_prefix(app_dir.join("profiles"))
         .ok()
         .and_then(|relative| relative.components().next())
@@ -2304,6 +2328,34 @@ mod tests {
         }
         assert_eq!(batches.get(), 1, "one listing per pass");
         assert_eq!(*inspected.borrow(), ["removing", "missing"]);
+    }
+
+    /// A parked row keeps its shared store, and the journal keeps naming the
+    /// legacy root it holds, for as long as it stays archived. Neither says a
+    /// private store is being written, so neither may gate `aoe sandbox
+    /// reclaim`, which would otherwise refuse on such a machine forever.
+    #[test]
+    fn only_a_published_transition_counts_as_in_flight() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"1111111111111111","sandbox_info":{"enabled":true},"archived_at":"2026-01-01T00:00:00Z"}]"#,
+        )
+        .unwrap();
+        fs::write(app.join(JOURNAL), br#"["/home/u/.claude/sandbox"]"#).unwrap();
+
+        assert!(transition_may_be_pending(&app).unwrap());
+        assert!(!transition_in_flight(&app).unwrap());
+
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"1111111111111111","sandbox_info":{"enabled":true},"sandbox_store_transition_paths":[{"source":"/a","destination":"/b"}]}]"#,
+        )
+        .unwrap();
+
+        assert!(transition_in_flight(&app).unwrap());
     }
 
     /// A machine whose container runtime is absent or unreachable must still

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -94,7 +94,7 @@ thread_local! {
 /// so its next answer asks the runtime again. Publishing calls this because
 /// the copy before it ran without the transition lock, and a container may
 /// have come up meanwhile.
-fn refresh_liveness() {
+pub(crate) fn refresh_liveness() {
     LIVENESS_EPOCH.with(|epoch| epoch.set(epoch.get() + 1));
 }
 
@@ -106,7 +106,7 @@ fn refresh_liveness() {
 /// it; a transitional or unrecognised state is inspected rather than read as
 /// stopped, so a new runtime state can only cost a subprocess, never a copy
 /// out from under a live agent.
-fn batched_running_probe_with(
+pub(crate) fn batched_running_probe_with(
     batch: impl Fn() -> std::collections::HashMap<String, crate::containers::ContainerState>,
     inspect: impl Fn(&str) -> Result<(bool, bool)>,
     announce: bool,
@@ -182,7 +182,7 @@ type ReapProbe<'a> = dyn Fn(&str) -> Result<bool> + 'a;
 /// later `aoe` invocation too. Callers substitute their own fail-closed answer
 /// and leave the row pending. A local I/O fault is a real failure and still
 /// propagates.
-fn runtime_cannot_answer(error: &crate::containers::error::DockerError) -> bool {
+pub(crate) fn runtime_cannot_answer(error: &crate::containers::error::DockerError) -> bool {
     use crate::containers::error::DockerError;
     matches!(
         error,

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -76,7 +76,7 @@ impl CopyState {
 /// `announce` lets the fallback probe say once, per pass, that the runtime
 /// could not be asked; the per-startup reconcile passes `false` so a machine
 /// whose runtime is down is not told the same thing on every command.
-fn batched_running_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
+pub(crate) fn batched_running_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
     batched_running_probe_with(
         crate::containers::batch_container_states,
         probe_container_running,
@@ -164,7 +164,7 @@ fn probe_container_running(id: &str) -> Result<(bool, bool)> {
 
 /// Reports whether a migrated row's container is live. See
 /// [`probe_container_running`] for what an unreachable runtime answers.
-type RunningProbe<'a> = dyn Fn(&str) -> Result<bool> + 'a;
+pub(crate) type RunningProbe<'a> = dyn Fn(&str) -> Result<bool> + 'a;
 
 /// Reaps the stopped container of a row whose store has moved. `Ok(false)`
 /// leaves the row pending; see [`reap_migrated_container`].
@@ -339,7 +339,7 @@ fn reconcile_scoped(
     Ok(())
 }
 
-fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
+pub(crate) fn transition_may_be_pending(app_dir: &Path) -> Result<bool> {
     if app_dir.join(JOURNAL).exists() {
         return Ok(true);
     }
@@ -1536,7 +1536,7 @@ fn profile_for_registry(app_dir: &Path, path: &Path) -> String {
         .to_string()
 }
 
-fn instance_children(root: &Path) -> Result<BTreeSet<std::ffi::OsString>> {
+pub(crate) fn instance_children(root: &Path) -> Result<BTreeSet<std::ffi::OsString>> {
     match fs::symlink_metadata(root) {
         Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
         Ok(_) => bail!(

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -111,6 +111,29 @@ pub(crate) fn batched_running_probe_with(
     inspect: impl Fn(&str) -> Result<(bool, bool)>,
     announce: bool,
 ) -> impl Fn(&str) -> Result<bool> {
+    batched_probe_with(
+        batch,
+        crate::containers::ContainerState::is_live,
+        inspect,
+        "checking which sandbox containers are running",
+        announce,
+    )
+}
+
+/// [`batched_running_probe_with`] over an arbitrary reading of a listed state.
+///
+/// A caller that asks a different question of the same listing reuses the
+/// batching and the fail-closed inspect fallback without changing what the
+/// migration asks. `listed` answers for a state the listing reported; `None`
+/// falls through to `inspect`, which is the only path that can distinguish
+/// "absent" from "could not be asked".
+pub(crate) fn batched_probe_with(
+    batch: impl Fn() -> std::collections::HashMap<String, crate::containers::ContainerState>,
+    listed: impl Fn(crate::containers::ContainerState) -> Option<bool>,
+    inspect: impl Fn(&str) -> Result<(bool, bool)>,
+    step: &'static str,
+    announce: bool,
+) -> impl Fn(&str) -> Result<bool> {
     let snapshot: std::cell::RefCell<
         Option<(
             u64,
@@ -122,7 +145,7 @@ pub(crate) fn batched_running_probe_with(
         let epoch = LIVENESS_EPOCH.with(std::cell::Cell::get);
         let mut snapshot = snapshot.borrow_mut();
         if !matches!(&*snapshot, Some((at, _)) if *at == epoch) {
-            progress::step("checking which sandbox containers are running");
+            progress::step(step);
             *snapshot = Some((epoch, batch()));
         }
         let listed = snapshot
@@ -130,7 +153,7 @@ pub(crate) fn batched_running_probe_with(
             .and_then(|(_, states)| {
                 states.get(&crate::containers::DockerContainer::generate_name(id))
             })
-            .and_then(|state| state.is_live());
+            .and_then(|state| listed(*state));
         drop(snapshot);
         if let Some(live) = listed {
             return Ok(live);
@@ -381,11 +404,13 @@ pub(crate) fn transition_in_flight(app_dir: &Path) -> Result<bool> {
         let Some(rows) = registry.value.as_array() else {
             continue;
         };
-        if rows
-            .iter()
-            .any(|row| transition_paths(row).ok().flatten().is_some())
-        {
-            return Ok(true);
+        // Not `.ok()`: metadata the migration cannot parse is state we cannot
+        // validate, and reading it as "no transition" would let a reclaim run
+        // against a store move it cannot see.
+        for row in rows {
+            if transition_paths(row)?.is_some() {
+                return Ok(true);
+            }
         }
     }
     Ok(false)
@@ -2356,6 +2381,17 @@ mod tests {
         .unwrap();
 
         assert!(transition_in_flight(&app).unwrap());
+
+        // Metadata the migration cannot parse is state it cannot validate, so
+        // it fails rather than reading as "no transition" and letting a
+        // reclaim run against a move it cannot see.
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"1111111111111111","sandbox_info":{"enabled":true},"sandbox_store_transition_paths":5}]"#,
+        )
+        .unwrap();
+
+        assert!(transition_in_flight(&app).is_err());
     }
 
     /// A machine whose container runtime is absent or unreachable must still

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -824,6 +824,57 @@ pub(crate) fn sandbox_store_migration_paths(
     }
     Ok(paths)
 }
+
+/// Every private store root an agent can own: one per config mount, or the
+/// single declared root when the profile points the agent elsewhere. This is
+/// the directory whose children are per-instance stores.
+pub(crate) fn sandbox_store_roots(
+    tool: &str,
+    home: &Path,
+    declared_config_dir: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    for mount in AGENT_CONFIG_MOUNTS
+        .iter()
+        .filter(|mount| mount.tool_name == tool)
+    {
+        let root = declared_config_dir
+            .map(|dir| dir.join(SANDBOX_PRIVATE_SUBDIR))
+            .unwrap_or_else(|| home.join(mount.host_rel).join(SANDBOX_PRIVATE_SUBDIR));
+        if !roots.contains(&root) {
+            roots.push(root);
+        }
+    }
+    roots
+}
+
+/// Every private store one instance owns. [`sandbox_store_dir`] answers for
+/// the mount an agent launches from; reclaiming has to reach the rest too,
+/// since agents such as OpenCode mount config and data separately.
+pub(crate) fn sandbox_store_dirs(
+    tool: &str,
+    home: &Path,
+    declared_config_dir: Option<&Path>,
+    instance_id: &str,
+) -> Result<Vec<PathBuf>> {
+    crate::session::validate_instance_id(instance_id)?;
+    Ok(sandbox_store_roots(tool, home, declared_config_dir)
+        .into_iter()
+        .map(|root| root.join(instance_id))
+        .collect())
+}
+
+/// Tool names with a config mount, deduplicated in table order.
+pub(crate) fn agent_config_mount_tools() -> Vec<&'static str> {
+    let mut tools: Vec<&'static str> = Vec::new();
+    for mount in AGENT_CONFIG_MOUNTS {
+        if !tools.contains(&mount.tool_name) {
+            tools.push(mount.tool_name);
+        }
+    }
+    tools
+}
+
 /// Seed a newly isolated Codex home from the legacy shared sandbox only for the
 /// credential that prior AoE versions migrated there. SQLite state is deliberately
 /// not copied: it is process-local and is the source of the single-instance lock.

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -722,8 +722,16 @@ fn perform_deletion_core(
     // container processes.
     if request.delete_sandbox && is_sandboxed {
         tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
-        deletion_messages_for(teardown(&request.instance.id), &mut messages, &mut errors);
-        stage_remove_agent_stores(request, &mut messages, &mut errors);
+        let outcome = teardown(&request.instance.id);
+        // A failed teardown can leave the container live with the store still
+        // bind mounted, and aborts the purge, so the session keeps running on
+        // the store: only remove it once the container is provably gone. One
+        // stranded by a failed purge is the reclaim pass's job.
+        let container_gone = !matches!(outcome, crate::containers::Teardown::Failed(_));
+        deletion_messages_for(outcome, &mut messages, &mut errors);
+        if container_gone {
+            stage_remove_agent_stores(request, &mut messages, &mut errors);
+        }
     }
 
     stage_remove_worktrees_and_branches(
@@ -1735,6 +1743,31 @@ mod tests {
             perform_deletion_with(&request, |_id| Teardown::Removed);
 
             assert!(store.exists());
+        }
+
+        /// A teardown that failed leaves the container, and the purge is
+        /// rolled back, so the session keeps running on the store it still
+        /// has mounted.
+        #[test]
+        #[serial_test::serial]
+        fn a_failed_teardown_leaves_the_store_for_the_reclaim_pass() {
+            let temp = tempfile::TempDir::new().unwrap();
+            let _home = crate::session::test_support::isolate_app_dir_at(temp.path());
+            let request = sandboxed_request();
+            let store = temp
+                .path()
+                .join(".claude")
+                .join("sandbox-v2")
+                .join(&request.instance.id);
+            std::fs::create_dir_all(&store).unwrap();
+            std::fs::write(store.join(".credentials.json"), b"token").unwrap();
+
+            let result = perform_deletion_with(&request, |_id| {
+                Teardown::Failed(crate::containers::error::DockerError::DaemonNotRunning)
+            });
+
+            assert!(store.exists(), "a failed teardown took the store with it");
+            assert!(!result.success);
         }
     }
 

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -723,6 +723,7 @@ fn perform_deletion_core(
     if request.delete_sandbox && is_sandboxed {
         tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
         deletion_messages_for(teardown(&request.instance.id), &mut messages, &mut errors);
+        stage_remove_agent_stores(request, &mut messages, &mut errors);
     }
 
     stage_remove_worktrees_and_branches(
@@ -1189,6 +1190,29 @@ fn stage_cleanup_scratch(
                 path.display()
             ));
         }
+    }
+}
+
+/// Stage 4: the session's own agent stores. Each holds a copy of the agent's
+/// credentials and is named by an instance id that stops resolving with this
+/// purge, so leaving it behind strands a credential nothing will ever open.
+///
+/// Runs with the container already removed, and only then: the store is bind
+/// mounted into it, so a kept container keeps its store. One that is stranded
+/// anyway is the reclaim pass's job.
+fn stage_remove_agent_stores(
+    request: &DeletionRequest,
+    messages: &mut Vec<String>,
+    errors: &mut Vec<String>,
+) {
+    tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "agent_store_remove", "perform_deletion: stage");
+    match crate::session::sandbox_store_reclaim::remove_stores_for(&request.instance) {
+        Ok((removed, _)) if removed.is_empty() => {}
+        Ok((_, freed)) => messages.push(format!(
+            "Agent store removed ({})",
+            crate::migrations::progress::format_bytes(freed)
+        )),
+        Err(error) => errors.push(format!("Agent store: {error}")),
     }
 }
 
@@ -1666,6 +1690,51 @@ mod tests {
                 "teardown must be invoked unconditionally, never gated behind a probe"
             );
             assert!(result.success);
+        }
+
+        /// The store holds the agent's credentials and is named by an id that
+        /// stops resolving with the purge, so nothing would ever open it
+        /// again and nothing else will find it.
+        #[test]
+        #[serial_test::serial]
+        fn call_site_removes_the_session_agent_store() {
+            let temp = tempfile::TempDir::new().unwrap();
+            let _home = crate::session::test_support::isolate_app_dir_at(temp.path());
+            let request = sandboxed_request();
+            let store = temp
+                .path()
+                .join(".claude")
+                .join("sandbox-v2")
+                .join(&request.instance.id);
+            std::fs::create_dir_all(&store).unwrap();
+            std::fs::write(store.join(".credentials.json"), b"token").unwrap();
+
+            let result = perform_deletion_with(&request, |_id| Teardown::Removed);
+
+            assert!(!store.exists(), "purge left the session's agent store");
+            assert!(result.success, "{:?}", result.errors);
+            assert!(result.messages.iter().any(|m| m.contains("Agent store")));
+        }
+
+        /// A session still on the shared legacy store owns no per-instance
+        /// directory, and v027 may be publishing the one it will own.
+        #[test]
+        #[serial_test::serial]
+        fn a_pre_transition_session_leaves_its_store_to_the_migration() {
+            let temp = tempfile::TempDir::new().unwrap();
+            let _home = crate::session::test_support::isolate_app_dir_at(temp.path());
+            let mut request = sandboxed_request();
+            request.instance.sandbox_store_generation = 0;
+            let store = temp
+                .path()
+                .join(".claude")
+                .join("sandbox-v2")
+                .join(&request.instance.id);
+            std::fs::create_dir_all(&store).unwrap();
+
+            perform_deletion_with(&request, |_id| Teardown::Removed);
+
+            assert!(store.exists());
         }
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -27,6 +27,7 @@ pub mod poller;
 pub mod projects;
 pub(crate) mod recovery;
 pub mod restart;
+pub mod sandbox_store_reclaim;
 pub mod scope;
 pub mod scratch;
 pub(crate) mod serde_helpers;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -324,6 +324,35 @@ pub fn debug_namespace_drift() -> Option<(PathBuf, PathBuf)> {
     }
 }
 
+/// The app dir of the *other* build namespace: the release dir from a debug
+/// build, the dev dir from a release build.
+///
+/// Debug and release builds keep separate app dirs but share `$HOME`, and so
+/// share the agent store roots under it. Anything that decides whether a store
+/// is owned has to read both registries or it will call the other build's
+/// sessions orphans. `None` when the paths cannot be resolved.
+pub(crate) fn sibling_namespace_app_dir() -> Option<PathBuf> {
+    let (xdg, other) = if cfg!(debug_assertions) {
+        ("agent-of-empires", ".agent-of-empires")
+    } else {
+        ("agent-of-empires-dev", ".agent-of-empires-dev")
+    };
+    #[cfg(target_os = "linux")]
+    {
+        let _ = other;
+        xdg_config_base().ok().map(|base| base.join(xdg))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos_app_dir(xdg, other)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = xdg;
+        dirs::home_dir().map(|home| home.join(other))
+    }
+}
+
 /// Format the user-facing warning shown when `debug_namespace_drift()`
 /// fires. Shared between the CLI stderr print and the TUI startup popup so
 /// both surfaces say exactly the same thing.

--- a/src/session/sandbox_store_reclaim.rs
+++ b/src/session/sandbox_store_reclaim.rs
@@ -1,0 +1,573 @@
+//! Reclaim per-instance agent stores whose session is gone.
+//!
+//! A sandboxed session mounts `<agent config>/sandbox-v2/<instance id>` as the
+//! agent's config directory, so the store holds that agent's credentials.
+//! Purging a session removes its own stores; this pass covers the ones already
+//! stranded, including stores left by versions that removed nothing.
+//!
+//! Both are deliberately narrow, because the thing being deleted is a copy of a
+//! live credential:
+//!
+//! - A store is an orphan only when its id resolves in *no* profile. A registry
+//!   that cannot be read is never "a profile with no sessions"; the pass fails
+//!   and deletes nothing.
+//! - Liveness is v027's judgement, not a second one: a store whose container is
+//!   running, or whose path is not a plain directory, is preserved, and a
+//!   container runtime that cannot answer reads as live.
+//! - The pass runs under v027's transition lock and refuses while that
+//!   migration has work outstanding, so it cannot delete a store `aoe migrate`
+//!   is mid-copy of.
+
+use crate::migrations::v027_isolate_sandbox_stores as v027;
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Why a store that resolves in no profile was kept anyway.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Preserved {
+    /// Its container is live. A runtime that cannot answer takes this arm
+    /// too, which is the whole point of v027's probe.
+    Live,
+    /// Not a plain directory, so what it is cannot be established.
+    Ambiguous,
+}
+
+impl Preserved {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Live => "container is running, or the runtime could not be asked",
+            Self::Ambiguous => "not a plain directory",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Orphan {
+    pub id: String,
+    pub path: PathBuf,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct Plan {
+    /// Store roots scanned, in path order.
+    pub roots: Vec<PathBuf>,
+    /// Stores that resolve in no profile and are safe to remove.
+    pub orphans: Vec<Orphan>,
+    /// Stores that resolve in no profile but were kept.
+    pub preserved: Vec<(PathBuf, Preserved)>,
+    /// Session rows that claim a store id, across every profile.
+    pub owners: usize,
+}
+
+impl Plan {
+    pub fn bytes(&self) -> u64 {
+        self.orphans.iter().map(|orphan| orphan.bytes).sum()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Outcome {
+    pub plan: Plan,
+    /// Stores actually removed.
+    pub removed: Vec<Orphan>,
+    pub failures: Vec<(PathBuf, String)>,
+}
+
+impl Outcome {
+    pub fn freed(&self) -> u64 {
+        self.removed.iter().map(|orphan| orphan.bytes).sum()
+    }
+}
+
+/// What would be reclaimed, without removing anything.
+pub fn report() -> Result<Plan> {
+    let app_dir = crate::session::get_app_dir()?;
+    let home = dirs::home_dir().context("home directory unavailable for store reclaim")?;
+    let _lock = guard(&app_dir)?;
+    plan_in(&app_dir, &home, &v027::batched_running_probe(true))
+}
+
+/// Remove every store [`report`] would name.
+pub fn reclaim() -> Result<Outcome> {
+    let app_dir = crate::session::get_app_dir()?;
+    let home = dirs::home_dir().context("home directory unavailable for store reclaim")?;
+    let _lock = guard(&app_dir)?;
+    reclaim_in(&app_dir, &home, &v027::batched_running_probe(true))
+}
+
+/// Hold v027's transition lock for the pass and refuse while that migration
+/// still has work. The lock is exclusive, and `Storage::update` takes it
+/// shared, so no session row can appear or vanish underneath a pass either.
+fn guard(app_dir: &Path) -> Result<crate::session::StorageFlock> {
+    fs::create_dir_all(app_dir)?;
+    let lock = crate::session::acquire_storage_flock(app_dir, v027::LOCK)?;
+    if v027::transition_may_be_pending(app_dir)? {
+        bail!(
+            "the sandbox store migration is still moving stores; run `aoe migrate` and try again"
+        );
+    }
+    Ok(lock)
+}
+
+/// The store ids every profile's registry claims.
+///
+/// Fails rather than answering short. A missing registry file is a profile
+/// with no sessions; a registry that exists but cannot be read, parsed, or
+/// understood is a profile whose sessions we cannot see, and treating its
+/// stores as unowned would delete them.
+fn owned_ids(app_dir: &Path) -> Result<BTreeSet<String>> {
+    let paths = registry_paths(app_dir)?;
+    if paths.is_empty() {
+        bail!(
+            "no session registry under {}; refusing to treat every agent store as unowned",
+            app_dir.display()
+        );
+    }
+    let mut ids = BTreeSet::new();
+    for path in paths {
+        let bytes = fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+        let value: Value = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing {}", path.display()))?;
+        let rows = value
+            .as_array()
+            .with_context(|| format!("{} is not a session array", path.display()))?;
+        for row in rows {
+            let id = row
+                .get("id")
+                .and_then(Value::as_str)
+                .with_context(|| format!("session row without an id in {}", path.display()))?;
+            ids.insert(id.to_string());
+        }
+    }
+    Ok(ids)
+}
+
+/// Every profile's registry, plus the default one. A `sessions.json` that is
+/// present but not a regular file is a registry we cannot read, so it fails
+/// the pass rather than being skipped.
+fn registry_paths(app_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut dirs = vec![app_dir.to_path_buf()];
+    let profiles = app_dir.join("profiles");
+    match fs::read_dir(&profiles) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry?;
+                if entry.file_type()?.is_dir() {
+                    dirs.push(entry.path());
+                }
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error).with_context(|| format!("reading {}", profiles.display())),
+    }
+    let mut paths = Vec::new();
+    for dir in dirs {
+        let path = dir.join("sessions.json");
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_file() => paths.push(path),
+            Ok(_) => bail!(
+                "{} is not a regular file; refusing to reclaim stores without reading it",
+                path.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("inspecting {}", path.display()))
+            }
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+/// Every `sandbox-v2` root any profile can place a store under: the built-in
+/// root per agent config mount, plus the root of each `agent_config_dir` a
+/// profile declares.
+fn store_roots(app_dir: &Path, home: &Path) -> Result<Vec<PathBuf>> {
+    let mut roots: BTreeSet<PathBuf> = BTreeSet::new();
+    let tools = crate::session::config::container_config::agent_config_mount_tools();
+    for tool in &tools {
+        roots.extend(
+            crate::session::config::container_config::sandbox_store_roots(tool, home, None),
+        );
+    }
+    for path in registry_paths(app_dir)? {
+        let profile = profile_of(app_dir, &path);
+        let config = crate::session::config::profile_config::resolve_config_or_warn(&profile);
+        for tool in &tools {
+            let declared = config.session.agent_config_dir_for(tool, home);
+            if declared.is_some() {
+                roots.extend(
+                    crate::session::config::container_config::sandbox_store_roots(
+                        tool,
+                        home,
+                        declared.as_deref(),
+                    ),
+                );
+            }
+        }
+    }
+    Ok(roots.into_iter().collect())
+}
+
+fn profile_of(app_dir: &Path, registry: &Path) -> String {
+    registry
+        .strip_prefix(app_dir.join("profiles"))
+        .ok()
+        .and_then(|relative| relative.components().next())
+        .and_then(|component| component.as_os_str().to_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn plan_in(app_dir: &Path, home: &Path, is_running: &v027::RunningProbe<'_>) -> Result<Plan> {
+    let owned = owned_ids(app_dir)?;
+    let roots = store_roots(app_dir, home)?;
+    let mut plan = Plan {
+        owners: owned.len(),
+        ..Plan::default()
+    };
+    for root in roots {
+        if !root.exists() {
+            continue;
+        }
+        plan.roots.push(root.clone());
+        for child in v027::instance_children(&root)? {
+            let id = child.to_string_lossy().into_owned();
+            if owned.contains(&id) {
+                continue;
+            }
+            let path = root.join(&child);
+            match classify(&path, &id, is_running)? {
+                Some(reason) => plan.preserved.push((path, reason)),
+                None => {
+                    let bytes = directory_bytes(&path)?;
+                    plan.orphans.push(Orphan { id, path, bytes });
+                }
+            }
+        }
+    }
+    Ok(plan)
+}
+
+/// `None` when the store may be removed. Mirrors v027's orphan gate: a path
+/// that is not a plain directory says nothing about what it holds, and a
+/// running container is still writing to it.
+fn classify(
+    path: &Path,
+    id: &str,
+    is_running: &v027::RunningProbe<'_>,
+) -> Result<Option<Preserved>> {
+    let metadata =
+        fs::symlink_metadata(path).with_context(|| format!("inspecting {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(Some(Preserved::Ambiguous));
+    }
+    if is_running(id)? {
+        return Ok(Some(Preserved::Live));
+    }
+    Ok(None)
+}
+
+fn reclaim_in(app_dir: &Path, home: &Path, is_running: &v027::RunningProbe<'_>) -> Result<Outcome> {
+    let plan = plan_in(app_dir, home, is_running)?;
+    let mut outcome = Outcome {
+        plan,
+        ..Outcome::default()
+    };
+    for orphan in &outcome.plan.orphans {
+        // The classification above is re-run against the path as it is now:
+        // cheap next to the removal, and the only thing standing between a
+        // swapped directory and `remove_dir_all`.
+        match classify(&orphan.path, &orphan.id, is_running) {
+            Ok(None) => {}
+            Ok(Some(reason)) => {
+                outcome
+                    .failures
+                    .push((orphan.path.clone(), reason.label().to_string()));
+                continue;
+            }
+            Err(error) => {
+                outcome
+                    .failures
+                    .push((orphan.path.clone(), error.to_string()));
+                continue;
+            }
+        }
+        match fs::remove_dir_all(&orphan.path) {
+            Ok(()) => {
+                tracing::info!(target: "session.store",
+                    "reclaimed orphan agent store {}", orphan.path.display());
+                outcome.removed.push(orphan.clone());
+            }
+            Err(error) => outcome
+                .failures
+                .push((orphan.path.clone(), error.to_string())),
+        }
+    }
+    Ok(outcome)
+}
+
+/// Bytes held by a directory tree, counting symlinks themselves rather than
+/// what they point at.
+fn directory_bytes(root: &Path) -> Result<u64> {
+    let mut total = 0;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error).with_context(|| format!("reading {}", dir.display())),
+        };
+        for entry in entries {
+            let entry = entry?;
+            // `DirEntry::metadata` does not traverse symlinks.
+            let metadata = entry.metadata()?;
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else {
+                total += metadata.len();
+            }
+        }
+    }
+    Ok(total)
+}
+
+/// Remove the stores of one session being purged.
+///
+/// Returns the paths removed and the bytes they held. A session still on a
+/// shared legacy store owns no per-instance directory to remove, and v027 may
+/// be publishing the private one it will own, so it is left to the reclaim
+/// pass.
+pub(crate) fn remove_stores_for(
+    instance: &crate::session::Instance,
+) -> Result<(Vec<PathBuf>, u64)> {
+    if instance.sandbox_store_generation
+        < crate::session::config::container_config::CURRENT_SANDBOX_STORE_GENERATION
+    {
+        return Ok((Vec::new(), 0));
+    }
+    let home = dirs::home_dir().context("home directory unavailable for store removal")?;
+    let Some(agent) = instance.resolved_agent() else {
+        return Ok((Vec::new(), 0));
+    };
+    let config = crate::session::config::profile_config::resolve_config_or_warn(
+        &instance.effective_profile(),
+    );
+    let declared = config.session.agent_config_dir_for(&instance.tool, &home);
+    let mut removed = Vec::new();
+    let mut freed = 0;
+    for path in crate::session::config::container_config::sandbox_store_dirs(
+        agent.name,
+        &home,
+        declared.as_deref(),
+        &instance.id,
+    )? {
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
+            Ok(_) => {
+                tracing::warn!(target: "session.store",
+                    "leaving agent store {}: not a plain directory", path.display());
+                continue;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error).with_context(|| format!("inspecting {}", path.display()))
+            }
+        }
+        let bytes = directory_bytes(&path).unwrap_or(0);
+        fs::remove_dir_all(&path).with_context(|| format!("removing {}", path.display()))?;
+        freed += bytes;
+        removed.push(path);
+    }
+    Ok((removed, freed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app_with_rows(app: &Path, rows: &[&str]) {
+        let ids: Vec<String> = rows
+            .iter()
+            .map(|id| format!(r#"{{"id":"{id}"}}"#))
+            .collect();
+        fs::write(app.join("sessions.json"), format!("[{}]", ids.join(","))).unwrap();
+    }
+
+    fn store(home: &Path, id: &str, bytes: usize) -> PathBuf {
+        let path = home.join(".claude").join("sandbox-v2").join(id);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join(".credentials.json"), vec![b'x'; bytes]).unwrap();
+        path
+    }
+
+    fn quiescent(_: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn live(_: &str) -> Result<bool> {
+        Ok(true)
+    }
+
+    #[test]
+    fn a_store_no_profile_claims_is_an_orphan_and_one_that_is_claimed_is_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &["1111111111111111"]);
+        store(&home, "1111111111111111", 10);
+        let orphan = store(&home, "2222222222222222", 40);
+
+        let plan = plan_in(&app, &home, &quiescent).unwrap();
+
+        assert_eq!(
+            plan.orphans.iter().map(|o| &o.path).collect::<Vec<_>>(),
+            vec![&orphan]
+        );
+        assert_eq!(plan.bytes(), 40);
+        assert!(plan.preserved.is_empty());
+    }
+
+    #[test]
+    fn a_store_claimed_by_another_profile_is_not_an_orphan() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        let other = app.join("profiles").join("work");
+        fs::create_dir_all(&other).unwrap();
+        app_with_rows(&app, &[]);
+        fs::write(
+            other.join("sessions.json"),
+            r#"[{"id":"2222222222222222"}]"#,
+        )
+        .unwrap();
+        store(&home, "2222222222222222", 40);
+
+        let plan = plan_in(&app, &home, &quiescent).unwrap();
+
+        assert!(plan.orphans.is_empty(), "{:?}", plan.orphans);
+        assert_eq!(plan.owners, 1);
+    }
+
+    #[test]
+    fn an_unreadable_registry_fails_the_pass_instead_of_orphaning_everything() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        let broken = app.join("profiles").join("work");
+        fs::create_dir_all(&broken).unwrap();
+        app_with_rows(&app, &[]);
+        store(&home, "2222222222222222", 40);
+
+        for content in [r#"{"not":"an array"}"#, "{", r#"[{"title":"no id"}]"#] {
+            fs::write(broken.join("sessions.json"), content).unwrap();
+            let error = plan_in(&app, &home, &quiescent).unwrap_err();
+            assert!(
+                error.chain().any(|cause| {
+                    let text = cause.to_string();
+                    text.contains("sessions.json") || text.contains("session array")
+                }),
+                "{content}: {error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_registry_at_all_fails_rather_than_reclaiming_every_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        store(&home, "2222222222222222", 40);
+
+        let error = plan_in(&app, &home, &quiescent).unwrap_err();
+
+        assert!(error.to_string().contains("refusing"), "{error:#}");
+    }
+
+    #[test]
+    fn a_live_orphan_is_preserved_and_never_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &[]);
+        let path = store(&home, "2222222222222222", 40);
+
+        let outcome = reclaim_in(&app, &home, &live).unwrap();
+
+        assert!(outcome.removed.is_empty());
+        assert_eq!(
+            outcome.plan.preserved,
+            vec![(path.clone(), Preserved::Live)]
+        );
+        assert!(path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_store_is_preserved_and_its_target_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &[]);
+        let target = dir.path().join("elsewhere");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("keep"), b"keep").unwrap();
+        let root = home.join(".claude").join("sandbox-v2");
+        fs::create_dir_all(&root).unwrap();
+        let link = root.join("2222222222222222");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let outcome = reclaim_in(&app, &home, &quiescent).unwrap();
+
+        assert_eq!(
+            outcome.plan.preserved,
+            vec![(link.clone(), Preserved::Ambiguous)]
+        );
+        assert!(target.join("keep").exists());
+    }
+
+    #[test]
+    fn reclaiming_removes_the_orphan_and_reports_what_it_freed() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &["1111111111111111"]);
+        let kept = store(&home, "1111111111111111", 10);
+        let orphan = store(&home, "2222222222222222", 40);
+
+        let outcome = reclaim_in(&app, &home, &quiescent).unwrap();
+
+        assert!(!orphan.exists());
+        assert!(kept.exists());
+        assert_eq!(outcome.freed(), 40);
+        assert!(outcome.failures.is_empty());
+    }
+
+    #[test]
+    fn a_directory_that_is_not_an_instance_id_is_never_touched() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &[]);
+        let staging = home
+            .join(".claude")
+            .join("sandbox-v2")
+            .join(".v027-staging");
+        fs::create_dir_all(&staging).unwrap();
+
+        let outcome = reclaim_in(&app, &home, &quiescent).unwrap();
+
+        assert!(staging.exists());
+        assert!(outcome.plan.orphans.is_empty());
+    }
+}

--- a/src/session/sandbox_store_reclaim.rs
+++ b/src/session/sandbox_store_reclaim.rs
@@ -13,7 +13,13 @@
 //!   no sessions"; the pass fails and deletes nothing.
 //! - Liveness is v027's judgement, not a second one: a store whose container is
 //!   running, or whose path is not a plain directory, is preserved, and a
-//!   container runtime that cannot answer reads as live.
+//!   container runtime that cannot answer reads as live. It is asked of every
+//!   runtime installed, not just the one this build's config names, because
+//!   ownership spans both build namespaces and each can name a different one.
+//! - A store seeded moments ago is preserved. Container preparation seeds the
+//!   store before the session row is inserted (`cli::add` runs `on_create`
+//!   hooks, and so `get_container_for_instance`, before it persists), so a
+//!   just-created store is briefly indistinguishable from an orphan.
 //! - The pass runs under v027's transition lock and refuses while a store move
 //!   is mid-flight. It cannot see a half-copied store either way: v027 copies
 //!   into `.v027-stage-<id>` and renames, and only a bare 16-hex name is ever a
@@ -35,6 +41,9 @@ pub enum Preserved {
     Live,
     /// Not a plain directory, so what it is cannot be established.
     Ambiguous,
+    /// Written to moments ago, so it may be a store being seeded for a session
+    /// whose row is not inserted yet.
+    Recent,
 }
 
 impl Preserved {
@@ -42,6 +51,7 @@ impl Preserved {
         match self {
             Self::Live => "container is running, or the runtime could not be asked",
             Self::Ambiguous => "not a plain directory",
+            Self::Recent => "written to too recently to rule out a session being created",
         }
     }
 }
@@ -90,12 +100,13 @@ impl Outcome {
 pub fn report() -> Result<Plan> {
     let app_dir = crate::session::get_app_dir()?;
     let home = dirs::home_dir().context("home directory unavailable for store reclaim")?;
-    let _lock = guard(&app_dir)?;
+    let _locks = guard(&app_dir)?;
     plan_in(
         &app_dir,
         &also_owned(&app_dir),
         &home,
-        &v027::batched_running_probe(true),
+        CREATION_GRACE,
+        &every_runtime_probe(true),
     )
 }
 
@@ -103,13 +114,88 @@ pub fn report() -> Result<Plan> {
 pub fn reclaim() -> Result<Outcome> {
     let app_dir = crate::session::get_app_dir()?;
     let home = dirs::home_dir().context("home directory unavailable for store reclaim")?;
-    let _lock = guard(&app_dir)?;
+    let _locks = guard(&app_dir)?;
     reclaim_in(
         &app_dir,
         &also_owned(&app_dir),
         &home,
-        &v027::batched_running_probe(true),
+        CREATION_GRACE,
+        &every_runtime_probe(true),
     )
+}
+
+/// How recently a store may have been written to and still be reclaimed.
+///
+/// Container preparation seeds a store before the session row exists, so
+/// within this window an orphan and a session being created look the same. A
+/// store stranded by a purge is minutes to months old, so the cost of the
+/// window is nothing and it closes the only gap the locks cannot.
+const CREATION_GRACE: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+
+/// Liveness asked of every container runtime installed, not just the one this
+/// build's config names.
+///
+/// `get_container_runtime` resolves through `Config::load`, whose path is the
+/// invoking build's app dir, and each namespace (or profile) can name a
+/// different runtime. Asking only ours would read a store mounted into a
+/// running container of another runtime as quiescent and delete it. Each
+/// runtime is asked through v027's own probe, so the fail-closed answer for a
+/// runtime that cannot be reached is unchanged; a runtime that is not
+/// installed holds no containers and contributes nothing.
+fn every_runtime_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
+    let constructors: Vec<fn() -> crate::containers::ContainerRuntime> = vec![
+        crate::containers::ContainerRuntime::docker,
+        crate::containers::ContainerRuntime::podman,
+        // Apple's runtime exists only on macOS; probing it elsewhere would let
+        // an unrelated binary named `container` decide whether a store lives.
+        #[cfg(target_os = "macos")]
+        crate::containers::ContainerRuntime::apple_container,
+    ];
+    let probes: Vec<Box<v027::RunningProbe<'static>>> = constructors
+        .into_iter()
+        .map(|new| {
+            Box::new(v027::batched_running_probe_with(
+                move || new().batch_container_states(crate::containers::SANDBOX_NAME_PREFIX),
+                move |id| probe_running_with(new(), id),
+                announce,
+            )) as Box<v027::RunningProbe<'static>>
+        })
+        .collect();
+    move |id: &str| any_live(&probes, id)
+}
+
+/// Live if any runtime says so. Short-circuits, so a runtime that cannot
+/// answer (and therefore answers "live") keeps the store without the rest
+/// being asked.
+fn any_live(probes: &[Box<v027::RunningProbe<'_>>], id: &str) -> Result<bool> {
+    for probe in probes {
+        if probe(id)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// One runtime's answer for one id, in the shape v027's probe expects: whether
+/// it is running, and whether that is the fail-closed substitute for a runtime
+/// that could not be asked. A runtime that is not installed answers a
+/// definitive "not running": it has no containers to hold this store.
+fn probe_running_with(
+    runtime: crate::containers::ContainerRuntime,
+    id: &str,
+) -> Result<(bool, bool)> {
+    let name = crate::containers::DockerContainer::generate_name(id);
+    match runtime.is_container_running(&name) {
+        Ok(running) => Ok((running, false)),
+        Err(crate::containers::error::DockerError::NotInstalled) => Ok((false, false)),
+        Err(error) if v027::runtime_cannot_answer(&error) => {
+            tracing::warn!(
+                "sandbox reclaim treating {id} as live: container runtime unavailable ({error})"
+            );
+            Ok((true, true))
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// App dirs beyond our own whose sessions still claim a store under these
@@ -123,25 +209,36 @@ fn also_owned(app_dir: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Hold v027's transition lock for the pass and refuse while a store move is
-/// mid-flight. The lock is exclusive, and `Storage::update` takes it shared,
-/// so no session row can appear or vanish underneath a pass either.
+/// Serialise reclaim passes against each other, and hold v027's transition
+/// lock for the duration.
+///
+/// The transition lock is taken *shared*. Exclusive would also block
+/// `Storage::update`, which is what publishes the session row for a store
+/// being created: holding it exclusively turns the creation race below into a
+/// guaranteed loss by preventing the very insert that would mark the store
+/// owned. Shared still excludes v027's own planning and publishing, which take
+/// it exclusively, and v027's copy phase holds no transition lock at all, so
+/// exclusivity buys nothing there either.
 ///
 /// A row that is merely still on the shared store does not block the pass: it
 /// owns no private store to reclaim yet, and the one it will own carries its
 /// id, which this pass reads as claimed. Blocking on that instead would refuse
 /// forever on any machine holding an archived or trashed pre-transition
 /// session, since those keep their shared store until they are started again.
-fn guard(app_dir: &Path) -> Result<crate::session::StorageFlock> {
+fn guard(app_dir: &Path) -> Result<(crate::session::StorageFlock, crate::session::StorageFlock)> {
     fs::create_dir_all(app_dir)?;
-    let lock = crate::session::acquire_storage_flock(app_dir, v027::LOCK)?;
+    let pass = crate::session::acquire_storage_flock(app_dir, RECLAIM_LOCK)?;
+    let transition = crate::session::acquire_storage_shared_flock(app_dir, v027::LOCK)?;
     if v027::transition_in_flight(app_dir)? {
         bail!(
             "the sandbox store migration is still moving stores; run `aoe migrate` and try again"
         );
     }
-    Ok(lock)
+    Ok((pass, transition))
 }
+
+/// Serialises reclaim passes so two do not race to remove the same store.
+const RECLAIM_LOCK: &str = ".sandbox-reclaim.lock";
 
 /// The store ids every profile's registry claims.
 ///
@@ -188,9 +285,13 @@ fn registry_paths(app_dir: &Path) -> Result<Vec<PathBuf>> {
     match fs::read_dir(&profiles) {
         Ok(entries) => {
             for entry in entries {
-                let entry = entry?;
-                if entry.file_type()?.is_dir() {
-                    dirs.push(entry.path());
+                let path = entry?.path();
+                // Resolved, not `DirEntry::file_type`, which does not follow
+                // symlinks: a symlinked profile directory would be skipped and
+                // its sessions would read as unowned. Reading more registries
+                // is always the safe direction here.
+                if fs::metadata(&path).is_ok_and(|metadata| metadata.is_dir()) {
+                    dirs.push(path);
                 }
             }
         }
@@ -200,15 +301,26 @@ fn registry_paths(app_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     for dir in dirs {
         let path = dir.join("sessions.json");
-        match fs::symlink_metadata(&path) {
+        // Presence is decided without following, resolution with: a registry
+        // that is there but cannot be resolved to a regular file (a dangling
+        // symlink, a directory) is one we cannot read, and reading none of it
+        // would call its sessions orphans.
+        if fs::symlink_metadata(&path).is_err() {
+            continue;
+        }
+        match fs::metadata(&path) {
             Ok(metadata) if metadata.is_file() => paths.push(path),
             Ok(_) => bail!(
                 "{} is not a regular file; refusing to reclaim stores without reading it",
                 path.display()
             ),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => {
-                return Err(error).with_context(|| format!("inspecting {}", path.display()))
+                return Err(error).with_context(|| {
+                    format!(
+                        "{} cannot be resolved; refusing to reclaim stores without reading it",
+                        path.display()
+                    )
+                })
             }
         }
     }
@@ -250,6 +362,7 @@ fn plan_in(
     app_dir: &Path,
     also_owned: &[PathBuf],
     home: &Path,
+    grace: std::time::Duration,
     is_running: &v027::RunningProbe<'_>,
 ) -> Result<Plan> {
     let owned = owned_ids(app_dir, also_owned)?;
@@ -269,7 +382,7 @@ fn plan_in(
                 continue;
             }
             let path = root.join(&child);
-            match classify(&path, &id, is_running)? {
+            match classify(&path, &id, grace, is_running)? {
                 Some(reason) => plan.preserved.push((path, reason)),
                 None => {
                     let bytes = directory_bytes(&path);
@@ -287,6 +400,7 @@ fn plan_in(
 fn classify(
     path: &Path,
     id: &str,
+    grace: std::time::Duration,
     is_running: &v027::RunningProbe<'_>,
 ) -> Result<Option<Preserved>> {
     let metadata =
@@ -294,28 +408,62 @@ fn classify(
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
         return Ok(Some(Preserved::Ambiguous));
     }
+    if written_within(&metadata, grace) {
+        return Ok(Some(Preserved::Recent));
+    }
     if is_running(id)? {
         return Ok(Some(Preserved::Live));
     }
     Ok(None)
 }
 
+/// Whether `metadata` was modified inside `window`. An unreadable or
+/// future-dated timestamp counts as recent: it is the arm that keeps the
+/// store.
+fn written_within(metadata: &fs::Metadata, window: std::time::Duration) -> bool {
+    let Ok(modified) = metadata.modified() else {
+        return true;
+    };
+    match std::time::SystemTime::now().duration_since(modified) {
+        Ok(age) => age < window,
+        Err(_) => true,
+    }
+}
+
 fn reclaim_in(
     app_dir: &Path,
     also_owned: &[PathBuf],
     home: &Path,
+    grace: std::time::Duration,
     is_running: &v027::RunningProbe<'_>,
 ) -> Result<Outcome> {
-    let plan = plan_in(app_dir, also_owned, home, is_running)?;
+    let plan = plan_in(app_dir, also_owned, home, grace, is_running)?;
     let mut outcome = Outcome {
         plan,
         ..Outcome::default()
     };
+    // Sizing the plan can take a while on a large store, and a container may
+    // have started since. v027's probe caches its container listing until the
+    // liveness epoch moves, and reclaim is the only thing that can move it
+    // here, so without this the re-check below would replay the planning-time
+    // answer and delete a store that has since been mounted. v027 does the
+    // same before it publishes.
+    v027::refresh_liveness();
+    // Ownership is re-read too: the pass holds the transition lock shared, so
+    // a session created during it can publish its row, and a store that was
+    // unclaimed at planning time may be claimed by the time we reach it.
+    let owned = owned_ids(app_dir, also_owned)?;
     for orphan in &outcome.plan.orphans {
-        // The classification above is re-run against the path as it is now:
-        // cheap next to the removal, and the only thing standing between a
-        // swapped directory and `remove_dir_all`.
-        match classify(&orphan.path, &orphan.id, is_running) {
+        if owned.contains(&orphan.id) {
+            outcome
+                .failures
+                .push((orphan.path.clone(), "claimed since the scan".to_string()));
+            continue;
+        }
+        // Re-classified against the path as it is now, with fresh liveness:
+        // the only thing standing between a swapped or newly live store and
+        // `remove_dir_all`.
+        match classify(&orphan.path, &orphan.id, grace, is_running) {
             Ok(None) => {}
             Ok(Some(reason)) => {
                 outcome
@@ -440,6 +588,10 @@ mod tests {
         path
     }
 
+    /// Tests plant a store and reclaim it in the same millisecond, so the
+    /// creation grace period is opted out of except where it is the subject.
+    const NO_GRACE: std::time::Duration = std::time::Duration::ZERO;
+
     fn quiescent(_: &str) -> Result<bool> {
         Ok(false)
     }
@@ -458,7 +610,7 @@ mod tests {
         store(&home, "1111111111111111", 10);
         let orphan = store(&home, "2222222222222222", 40);
 
-        let plan = plan_in(&app, &[], &home, &quiescent).unwrap();
+        let plan = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
 
         assert_eq!(
             plan.orphans.iter().map(|o| &o.path).collect::<Vec<_>>(),
@@ -483,7 +635,7 @@ mod tests {
         .unwrap();
         store(&home, "2222222222222222", 40);
 
-        let plan = plan_in(&app, &[], &home, &quiescent).unwrap();
+        let plan = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
 
         assert!(plan.orphans.is_empty(), "{:?}", plan.orphans);
         assert_eq!(plan.owners, 1);
@@ -501,7 +653,7 @@ mod tests {
 
         for content in [r#"{"not":"an array"}"#, "{", r#"[{"title":"no id"}]"#] {
             fs::write(broken.join("sessions.json"), content).unwrap();
-            let error = plan_in(&app, &[], &home, &quiescent).unwrap_err();
+            let error = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap_err();
             assert!(
                 error.chain().any(|cause| {
                     let text = cause.to_string();
@@ -520,7 +672,7 @@ mod tests {
         fs::create_dir_all(&app).unwrap();
         store(&home, "2222222222222222", 40);
 
-        let error = plan_in(&app, &[], &home, &quiescent).unwrap_err();
+        let error = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap_err();
 
         assert!(error.to_string().contains("refusing"), "{error:#}");
     }
@@ -534,7 +686,7 @@ mod tests {
         app_with_rows(&app, &[]);
         let path = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &[], &home, &live).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &live).unwrap();
 
         assert!(outcome.removed.is_empty());
         assert_eq!(
@@ -560,7 +712,7 @@ mod tests {
         let link = root.join("2222222222222222");
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
-        let outcome = reclaim_in(&app, &[], &home, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
 
         assert_eq!(
             outcome.plan.preserved,
@@ -579,7 +731,7 @@ mod tests {
         let kept = store(&home, "1111111111111111", 10);
         let orphan = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &[], &home, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
 
         assert!(!orphan.exists());
         assert!(kept.exists());
@@ -630,10 +782,136 @@ mod tests {
         .unwrap();
         let store = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &[sibling], &home, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[sibling], &home, NO_GRACE, &quiescent).unwrap();
 
         assert!(outcome.removed.is_empty(), "{:?}", outcome.removed);
         assert!(store.exists(), "the other build's store was reclaimed");
+    }
+
+    /// Container preparation seeds the store before the session row is
+    /// inserted, so a store written to moments ago may belong to a session
+    /// being created right now rather than to no one.
+    #[test]
+    fn a_store_being_created_is_preserved_until_the_grace_period_lapses() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &[]);
+        let seeding = store(&home, "2222222222222222", 40);
+
+        let outcome = reclaim_in(
+            &app,
+            &[],
+            &home,
+            std::time::Duration::from_secs(600),
+            &quiescent,
+        )
+        .unwrap();
+
+        assert!(seeding.exists(), "a store being seeded was reclaimed");
+        assert_eq!(
+            outcome.plan.preserved,
+            vec![(seeding, Preserved::Recent)],
+            "and the report says why"
+        );
+    }
+
+    /// A store unclaimed when the plan was made can be claimed by the time the
+    /// pass reaches it: the transition lock is held shared precisely so that
+    /// insert is not blocked, so the delete phase has to look again.
+    #[test]
+    fn a_store_claimed_after_the_scan_is_not_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &[]);
+        let path = store(&home, "2222222222222222", 40);
+
+        // The probe runs between planning and deletion, which is where a
+        // concurrent `aoe add` would publish its row.
+        let claim_on_probe = |_: &str| {
+            app_with_rows(&app, &["2222222222222222"]);
+            Ok(false)
+        };
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &claim_on_probe).unwrap();
+
+        assert!(path.exists(), "a store claimed mid-pass was reclaimed");
+        assert!(outcome.removed.is_empty());
+    }
+
+    /// A container of a runtime this build's config does not name still holds
+    /// the store it has mounted, so every runtime is asked and any one of them
+    /// saying live is enough.
+    #[test]
+    fn liveness_is_the_union_of_every_runtime_asked() {
+        let quiet: Box<v027::RunningProbe<'_>> = Box::new(|_| Ok(false));
+        let busy: Box<v027::RunningProbe<'_>> = Box::new(|_| Ok(true));
+        let angry: Box<v027::RunningProbe<'_>> =
+            Box::new(|_| Err(anyhow::anyhow!("runtime exploded")));
+
+        assert!(!any_live(&[], "1111111111111111").unwrap());
+        assert!(!any_live(std::slice::from_ref(&quiet), "1111111111111111").unwrap());
+        assert!(any_live(&[quiet, busy, angry], "1111111111111111").unwrap());
+
+        let angry: Box<v027::RunningProbe<'_>> =
+            Box::new(|_| Err(anyhow::anyhow!("runtime exploded")));
+        assert!(
+            any_live(&[angry], "1111111111111111").is_err(),
+            "a real fault must fail the pass, not read as quiescent"
+        );
+    }
+
+    /// A store live under a runtime this build does not use must survive.
+    #[test]
+    fn a_store_live_under_another_runtime_is_preserved() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &[]);
+        let path = store(&home, "2222222222222222", 40);
+        let probes: Vec<Box<v027::RunningProbe<'_>>> =
+            vec![Box::new(|_| Ok(false)), Box::new(|_| Ok(true))];
+        let any = move |id: &str| any_live(&probes, id);
+
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &any).unwrap();
+
+        assert!(
+            path.exists(),
+            "a store live under another runtime was removed"
+        );
+        assert_eq!(outcome.plan.preserved, vec![(path, Preserved::Live)]);
+    }
+
+    /// `remove_stores_for` must not follow a symlink out of the store root.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn purging_never_follows_a_symlinked_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let _home = crate::session::test_support::isolate_app_dir_at(dir.path());
+        let target = dir.path().join("elsewhere");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("keep"), b"keep").unwrap();
+        let mut instance = crate::session::Instance::new("t", "/tmp/p");
+        let root = dir.path().join(".claude").join("sandbox-v2");
+        fs::create_dir_all(&root).unwrap();
+        let link = root.join(&instance.id);
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        instance.sandbox_store_generation =
+            crate::session::config::container_config::CURRENT_SANDBOX_STORE_GENERATION;
+
+        let (removed, freed) = remove_stores_for(&instance).unwrap();
+
+        assert!(removed.is_empty(), "{removed:?}");
+        assert_eq!(freed, 0);
+        assert!(link.exists(), "the symlink was removed");
+        assert!(
+            target.join("keep").exists(),
+            "the symlink target was followed"
+        );
     }
 
     #[test]
@@ -649,7 +927,7 @@ mod tests {
             .join(".v027-staging");
         fs::create_dir_all(&staging).unwrap();
 
-        let outcome = reclaim_in(&app, &[], &home, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
 
         assert!(staging.exists());
         assert!(outcome.plan.orphans.is_empty());

--- a/src/session/sandbox_store_reclaim.rs
+++ b/src/session/sandbox_store_reclaim.rs
@@ -8,9 +8,9 @@
 //! Both are deliberately narrow, because the thing being deleted is a copy of a
 //! live credential:
 //!
-//! - A store is an orphan only when its id resolves in *no* profile. A registry
-//!   that cannot be read is never "a profile with no sessions"; the pass fails
-//!   and deletes nothing.
+//! - A store is an orphan only when its id resolves in no profile of either
+//!   build namespace. A registry that cannot be read is never "a profile with
+//!   no sessions"; the pass fails and deletes nothing.
 //! - Liveness is v027's judgement, not a second one: a store whose container is
 //!   running, or whose path is not a plain directory, is preserved, and a
 //!   container runtime that cannot answer reads as live.
@@ -61,7 +61,8 @@ pub struct Plan {
     pub orphans: Vec<Orphan>,
     /// Stores that resolve in no profile but were kept.
     pub preserved: Vec<(PathBuf, Preserved)>,
-    /// Session rows that claim a store id, across every profile.
+    /// Session rows that claim a store id, across every profile of both
+    /// build namespaces.
     pub owners: usize,
 }
 

--- a/src/session/sandbox_store_reclaim.rs
+++ b/src/session/sandbox_store_reclaim.rs
@@ -11,11 +11,15 @@
 //! - A store is an orphan only when its id resolves in no profile of either
 //!   build namespace. A registry that cannot be read is never "a profile with
 //!   no sessions"; the pass fails and deletes nothing.
-//! - Liveness is v027's judgement, not a second one: a store whose container is
-//!   running, or whose path is not a plain directory, is preserved, and a
-//!   container runtime that cannot answer reads as live. It is asked of every
-//!   runtime installed, not just the one this build's config names, because
-//!   ownership spans both build namespaces and each can name a different one.
+//! - A store is removed only when *no* container for its id exists, under any
+//!   installed runtime. Not merely "not running": a stopped container can be
+//!   started between the check and the removal, and no lock a reclaim can hold
+//!   is observed by `docker start`. Requiring absence closes that race by
+//!   construction, since a container for an id no session owns cannot be
+//!   created either. A runtime that cannot answer reads as "exists", which is
+//!   v027's fail-closed posture. Every runtime is asked, not just the one this
+//!   build's config names, because ownership spans both build namespaces and
+//!   each can name a different one.
 //! - A store seeded moments ago is preserved. Container preparation seeds the
 //!   store before the session row is inserted (`cli::add` runs `on_create`
 //!   hooks, and so `get_container_for_instance`, before it persists), so a
@@ -36,9 +40,9 @@ use std::path::{Path, PathBuf};
 /// Why a store that resolves in no profile was kept anyway.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Preserved {
-    /// Its container is live. A runtime that cannot answer takes this arm
-    /// too, which is the whole point of v027's probe.
-    Live,
+    /// A container for it still exists, running or stopped, so it may be
+    /// started again. A runtime that cannot answer takes this arm too.
+    Retained,
     /// Not a plain directory, so what it is cannot be established.
     Ambiguous,
     /// Written to moments ago, so it may be a store being seeded for a session
@@ -49,7 +53,7 @@ pub enum Preserved {
 impl Preserved {
     pub fn label(self) -> &'static str {
         match self {
-            Self::Live => "container is running, or the runtime could not be asked",
+            Self::Retained => "a container for it still exists, or a runtime could not be asked",
             Self::Ambiguous => "not a plain directory",
             Self::Recent => "written to too recently to rule out a session being created",
         }
@@ -132,16 +136,15 @@ pub fn reclaim() -> Result<Outcome> {
 /// window is nothing and it closes the only gap the locks cannot.
 const CREATION_GRACE: std::time::Duration = std::time::Duration::from_secs(15 * 60);
 
-/// Liveness asked of every container runtime installed, not just the one this
-/// build's config names.
+/// Whether any installed runtime still has a container for this id, in any
+/// state.
 ///
 /// `get_container_runtime` resolves through `Config::load`, whose path is the
 /// invoking build's app dir, and each namespace (or profile) can name a
-/// different runtime. Asking only ours would read a store mounted into a
-/// running container of another runtime as quiescent and delete it. Each
-/// runtime is asked through v027's own probe, so the fail-closed answer for a
-/// runtime that cannot be reached is unchanged; a runtime that is not
-/// installed holds no containers and contributes nothing.
+/// different runtime, so asking only ours would miss a container holding the
+/// store. Each runtime is asked through v027's own probe, so the fail-closed
+/// answer for a runtime that cannot be reached is unchanged; a runtime that is
+/// not installed holds no containers and contributes nothing.
 fn every_runtime_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
     let constructors: Vec<fn() -> crate::containers::ContainerRuntime> = vec![
         crate::containers::ContainerRuntime::docker,
@@ -156,18 +159,18 @@ fn every_runtime_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
         .map(|new| {
             Box::new(v027::batched_running_probe_with(
                 move || new().batch_container_states(crate::containers::SANDBOX_NAME_PREFIX),
-                move |id| probe_running_with(new(), id),
+                move |id| probe_exists_with(new(), id),
                 announce,
             )) as Box<v027::RunningProbe<'static>>
         })
         .collect();
-    move |id: &str| any_live(&probes, id)
+    move |id: &str| any_retained(&probes, id)
 }
 
-/// Live if any runtime says so. Short-circuits, so a runtime that cannot
-/// answer (and therefore answers "live") keeps the store without the rest
+/// Retained if any runtime says so. Short-circuits, so a runtime that cannot
+/// answer (and therefore answers "retained") keeps the store without the rest
 /// being asked.
-fn any_live(probes: &[Box<v027::RunningProbe<'_>>], id: &str) -> Result<bool> {
+fn any_retained(probes: &[Box<v027::RunningProbe<'_>>], id: &str) -> Result<bool> {
     for probe in probes {
         if probe(id)? {
             return Ok(true);
@@ -177,21 +180,19 @@ fn any_live(probes: &[Box<v027::RunningProbe<'_>>], id: &str) -> Result<bool> {
 }
 
 /// One runtime's answer for one id, in the shape v027's probe expects: whether
-/// it is running, and whether that is the fail-closed substitute for a runtime
-/// that could not be asked. A runtime that is not installed answers a
-/// definitive "not running": it has no containers to hold this store.
-fn probe_running_with(
+/// a container exists, and whether that is the fail-closed substitute for a
+/// runtime that could not be asked. A runtime that is not installed answers a
+/// definitive "no": it has no containers to hold this store.
+fn probe_exists_with(
     runtime: crate::containers::ContainerRuntime,
     id: &str,
 ) -> Result<(bool, bool)> {
     let name = crate::containers::DockerContainer::generate_name(id);
-    match runtime.is_container_running(&name) {
+    match runtime.does_container_exist(&name) {
         Ok(running) => Ok((running, false)),
         Err(crate::containers::error::DockerError::NotInstalled) => Ok((false, false)),
         Err(error) if v027::runtime_cannot_answer(&error) => {
-            tracing::warn!(
-                "sandbox reclaim treating {id} as live: container runtime unavailable ({error})"
-            );
+            tracing::warn!("sandbox reclaim keeping {id}: container runtime unavailable ({error})");
             Ok((true, true))
         }
         Err(error) => Err(error.into()),
@@ -287,11 +288,23 @@ fn registry_paths(app_dir: &Path) -> Result<Vec<PathBuf>> {
             for entry in entries {
                 let path = entry?.path();
                 // Resolved, not `DirEntry::file_type`, which does not follow
-                // symlinks: a symlinked profile directory would be skipped and
-                // its sessions would read as unowned. Reading more registries
-                // is always the safe direction here.
-                if fs::metadata(&path).is_ok_and(|metadata| metadata.is_dir()) {
-                    dirs.push(path);
+                // symlinks: a symlinked profile directory would otherwise be
+                // skipped and its sessions would read as unowned. An entry we
+                // cannot stat at all fails the pass rather than being skipped,
+                // for the same reason.
+                match fs::metadata(&path) {
+                    Ok(metadata) if metadata.is_dir() => dirs.push(path),
+                    // A stray file under `profiles/` is not a profile.
+                    Ok(_) => {}
+                    Err(error) => {
+                        return Err(error).with_context(|| {
+                            format!(
+                                "{} cannot be inspected; refusing to reclaim stores \
+                                 without reading every profile",
+                                path.display()
+                            )
+                        })
+                    }
                 }
             }
         }
@@ -301,12 +314,23 @@ fn registry_paths(app_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     for dir in dirs {
         let path = dir.join("sessions.json");
-        // Presence is decided without following, resolution with: a registry
-        // that is there but cannot be resolved to a regular file (a dangling
-        // symlink, a directory) is one we cannot read, and reading none of it
-        // would call its sessions orphans.
-        if fs::symlink_metadata(&path).is_err() {
-            continue;
+        // Only a genuinely absent registry is a profile with no sessions.
+        // Every other failure means a registry we cannot read, and skipping it
+        // would drop its sessions from the ownership inventory and make its
+        // stores look like orphans. Presence is decided without following the
+        // link, resolution with it, so a dangling symlink fails here rather
+        // than reading as absent.
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "{} cannot be inspected; refusing to reclaim stores without reading it",
+                        path.display()
+                    )
+                })
+            }
         }
         match fs::metadata(&path) {
             Ok(metadata) if metadata.is_file() => paths.push(path),
@@ -363,7 +387,7 @@ fn plan_in(
     also_owned: &[PathBuf],
     home: &Path,
     grace: std::time::Duration,
-    is_running: &v027::RunningProbe<'_>,
+    container_exists: &v027::RunningProbe<'_>,
 ) -> Result<Plan> {
     let owned = owned_ids(app_dir, also_owned)?;
     let roots = store_roots(app_dir, home)?;
@@ -382,7 +406,7 @@ fn plan_in(
                 continue;
             }
             let path = root.join(&child);
-            match classify(&path, &id, grace, is_running)? {
+            match classify(&path, &id, grace, container_exists)? {
                 Some(reason) => plan.preserved.push((path, reason)),
                 None => {
                     let bytes = directory_bytes(&path);
@@ -401,7 +425,7 @@ fn classify(
     path: &Path,
     id: &str,
     grace: std::time::Duration,
-    is_running: &v027::RunningProbe<'_>,
+    container_exists: &v027::RunningProbe<'_>,
 ) -> Result<Option<Preserved>> {
     let metadata =
         fs::symlink_metadata(path).with_context(|| format!("inspecting {}", path.display()))?;
@@ -411,8 +435,8 @@ fn classify(
     if written_within(&metadata, grace) {
         return Ok(Some(Preserved::Recent));
     }
-    if is_running(id)? {
-        return Ok(Some(Preserved::Live));
+    if container_exists(id)? {
+        return Ok(Some(Preserved::Retained));
     }
     Ok(None)
 }
@@ -435,35 +459,34 @@ fn reclaim_in(
     also_owned: &[PathBuf],
     home: &Path,
     grace: std::time::Duration,
-    is_running: &v027::RunningProbe<'_>,
+    container_exists: &v027::RunningProbe<'_>,
 ) -> Result<Outcome> {
-    let plan = plan_in(app_dir, also_owned, home, grace, is_running)?;
+    let plan = plan_in(app_dir, also_owned, home, grace, container_exists)?;
     let mut outcome = Outcome {
         plan,
         ..Outcome::default()
     };
-    // Sizing the plan can take a while on a large store, and a container may
-    // have started since. v027's probe caches its container listing until the
-    // liveness epoch moves, and reclaim is the only thing that can move it
-    // here, so without this the re-check below would replay the planning-time
-    // answer and delete a store that has since been mounted. v027 does the
-    // same before it publishes.
-    v027::refresh_liveness();
-    // Ownership is re-read too: the pass holds the transition lock shared, so
-    // a session created during it can publish its row, and a store that was
+    // Ownership is re-read: the pass holds the transition lock shared, so a
+    // session created during it can publish its row, and a store that was
     // unclaimed at planning time may be claimed by the time we reach it.
     let owned = owned_ids(app_dir, also_owned)?;
     for orphan in &outcome.plan.orphans {
+        // Per candidate, not once for the loop. v027's probe caches its
+        // container listing until the liveness epoch moves, and removing an
+        // earlier candidate can take a while, so a snapshot taken before the
+        // first removal is stale by the last. v027 refreshes for the same
+        // reason before it publishes.
+        v027::refresh_liveness();
         if owned.contains(&orphan.id) {
             outcome
                 .failures
                 .push((orphan.path.clone(), "claimed since the scan".to_string()));
             continue;
         }
-        // Re-classified against the path as it is now, with fresh liveness:
-        // the only thing standing between a swapped or newly live store and
-        // `remove_dir_all`.
-        match classify(&orphan.path, &orphan.id, grace, is_running) {
+        // Re-classified against the path as it is now, with fresh container
+        // evidence: the last thing standing between a swapped store, or one
+        // whose container reappeared, and `remove_dir_all`.
+        match classify(&orphan.path, &orphan.id, grace, container_exists) {
             Ok(None) => {}
             Ok(Some(reason)) => {
                 outcome
@@ -592,11 +615,13 @@ mod tests {
     /// creation grace period is opted out of except where it is the subject.
     const NO_GRACE: std::time::Duration = std::time::Duration::ZERO;
 
-    fn quiescent(_: &str) -> Result<bool> {
+    /// No container anywhere for this id.
+    fn gone(_: &str) -> Result<bool> {
         Ok(false)
     }
 
-    fn live(_: &str) -> Result<bool> {
+    /// A container still exists for it.
+    fn retained(_: &str) -> Result<bool> {
         Ok(true)
     }
 
@@ -610,7 +635,7 @@ mod tests {
         store(&home, "1111111111111111", 10);
         let orphan = store(&home, "2222222222222222", 40);
 
-        let plan = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
+        let plan = plan_in(&app, &[], &home, NO_GRACE, &gone).unwrap();
 
         assert_eq!(
             plan.orphans.iter().map(|o| &o.path).collect::<Vec<_>>(),
@@ -635,7 +660,7 @@ mod tests {
         .unwrap();
         store(&home, "2222222222222222", 40);
 
-        let plan = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
+        let plan = plan_in(&app, &[], &home, NO_GRACE, &gone).unwrap();
 
         assert!(plan.orphans.is_empty(), "{:?}", plan.orphans);
         assert_eq!(plan.owners, 1);
@@ -653,7 +678,7 @@ mod tests {
 
         for content in [r#"{"not":"an array"}"#, "{", r#"[{"title":"no id"}]"#] {
             fs::write(broken.join("sessions.json"), content).unwrap();
-            let error = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap_err();
+            let error = plan_in(&app, &[], &home, NO_GRACE, &gone).unwrap_err();
             assert!(
                 error.chain().any(|cause| {
                     let text = cause.to_string();
@@ -672,7 +697,7 @@ mod tests {
         fs::create_dir_all(&app).unwrap();
         store(&home, "2222222222222222", 40);
 
-        let error = plan_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap_err();
+        let error = plan_in(&app, &[], &home, NO_GRACE, &gone).unwrap_err();
 
         assert!(error.to_string().contains("refusing"), "{error:#}");
     }
@@ -686,12 +711,12 @@ mod tests {
         app_with_rows(&app, &[]);
         let path = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &live).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &retained).unwrap();
 
         assert!(outcome.removed.is_empty());
         assert_eq!(
             outcome.plan.preserved,
-            vec![(path.clone(), Preserved::Live)]
+            vec![(path.clone(), Preserved::Retained)]
         );
         assert!(path.exists());
     }
@@ -712,7 +737,7 @@ mod tests {
         let link = root.join("2222222222222222");
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
-        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &gone).unwrap();
 
         assert_eq!(
             outcome.plan.preserved,
@@ -731,7 +756,7 @@ mod tests {
         let kept = store(&home, "1111111111111111", 10);
         let orphan = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &gone).unwrap();
 
         assert!(!orphan.exists());
         assert!(kept.exists());
@@ -782,7 +807,7 @@ mod tests {
         .unwrap();
         let store = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &[sibling], &home, NO_GRACE, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[sibling], &home, NO_GRACE, &gone).unwrap();
 
         assert!(outcome.removed.is_empty(), "{:?}", outcome.removed);
         assert!(store.exists(), "the other build's store was reclaimed");
@@ -800,14 +825,8 @@ mod tests {
         app_with_rows(&app, &[]);
         let seeding = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(
-            &app,
-            &[],
-            &home,
-            std::time::Duration::from_secs(600),
-            &quiescent,
-        )
-        .unwrap();
+        let outcome =
+            reclaim_in(&app, &[], &home, std::time::Duration::from_secs(600), &gone).unwrap();
 
         assert!(seeding.exists(), "a store being seeded was reclaimed");
         assert_eq!(
@@ -851,14 +870,14 @@ mod tests {
         let angry: Box<v027::RunningProbe<'_>> =
             Box::new(|_| Err(anyhow::anyhow!("runtime exploded")));
 
-        assert!(!any_live(&[], "1111111111111111").unwrap());
-        assert!(!any_live(std::slice::from_ref(&quiet), "1111111111111111").unwrap());
-        assert!(any_live(&[quiet, busy, angry], "1111111111111111").unwrap());
+        assert!(!any_retained(&[], "1111111111111111").unwrap());
+        assert!(!any_retained(std::slice::from_ref(&quiet), "1111111111111111").unwrap());
+        assert!(any_retained(&[quiet, busy, angry], "1111111111111111").unwrap());
 
         let angry: Box<v027::RunningProbe<'_>> =
             Box::new(|_| Err(anyhow::anyhow!("runtime exploded")));
         assert!(
-            any_live(&[angry], "1111111111111111").is_err(),
+            any_retained(&[angry], "1111111111111111").is_err(),
             "a real fault must fail the pass, not read as quiescent"
         );
     }
@@ -874,7 +893,7 @@ mod tests {
         let path = store(&home, "2222222222222222", 40);
         let probes: Vec<Box<v027::RunningProbe<'_>>> =
             vec![Box::new(|_| Ok(false)), Box::new(|_| Ok(true))];
-        let any = move |id: &str| any_live(&probes, id);
+        let any = move |id: &str| any_retained(&probes, id);
 
         let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &any).unwrap();
 
@@ -882,7 +901,7 @@ mod tests {
             path.exists(),
             "a store live under another runtime was removed"
         );
-        assert_eq!(outcome.plan.preserved, vec![(path, Preserved::Live)]);
+        assert_eq!(outcome.plan.preserved, vec![(path, Preserved::Retained)]);
     }
 
     /// `remove_stores_for` must not follow a symlink out of the store root.
@@ -914,6 +933,86 @@ mod tests {
         );
     }
 
+    /// A registry that is there but cannot be resolved must abort the pass.
+    /// Skipping it would drop its sessions from the ownership inventory and
+    /// make their stores, which are perfectly readable, look like orphans.
+    ///
+    /// Dangling symlinks rather than permission bits: tests run as root in
+    /// some environments, where a mode of `000` is not an error at all.
+    #[cfg(unix)]
+    #[test]
+    fn an_unresolvable_registry_aborts_before_removing_anything() {
+        type Plant = fn(&Path);
+        let cases: &[(&str, Plant)] = &[
+            ("profile directory", |app: &Path| {
+                std::os::unix::fs::symlink(app.join("nowhere"), app.join("profiles").join("work"))
+                    .unwrap();
+            }),
+            ("registry file", |app: &Path| {
+                let profile = app.join("profiles").join("work");
+                fs::create_dir_all(&profile).unwrap();
+                std::os::unix::fs::symlink(app.join("nowhere"), profile.join("sessions.json"))
+                    .unwrap();
+            }),
+        ];
+
+        for (name, plant) in cases {
+            let dir = tempfile::tempdir().unwrap();
+            let app = dir.path().join("app");
+            let home = dir.path().join("home");
+            fs::create_dir_all(app.join("profiles")).unwrap();
+            app_with_rows(&app, &[]);
+            let orphan = store(&home, "2222222222222222", 40);
+            plant(&app);
+
+            let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &gone);
+
+            assert!(
+                outcome.is_err(),
+                "{name}: an unresolvable registry must fail the pass, \
+                 not empty the ownership set"
+            );
+            assert!(
+                orphan.exists(),
+                "{name}: a store was removed despite the failure"
+            );
+        }
+    }
+
+    /// Removing one store takes time, and a container for a later candidate
+    /// can appear while it happens. Evidence has to be re-taken per candidate,
+    /// not once for the loop.
+    #[test]
+    fn a_candidate_whose_container_appears_mid_pass_survives() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        app_with_rows(&app, &[]);
+        let first = store(&home, "2222222222222222", 40);
+        let second = store(&home, "3333333333333333", 40);
+
+        // Stands in for a container coming up during the first removal: both
+        // stores are unattached while the plan is made, and the second gains a
+        // container the moment the first is gone.
+        let gate = first.clone();
+        let appears = move |_: &str| Ok(!gate.exists());
+
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &appears).unwrap();
+
+        assert!(!first.exists(), "the first orphan should still be removed");
+        assert!(
+            second.exists(),
+            "a store whose container appeared mid-pass was removed"
+        );
+        assert_eq!(
+            outcome.plan.orphans.len(),
+            2,
+            "both were candidates when the plan was made"
+        );
+        assert_eq!(outcome.removed.len(), 1);
+    }
+
     #[test]
     fn a_directory_that_is_not_an_instance_id_is_never_touched() {
         let dir = tempfile::tempdir().unwrap();
@@ -927,7 +1026,7 @@ mod tests {
             .join(".v027-staging");
         fs::create_dir_all(&staging).unwrap();
 
-        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, NO_GRACE, &gone).unwrap();
 
         assert!(staging.exists());
         assert!(outcome.plan.orphans.is_empty());

--- a/src/session/sandbox_store_reclaim.rs
+++ b/src/session/sandbox_store_reclaim.rs
@@ -14,9 +14,11 @@
 //! - Liveness is v027's judgement, not a second one: a store whose container is
 //!   running, or whose path is not a plain directory, is preserved, and a
 //!   container runtime that cannot answer reads as live.
-//! - The pass runs under v027's transition lock and refuses while that
-//!   migration has work outstanding, so it cannot delete a store `aoe migrate`
-//!   is mid-copy of.
+//! - The pass runs under v027's transition lock and refuses while a store move
+//!   is mid-flight. It cannot see a half-copied store either way: v027 copies
+//!   into `.v027-stage-<id>` and renames, and only a bare 16-hex name is ever a
+//!   candidate here, so a store appears to this pass whole or not at all.
+//!   Widening that name filter would break the guarantee.
 
 use crate::migrations::v027_isolate_sandbox_stores as v027;
 use anyhow::{bail, Context, Result};
@@ -88,7 +90,12 @@ pub fn report() -> Result<Plan> {
     let app_dir = crate::session::get_app_dir()?;
     let home = dirs::home_dir().context("home directory unavailable for store reclaim")?;
     let _lock = guard(&app_dir)?;
-    plan_in(&app_dir, &home, &v027::batched_running_probe(true))
+    plan_in(
+        &app_dir,
+        &also_owned(&app_dir),
+        &home,
+        &v027::batched_running_probe(true),
+    )
 }
 
 /// Remove every store [`report`] would name.
@@ -96,16 +103,38 @@ pub fn reclaim() -> Result<Outcome> {
     let app_dir = crate::session::get_app_dir()?;
     let home = dirs::home_dir().context("home directory unavailable for store reclaim")?;
     let _lock = guard(&app_dir)?;
-    reclaim_in(&app_dir, &home, &v027::batched_running_probe(true))
+    reclaim_in(
+        &app_dir,
+        &also_owned(&app_dir),
+        &home,
+        &v027::batched_running_probe(true),
+    )
 }
 
-/// Hold v027's transition lock for the pass and refuse while that migration
-/// still has work. The lock is exclusive, and `Storage::update` takes it
-/// shared, so no session row can appear or vanish underneath a pass either.
+/// App dirs beyond our own whose sessions still claim a store under these
+/// roots. Debug and release builds keep separate app dirs but share `$HOME`,
+/// and so share the store roots under it: reading only our own registry would
+/// call every session of the other build an orphan and delete its credentials.
+fn also_owned(app_dir: &Path) -> Vec<PathBuf> {
+    crate::session::sibling_namespace_app_dir()
+        .filter(|sibling| sibling != app_dir)
+        .into_iter()
+        .collect()
+}
+
+/// Hold v027's transition lock for the pass and refuse while a store move is
+/// mid-flight. The lock is exclusive, and `Storage::update` takes it shared,
+/// so no session row can appear or vanish underneath a pass either.
+///
+/// A row that is merely still on the shared store does not block the pass: it
+/// owns no private store to reclaim yet, and the one it will own carries its
+/// id, which this pass reads as claimed. Blocking on that instead would refuse
+/// forever on any machine holding an archived or trashed pre-transition
+/// session, since those keep their shared store until they are started again.
 fn guard(app_dir: &Path) -> Result<crate::session::StorageFlock> {
     fs::create_dir_all(app_dir)?;
     let lock = crate::session::acquire_storage_flock(app_dir, v027::LOCK)?;
-    if v027::transition_may_be_pending(app_dir)? {
+    if v027::transition_in_flight(app_dir)? {
         bail!(
             "the sandbox store migration is still moving stores; run `aoe migrate` and try again"
         );
@@ -119,13 +148,16 @@ fn guard(app_dir: &Path) -> Result<crate::session::StorageFlock> {
 /// with no sessions; a registry that exists but cannot be read, parsed, or
 /// understood is a profile whose sessions we cannot see, and treating its
 /// stores as unowned would delete them.
-fn owned_ids(app_dir: &Path) -> Result<BTreeSet<String>> {
-    let paths = registry_paths(app_dir)?;
+fn owned_ids(app_dir: &Path, also: &[PathBuf]) -> Result<BTreeSet<String>> {
+    let mut paths = registry_paths(app_dir)?;
     if paths.is_empty() {
         bail!(
             "no session registry under {}; refusing to treat every agent store as unowned",
             app_dir.display()
         );
+    }
+    for dir in also {
+        paths.extend(registry_paths(dir)?);
     }
     let mut ids = BTreeSet::new();
     for path in paths {
@@ -195,7 +227,7 @@ fn store_roots(app_dir: &Path, home: &Path) -> Result<Vec<PathBuf>> {
         );
     }
     for path in registry_paths(app_dir)? {
-        let profile = profile_of(app_dir, &path);
+        let profile = v027::profile_for_registry(app_dir, &path);
         let config = crate::session::config::profile_config::resolve_config_or_warn(&profile);
         for tool in &tools {
             let declared = config.session.agent_config_dir_for(tool, home);
@@ -213,18 +245,13 @@ fn store_roots(app_dir: &Path, home: &Path) -> Result<Vec<PathBuf>> {
     Ok(roots.into_iter().collect())
 }
 
-fn profile_of(app_dir: &Path, registry: &Path) -> String {
-    registry
-        .strip_prefix(app_dir.join("profiles"))
-        .ok()
-        .and_then(|relative| relative.components().next())
-        .and_then(|component| component.as_os_str().to_str())
-        .unwrap_or("")
-        .to_string()
-}
-
-fn plan_in(app_dir: &Path, home: &Path, is_running: &v027::RunningProbe<'_>) -> Result<Plan> {
-    let owned = owned_ids(app_dir)?;
+fn plan_in(
+    app_dir: &Path,
+    also_owned: &[PathBuf],
+    home: &Path,
+    is_running: &v027::RunningProbe<'_>,
+) -> Result<Plan> {
+    let owned = owned_ids(app_dir, also_owned)?;
     let roots = store_roots(app_dir, home)?;
     let mut plan = Plan {
         owners: owned.len(),
@@ -244,7 +271,7 @@ fn plan_in(app_dir: &Path, home: &Path, is_running: &v027::RunningProbe<'_>) -> 
             match classify(&path, &id, is_running)? {
                 Some(reason) => plan.preserved.push((path, reason)),
                 None => {
-                    let bytes = directory_bytes(&path)?;
+                    let bytes = directory_bytes(&path);
                     plan.orphans.push(Orphan { id, path, bytes });
                 }
             }
@@ -272,8 +299,13 @@ fn classify(
     Ok(None)
 }
 
-fn reclaim_in(app_dir: &Path, home: &Path, is_running: &v027::RunningProbe<'_>) -> Result<Outcome> {
-    let plan = plan_in(app_dir, home, is_running)?;
+fn reclaim_in(
+    app_dir: &Path,
+    also_owned: &[PathBuf],
+    home: &Path,
+    is_running: &v027::RunningProbe<'_>,
+) -> Result<Outcome> {
+    let plan = plan_in(app_dir, also_owned, home, is_running)?;
     let mut outcome = Outcome {
         plan,
         ..Outcome::default()
@@ -313,19 +345,21 @@ fn reclaim_in(app_dir: &Path, home: &Path, is_running: &v027::RunningProbe<'_>) 
 
 /// Bytes held by a directory tree, counting symlinks themselves rather than
 /// what they point at.
-fn directory_bytes(root: &Path) -> Result<u64> {
+fn directory_bytes(root: &Path) -> u64 {
     let mut total = 0;
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let entries = match fs::read_dir(&dir) {
-            Ok(entries) => entries,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(error).with_context(|| format!("reading {}", dir.display())),
+        // Sizing is advisory, so a subtree that cannot be read is counted as
+        // zero rather than failing the report. A store that cannot be read
+        // also cannot be removed, and that failure is reported per store.
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
         };
-        for entry in entries {
-            let entry = entry?;
+        for entry in entries.flatten() {
             // `DirEntry::metadata` does not traverse symlinks.
-            let metadata = entry.metadata()?;
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
             if metadata.is_dir() {
                 stack.push(entry.path());
             } else {
@@ -333,7 +367,7 @@ fn directory_bytes(root: &Path) -> Result<u64> {
             }
         }
     }
-    Ok(total)
+    total
 }
 
 /// Remove the stores of one session being purged.
@@ -378,7 +412,7 @@ pub(crate) fn remove_stores_for(
                 return Err(error).with_context(|| format!("inspecting {}", path.display()))
             }
         }
-        let bytes = directory_bytes(&path).unwrap_or(0);
+        let bytes = directory_bytes(&path);
         fs::remove_dir_all(&path).with_context(|| format!("removing {}", path.display()))?;
         freed += bytes;
         removed.push(path);
@@ -423,7 +457,7 @@ mod tests {
         store(&home, "1111111111111111", 10);
         let orphan = store(&home, "2222222222222222", 40);
 
-        let plan = plan_in(&app, &home, &quiescent).unwrap();
+        let plan = plan_in(&app, &[], &home, &quiescent).unwrap();
 
         assert_eq!(
             plan.orphans.iter().map(|o| &o.path).collect::<Vec<_>>(),
@@ -448,7 +482,7 @@ mod tests {
         .unwrap();
         store(&home, "2222222222222222", 40);
 
-        let plan = plan_in(&app, &home, &quiescent).unwrap();
+        let plan = plan_in(&app, &[], &home, &quiescent).unwrap();
 
         assert!(plan.orphans.is_empty(), "{:?}", plan.orphans);
         assert_eq!(plan.owners, 1);
@@ -466,7 +500,7 @@ mod tests {
 
         for content in [r#"{"not":"an array"}"#, "{", r#"[{"title":"no id"}]"#] {
             fs::write(broken.join("sessions.json"), content).unwrap();
-            let error = plan_in(&app, &home, &quiescent).unwrap_err();
+            let error = plan_in(&app, &[], &home, &quiescent).unwrap_err();
             assert!(
                 error.chain().any(|cause| {
                     let text = cause.to_string();
@@ -485,7 +519,7 @@ mod tests {
         fs::create_dir_all(&app).unwrap();
         store(&home, "2222222222222222", 40);
 
-        let error = plan_in(&app, &home, &quiescent).unwrap_err();
+        let error = plan_in(&app, &[], &home, &quiescent).unwrap_err();
 
         assert!(error.to_string().contains("refusing"), "{error:#}");
     }
@@ -499,7 +533,7 @@ mod tests {
         app_with_rows(&app, &[]);
         let path = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &home, &live).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, &live).unwrap();
 
         assert!(outcome.removed.is_empty());
         assert_eq!(
@@ -525,7 +559,7 @@ mod tests {
         let link = root.join("2222222222222222");
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
-        let outcome = reclaim_in(&app, &home, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, &quiescent).unwrap();
 
         assert_eq!(
             outcome.plan.preserved,
@@ -544,12 +578,61 @@ mod tests {
         let kept = store(&home, "1111111111111111", 10);
         let orphan = store(&home, "2222222222222222", 40);
 
-        let outcome = reclaim_in(&app, &home, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, &quiescent).unwrap();
 
         assert!(!orphan.exists());
         assert!(kept.exists());
         assert_eq!(outcome.freed(), 40);
         assert!(outcome.failures.is_empty());
+    }
+
+    #[test]
+    fn a_move_in_flight_blocks_the_pass_but_a_parked_session_does_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        // Archived and trashed rows keep their shared store until they are
+        // started again, so this one is pending for as long as it exists.
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"1111111111111111","sandbox_info":{"enabled":true},"archived_at":"2026-01-01T00:00:00Z"}]"#,
+        )
+        .unwrap();
+
+        guard(&app).expect("a parked pre-transition session must not block the pass");
+
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"1111111111111111","sandbox_info":{"enabled":true},"sandbox_store_transition_paths":[{"source":"/a","destination":"/b"}]}]"#,
+        )
+        .unwrap();
+
+        assert!(guard(&app).is_err(), "a move in flight must block the pass");
+    }
+
+    /// Debug and release builds keep separate app dirs but share `$HOME`, so
+    /// a pass that read only its own registry would delete the credentials of
+    /// every session belonging to the other build.
+    #[test]
+    fn a_session_of_the_other_build_namespace_is_not_an_orphan() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("app");
+        let sibling = dir.path().join("app-dev");
+        let home = dir.path().join("home");
+        fs::create_dir_all(&app).unwrap();
+        fs::create_dir_all(&sibling).unwrap();
+        app_with_rows(&app, &[]);
+        fs::write(
+            sibling.join("sessions.json"),
+            r#"[{"id":"2222222222222222"}]"#,
+        )
+        .unwrap();
+        let store = store(&home, "2222222222222222", 40);
+
+        let outcome = reclaim_in(&app, &[sibling], &home, &quiescent).unwrap();
+
+        assert!(outcome.removed.is_empty(), "{:?}", outcome.removed);
+        assert!(store.exists(), "the other build's store was reclaimed");
     }
 
     #[test]
@@ -565,7 +648,7 @@ mod tests {
             .join(".v027-staging");
         fs::create_dir_all(&staging).unwrap();
 
-        let outcome = reclaim_in(&app, &home, &quiescent).unwrap();
+        let outcome = reclaim_in(&app, &[], &home, &quiescent).unwrap();
 
         assert!(staging.exists());
         assert!(outcome.plan.orphans.is_empty());

--- a/src/session/sandbox_store_reclaim.rs
+++ b/src/session/sandbox_store_reclaim.rs
@@ -157,7 +157,7 @@ fn every_runtime_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
     let probes: Vec<Box<v027::RunningProbe<'static>>> = constructors
         .into_iter()
         .map(|new| {
-            Box::new(v027::batched_running_probe_with(
+            Box::new(presence_probe(
                 move || new().batch_container_states(crate::containers::SANDBOX_NAME_PREFIX),
                 move |id| probe_exists_with(new(), id),
                 announce,
@@ -165,6 +165,29 @@ fn every_runtime_probe(announce: bool) -> impl Fn(&str) -> Result<bool> {
         })
         .collect();
     move |id: &str| any_retained(&probes, id)
+}
+
+/// One runtime's presence answer, batched.
+///
+/// Every listed state counts as present, including `Exited` and `Created`. The
+/// migration's probe reads the same listing for *liveness*, where a stopped
+/// container is `Some(false)` and short-circuits before the fallback; reusing
+/// that here would let an ordinary stopped container read as absent and take
+/// its store with it. Only a container the listing does not mention reaches
+/// the inspect fallback, which is the sole path that can tell "absent" from
+/// "could not be asked".
+fn presence_probe(
+    batch: impl Fn() -> std::collections::HashMap<String, crate::containers::ContainerState>,
+    inspect: impl Fn(&str) -> Result<(bool, bool)>,
+    announce: bool,
+) -> impl Fn(&str) -> Result<bool> {
+    v027::batched_probe_with(
+        batch,
+        |_| Some(true),
+        inspect,
+        "checking which sandbox containers exist",
+        announce,
+    )
 }
 
 /// Retained if any runtime says so. Short-circuits, so a runtime that cannot
@@ -879,6 +902,65 @@ mod tests {
         assert!(
             any_retained(&[angry], "1111111111111111").is_err(),
             "a real fault must fail the pass, not read as quiescent"
+        );
+    }
+
+    /// The batch listing is read for presence, not liveness. A stopped
+    /// container is listed, and the migration's own probe answers `Some(false)`
+    /// for it and short-circuits before the existence fallback; reading the
+    /// listing that way here would let every ordinary stopped container's
+    /// store be reclaimed out from under a restart.
+    ///
+    /// Drives the composed probe with an injected listing rather than a final
+    /// boolean, which is the layer the bug lived in.
+    #[test]
+    fn a_listed_stopped_container_counts_as_present() {
+        use crate::containers::{ContainerState, DockerContainer};
+
+        let id = "2222222222222222";
+        let listed = |state: ContainerState| {
+            let probe = presence_probe(
+                move || {
+                    let mut states = std::collections::HashMap::new();
+                    states.insert(DockerContainer::generate_name(id), state);
+                    states
+                },
+                // Would report the container absent. Reaching it at all for a
+                // listed container is the defect.
+                |_| Ok((false, false)),
+                false,
+            );
+            probe(id).unwrap()
+        };
+
+        for state in [
+            ContainerState::Exited,
+            ContainerState::Created,
+            ContainerState::Dead,
+            ContainerState::Running,
+            ContainerState::Paused,
+            ContainerState::Restarting,
+            ContainerState::Other,
+        ] {
+            v027::refresh_liveness();
+            assert!(listed(state), "{state:?} was read as absent");
+        }
+
+        // Not listed at all: only then does the fallback decide, and it is the
+        // one answer that can distinguish absent from unanswerable.
+        v027::refresh_liveness();
+        let absent = presence_probe(
+            std::collections::HashMap::new,
+            |_| Ok((false, false)),
+            false,
+        );
+        assert!(!absent(id).unwrap());
+        v027::refresh_liveness();
+        let unanswerable =
+            presence_probe(std::collections::HashMap::new, |_| Ok((true, true)), false);
+        assert!(
+            unanswerable(id).unwrap(),
+            "an unreachable runtime must keep the store"
         );
     }
 

--- a/tests/e2e/sandbox.rs
+++ b/tests/e2e/sandbox.rs
@@ -100,3 +100,58 @@ fn test_cli_add_sandbox_on_create_hooks_run_in_container() {
         marker
     );
 }
+
+/// `aoe sandbox reclaim` reports the stores whose session resolves in no
+/// profile, and removes them only when asked. The stub `docker` on PATH
+/// answers "not running" for every container, which is the quiescent arm; the
+/// unstubbed runtime fails closed to "live" and would preserve everything.
+#[test]
+#[parallel]
+fn sandbox_reclaim_reports_before_it_removes() {
+    let mut h = TuiTestHarness::new("sandbox_reclaim");
+    h.install_path_command("docker");
+    let project = h.project_path();
+
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "Reclaim Owner"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let registry = crate::harness::app_dir_in(h.home_path()).join("profiles/default/sessions.json");
+    let rows: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&registry).expect("read registry"))
+            .expect("parse registry");
+    let owned_id = rows[0]["id"].as_str().expect("session id").to_string();
+
+    let root = h.home_path().join(".claude").join("sandbox-v2");
+    let owned = root.join(&owned_id);
+    let orphan = root.join("2222222222222222");
+    for store in [&owned, &orphan] {
+        std::fs::create_dir_all(store).expect("create store");
+        std::fs::write(store.join(".credentials.json"), vec![b'x'; 4096]).expect("write store");
+    }
+
+    let report = h.run_cli(&["sandbox", "reclaim"]);
+    assert!(
+        report.status.success(),
+        "aoe sandbox reclaim failed: {}",
+        String::from_utf8_lossy(&report.stderr)
+    );
+    let reported = String::from_utf8_lossy(&report.stdout);
+    assert!(
+        reported.contains("2222222222222222") && !reported.contains(&owned_id),
+        "report should name only the orphan.\nOutput:\n{reported}"
+    );
+    assert!(orphan.exists(), "a bare report must delete nothing");
+
+    let deleted = h.run_cli(&["sandbox", "reclaim", "--delete"]);
+    assert!(
+        deleted.status.success(),
+        "aoe sandbox reclaim --delete failed: {}",
+        String::from_utf8_lossy(&deleted.stderr)
+    );
+    assert!(!orphan.exists(), "the orphaned store was not removed");
+    assert!(owned.exists(), "a claimed store must survive the pass");
+}

--- a/tests/e2e/sandbox.rs
+++ b/tests/e2e/sandbox.rs
@@ -109,7 +109,16 @@ fn test_cli_add_sandbox_on_create_hooks_run_in_container() {
 #[parallel]
 fn sandbox_reclaim_reports_before_it_removes() {
     let mut h = TuiTestHarness::new("sandbox_reclaim");
-    h.install_path_command("docker");
+    // A runtime that lists nothing and reports every container absent. The
+    // reclaim keeps any store a container still exists for, so a stub that
+    // merely exits 0 would report every store as attached.
+    let bin = h.install_path_command("docker");
+    std::fs::write(
+        bin.join("docker"),
+        "#!/bin/sh\ncase \"$1\" in\n  ps) exit 0 ;;\nesac\n\
+         echo \"Error: No such container: $3\" >&2\nexit 1\n",
+    )
+    .expect("write docker stub");
     let project = h.project_path();
 
     let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "Reclaim Owner"]);

--- a/tests/e2e/sandbox.rs
+++ b/tests/e2e/sandbox.rs
@@ -131,6 +131,13 @@ fn sandbox_reclaim_reports_before_it_removes() {
     for store in [&owned, &orphan] {
         std::fs::create_dir_all(store).expect("create store");
         std::fs::write(store.join(".credentials.json"), vec![b'x'; 4096]).expect("write store");
+        // Past the creation grace period, which exists to protect a store
+        // being seeded for a session whose row is not inserted yet.
+        let aged = std::time::SystemTime::now() - std::time::Duration::from_secs(24 * 60 * 60);
+        std::fs::File::open(store)
+            .expect("open store")
+            .set_times(std::fs::FileTimes::new().set_modified(aged))
+            .expect("age store");
     }
 
     let report = h.run_cli(&["sandbox", "reclaim"]);
@@ -146,6 +153,12 @@ fn sandbox_reclaim_reports_before_it_removes() {
     );
     assert!(orphan.exists(), "a bare report must delete nothing");
 
+    // A store written to just now is held back, so a session being created
+    // concurrently cannot have its seeded credentials swept.
+    let fresh = root.join("3333333333333333");
+    std::fs::create_dir_all(&fresh).expect("create fresh store");
+    std::fs::write(fresh.join(".credentials.json"), b"seeding").expect("write fresh store");
+
     let deleted = h.run_cli(&["sandbox", "reclaim", "--delete"]);
     assert!(
         deleted.status.success(),
@@ -154,4 +167,5 @@ fn sandbox_reclaim_reports_before_it_removes() {
     );
     assert!(!orphan.exists(), "the orphaned store was not removed");
     assert!(owned.exists(), "a claimed store must survive the pass");
+    assert!(fresh.exists(), "a store being seeded right now was swept");
 }

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -73,11 +73,13 @@ export function DeleteSessionDialog({
       ? `Removes the workspace branch "${branchName}"`
       : `Removes branch "${branchName}"`
     : undefined;
+  // The agent store holds that session's saved agent login and history, and
+  // goes with the container it is mounted into.
   const sandboxDetail = isWorkspaceDelete
     ? sandboxedSessionCount > 0 && sandboxedSessionCount < sessions.length
-      ? `Removes Docker sandbox containers for ${sandboxedSessionCount} sandboxed ${sandboxedSessionLabel} in this workspace`
-      : "Removes Docker sandbox containers for all sessions in this workspace"
-    : "Removes the Docker sandbox container";
+      ? `Removes Docker sandbox containers and agent stores for ${sandboxedSessionCount} sandboxed ${sandboxedSessionLabel} in this workspace`
+      : "Removes Docker sandbox containers and agent stores for all sessions in this workspace"
+    : "Removes the Docker sandbox container and the session's agent store (its saved agent login)";
   const scratchDetail = isWorkspaceDelete
     ? "Leaves scratch directories on disk; session records are still removed"
     : "Leaves the scratch directory on disk; session record is still removed";

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -74,12 +74,14 @@ export function DeleteSessionDialog({
       : `Removes branch "${branchName}"`
     : undefined;
   // The agent store holds that session's saved agent login and history, and
-  // goes with the container it is mounted into.
+  // goes with the container it is mounted into. Hedged because a session still
+  // on the pre-v027 shared store has no private store of its own to remove;
+  // the dialog cannot see a session's store generation to say which it is.
   const sandboxDetail = isWorkspaceDelete
     ? sandboxedSessionCount > 0 && sandboxedSessionCount < sessions.length
-      ? `Removes Docker sandbox containers and agent stores for ${sandboxedSessionCount} sandboxed ${sandboxedSessionLabel} in this workspace`
-      : "Removes Docker sandbox containers and agent stores for all sessions in this workspace"
-    : "Removes the Docker sandbox container and the session's agent store (its saved agent login)";
+      ? `Removes Docker sandbox containers, and any private agent store, for ${sandboxedSessionCount} sandboxed ${sandboxedSessionLabel} in this workspace`
+      : "Removes Docker sandbox containers, and any private agent store, for all sessions in this workspace"
+    : "Removes the Docker sandbox container and any private agent store it has (including the saved agent login)";
   const scratchDetail = isWorkspaceDelete
     ? "Leaves scratch directories on disk; session records are still removed"
     : "Leaves the scratch directory on disk; session record is still removed";

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -182,7 +182,9 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     expect(container.textContent).toMatch(/Removes the workspace worktree for branch "feature\/foo"/);
     expect(container.textContent).toMatch(/Removes the workspace branch "feature\/foo"/);
     expect(container.textContent).toMatch(/Delete containers/);
-    expect(container.textContent).toMatch(/Removes Docker sandbox containers for all sessions in this workspace/);
+    expect(container.textContent).toMatch(
+      /Removes Docker sandbox containers and agent stores for all sessions in this workspace/,
+    );
     expect(container.textContent).toMatch(/Keep scratch directories/);
     expect(container.textContent).toMatch(/Leaves scratch directories on disk; session records are still removed/);
   });
@@ -197,7 +199,7 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     });
 
     expect(container.textContent).toMatch(
-      /Removes Docker sandbox containers for 1 sandboxed session in this workspace/,
+      /Removes Docker sandbox containers and agent stores for 1 sandboxed session in this workspace/,
     );
   });
 
@@ -331,6 +333,14 @@ describe("DeleteSessionDialog keyboard affordances", () => {
       delete_sandbox: true,
       force_delete: false,
     });
+  });
+
+  it("says the sandbox checkbox removes the agent store, not just the container", () => {
+    const { container } = setup({ hasManagedWorktree: false, isSandboxed: true });
+
+    expect(container.textContent).toMatch(
+      /Removes the Docker sandbox container and the session's agent store \(its saved agent login\)/,
+    );
   });
 
   it("no-options session (no worktree, no sandbox) confirms with an all-false body", () => {

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -183,7 +183,7 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     expect(container.textContent).toMatch(/Removes the workspace branch "feature\/foo"/);
     expect(container.textContent).toMatch(/Delete containers/);
     expect(container.textContent).toMatch(
-      /Removes Docker sandbox containers and agent stores for all sessions in this workspace/,
+      /Removes Docker sandbox containers, and any private agent store, for all sessions in this workspace/,
     );
     expect(container.textContent).toMatch(/Keep scratch directories/);
     expect(container.textContent).toMatch(/Leaves scratch directories on disk; session records are still removed/);
@@ -199,7 +199,7 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     });
 
     expect(container.textContent).toMatch(
-      /Removes Docker sandbox containers and agent stores for 1 sandboxed session in this workspace/,
+      /Removes Docker sandbox containers, and any private agent store, for 1 sandboxed session in this workspace/,
     );
   });
 
@@ -339,7 +339,7 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     const { container } = setup({ hasManagedWorktree: false, isSandboxed: true });
 
     expect(container.textContent).toMatch(
-      /Removes the Docker sandbox container and the session's agent store \(its saved agent login\)/,
+      /Removes the Docker sandbox container and any private agent store it has \(including the saved agent login\)/,
     );
   });
 


### PR DESCRIPTION
## Description

When you permanently delete a sandboxed session, AoE was leaving behind the private folder that session used as its agent's home. Every sandboxed session gets one, and it holds that agent's saved login, its history and its config. Nothing ever cleaned these up, so they piled up: one machine had 22 of them, 5.68 GB, all belonging to sessions that no longer exist. Worse than the disk, each one is a working copy of a credential sitting in a folder nothing will ever open again, and since the folder is named after a session id that no longer resolves, there was no way to even find them.

Two things change. Deleting a session now removes its folder along with its container. And a new command finds the ones already stranded and offers to remove them, which covers everything that leaked before this landed.

Because these folders hold live credentials, the sweep is deliberately timid. It only calls one an orphan if its session is missing from every profile, not just one. If it cannot read a profile's session list for any reason, it stops and removes nothing rather than assuming those sessions do not exist. It removes a folder only when no container for it exists at all, under any runtime installed, not merely when the container is stopped, and if it cannot reach a runtime to ask, it assumes one exists. And it reports before it removes: the bare command prints what would go and how much space that frees, and only `--delete` actually removes anything.

```
$ aoe sandbox reclaim
Scanned 1 store root(s) against 1 session(s) across all profiles.
  orphan     ~/.claude/sandbox-v2/2222222222222222  (244 KB)
1 orphaned store(s), 244 KB total.

Run `aoe sandbox reclaim --delete` to remove them.
```

A session still on the old shared store is skipped: it owns no private folder yet, and the migration may be publishing the one it will own. The sweep picks it up later if it ends up stranded.

Container evidence goes through v027's own probe, including its fail-closed answer for a runtime that cannot be reached, and is re-taken per candidate rather than once for the pass. Requiring absence rather than quiescence is what makes it safe: a stopped container can be started between the check and the removal, and no lock a reclaim can hold is observed by `docker start`.

The pass holds v027's transition lock **shared**, not exclusive. Exclusive would also block `Storage::update`, which is what publishes the row for a store being created, so it would have turned the creation race into a guaranteed loss. Shared still excludes v027's own planning and publishing. The pass also cannot see a half-copied store: v027 stages under `.v027-stage-<id>` and renames, and only a bare 16-hex name is ever a candidate, so a store appears whole or not at all.

Ownership spans both build namespaces. Debug and release builds keep separate app dirs but share `$HOME`, and so share these store roots; reading only one registry would make `cargo run -- sandbox reclaim --delete` delete the installed build's credentials.

One deliberate gap: purge removes stores only when the delete also removes the container, since the store is bind mounted into it. A delete that keeps the container leaves the store, and the sweep catches it later. Documented in `docs/guides/sandbox.md`.

### Known limitation

Store seeding happens before the owning row is published (`cli::add` runs `on_create` hooks, and so container preparation, before it persists). The pass mitigates that with a fifteen-minute mtime grace period and an ownership re-read before deletion, but a root-mtime window is not a reservation through registry publication. Closing it properly belongs on the creation path, not here.

### Review round

A fresh-context review found three defects in the first commit, all fixed in `291c85d`:

- A purge whose container teardown **failed** still deleted the store. `PurgeTransaction::complete_inner` rolls the purge back on teardown failure, so the session survived, logged out and with its history gone. Removal now runs only once the container is provably gone.
- `aoe sandbox reclaim` **refused forever** on any install holding an archived or trashed pre-v027 sandboxed session, because parked rows stay below the current store generation by design. `aoe migrate` said "migrations complete" and the next reclaim still claimed a move was in flight, which killed the feature on exactly the long-lived installs that accumulate stranded stores. The guard now keys on a published transition plan.
- The dev/release namespace hazard above.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Copy-only web change: the delete dialog said the sandbox checkbox removes only the container, which now understates it. Covered by a new assertion in `DeleteSessionDialog.test.tsx`, which the existing `session.delete-dialog-keyboard` matrix entry already maps to that component, so no new matrix entry is owed. `node tests/validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

`tests/e2e/sandbox.rs::sandbox_reclaim_reports_before_it_removes` creates a real session, plants one claimed and one orphaned store, and asserts the bare report names only the orphan and deletes nothing, then that `--delete` removes the orphan and leaves the claimed store.

Unit coverage: 10 tests in `src/session/sandbox_store_reclaim.rs` and 3 in `src/session/deletion.rs`, including the failed-teardown and parked-session regressions, each confirmed to fail without its fix.

`cargo fmt`, `cargo clippy --all-targets`, `cargo test` (6799 + 286), the e2e test, and the web `format:check` / `lint` / `tsc -b` / `test:unit` all pass locally.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Implementation and tests written by the model from the issue plus direction on the three judgement calls (what counts as an orphan, reusing v027's liveness rule instead of inventing one, and requiring a report mode before anything deletes). Reviewed by a separate fresh-context agent; its three findings are the review round above.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MFqV7cqtjPMwMBmUmwGDV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Removes private sandbox stores after successful session container deletion.
- Adds `aoe sandbox reclaim` to report or delete orphaned stores.
- Checks all profiles, runtimes, and debug/release namespaces before reclaiming stores.
- Preserves stores linked to active, stopped, recent, or uncertain sessions.
- Fails safely when registry, migration, or container runtime data is unavailable.
- Updates documentation, deletion-dialog text, and test coverage.

## Benefits

This reduces disk usage and limits exposure of stranded credentials and session data. Conservative checks reduce the risk of deleting stores that may still be needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
