### PR TITLE
fix(sandbox): keep the agent store through any purge that gets rolled back

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -345,8 +345,9 @@ variable or run `aoe migrate` before launching it.
 ### Reclaiming stores
 
 Permanently deleting a sandboxed session removes its store along with its
-container. Stores stranded before that (or by a delete that kept the container)
-are found by their instance id resolving in no profile:
+container. Stores stranded before that, by a delete that kept the container, or
+by a delete that failed part-way and kept the session, are found by their
+instance id resolving in no profile:
 
 ```bash
 aoe sandbox reclaim            # report what would go, and how much it frees

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -720,18 +720,15 @@ fn perform_deletion_core(
     // Stage 3: container removal. Releases the bind mount on the
     // worktree so the host can finish cleanup without racing in-
     // container processes.
+    let mut container_gone = false;
     if request.delete_sandbox && is_sandboxed {
         tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
         let outcome = teardown(&request.instance.id);
         // A failed teardown can leave the container live with the store still
-        // bind mounted, and aborts the purge, so the session keeps running on
-        // the store: only remove it once the container is provably gone. One
-        // stranded by a failed purge is the reclaim pass's job.
-        let container_gone = !matches!(outcome, crate::containers::Teardown::Failed(_));
+        // bind mounted, so the store may only go once the container is
+        // provably gone.
+        container_gone = !matches!(outcome, crate::containers::Teardown::Failed(_));
         deletion_messages_for(outcome, &mut messages, &mut errors);
-        if container_gone {
-            stage_remove_agent_stores(request, &mut messages, &mut errors);
-        }
     }
 
     stage_remove_worktrees_and_branches(
@@ -744,6 +741,14 @@ fn perform_deletion_core(
     );
 
     stage_cleanup_scratch(request, &mut errors, &mut messages);
+
+    // Last, and only when nothing else failed: any error here rolls the purge
+    // back (`PurgeTransaction::complete_inner`), and a session that survives
+    // its own purge must survive with the store holding its login and history.
+    // One stranded by a rolled-back purge is the reclaim pass's job.
+    if container_gone && errors.is_empty() {
+        stage_remove_agent_stores(request, &mut messages);
+    }
 
     // Stage 6: hook status cleanup
     tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "hook_status_cleanup", "perform_deletion: stage");
@@ -1201,18 +1206,18 @@ fn stage_cleanup_scratch(
     }
 }
 
-/// Stage 4: the session's own agent stores. Each holds a copy of the agent's
-/// credentials and is named by an instance id that stops resolving with this
-/// purge, so leaving it behind strands a credential nothing will ever open.
+/// Final stage: the session's own agent stores. Each holds a copy of the
+/// agent's credentials and is named by an instance id that stops resolving
+/// with this purge, so leaving it behind strands a credential nothing will
+/// ever open.
 ///
 /// Runs with the container already removed, and only then: the store is bind
-/// mounted into it, so a kept container keeps its store. One that is stranded
-/// anyway is the reclaim pass's job.
-fn stage_remove_agent_stores(
-    request: &DeletionRequest,
-    messages: &mut Vec<String>,
-    errors: &mut Vec<String>,
-) {
+/// mounted into it, so a kept container keeps its store.
+///
+/// Reports rather than fails. An error here would roll the purge back and
+/// keep the session, which is the outcome this stage exists to avoid; a store
+/// left behind is the reclaim pass's job instead.
+fn stage_remove_agent_stores(request: &DeletionRequest, messages: &mut Vec<String>) {
     tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "agent_store_remove", "perform_deletion: stage");
     match crate::session::sandbox_store_reclaim::remove_stores_for(&request.instance) {
         Ok((removed, _)) if removed.is_empty() => {}
@@ -1220,7 +1225,13 @@ fn stage_remove_agent_stores(
             "Agent store removed ({})",
             crate::migrations::progress::format_bytes(freed)
         )),
-        Err(error) => errors.push(format!("Agent store: {error}")),
+        Err(error) => {
+            tracing::warn!(target: "session.store",
+                "leaving the agent store of {}: {error}", request.session_id);
+            messages.push(format!(
+                "Agent store kept ({error}); `aoe sandbox reclaim` removes it later"
+            ));
+        }
     }
 }
 
@@ -1768,6 +1779,42 @@ mod tests {
 
             assert!(store.exists(), "a failed teardown took the store with it");
             assert!(!result.success);
+        }
+
+        /// A purge that fails after the container came down is rolled back by
+        /// `PurgeTransaction::complete_inner`, so the session survives. Its
+        /// store must survive with it, or the session is left logged out with
+        /// its history gone.
+        #[test]
+        #[serial_test::serial]
+        fn a_purge_that_fails_after_teardown_leaves_the_store() {
+            let temp = tempfile::TempDir::new().unwrap();
+            let _home = crate::session::test_support::isolate_app_dir_at(temp.path());
+            let mut request = sandboxed_request();
+            request.delete_worktree = true;
+            request.instance.worktree_info = Some(crate::session::WorktreeInfo {
+                branch: "feature/x".to_string(),
+                main_repo_path: temp.path().join("not-a-repo").display().to_string(),
+                managed_by_aoe: true,
+                created_at: chrono::Utc::now(),
+                base_branch: None,
+            });
+            let store = temp
+                .path()
+                .join(".claude")
+                .join("sandbox-v2")
+                .join(&request.instance.id);
+            std::fs::create_dir_all(&store).unwrap();
+            std::fs::write(store.join(".credentials.json"), b"token").unwrap();
+
+            let result = perform_deletion_with(&request, |_id| Teardown::Removed);
+
+            assert!(!result.success, "{:?}", result.messages);
+            assert!(
+                store.exists(),
+                "a purge that will be rolled back took the store with it: {:?}",
+                result.errors
+            );
         }
     }
 


### PR DESCRIPTION
## Description

Deleting a sandboxed session for good was supposed to remove the private folder that session used as its agent's home, since it holds that agent's saved login and history. #3820 added that, and guarded it so a session whose container could not be torn down keeps its folder.

That guard covered only the container step. Deleting a session is a sequence: kill tmux, remove the container, remove the worktree, delete the branch, clean up scratch. If *any* of those later steps fails, the whole delete is rolled back and the session stays. The folder had already been removed by then, so the session came back alive but logged out, with its history gone, and every retry did the same thing again.

The ordinary way to hit this is to delete the repo directory a session lives in and then purge the session: worktree removal fails with "Path is not in a git repository", the delete rolls back, and the credentials are already gone. A failed `git branch -D` does it too.

Removing the folder now happens last, and only when nothing else has failed. Anything stranded that way is picked up by `aoe sandbox reclaim`, which exists for precisely that.

A failure to remove the folder is also no longer treated as an error in its own right. Reporting one rolled the delete back and kept a session whose container was already gone, and it would have failed the same way forever.

The dashboard path was already safe: it commits the row before teardown and never rolls back. This is the CLI and TUI path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by a unit test rather than an e2e one: `a_purge_that_fails_after_teardown_leaves_the_store` drives `perform_deletion_core` through its real stage sequence with a worktree that fails, and asserts the store survives. It fails without the reordering. An e2e test would need a real container runtime to reach the same stage.

`cargo fmt`, `cargo clippy --all-targets` and `cargo test` all pass.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Found by a fresh-context review of #3820 after it was approved, and reproduced with a failing test before the fix was written.

- [x] I am an AI Agent filling out this form (check box if true)

Follow-up to #3820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MFqV7cqtjPMwMBmUmwGDV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve an agent’s private store when any sandbox purge stage fails.
- Remove the store only after teardown and cleanup complete successfully.
- Report store-removal failures without rolling back the purge.
- Document recovery through `aoe sandbox reclaim`.
- Add a regression test for worktree-removal failure.
- Verify formatting, Clippy, and tests.

## Benefits

This prevents credential and history loss after partial purge failures. Operators can reclaim leftover stores after resolving the underlying issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->