### PR TITLE
fix(migrations): stop the v027 store move expanding and re-flushing everything

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -319,8 +319,9 @@ being replicated into every session, so if any are left the shared store is
 kept rather than deleted and AoE names it when the move finishes; remove it
 yourself once you no longer want it. A store with nothing left in it is
 deleted as before. A large store takes a while, so the first start of a
-session is slower than usual; the TUI shows the copy's progress on its status line and opens the
-session once it is done, and a plain `aoe` start says how many sessions still
+session is slower than usual; the TUI shows the copy's progress on its status
+line and opens the session once it is done, and a plain `aoe` start says how
+many sessions still
 have the move ahead of them. A session whose container is still running is
 skipped and moved on a later start, after it stops. Trashed and archived sessions stay on the shared
 store. Starting one moves it; restoring or unarchiving alone does not, so run

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -311,8 +311,14 @@ example `~/.claude/sandbox`). Each one moves when you start it: AoE copies the
 shared store into that session's private directory, removes its stopped
 container so the next launch mounts the copy, and deletes the shared store once
 every session that used it has moved (the private copies are the data from then
-on). A large store takes a while, so the first start of a session is slower
-than usual; the TUI shows the copy's progress on its status line and opens the
+on). For an agent whose sessions already had a private store of their own, the
+copy takes the shared store's top-level files, its credentials, config and
+state, and not its directories: caches, logs, plugin trees and conversation
+history belonging to no one session. Those stay where they are rather than
+being replicated into every session, so that shared store is kept instead of
+deleted and AoE names it when the move finishes; remove it yourself once you
+are sure you no longer want it. A large store takes a while, so the first
+start of a session is slower than usual; the TUI shows the copy's progress on its status line and opens the
 session once it is done, and a plain `aoe` start says how many sessions still
 have the move ahead of them. A session whose container is still running is
 skipped and moved on a later start, after it stops. Trashed and archived sessions stay on the shared

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -315,10 +315,11 @@ on). For an agent whose sessions already had a private store of their own, the
 copy takes the shared store's top-level files, its credentials, config and
 state, and not its directories: caches, logs, plugin trees and conversation
 history belonging to no one session. Those stay where they are rather than
-being replicated into every session, so that shared store is kept instead of
-deleted and AoE names it when the move finishes; remove it yourself once you
-are sure you no longer want it. A large store takes a while, so the first
-start of a session is slower than usual; the TUI shows the copy's progress on its status line and opens the
+being replicated into every session, so if any are left the shared store is
+kept rather than deleted and AoE names it when the move finishes; remove it
+yourself once you no longer want it. A store with nothing left in it is
+deleted as before. A large store takes a while, so the first start of a
+session is slower than usual; the TUI shows the copy's progress on its status line and opens the
 session once it is done, and a plain `aoe` start says how many sessions still
 have the move ahead of them. A session whose container is still running is
 skipped and moved on a later start, after it stops. Trashed and archived sessions stay on the shared

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -9,6 +9,7 @@
 //! 3. Add it to the `MIGRATIONS` array below
 
 pub mod progress;
+mod store_fs;
 mod v001_xdg_linux;
 mod v002_seed_sandbox_from_volumes;
 mod v003_yolo_mode_config;

--- a/src/migrations/store_fs.rs
+++ b/src/migrations/store_fs.rs
@@ -1,0 +1,235 @@
+//! Filesystem primitives for the v027 sandbox store move.
+//!
+//! The move stages a tree, makes it durable, then publishes it with one
+//! rename. Two costs dominated that: it wrote every byte of every file, and it
+//! forced a full drive cache flush per file. Both have cheaper answers that
+//! keep the guarantee the publish actually needs, which is that the staged
+//! tree is on the media before the rename is.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Whether this move may still try a copy-on-write clone.
+///
+/// A filesystem pair answers the same way for every file in one tree, so the
+/// first refusal turns clones off for the rest of the move instead of paying
+/// a failing syscall per file.
+#[cfg(unix)]
+#[derive(Default)]
+pub(super) struct CloneSupport {
+    refused: bool,
+}
+
+#[cfg(unix)]
+impl CloneSupport {
+    /// Create `target` as a copy-on-write clone of the open regular file
+    /// `source`, described by `stat`. `target` must not exist.
+    ///
+    /// `None` means the caller must copy the bytes itself; nothing is left at
+    /// `target`. Every failure answers that way, not only a filesystem's
+    /// refusal: `clonefile` fails across filesystems and on non-APFS volumes,
+    /// `FICLONE` fails outside btrfs and XFS, and a store move that aborted on
+    /// any of those would be worse than one that copies.
+    pub(super) fn clone_file(
+        &mut self,
+        source: &fs::File,
+        stat: &libc::stat,
+        target: &Path,
+    ) -> Option<fs::File> {
+        if self.refused {
+            return None;
+        }
+        match clone_regular_file(source, stat, target) {
+            Ok(file) => Some(file),
+            Err(error) => {
+                tracing::debug!(
+                    "v027 copying {} rather than cloning it: {error}",
+                    target.display()
+                );
+                self.refused = true;
+                None
+            }
+        }
+    }
+}
+
+/// `clonefile` copies content, mode, timestamps and extended attributes, so
+/// the clone needs nothing stamped onto it afterwards. The returned handle is
+/// read-only: writing through it would break the sharing the clone exists for.
+#[cfg(target_vendor = "apple")]
+fn clone_regular_file(
+    source: &fs::File,
+    _stat: &libc::stat,
+    target: &Path,
+) -> io::Result<fs::File> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::io::AsRawFd;
+
+    let name = std::ffi::CString::new(target.as_os_str().as_bytes())
+        .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+    // SAFETY: `source` is an open descriptor for the call's duration and
+    // `name` is a NUL-terminated path valid for the same span.
+    let cloned =
+        unsafe { libc::fclonefileat(source.as_raw_fd(), libc::AT_FDCWD, name.as_ptr(), 0) };
+    if cloned != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(target)
+}
+
+/// `FICLONE` shares the source's extents and nothing else, so the clone is
+/// stamped with the source's mode and timestamps here, exactly as the copy
+/// path stamps a file it wrote.
+#[cfg(target_os = "linux")]
+fn clone_regular_file(source: &fs::File, stat: &libc::stat, target: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    use std::os::unix::io::AsRawFd;
+
+    let output = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(target)?;
+    // SAFETY: both descriptors are open for the call's duration and `FICLONE`
+    // takes the source descriptor by value, not a pointer.
+    let cloned = unsafe { libc::ioctl(output.as_raw_fd(), libc::FICLONE, source.as_raw_fd()) };
+    if cloned != 0 {
+        let error = io::Error::last_os_error();
+        drop(output);
+        let _ = fs::remove_file(target);
+        return Err(error);
+    }
+    output.set_permissions(fs::Permissions::from_mode(stat.st_mode))?;
+    nix::sys::stat::futimens(
+        &output,
+        &nix::sys::time::TimeSpec::new(stat.st_atime, stat.st_atime_nsec),
+        &nix::sys::time::TimeSpec::new(stat.st_mtime, stat.st_mtime_nsec),
+    )?;
+    Ok(output)
+}
+
+/// Unix without a reflink call of its own copies, as it always has.
+#[cfg(all(unix, not(target_vendor = "apple"), not(target_os = "linux")))]
+fn clone_regular_file(
+    _source: &fs::File,
+    _stat: &libc::stat,
+    _target: &Path,
+) -> io::Result<fs::File> {
+    Err(io::Error::from(io::ErrorKind::Unsupported))
+}
+
+/// `fsync(2)` on a file or directory the move just created.
+///
+/// Deliberately not [`fs::File::sync_all`]: on Apple platforms the standard
+/// library maps both `sync_all` and `sync_data` to `F_FULLFSYNC`, a whole
+/// drive cache flush that measured 7.29 ms per file against 0.58 ms for plain
+/// `fsync` and made the flushing, not the copying, the whole runtime of the
+/// move (#3819). Per entry the move needs only that the bytes reach the
+/// drive; [`barrier`] is what orders them ahead of the publish.
+pub(super) fn sync_to_drive(file: &fs::File) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        // SAFETY: `file` owns an open descriptor for the call's duration.
+        if unsafe { libc::fsync(file.as_raw_fd()) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    file.sync_all()
+}
+
+/// Order everything [`sync_to_drive`] has pushed ahead of the rename that
+/// publishes the staged tree. `dir` is any directory on the volume the
+/// publish happens on.
+///
+/// On Apple platforms `fsync` moves a file's bytes to the drive but not onto
+/// the media, and the drive may commit what is still in its cache out of
+/// order; `F_BARRIERFSYNC` costs one call per publish and forbids that
+/// reordering across the barrier, so no crash can expose the rename without
+/// the data it published. `F_FULLFSYNC` is the fallback for a volume that
+/// refuses the barrier: stronger, and still one call rather than one per file.
+/// Elsewhere `fsync` already reaches the media, so the per-entry calls have
+/// left nothing to order.
+pub(super) fn barrier(dir: &fs::File) -> io::Result<()> {
+    #[cfg(target_vendor = "apple")]
+    {
+        use std::os::unix::io::AsRawFd;
+        for command in [libc::F_BARRIERFSYNC, libc::F_FULLFSYNC] {
+            // SAFETY: `dir` owns an open descriptor for the call's duration
+            // and neither command reads an argument.
+            if unsafe { libc::fcntl(dir.as_raw_fd(), command) } != -1 {
+                return Ok(());
+            }
+        }
+        Err(io::Error::last_os_error())
+    }
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        let _ = dir;
+        Ok(())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// A clone the filesystem cannot serve must read as "copy it yourself",
+    /// never as a failed migration. A character device is a source no clone
+    /// implementation accepts, so this holds on every platform, including one
+    /// whose filesystem would happily clone a regular file.
+    #[test]
+    fn an_unclonable_source_falls_back_instead_of_failing() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("copy");
+        let source = fs::File::open("/dev/null").unwrap();
+        let stat = nix::sys::stat::fstat(&source).unwrap();
+        let mut support = CloneSupport::default();
+
+        assert!(support.clone_file(&source, &stat, &target).is_none());
+        assert!(
+            !target.exists(),
+            "a refused clone must not leave a partial file behind"
+        );
+        assert!(
+            support.refused,
+            "one refusal must stop the move retrying a clone per file"
+        );
+    }
+
+    /// Once refused, later files skip the syscall entirely rather than paying
+    /// a failure each.
+    #[test]
+    fn a_refused_clone_is_not_retried() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source");
+        fs::write(&source_path, b"contents").unwrap();
+        let source = fs::File::open(&source_path).unwrap();
+        let stat = nix::sys::stat::fstat(&source).unwrap();
+        let mut support = CloneSupport { refused: true };
+
+        assert!(support
+            .clone_file(&source, &stat, &temp.path().join("copy"))
+            .is_none());
+        assert!(!temp.path().join("copy").exists());
+    }
+
+    #[test]
+    fn syncing_and_barriering_a_directory_succeed() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("file"), b"contents").unwrap();
+        let file = fs::File::open(temp.path().join("file")).unwrap();
+        let dir = fs::File::open(temp.path()).unwrap();
+
+        sync_to_drive(&file).unwrap();
+        sync_to_drive(&dir).unwrap();
+        barrier(&dir).unwrap();
+    }
+}

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -2016,7 +2016,14 @@ fn copy_tree_no_links(
                 Ok(existing) if overwrite_newer && existing.is_file() => {
                     metadata.modified()? > existing.modified()?
                 }
-                Ok(_) => false,
+                // Fails closed as the Unix path does. Skipping instead would
+                // leave the overlay's file out of the private store while
+                // `retire_legacy_children` still counted it as replicated and
+                // removed the only other copy.
+                Ok(_) => bail!(
+                    "v027 copy destination has conflicting type: {}",
+                    target.display()
+                ),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
                 Err(error) => return Err(error.into()),
             };

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -941,12 +941,10 @@ fn run_pass(
             if gated_roots.insert(root.clone()) {
                 copy_gate(root);
             }
-            // Reaped before the move, where a copied store was reaped after
-            // it. A copy left the source in place, so a container that came
-            // up since the probe kept a store to write to; a rename does not,
-            // and nothing later can put it back. Removing without force fails
-            // on a live container, which is what keeps this from moving a
-            // store out from under one.
+            // Reaped before the move, not after: a rename leaves no source
+            // behind for a container that came up since the probe, and
+            // nothing later can put one back. Removing without force fails on
+            // a live container, which is what stops the move.
             if !reap(&id)? {
                 blocked_roots.insert(root.clone());
                 orphan_blocked_roots.insert(root.clone());
@@ -1613,10 +1611,9 @@ fn publish_store(
         // is the credentials, config and state files that home kept at its
         // root. Its directories are the shared home's own accumulation:
         // conversation history belonging to other sessions, caches, logs and
-        // plugin trees. Replicating those per session is what turned a 17 MB
-        // legacy store into a 252 MB private one, and none of it is the
-        // single-instance lock this migration exists to unshare (#3819). What
-        // is not folded in is not deleted either: `retire_legacy_children`
+        // plugin trees, none of them the single-instance lock this migration
+        // exists to unshare, and each replicated once per session (#3819).
+        // What is not folded in is not deleted either: `retire_legacy_children`
         // leaves the shared root holding it.
         copy_tree_no_links(
             overlay,
@@ -1718,11 +1715,15 @@ fn relocate_store(source: &Path, destination: &Path) -> Result<()> {
         .parent()
         .context("private store has no parent")?;
     let publication = Publication::prepare(destination)?;
+    let mut quarantined = false;
     match fs::symlink_metadata(destination) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
             bail!("v027 destination is a symlink: {}", destination.display())
         }
-        Ok(_) => fs::rename(destination, &publication.quarantine)?,
+        Ok(_) => {
+            fs::rename(destination, &publication.quarantine)?;
+            quarantined = true;
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => {
             return Err(error).with_context(|| format!("inspecting {}", destination.display()))
@@ -1733,6 +1734,12 @@ fn relocate_store(source: &Path, destination: &Path) -> Result<()> {
             "v027 copying {} instead of moving it: {error}",
             source.display()
         );
+        // The copy stages before it publishes, so put the destination back
+        // first: falling back with it still quarantined would leave nothing
+        // published for the length of the copy.
+        if quarantined {
+            fs::rename(&publication.quarantine, destination)?;
+        }
         return publish_store(source, destination, &BTreeSet::new(), None, false);
     }
     fs::File::open(parent)?.sync_all()?;
@@ -2047,7 +2054,9 @@ fn sync_tree(path: &Path) -> Result<()> {
 /// other sessions' conversation history, caches, logs and plugin trees. This
 /// root is now the only copy of them, so deleting them to reclaim space would
 /// destroy state that belongs to no single session. Returns the root when
-/// anything was kept, so the caller can say where it is.
+/// this pass both kept something and removed something, which is what the
+/// caller says out loud; a later pass over a root it already stripped has
+/// nothing to report.
 ///
 /// Stores go before files, and everything is renamed aside before it is
 /// removed. This runs before the generation commit, so an interrupted
@@ -2063,20 +2072,33 @@ fn retire_legacy_children(
 ) -> Result<Option<PathBuf>> {
     let quarantine = root.join(".v027-retired.v027-quarantine");
     remove_tree_no_links(&quarantine)?;
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        // A root an earlier pass already emptied and removed. Every later row
+        // under it plans against it and arrives here, so treating its absence
+        // as a failure would fail `aoe migrate`, and every command that runs
+        // migrations, from then on. [`retire_legacy`] is the no-op that also
+        // clears what a killed pass left beside it.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            retire_legacy(root)?;
+            return Ok(None);
+        }
+        Err(error) => return Err(error).with_context(|| format!("reading {}", root.display())),
+    };
     let mut kept = false;
     let mut stores = Vec::new();
     let mut files = Vec::new();
-    for entry in fs::read_dir(root)? {
+    for entry in entries {
         let name = entry?.file_name();
-        let metadata = fs::symlink_metadata(root.join(&name))?;
         if replicated.contains(name.as_os_str()) {
             stores.push(name);
-        } else if metadata.is_file() && !metadata.file_type().is_symlink() {
+        } else if fs::symlink_metadata(root.join(&name))?.is_file() {
             files.push(name);
         } else {
             kept = true;
         }
     }
+    let removed = !stores.is_empty() || !files.is_empty();
     fs::create_dir(&quarantine)?;
     for name in stores {
         fs::rename(root.join(&name), quarantine.join(&name))?;
@@ -2095,7 +2117,7 @@ fn retire_legacy_children(
         retire_legacy(root)?;
         return Ok(None);
     }
-    Ok(Some(root.to_path_buf()))
+    Ok(removed.then(|| root.to_path_buf()))
 }
 
 fn retire_legacy(source: &Path) -> Result<()> {
@@ -3652,6 +3674,47 @@ gemini = "{}"
             "a symlink the overlay refused to carry has no other copy"
         );
         assert!(!root.join(".v027-retired.v027-quarantine").exists());
+    }
+
+    /// Retiring a fully replicated root deletes it, so every later row that
+    /// plans against it meets a root that is not there: a restored session, a
+    /// second profile, a generation reset. That row must publish and commit.
+    /// Failing instead would fail `aoe migrate`, and every command that runs
+    /// migrations, from then on, with nothing able to clear it.
+    #[test]
+    #[serial_test::serial]
+    fn a_retired_root_does_not_fail_the_next_row() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        fs::create_dir_all(&app).unwrap();
+        let root = home.join(".codex/sandbox");
+        fs::create_dir_all(root.join("codex-one")).unwrap();
+        fs::write(root.join("codex-one").join("own"), b"own").unwrap();
+        fs::write(root.join("auth.json"), b"secret").unwrap();
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"codex-one","tool":"codex","sandbox_info":{"enabled":true}}]"#,
+        )
+        .unwrap();
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+        assert!(!root.exists(), "nothing was left unreplicated, so it goes");
+
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"codex-one","tool":"codex","sandbox_info":{"enabled":true},"sandbox_store_generation":2},
+                {"id":"codex-two","tool":"codex","sandbox_info":{"enabled":true}}]"#,
+        )
+        .unwrap();
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+
+        let rows: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_eq!(rows[1]["sandbox_store_generation"], 2);
+        assert!(home.join(".codex/sandbox-v2/codex-two").is_dir());
     }
 
     /// Retirement runs before the generation commit, so a pass killed partway

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -802,7 +802,6 @@ fn run_pass(
     let mut pending = Vec::new();
     let mut blocked_roots = BTreeSet::new();
     let mut orphan_blocked_roots = BTreeSet::new();
-    let mut orphan_ready_ids = BTreeSet::new();
     let mut excluded_by_root = BTreeMap::new();
     let private_roots: BTreeSet<PathBuf> = cohorts
         .values()
@@ -942,8 +941,18 @@ fn run_pass(
             if gated_roots.insert(root.clone()) {
                 copy_gate(root);
             }
+            // Reaped before the move, where a copied store was reaped after
+            // it. A copy left the source in place, so a container that came
+            // up since the probe kept a store to write to; a rename does not,
+            // and nothing later can put it back. Removing without force fails
+            // on a live container, which is what keeps this from moving a
+            // store out from under one.
+            if !reap(&id)? {
+                blocked_roots.insert(root.clone());
+                orphan_blocked_roots.insert(root.clone());
+                continue;
+            }
             relocate_store(&source, &destination_parent.join(orphan))?;
-            orphan_ready_ids.insert((root.clone(), id.into_owned()));
         }
     }
 
@@ -1113,12 +1122,6 @@ fn run_pass(
         }
     }
 
-    for (root, id) in orphan_ready_ids {
-        if !reap(&id)? {
-            blocked_roots.insert(root);
-        }
-    }
-
     // Remove stopped containers only after every store for the row is durable.
     // `force=false` makes a concurrent start fail the transition rather than
     // stopping a container that became live after the probe. A runtime that
@@ -1192,9 +1195,10 @@ fn run_pass(
                     .context("missing cleanup-root exclusions")?;
                 if let Some(kept) = retire_legacy_children(root, replicated)? {
                     progress::notice(format!(
-                        "Kept {}: it holds shared agent state (other sessions' history, caches, logs) \
-                         that is not per-session, so no private store received a copy of it. Nothing \
-                         was deleted; remove it yourself when you no longer want it.",
+                        "Kept {}: it holds shared agent state (other sessions' history, caches, \
+                         logs) that belongs to no one session, so it was not copied into every \
+                         private store. Everything removed from it is in those stores; what is \
+                         left has no other copy. Remove it yourself once you no longer want it.",
                         kept.display()
                     ));
                 }
@@ -1800,6 +1804,11 @@ fn copy_tree_from_fd(
         }
         let stat = fstatat(&dir, name, AtFlags::AT_SYMLINK_NOFOLLOW)?;
         let kind = stat.st_mode & nix::libc::S_IFMT;
+        // A symlink at a shared root usually points into one of the
+        // directories below, so carrying it would publish a dangler.
+        if files_only && kind != nix::libc::S_IFREG {
+            continue;
+        }
         let target = destination.join(name);
         if kind == nix::libc::S_IFLNK {
             let link = readlinkat(&dir, name)?;
@@ -1834,9 +1843,6 @@ fn copy_tree_from_fd(
             continue;
         }
         if kind == nix::libc::S_IFDIR {
-            if files_only {
-                continue;
-            }
             let child = openat(
                 &dir,
                 name,
@@ -1985,11 +1991,11 @@ fn copy_tree_no_links(
                 entry.path().display()
             );
         }
+        if files_only && !metadata.is_file() {
+            continue;
+        }
         let target = destination.join(entry.file_name());
         if metadata.is_dir() {
-            if files_only {
-                continue;
-            }
             match fs::create_dir(&target) {
                 Ok(()) => {}
                 Err(error)
@@ -2036,48 +2042,55 @@ fn sync_tree(path: &Path) -> Result<()> {
 /// Retire a legacy root by removing only what the private stores received.
 ///
 /// Every per-instance child moved into the private layout, and every
-/// top-level file was folded into each of them, so both go. The root's other
-/// directories are what [`publish_store`]'s overlay deliberately did not
-/// replicate: other sessions' conversation history, caches, logs and plugin
-/// trees. This is now the only copy of them, so deleting them to reclaim
-/// space would destroy state that belongs to no single session. Returns the
-/// root when anything was kept, so the caller can say where it is.
+/// top-level regular file was folded into each of them, so both go. What is
+/// left is what [`publish_store`]'s overlay deliberately did not replicate:
+/// other sessions' conversation history, caches, logs and plugin trees. This
+/// root is now the only copy of them, so deleting them to reclaim space would
+/// destroy state that belongs to no single session. Returns the root when
+/// anything was kept, so the caller can say where it is.
 ///
-/// Each entry is renamed aside before it is removed. A crash here leaves rows
-/// still at their pending generation, and a half-deleted store those rows
-/// would copy back over the published one is the failure that protocol
-/// prevents: an entry is either wholly there or wholly gone.
+/// Stores go before files, and everything is renamed aside before it is
+/// removed. This runs before the generation commit, so an interrupted
+/// retirement leaves rows still pending, and a pending row re-copies its
+/// legacy store over the one it already published. Either that store is
+/// wholly gone, and the row keeps what it published, or it is wholly there
+/// and so is every file the overlay folds in beside it. Removing a file
+/// first is what would let a pass re-publish a store without the credentials
+/// the root no longer has.
 fn retire_legacy_children(
     root: &Path,
     replicated: &BTreeSet<std::ffi::OsString>,
 ) -> Result<Option<PathBuf>> {
+    let quarantine = root.join(".v027-retired.v027-quarantine");
+    remove_tree_no_links(&quarantine)?;
     let mut kept = false;
-    let names: Vec<std::ffi::OsString> = fs::read_dir(root)?
-        .map(|entry| Ok(entry?.file_name()))
-        .collect::<Result<_>>()?;
-    for name in names {
-        let leaf = name.to_string_lossy().into_owned();
-        let path = root.join(&name);
-        let quarantine = root.join(format!(".{leaf}.v027-quarantine"));
-        let metadata = fs::symlink_metadata(&path)?;
-        let stale_quarantine = leaf.starts_with('.') && leaf.ends_with(".v027-quarantine");
-        if stale_quarantine {
-            remove_tree_no_links(&path)?;
-            continue;
-        }
-        if metadata.is_dir()
-            && !metadata.file_type().is_symlink()
-            && !replicated.contains(name.as_os_str())
-        {
+    let mut stores = Vec::new();
+    let mut files = Vec::new();
+    for entry in fs::read_dir(root)? {
+        let name = entry?.file_name();
+        let metadata = fs::symlink_metadata(root.join(&name))?;
+        if replicated.contains(name.as_os_str()) {
+            stores.push(name);
+        } else if metadata.is_file() && !metadata.file_type().is_symlink() {
+            files.push(name);
+        } else {
             kept = true;
-            continue;
         }
-        remove_tree_no_links(&quarantine)?;
-        fs::rename(&path, &quarantine)?;
-        fs::File::open(root)?.sync_all()?;
-        remove_tree_no_links(&quarantine)?;
-        fs::File::open(root)?.sync_all()?;
     }
+    fs::create_dir(&quarantine)?;
+    for name in stores {
+        fs::rename(root.join(&name), quarantine.join(&name))?;
+    }
+    // The barrier is the ordering, not the syncs around it: without it the
+    // drive is free to commit a file's removal before a store's.
+    super::store_fs::sync_to_drive(&fs::File::open(root)?)?;
+    super::store_fs::barrier(&fs::File::open(root)?)?;
+    for name in files {
+        fs::rename(root.join(&name), quarantine.join(&name))?;
+    }
+    super::store_fs::sync_to_drive(&fs::File::open(root)?)?;
+    remove_tree_no_links(&quarantine)?;
+    fs::File::open(root)?.sync_all()?;
     if !kept {
         retire_legacy(root)?;
         return Ok(None);
@@ -3604,6 +3617,79 @@ gemini = "{}"
             b"other",
             "what no private store received is the only copy left, so it stays"
         );
+    }
+
+    /// What no private store received is kept, whatever its type; what every
+    /// private store did receive is removed.
+    #[test]
+    fn retiring_a_root_keeps_only_what_no_store_received() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("sandbox");
+        fs::create_dir_all(root.join("one")).unwrap();
+        fs::create_dir_all(root.join("sessions")).unwrap();
+        fs::write(root.join("one").join("own"), b"own").unwrap();
+        fs::write(root.join("sessions").join("other"), b"other").unwrap();
+        fs::write(root.join("auth.json"), b"secret").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("sessions", root.join("latest")).unwrap();
+        let replicated: BTreeSet<std::ffi::OsString> = [std::ffi::OsString::from("one")].into();
+
+        let kept = retire_legacy_children(&root, &replicated).unwrap();
+
+        assert_eq!(kept.as_deref(), Some(root.as_path()));
+        assert!(!root.join("one").exists(), "a replicated store is removed");
+        assert!(
+            !root.join("auth.json").exists(),
+            "a top-level file reached every private store, so it is removed"
+        );
+        assert_eq!(
+            fs::read(root.join("sessions").join("other")).unwrap(),
+            b"other"
+        );
+        #[cfg(unix)]
+        assert!(
+            fs::symlink_metadata(root.join("latest")).is_ok(),
+            "a symlink the overlay refused to carry has no other copy"
+        );
+        assert!(!root.join(".v027-retired.v027-quarantine").exists());
+    }
+
+    /// Retirement runs before the generation commit, so a pass killed partway
+    /// through it leaves the row pending and the shared root half emptied.
+    /// Removing the per-instance stores first is what makes that safe: the
+    /// row's source is gone, so the next pass keeps the store it published
+    /// rather than re-copying a root that has lost the credential it needs.
+    #[test]
+    #[serial_test::serial]
+    fn an_interrupted_retirement_keeps_the_published_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        fs::create_dir_all(&app).unwrap();
+        let root = home.join(".codex/sandbox");
+        let destination = home.join(".codex/sandbox-v2/codex-one");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&destination).unwrap();
+        // The store published, its per-instance source already removed, and
+        // the shared root still holding the files that reached it.
+        fs::write(destination.join("auth.json"), b"secret").unwrap();
+        fs::write(destination.join("own"), b"own").unwrap();
+        fs::write(root.join("auth.json"), b"secret").unwrap();
+        fs::write(
+            app.join("sessions.json"),
+            r#"[{"id":"codex-one","tool":"codex","sandbox_info":{"enabled":true}}]"#,
+        )
+        .unwrap();
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+
+        assert_eq!(fs::read(destination.join("auth.json")).unwrap(), b"secret");
+        assert_eq!(fs::read(destination.join("own")).unwrap(), b"own");
+        assert!(!root.exists());
+        let rows: Value =
+            serde_json::from_slice(&fs::read(app.join("sessions.json")).unwrap()).unwrap();
+        assert_eq!(rows[0]["sandbox_store_generation"], 2);
     }
 
     /// The shared root goes when everything in it was replicated, exactly as

--- a/src/migrations/v027_isolate_sandbox_stores.rs
+++ b/src/migrations/v027_isolate_sandbox_stores.rs
@@ -31,18 +31,23 @@ fn defer_requested_by(value: Option<&std::ffi::OsStr>) -> bool {
     value.is_some_and(|value| !value.is_empty())
 }
 
-/// Files and bytes copied by one store move, for the progress line. Per move
-/// rather than process-wide: per-root cohort locks let moves copy at the same
-/// time, each reporting to the reporter installed on its own thread (#3777).
+/// What one store move carries between entries: the progress counters, and
+/// whether this filesystem pair has already refused a copy-on-write clone.
+/// Per move rather than process-wide: per-root cohort locks let moves copy at
+/// the same time, each reporting to the reporter installed on its own thread
+/// (#3777).
 #[derive(Default)]
-struct CopyProgress {
+struct CopyState {
     files: u64,
     bytes: u64,
+    /// Only the Unix copy path clones; the portable fallback uses `fs::copy`.
+    #[cfg(unix)]
+    clone: super::store_fs::CloneSupport,
 }
 
-impl CopyProgress {
-    /// One regular file copied. Reports every 100 files so a large store shows
-    /// movement without flooding the reporter.
+impl CopyState {
+    /// One regular file copied or cloned. Reports every 100 files so a large
+    /// store shows movement without flooding the reporter.
     fn copied_file(&mut self, bytes: u64) {
         self.files += 1;
         self.bytes += bytes;
@@ -933,19 +938,11 @@ fn run_pass(
                 orphan_blocked_roots.insert(root.clone());
                 continue;
             }
-            progress::step(format!("copying unregistered store {}", source.display()));
+            progress::step(format!("moving unregistered store {}", source.display()));
             if gated_roots.insert(root.clone()) {
                 copy_gate(root);
             }
-            publish_store(
-                &source,
-                &destination_parent.join(orphan),
-                excluded_by_root
-                    .get(root)
-                    .context("missing orphan cleanup-root exclusions")?,
-                Some(root),
-                false,
-            )?;
+            relocate_store(&source, &destination_parent.join(orphan))?;
             orphan_ready_ids.insert((root.clone(), id.into_owned()));
         }
     }
@@ -1189,7 +1186,21 @@ fn run_pass(
             });
         if !defer_source_retirement && !blocked_roots.contains(root) && all_ready {
             progress::step(format!("retiring shared agent store {}", root.display()));
-            retire_legacy(root)?;
+            if private_roots.contains(root) {
+                let replicated = excluded_by_root
+                    .get(root)
+                    .context("missing cleanup-root exclusions")?;
+                if let Some(kept) = retire_legacy_children(root, replicated)? {
+                    progress::notice(format!(
+                        "Kept {}: it holds shared agent state (other sessions' history, caches, logs) \
+                         that is not per-session, so no private store received a copy of it. Nothing \
+                         was deleted; remove it yourself when you no longer want it.",
+                        kept.display()
+                    ));
+                }
+            } else {
+                retire_legacy(root)?;
+            }
         } else {
             pending.push(root.to_string_lossy().into_owned());
         }
@@ -1571,48 +1582,60 @@ fn publish_store(
             return Err(error).with_context(|| format!("inspecting {}", source.display()))
         }
     };
-    let layout_root = parent.parent().context("private layout has no parent")?;
-    fs::create_dir_all(layout_root)?;
-    let anchored_parent = crate::session::AnchoredDir::create(parent)?;
-    fs::File::open(layout_root)?.sync_all()?;
-    let leaf = destination
-        .file_name()
-        .context("private store has no leaf")?;
-    let stage_leaf = format!(".v027-stage-{}", leaf.to_string_lossy());
-    let stage = anchored_parent.path().join(&stage_leaf);
-    let quarantine_leaf = format!(".v027-quarantine-{}", leaf.to_string_lossy());
-    let quarantine = anchored_parent.path().join(&quarantine_leaf);
-    remove_tree_no_links(&stage)?;
-    remove_tree_no_links(&quarantine)?;
+    let publication = Publication::prepare(destination)?;
     if !source_exists {
-        anchored_parent.ensure_dir(Path::new(leaf))?;
+        publication.anchored_parent.ensure_dir(Path::new(
+            destination
+                .file_name()
+                .context("private store has no leaf")?,
+        ))?;
         fs::File::open(parent)?.sync_all()?;
         return Ok(());
     }
-    fs::create_dir(&stage)?;
-    let mut copied = CopyProgress::default();
+    let stage = &publication.stage;
+    fs::create_dir(stage)?;
+    let mut copied = CopyState::default();
     copy_tree_no_links(
         source,
-        &stage,
+        stage,
         exclude_source_children.then_some(excluded_root_children),
+        false,
         false,
         &mut copied,
     )?;
     if let Some(overlay) = overlay_shared_root {
+        // Files only. The overlay folds a shared agent home into a session
+        // that already has a private one of its own, so what it has to carry
+        // is the credentials, config and state files that home kept at its
+        // root. Its directories are the shared home's own accumulation:
+        // conversation history belonging to other sessions, caches, logs and
+        // plugin trees. Replicating those per session is what turned a 17 MB
+        // legacy store into a 252 MB private one, and none of it is the
+        // single-instance lock this migration exists to unshare (#3819). What
+        // is not folded in is not deleted either: `retire_legacy_children`
+        // leaves the shared root holding it.
         copy_tree_no_links(
             overlay,
-            &stage,
+            stage,
             Some(excluded_root_children),
+            true,
             true,
             &mut copied,
         )?;
     }
-    fs::set_permissions(&stage, fs::symlink_metadata(source)?.permissions())?;
-    sync_tree(&stage)?;
+    fs::set_permissions(stage, fs::symlink_metadata(source)?.permissions())?;
+    sync_tree(stage)?;
+    // One barrier for the whole tree, in place of a full drive flush per
+    // file. Everything above reached the drive as it was written; this orders
+    // all of it ahead of the rename below, so a crash can lose the publish
+    // but cannot expose a published store whose bytes never reached the
+    // media. The parent sync after the rename is what makes the publish
+    // itself durable.
+    super::store_fs::barrier(&fs::File::open(stage)?)?;
 
     let destination_exists = match fs::symlink_metadata(destination) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
-            remove_tree_no_links(&stage)?;
+            remove_tree_no_links(stage)?;
             bail!("v027 destination is a symlink: {}", destination.display());
         }
         Ok(_) => true,
@@ -1622,11 +1645,94 @@ fn publish_store(
         }
     };
     if destination_exists {
-        fs::rename(destination, &quarantine)?;
+        fs::rename(destination, &publication.quarantine)?;
     }
-    fs::rename(&stage, destination)?;
+    fs::rename(stage, destination)?;
     fs::File::open(parent)?.sync_all()?;
-    remove_tree_no_links(&quarantine)?;
+    remove_tree_no_links(&publication.quarantine)?;
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+/// The staging and quarantine paths one destination publishes through, with
+/// whatever an interrupted pass left at them already removed.
+///
+/// Shared by the copy and the rename so both publish through the same
+/// artifacts and both clear the same debris: a killed `aoe migrate` leaves a
+/// half-written `.v027-stage-<id>` behind, and the pass that picks the store
+/// up again must not build on it or leave it sitting in the private layout.
+struct Publication {
+    anchored_parent: crate::session::AnchoredDir,
+    stage: PathBuf,
+    quarantine: PathBuf,
+}
+
+impl Publication {
+    fn prepare(destination: &Path) -> Result<Self> {
+        let parent = destination
+            .parent()
+            .context("private store has no parent")?;
+        let layout_root = parent.parent().context("private layout has no parent")?;
+        fs::create_dir_all(layout_root)?;
+        let anchored_parent = crate::session::AnchoredDir::create(parent)?;
+        fs::File::open(layout_root)?.sync_all()?;
+        let leaf = destination
+            .file_name()
+            .context("private store has no leaf")?
+            .to_string_lossy()
+            .into_owned();
+        let stage = anchored_parent.path().join(format!(".v027-stage-{leaf}"));
+        let quarantine = anchored_parent
+            .path()
+            .join(format!(".v027-quarantine-{leaf}"));
+        remove_tree_no_links(&stage)?;
+        remove_tree_no_links(&quarantine)?;
+        Ok(Self {
+            anchored_parent,
+            stage,
+            quarantine,
+        })
+    }
+}
+
+/// Move a store that belongs to no session into the private layout.
+///
+/// An unregistered legacy child is nobody's store: no row names it, nothing
+/// will start it, and folding the shared agent home into it buys a dead
+/// session a private copy of live sessions' history. Renaming it preserves it
+/// exactly at the cost of one syscall, where copying it cost a full store
+/// each: an interrupted `aoe migrate` wrote 16 GB across 63 such stores, none
+/// of which resolved to a session (#3819).
+///
+/// The publish protocol is [`publish_store`]'s: stale staging is cleared
+/// first, an existing destination is quarantined, and the parent is synced
+/// around the rename, so a crash leaves either the old destination or the new
+/// one. A rename that cannot reach the destination, across filesystems or
+/// otherwise, falls back to the copy.
+fn relocate_store(source: &Path, destination: &Path) -> Result<()> {
+    let parent = destination
+        .parent()
+        .context("private store has no parent")?;
+    let publication = Publication::prepare(destination)?;
+    match fs::symlink_metadata(destination) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!("v027 destination is a symlink: {}", destination.display())
+        }
+        Ok(_) => fs::rename(destination, &publication.quarantine)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspecting {}", destination.display()))
+        }
+    }
+    if let Err(error) = fs::rename(source, destination) {
+        tracing::warn!(
+            "v027 copying {} instead of moving it: {error}",
+            source.display()
+        );
+        return publish_store(source, destination, &BTreeSet::new(), None, false);
+    }
+    fs::File::open(parent)?.sync_all()?;
+    remove_tree_no_links(&publication.quarantine)?;
     fs::File::open(parent)?.sync_all()?;
     Ok(())
 }
@@ -1637,7 +1743,8 @@ fn copy_tree_no_links(
     destination: &Path,
     excluded_children: Option<&BTreeSet<std::ffi::OsString>>,
     overwrite_newer: bool,
-    copied: &mut CopyProgress,
+    files_only: bool,
+    copied: &mut CopyState,
 ) -> Result<()> {
     use nix::fcntl::{open, OFlag};
     use nix::sys::stat::Mode;
@@ -1652,6 +1759,7 @@ fn copy_tree_no_links(
         excluded_children,
         Path::new(""),
         overwrite_newer,
+        files_only,
         copied,
     )
 }
@@ -1663,7 +1771,8 @@ fn copy_tree_from_fd(
     excluded_children: Option<&BTreeSet<std::ffi::OsString>>,
     relative: &Path,
     overwrite_newer: bool,
-    copied: &mut CopyProgress,
+    files_only: bool,
+    copied: &mut CopyState,
 ) -> Result<()> {
     use nix::dir::Dir;
     use nix::fcntl::{openat, readlinkat, AtFlags, OFlag};
@@ -1725,6 +1834,9 @@ fn copy_tree_from_fd(
             continue;
         }
         if kind == nix::libc::S_IFDIR {
+            if files_only {
+                continue;
+            }
             let child = openat(
                 &dir,
                 name,
@@ -1755,6 +1867,7 @@ fn copy_tree_from_fd(
                 None,
                 &relative.join(name),
                 overwrite_newer,
+                false,
                 copied,
             )?;
             if !existed || source_stat_is_newer(&stat, &target)? {
@@ -1792,23 +1905,34 @@ fn copy_tree_from_fd(
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
                 Err(error) => return Err(error.into()),
             };
-            let mut options = fs::OpenOptions::new();
-            options.write(true);
+            // A clone has to create its own destination, so an entry being
+            // replaced is unlinked rather than truncated and both paths take
+            // the same `create_new` route.
             if target_exists {
-                options.truncate(true);
-            } else {
-                options.create_new(true);
+                fs::remove_file(&target)?;
             }
-            let mut output = options.open(&target)?;
-            let bytes = std::io::copy(&mut input, &mut output)?;
-            copied.copied_file(bytes);
-            output.set_permissions(fs::Permissions::from_mode(opened.st_mode as u32))?;
-            futimens(
-                &output,
-                &TimeSpec::new(opened.st_atime, opened.st_atime_nsec),
-                &TimeSpec::new(opened.st_mtime, opened.st_mtime_nsec),
-            )?;
-            output.sync_all()?;
+            let output = match copied.clone.clone_file(&input, &opened, &target) {
+                Some(output) => {
+                    copied.copied_file(opened.st_size.max(0) as u64);
+                    output
+                }
+                None => {
+                    let mut output = fs::OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(&target)?;
+                    let bytes = std::io::copy(&mut input, &mut output)?;
+                    copied.copied_file(bytes);
+                    output.set_permissions(fs::Permissions::from_mode(opened.st_mode as u32))?;
+                    futimens(
+                        &output,
+                        &TimeSpec::new(opened.st_atime, opened.st_atime_nsec),
+                        &TimeSpec::new(opened.st_mtime, opened.st_mtime_nsec),
+                    )?;
+                    output
+                }
+            };
+            super::store_fs::sync_to_drive(&output)?;
         }
     }
     Ok(())
@@ -1846,7 +1970,8 @@ fn copy_tree_no_links(
     destination: &Path,
     excluded_children: Option<&BTreeSet<std::ffi::OsString>>,
     overwrite_newer: bool,
-    copied: &mut CopyProgress,
+    files_only: bool,
+    copied: &mut CopyState,
 ) -> Result<()> {
     for entry in fs::read_dir(source)? {
         let entry = entry?;
@@ -1862,13 +1987,16 @@ fn copy_tree_no_links(
         }
         let target = destination.join(entry.file_name());
         if metadata.is_dir() {
+            if files_only {
+                continue;
+            }
             match fs::create_dir(&target) {
                 Ok(()) => {}
                 Err(error)
                     if overwrite_newer && error.kind() == std::io::ErrorKind::AlreadyExists => {}
                 Err(error) => return Err(error.into()),
             }
-            copy_tree_no_links(&entry.path(), &target, None, overwrite_newer, copied)?;
+            copy_tree_no_links(&entry.path(), &target, None, overwrite_newer, false, copied)?;
             fs::set_permissions(&target, metadata.permissions())?;
         } else if metadata.is_file() {
             let should_copy = match fs::symlink_metadata(&target) {
@@ -1882,13 +2010,17 @@ fn copy_tree_no_links(
             if should_copy {
                 copied.copied_file(fs::copy(entry.path(), &target)?);
                 fs::set_permissions(&target, metadata.permissions())?;
-                fs::File::open(&target)?.sync_all()?;
+                super::store_fs::sync_to_drive(&fs::File::open(&target)?)?;
             }
         }
     }
     Ok(())
 }
 
+/// Push every directory of the staged tree to the drive. Its regular files
+/// were pushed as they were created; this covers the directory entries that
+/// name them. What makes the whole tree durable is the barrier
+/// [`publish_store`] issues afterwards, not these calls.
 fn sync_tree(path: &Path) -> Result<()> {
     for entry in fs::read_dir(path)? {
         let entry = entry?;
@@ -1897,8 +2029,60 @@ fn sync_tree(path: &Path) -> Result<()> {
             sync_tree(&entry.path())?;
         }
     }
-    fs::File::open(path)?.sync_all()?;
+    super::store_fs::sync_to_drive(&fs::File::open(path)?)?;
     Ok(())
+}
+
+/// Retire a legacy root by removing only what the private stores received.
+///
+/// Every per-instance child moved into the private layout, and every
+/// top-level file was folded into each of them, so both go. The root's other
+/// directories are what [`publish_store`]'s overlay deliberately did not
+/// replicate: other sessions' conversation history, caches, logs and plugin
+/// trees. This is now the only copy of them, so deleting them to reclaim
+/// space would destroy state that belongs to no single session. Returns the
+/// root when anything was kept, so the caller can say where it is.
+///
+/// Each entry is renamed aside before it is removed. A crash here leaves rows
+/// still at their pending generation, and a half-deleted store those rows
+/// would copy back over the published one is the failure that protocol
+/// prevents: an entry is either wholly there or wholly gone.
+fn retire_legacy_children(
+    root: &Path,
+    replicated: &BTreeSet<std::ffi::OsString>,
+) -> Result<Option<PathBuf>> {
+    let mut kept = false;
+    let names: Vec<std::ffi::OsString> = fs::read_dir(root)?
+        .map(|entry| Ok(entry?.file_name()))
+        .collect::<Result<_>>()?;
+    for name in names {
+        let leaf = name.to_string_lossy().into_owned();
+        let path = root.join(&name);
+        let quarantine = root.join(format!(".{leaf}.v027-quarantine"));
+        let metadata = fs::symlink_metadata(&path)?;
+        let stale_quarantine = leaf.starts_with('.') && leaf.ends_with(".v027-quarantine");
+        if stale_quarantine {
+            remove_tree_no_links(&path)?;
+            continue;
+        }
+        if metadata.is_dir()
+            && !metadata.file_type().is_symlink()
+            && !replicated.contains(name.as_os_str())
+        {
+            kept = true;
+            continue;
+        }
+        remove_tree_no_links(&quarantine)?;
+        fs::rename(&path, &quarantine)?;
+        fs::File::open(root)?.sync_all()?;
+        remove_tree_no_links(&quarantine)?;
+        fs::File::open(root)?.sync_all()?;
+    }
+    if !kept {
+        retire_legacy(root)?;
+        return Ok(None);
+    }
+    Ok(Some(root.to_path_buf()))
 }
 
 fn retire_legacy(source: &Path) -> Result<()> {
@@ -3365,7 +3549,7 @@ gemini = "{}"
 
     #[test]
     #[serial_test::serial]
-    fn orphan_store_is_preserved_without_contaminating_a_peer() {
+    fn an_unregistered_store_moves_without_being_expanded() {
         let temp = tempfile::tempdir().unwrap();
         let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
         let app = crate::session::get_app_dir().unwrap();
@@ -3375,9 +3559,11 @@ gemini = "{}"
         let orphan = "2222222222222222";
         fs::create_dir_all(root.join(peer)).unwrap();
         fs::create_dir_all(root.join(orphan)).unwrap();
+        fs::create_dir_all(root.join("sessions")).unwrap();
         fs::write(root.join(peer).join("peer"), b"peer").unwrap();
         fs::write(root.join(orphan).join("orphan"), b"orphan").unwrap();
         fs::write(root.join("common"), b"common").unwrap();
+        fs::write(root.join("sessions").join("other"), b"other").unwrap();
         fs::write(
             app.join("sessions.json"),
             format!(r#"[{{"id":"{peer}","tool":"codex","sandbox_info":{{"enabled":true}}}}]"#),
@@ -3392,19 +3578,106 @@ gemini = "{}"
             b"peer"
         );
         assert_eq!(
+            fs::read(destination.join(peer).join("common")).unwrap(),
+            b"common",
+            "a shared root file still reaches the session that had no copy of it"
+        );
+        assert!(
+            !destination.join(peer).join("sessions").exists(),
+            "another session's history must not be replicated into a private store"
+        );
+        assert_eq!(
+            fs::read(destination.join(orphan).join("orphan")).unwrap(),
+            b"orphan",
+            "a store no session claims is preserved as it was"
+        );
+        assert!(
+            !destination.join(orphan).join("common").exists(),
+            "a store no session claims must not be expanded with the shared root"
+        );
+        assert!(!destination.join(peer).join(orphan).exists());
+        assert!(!root.join(peer).exists());
+        assert!(!root.join(orphan).exists());
+        assert!(!root.join("common").exists());
+        assert_eq!(
+            fs::read(root.join("sessions").join("other")).unwrap(),
+            b"other",
+            "what no private store received is the only copy left, so it stays"
+        );
+    }
+
+    /// The shared root goes when everything in it was replicated, exactly as
+    /// it did before the overlay stopped folding directories in.
+    #[test]
+    #[serial_test::serial]
+    fn a_fully_replicated_shared_root_is_still_retired() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let root = home.join(".codex/sandbox");
+        let peer = "1111111111111111";
+        fs::create_dir_all(root.join(peer)).unwrap();
+        fs::write(root.join(peer).join("peer"), b"peer").unwrap();
+        fs::write(root.join("common"), b"common").unwrap();
+        fs::write(
+            app.join("sessions.json"),
+            format!(r#"[{{"id":"{peer}","tool":"codex","sandbox_info":{{"enabled":true}}}}]"#),
+        )
+        .unwrap();
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+
+        assert_eq!(
+            fs::read(home.join(".codex/sandbox-v2").join(peer).join("common")).unwrap(),
+            b"common"
+        );
+        assert!(!root.exists());
+    }
+
+    /// A killed `aoe migrate` leaves a half-written staging directory in the
+    /// private layout. The pass that picks that store up again must clear it,
+    /// including on the rename path, which never opens the staging directory
+    /// it has to remove.
+    #[test]
+    #[serial_test::serial]
+    fn an_interrupted_stage_is_cleared_when_an_unregistered_store_moves() {
+        let temp = tempfile::tempdir().unwrap();
+        let _app_guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+        let app = crate::session::get_app_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+        let root = home.join(".codex/sandbox");
+        let peer = "1111111111111111";
+        let orphan = "2222222222222222";
+        let destination = home.join(".codex/sandbox-v2");
+        fs::create_dir_all(root.join(peer)).unwrap();
+        fs::create_dir_all(root.join(orphan)).unwrap();
+        fs::write(root.join(orphan).join("orphan"), b"orphan").unwrap();
+        let stage = destination.join(format!(".v027-stage-{orphan}"));
+        fs::create_dir_all(stage.join("half")).unwrap();
+        fs::write(stage.join("half").join("written"), b"partial").unwrap();
+        fs::create_dir_all(destination.join(orphan)).unwrap();
+        fs::write(destination.join(orphan).join("stale"), b"stale").unwrap();
+        fs::write(
+            app.join("sessions.json"),
+            format!(r#"[{{"id":"{peer}","tool":"codex","sandbox_info":{{"enabled":true}}}}]"#),
+        )
+        .unwrap();
+
+        run_in(&app, &home, &|_| Ok(false)).unwrap();
+
+        assert!(!stage.exists(), "the interrupted staging tree must be gone");
+        assert!(!destination
+            .join(format!(".v027-quarantine-{orphan}"))
+            .exists());
+        assert_eq!(
             fs::read(destination.join(orphan).join("orphan")).unwrap(),
             b"orphan"
         );
-        assert_eq!(
-            fs::read(destination.join(peer).join("common")).unwrap(),
-            b"common"
+        assert!(
+            !destination.join(orphan).join("stale").exists(),
+            "the interrupted run's destination must be replaced, not merged into"
         );
-        assert_eq!(
-            fs::read(destination.join(orphan).join("common")).unwrap(),
-            b"common"
-        );
-        assert!(!destination.join(peer).join(orphan).exists());
-        assert!(!root.exists());
     }
 
     /// A registry row shaped like a real `Instance`, so `Storage::update`


### PR DESCRIPTION
## Description

When you upgrade, AoE gives every sandboxed session its own copy of the agent's files instead of one shared folder. That move was doing far more work than it needed to. It handed each session a full copy of the whole shared folder, including other sessions' conversation history, caches, logs and plugin trees, and it did that even for sessions deleted long ago. It also asked the disk to fully flush itself after every single file, which on a Mac is the slowest thing you can ask a drive to do. The reported run took 43 minutes, wrote 16 GB, and produced 63 folders belonging to no session at all.

This changes what gets copied before it changes how fast copying is. A folder no session claims is moved rather than duplicated. A session that already had its own folder gets the shared folder's loose files, its login and settings, and not its subfolders. Nothing skipped is deleted: the old shared folder stays put and AoE tells you where it is. Then files are shared on disk rather than copied where the filesystem allows, and the per-file flush becomes one write barrier before each folder is published.

Fixes #3819

### Scope, first

- **A store no registry row names is renamed into the private layout, not copied.** All 63 stores the reported run created resolved to no session in any profile. Renaming preserves one exactly for one syscall, and nothing will start it, so the shared agent home is not folded in.
- **The overlay carries top-level files, not directories.** It folds a shared agent home into a session that already had a private one. That session needs the credentials, config and state kept at that home's root. Its directories are the home's own accumulation: 109 MB of other sessions' history, 26 MB of plugins, 16 MB of cache, 5.9 MB of shell snapshots. None of it is the SQLite single-instance lock this migration exists to unshare, and it turned a 17 MB legacy store into a 252 MB private one.
- **What no private store received is not deleted.** Retirement removes the per-instance children and the top-level files every private store did receive; the legacy root keeps the rest and the migration names it, since it has become the only copy. A `~/.gemini/sandbox`-style root, where the shared store genuinely was each session's working state, is still retired whole.

### Then cost

- **Copy-on-write clones** through `clonefile` on APFS and `FICLONE` on btrfs and XFS. Every clone failure falls back to writing the bytes, not only the filesystem's refusal, and one refusal turns clones off for the rest of the move rather than paying a failing syscall per file.
- **One barrier per publish instead of a full flush per file.** `File::sync_all` is `F_FULLFSYNC` on Apple platforms, measured in the issue at 7.29 ms/file against 0.58 ms for plain `fsync`. Each entry is pushed to the drive with `fsync` as it is created; one `F_BARRIERFSYNC` orders the tree ahead of the publishing rename.

### Durability is unchanged

The requirement is that the staged tree reaches the media before the rename that publishes it. `fsync` moves bytes host-to-drive, the barrier forbids the drive committing anything after it before everything issued before it, and the existing `sync_all` on the parent after the rename makes the publish durable. A crash can lose a publish; it cannot expose a published store whose bytes never reached the media. A clone is metadata only, and its `fsync` persists the new inode's extent map; the extents it shares are the source's, which the same barrier covers.

`recovers_publication_before_registry_commit` and `recovers_legacy_quarantine_before_generation_commit` still run through the same staging protocol: `Publication::prepare` is the old prologue, extracted so the rename path clears the debris the copy path did. Removing a legacy child still renames it aside first, because a half-deleted legacy store is one a still-pending row would copy back over the published one.

### Measured

`aoe migrate` over a store built from a real tree (10,867 files, 163.8 MB, median file 3.8 KB, a slice of `~/.cargo/registry/src`) as the shared agent home, plus nine per-instance children of which one is registered. Debug build, Linux aarch64 container, overlayfs over ext4, medians of three paired runs.

| | before | after |
|---|---|---|
| elapsed | 50.7 s | 3.4 s |
| published | 100,818 files / 1495.5 MB | 2,999 files / 4.7 MB |
| files/s | 1989 | 874 |
| MB/s | 29.5 | 1.4 |

Throughput falls because almost nothing is left to write: 318x fewer bytes, 15x shorter wall clock. The remaining 3.4 s is directory scanning and the one registered store.

The copy path alone, same tree as a `~/.gemini/sandbox` shared store that must be copied whole, five paired runs, medians: before 6.32 s / 1720 files/s / 25.9 MB/s, after 6.44 s / 1688 files/s / 25.5 MB/s. No measurable change, which is all this machine can show: `fsync` and `sync_all` cost the same on Linux, and `ioctl(FICLONE)` here returns `EOPNOTSUPP (95)`, so the fallback is what ran for all 10,867 files and produced trees identical to the old code's. **The clone win is argued here, not measured.**

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --all-targets`, `cargo test` (6798 + 289 pass). `docs/guides/sandbox.md` said the shared store is deleted once every session has moved; updated.

New tests: `an_unregistered_store_moves_without_being_expanded`, `a_fully_replicated_shared_root_is_still_retired`, `retiring_a_root_keeps_only_what_no_store_received`, `an_interrupted_retirement_keeps_the_published_store`, `a_retired_root_does_not_fail_the_next_row`, `an_interrupted_stage_is_cleared_when_an_unregistered_store_moves` (the reported leftover `.v027-stage-<id>`, on the rename path that never opens it), `an_unclonable_source_falls_back_instead_of_failing` and `a_refused_clone_is_not_retried` (a source no clone implementation accepts, so the fallback is covered on a reflink-capable filesystem too).

`ci-macos` is labelled on this PR: the macOS job is gated behind it, and the `clonefile` and `F_BARRIERFSYNC` paths are the point of the change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Skipped a test, because: the in-module tests drive the whole pass (`run_in`) with the container probes injected, which is the cheapest test that catches these regressions. A full-binary run would reach nothing they do not.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Investigation, implementation and benchmarking by the model in discussion with @njbrake; the scope decision, that the fix is what gets copied rather than how fast it copies, is his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvnVeqAwMg7iVZc2rRpKWZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated v027 migration to rename unregistered stores instead of copying them.
- Copies only required top-level files into existing private stores.
- Preserves unrelated caches, logs, histories, and plugin data.
- Added copy-on-write cloning with a byte-copy fallback.
- Replaced repeated full-drive flushes with staged syncing and one publish barrier.
- Improved recovery for interrupted staging and retirement.
- Updated documentation and migration tests.

## Benefits

- Reduces migration time and disk usage.
- Preserves data that does not require migration.
- Improves safety during interrupted migrations.

## Technical follow-up

- Continue validating clone support and recovery behavior across supported filesystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->