### PR TITLE
fix(tests): measure the live cursor against the prompt the agent just drew

### DIFF
--- a/web/tests/live/live-size-owner-takeover.spec.ts
+++ b/web/tests/live/live-size-owner-takeover.spec.ts
@@ -26,14 +26,24 @@ async function openLiveView(page: Page, baseUrl: string) {
 }
 
 /** Vertical distance (px) between the cursor overlay and the top of the
- *  rendered row containing the prompt. 0 means perfectly aligned. */
+ *  rendered row containing the live prompt. 0 means perfectly aligned.
+ *
+ *  The *last* matching row, not the first. A hand-off resizes the pane, the
+ *  agent redraws its prompt on SIGWINCH, and when the pane grows the redraw
+ *  lands on a new row while the pre-resize prompt stays behind in the
+ *  scrollback. Both rows then contain the prompt, and measuring against the
+ *  stale one reports the distance between the two prompts rather than any
+ *  cursor drift. That is a fixed 76.75px here, so it never converges and the
+ *  poll always times out. A cursor that really did sit one row off the live
+ *  prompt is still one row height away, well over the threshold. */
 async function cursorToPromptDelta(page: Page): Promise<number> {
   return page.evaluate((prompt) => {
     const content = document.querySelector("[data-live-content]");
     const cursor = document.querySelector("[data-live-cursor]");
     if (!content || !cursor) return Number.NaN;
     const rows = Array.from(content.children).filter((el) => !el.hasAttribute("data-live-cursor"));
-    const promptRow = rows.find((el) => (el.textContent ?? "").includes(prompt));
+    const promptRows = rows.filter((el) => (el.textContent ?? "").includes(prompt));
+    const promptRow = promptRows[promptRows.length - 1];
     if (!promptRow) return Number.NaN;
     const c = cursor.getBoundingClientRect();
     const r = promptRow.getBoundingClientRect();


### PR DESCRIPTION
## Description

One live Playwright spec has been failing on and off across several unrelated PRs and on main, always on the same line with the same number: a cursor-to-prompt distance of 76.75 pixels against a threshold of 2. It looked like a flake, so it kept getting re-run rather than investigated.

The constant was the giveaway. A genuine timing problem gives you a different number every time; the same number every time means the test is measuring the wrong thing.

The test checks that after two viewers ping-pong control of a session, the cursor sits on the row holding the agent's prompt. Handing control over resizes the terminal, and the fake agent redraws its prompt when that happens. If the pane grew, the redraw lands on a new row and the old prompt stays behind in the scrollback. Two rows now contain the prompt. The test picked the first one, so it was reporting the gap between the old prompt and the new one, not any cursor drift. That gap never closes, so the ten-second retry always ran out.

Whether the old prompt survives the resize depends on the timing of the redraw, which is what made it look intermittent.

Measuring against the last matching row, the one the agent just drew, fixes it.

## Evidence

Instrumented the DOM at the moment of failure:

```
failing: rows=39  cursorTop=589.40625  prompts=[{row:30, top:512.65625}, {row:38, top:589.40625}]
passing: rows=31  cursorTop=589.40625  prompts=[{row:30, top:589.40625}]
```

The cursor is exactly on row 38, the live prompt. `589.40625 - 512.65625 = 76.75`, the reported value.

Locally, with the CI configuration (debug build, `AOE_COVERAGE=1`, three workers):

- before: **3 of 6** runs failed
- after: **20 of 20** passed

The regression this test guards is still guarded. Injecting a one-row cursor drift makes it fail at 9.59px, well over the threshold of 2.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

This is a fix to a live Playwright spec itself. Its `coverage-matrix.json` entry already points at this file and needs no change; `node tests/validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No product code changes: the cursor was in the right place all along.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Diagnosed by reproducing the failure locally and dumping the row geometry at the point of failure, rather than from the stack trace alone.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MFqV7cqtjPMwMBmUmwGDV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the live Playwright test to measure the cursor against the latest prompt row after terminal resizing.
- Documented why older prompt rows can remain in scrollback.
- Stabilized the test without changing product code or coverage.

This prevents stale-row measurements and removes the reported test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->