### PR TITLE
fix: get main green on the sun_path and capture-lease regressions

### DIFF
--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -3107,7 +3107,11 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn watchdog_teardown_preserves_replacement_registry_owner() {
-        let _app_dir = crate::session::test_support::isolate_app_dir();
+        // Rooted under /tmp, not $TMPDIR: macOS resolves the latter to
+        // /var/folders/<uid hash>/T/, which leaves the control socket past the
+        // 104-byte sun_path limit once <app_dir>/acp-workers/<id> is appended.
+        let app_root = tempfile::TempDir::with_prefix_in("aoe-wd-", "/tmp").unwrap();
+        let _app_dir = crate::session::test_support::isolate_app_dir_at(app_root.path());
         let session_id = "watchdog-replacement";
         let socket = worker_registry::socket_path_for(session_id).unwrap();
         let control_socket = crate::process::worker::control_socket_sibling(&socket);

--- a/src/session/instance/polling.rs
+++ b/src/session/instance/polling.rs
@@ -29,20 +29,55 @@ pub enum PollerStart {
     SpawnFailed,
 }
 
+/// An exclusive claim on one physical capture store, held for as long as the
+/// poller that owns it runs.
+///
+/// `Drop` unlocks explicitly rather than letting the descriptor close do it. A
+/// `flock` belongs to the open file description, not to one descriptor, so a
+/// process forked while the lease was open holds the lock alive through its
+/// inherited copy until `exec` clears it. Releasing by close alone leaves the
+/// store reading as owned by someone else for that window; `unlock` releases
+/// the description itself, and every inherited copy with it.
+#[derive(Debug)]
+struct ManagedCaptureLease(std::fs::File);
+
+impl Drop for ManagedCaptureLease {
+    fn drop(&mut self) {
+        // Spelled through the trait: `File`'s inherent `unlock` is newer than
+        // this crate's MSRV.
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
+}
+
+/// Why a managed capture store is not available to poll.
+#[derive(Debug, PartialEq, Eq)]
+enum LeaseRefusal {
+    /// Another owner holds this physical store.
+    Contended,
+    /// The claim could not be evaluated at all: the app dir, the store path,
+    /// or the lock file did not resolve. Not evidence of another owner.
+    Unresolved,
+}
+
 fn try_acquire_managed_capture_lease(
     backend: crate::agents::SessionCaptureBackend,
     store: &Path,
-) -> Option<std::fs::File> {
-    let lock_dir = crate::session::get_app_dir().ok()?.join("capture-locks");
-    std::fs::create_dir_all(&lock_dir).ok()?;
-    let store = std::fs::canonicalize(store).ok()?;
+) -> Result<ManagedCaptureLease, LeaseRefusal> {
+    fn unresolved<E>(_: E) -> LeaseRefusal {
+        LeaseRefusal::Unresolved
+    }
+    let lock_dir = crate::session::get_app_dir()
+        .map_err(unresolved)?
+        .join("capture-locks");
+    std::fs::create_dir_all(&lock_dir).map_err(unresolved)?;
+    let store = std::fs::canonicalize(store).map_err(unresolved)?;
     let mut digest = Sha256::new();
     digest.update(format!("{backend:?}\0"));
     digest.update(store.as_os_str().as_encoded_bytes());
     let mut key = String::with_capacity(64);
     for byte in digest.finalize() {
         use std::fmt::Write as _;
-        write!(&mut key, "{byte:02x}").ok()?;
+        write!(&mut key, "{byte:02x}").map_err(unresolved)?;
     }
     let path = lock_dir.join(format!("{key}.lock"));
 
@@ -58,11 +93,13 @@ fn try_acquire_managed_capture_lease(
         .map(|metadata| metadata.file_type().is_symlink())
         .unwrap_or(false)
     {
-        return None;
+        return Err(LeaseRefusal::Unresolved);
     }
-    let lease = options.open(path).ok()?;
-    lease.try_lock_exclusive().ok()?;
-    Some(lease)
+    let lease = options.open(path).map_err(unresolved)?;
+    lease
+        .try_lock_exclusive()
+        .map_err(|_| LeaseRefusal::Contended)?;
+    Ok(ManagedCaptureLease(lease))
 }
 
 impl Instance {
@@ -201,31 +238,43 @@ impl Instance {
         if !self.supports_session_poller() {
             return PollerStart::NotApplicable;
         }
-        let managed_lease =
-            if context == crate::agents::SessionCaptureContext::ManagedExclusiveStore {
-                let Some(store) = self.sandbox_capture_store_dir() else {
-                    return PollerStart::NotApplicable;
-                };
-                // Lease contention is the common multi-process loser path. Check it
-                // before loading every profile to prove store exclusivity.
-                let Some(lease) = try_acquire_managed_capture_lease(backend, &store) else {
+        let managed_lease = if context
+            == crate::agents::SessionCaptureContext::ManagedExclusiveStore
+        {
+            let Some(store) = self.sandbox_capture_store_dir() else {
+                return PollerStart::NotApplicable;
+            };
+            // Lease contention is the common multi-process loser path. Check it
+            // before loading every profile to prove store exclusivity.
+            let lease = match try_acquire_managed_capture_lease(backend, &store) {
+                Ok(lease) => lease,
+                Err(refusal) => {
                     self.session_id_poller_retry_after =
                         Some(std::time::Instant::now() + MANAGED_CAPTURE_RETRY_BACKOFF);
-                    tracing::warn!(target: "session.capture", session = %self.id, ?backend,
-                    "Session capture deferred because another process owns this store");
-                    return PollerStart::Deferred;
-                };
-                if !self.managed_capture_store_is_exclusive(backend) {
-                    self.session_id_poller_retry_after =
-                        Some(std::time::Instant::now() + MANAGED_CAPTURE_RETRY_BACKOFF);
-                    tracing::warn!(target: "session.capture", session = %self.id, ?backend,
-                    "Session capture deferred because store ownership is ambiguous");
+                    match refusal {
+                        LeaseRefusal::Contended => {
+                            tracing::warn!(target: "session.capture", session = %self.id, ?backend,
+                                "Session capture deferred because another process owns this store");
+                        }
+                        LeaseRefusal::Unresolved => {
+                            tracing::warn!(target: "session.capture", session = %self.id, ?backend,
+                                "Session capture deferred because this store's lease could not be resolved");
+                        }
+                    }
                     return PollerStart::Deferred;
                 }
-                Some(lease)
-            } else {
-                None
             };
+            if !self.managed_capture_store_is_exclusive(backend) {
+                self.session_id_poller_retry_after =
+                    Some(std::time::Instant::now() + MANAGED_CAPTURE_RETRY_BACKOFF);
+                tracing::warn!(target: "session.capture", session = %self.id, ?backend,
+                    "Session capture deferred because store ownership is ambiguous");
+                return PollerStart::Deferred;
+            }
+            Some(lease)
+        } else {
+            None
+        };
         self.session_id_poller_retry_after = None;
 
         let tmux_session_name = self
@@ -874,29 +923,33 @@ mod tests {
         let backend = crate::agents::SessionCaptureBackend::Gemini;
         let first =
             super::try_acquire_managed_capture_lease(backend, store.path()).expect("first owner");
-        assert!(
-            super::try_acquire_managed_capture_lease(backend, store.path()).is_none(),
+        assert_eq!(
+            super::try_acquire_managed_capture_lease(backend, store.path()).unwrap_err(),
+            super::LeaseRefusal::Contended,
             "another row using the same store must contend regardless of workspace"
         );
         #[cfg(unix)]
         {
             let alias = app.path().join("store-alias");
             std::os::unix::fs::symlink(store.path(), &alias).unwrap();
-            assert!(
-                super::try_acquire_managed_capture_lease(backend, &alias).is_none(),
+            assert_eq!(
+                super::try_acquire_managed_capture_lease(backend, &alias).unwrap_err(),
+                super::LeaseRefusal::Contended,
                 "a symlink to the same physical store must contend"
             );
         }
-        assert!(
+        assert_eq!(
             super::try_acquire_managed_capture_lease(backend, &app.path().join("missing"))
-                .is_none(),
-            "an unresolved store identity must fail closed"
+                .unwrap_err(),
+            super::LeaseRefusal::Unresolved,
+            "an unresolved store identity fails closed without claiming another owner"
         );
         let distinct = super::try_acquire_managed_capture_lease(backend, other_store.path())
             .expect("a distinct store has a distinct lease");
 
         drop(first);
-        assert!(super::try_acquire_managed_capture_lease(backend, store.path()).is_some());
+        super::try_acquire_managed_capture_lease(backend, store.path())
+            .expect("the released store is claimable again");
         drop(distinct);
     }
 }


### PR DESCRIPTION
## Description

Main has been red for 16 commits on two unrelated regressions.

**`runner.rs:3114`, macOS only.** `watchdog_teardown_preserves_replacement_registry_owner` binds the runner control socket under `isolate_app_dir()`, which roots the app dir at `$TMPDIR`. macOS resolves that to `/var/folders/<uid hash>/T/`, so `<app_dir>/acp-workers/<id>.control.sock` runs ~127 bytes against the 104-byte `sun_path` cap and `bind` fails with `path must be shorter than SUN_LEN`. Rooted under `/tmp` instead, matching the convention already used in `worker_registry` and `acp::supervisor` tests. Reproduced on Linux by pointing `TMPDIR` at a macOS-length path, which fails identically before this change and passes after.

**`polling.rs:899`, macOS and bare-core, roughly one run in three.** `/proc/locks` at the failure shows the exclusive flock still held by our own pid after the owning `File` was dropped, while `/proc/self/fd` holds no descriptor for it. A process forked elsewhere in the suite inherited the descriptor before its `exec` cleared it. A flock belongs to the open file description, not to one descriptor, so closing the owner's copy releases nothing while an inherited copy is alive. `Drop` now unlocks the description itself, which releases every inherited copy with it. This is why the failure always landed on the final assertion, the only one that re-acquires after a release.

That path also collapsed "could not resolve the app dir", "could not canonicalize the store" and "another owner holds this" into one `None` through an `.ok()?` chain, so a transient local failure was reported to the user as another process owning their store. It now returns a typed refusal and logs the two cases apart. The test asserts the specific refusal, so a future failure names its cause instead of reporting a bare `is_none()`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Both regressions are covered by the existing unit tests they broke. The lease fix was verified by looping the test body 3000 times inside the full parallel suite: it failed within ~100 iterations before the change and passes 3000 after. Local runs: `cargo fmt`, `cargo clippy --all-targets` clean, `cargo test` green (6790 lib, 289 integration).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Root causes were reproduced locally before either fix was written, not inferred from CI logs.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176k3KdBmw1AfEiGvz4DVqt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Shortened the macOS watchdog test app path to keep its control socket within system limits.
- Improved capture-lease cleanup so inherited file locks are released correctly.
- Separated path and store errors from genuine ownership conflicts.
- Added clearer logging and test coverage for lease handling.

These changes prevent test failures and allow resources to be reacquired reliably after release. Validation passed with formatting, Clippy, and the full test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->