### PR TITLE
fix(tests): release the ready-marker pane causally, not on a sleep

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2770,17 +2770,32 @@ mod tests {
         assert!(status.success());
         refresh_session_cache();
 
+        /// Releases the pane on the way out, so an unwind inside the scope
+        /// below cannot leave the waiter forking against a killed session
+        /// until its budget expires.
+        struct ReleaseOnDrop<'a>(&'a std::path::Path);
+        impl Drop for ReleaseOnDrop<'_> {
+            fn drop(&mut self) {
+                let _ = std::fs::write(self.0, b"");
+            }
+        }
+
         let (returned_tx, returned_rx) = std::sync::mpsc::channel();
         let session = Session::from_name(&name);
-        // Observations are collected, not asserted, inside the scope: the
-        // release below then always runs, so no failure path leaves the waiter
-        // forking against a killed session and the scope's join stays prompt.
+        // Observations are collected, not asserted, inside the scope, and the
+        // release runs on every path out of it, so no failure leaves the
+        // waiter forking against a killed session and the join stays prompt.
         let (settled, last, premature, early, released) = std::thread::scope(|scope| {
             scope.spawn(|| {
+                // Only a failure deadline, and it has to dominate the
+                // sample-bounded window below: a budget the window can reach
+                // on a slow host would expire mid-window and read as the
+                // early return this test exists to catch.
                 Session::from_name(&name)
-                    .wait_until_ready(std::time::Duration::from_secs(15), Some("ask anything"));
+                    .wait_until_ready(std::time::Duration::from_secs(60), Some("ask anything"));
                 let _ = returned_tx.send(());
             });
+            let _release_on_unwind = ReleaseOnDrop(&release);
             // Negative claim, so it needs a window: hold the settled markerless
             // screen across several of the waiter's 200ms polls, which is the
             // state an early return would key on. Bounded by sample count, not
@@ -2823,6 +2838,7 @@ mod tests {
         );
         released.expect("did not return promptly once the marker appeared");
     }
+
     #[test]
     fn chrome_rows_accounts_for_status_bar_and_ignores_splits() {
         // #2766: the reporter's tmux yields a pane one row shorter than the

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2722,6 +2722,7 @@ mod tests {
     /// (a "still loading" screen can look "settled" long before the agent is
     /// really listening).
     #[test]
+    #[serial_test::serial]
     fn wait_until_ready_blocks_until_the_marker_appears() {
         if !tmux_available() {
             eprintln!("Skipping test: tmux not available");
@@ -2731,6 +2732,8 @@ mod tests {
         let name = guard.name().to_string();
         let temp = tempfile::tempdir().expect("release tempdir");
         let release = temp.path().join("release");
+        let quote =
+            |p: &std::path::Path| format!("'{}'", p.to_string_lossy().replace('\'', r#"'\''"#));
         // The pane holds a screen the generic fallback would accept (over 20
         // characters, unchanging) and prints the marker only once this test
         // creates the release file, so the marker's arrival is caused here
@@ -2739,8 +2742,8 @@ mod tests {
         // `append_pane_base_index_args` so the `^.0` capture target resolves
         // on hosts with `pane-base-index 1` set globally (#488, #2231).
         let script = format!(
-            "echo 'booting, please wait ...'; while [ ! -f '{}' ]; do sleep 0.02; done; echo 'ask anything...'; sleep 30",
-            release.display()
+            "echo 'booting, please wait ...'; until [ -f {} ]; do sleep 0.02; done; echo 'ask anything...'; sleep 30",
+            quote(&release)
         );
         let status = crate::tmux::tmux_command()
             .args([
@@ -2768,53 +2771,58 @@ mod tests {
         refresh_session_cache();
 
         let (returned_tx, returned_rx) = std::sync::mpsc::channel();
-        let waiter_name = name.clone();
-        let waiter = std::thread::spawn(move || {
-            Session::from_name(&waiter_name)
-                .wait_until_ready(std::time::Duration::from_secs(20), Some("ask anything"));
-            let _ = returned_tx.send(());
+        let session = Session::from_name(&name);
+        // Observations are collected, not asserted, inside the scope: the
+        // release below then always runs, so no failure path leaves the waiter
+        // forking against a killed session and the scope's join stays prompt.
+        let (settled, last, premature, early, released) = std::thread::scope(|scope| {
+            scope.spawn(|| {
+                Session::from_name(&name)
+                    .wait_until_ready(std::time::Duration::from_secs(15), Some("ask anything"));
+                let _ = returned_tx.send(());
+            });
+            // Negative claim, so it needs a window: hold the settled markerless
+            // screen across several of the waiter's 200ms polls, which is the
+            // state an early return would key on. Bounded by sample count, not
+            // wall time, so a slow host lengthens the window the waiter has to
+            // survive instead of starving the loop of samples.
+            let mut settled = 0;
+            let mut last: Option<String> = None;
+            let mut premature = None;
+            for _ in 0..12 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let now = session.capture_pane(5).expect("capture pane");
+                if now.to_lowercase().contains("ask anything") {
+                    premature = Some(now.clone());
+                }
+                if now.trim().len() > 20 && last.as_deref() == Some(now.as_str()) {
+                    settled += 1;
+                }
+                last = Some(now);
+            }
+            let early = returned_rx.try_recv();
+            std::fs::write(&release, b"").expect("release the pane");
+            // Far above the ~200ms poll interval the marker path returns on,
+            // far below the waiter's budget, so this separates "the marker
+            // fired" from both "it idled" and "it gave up".
+            let released = returned_rx.recv_timeout(std::time::Duration::from_secs(2));
+            (settled, last, premature, early, released)
         });
 
-        let session = Session::from_name(&name);
-        // Negative claim, so it needs a window: hold the settled markerless
-        // screen past several of the waiter's 200ms polls, which is the state
-        // an early return would key on.
-        let observe_until = std::time::Instant::now() + std::time::Duration::from_millis(1500);
-        let mut settled = 0;
-        let mut last: Option<String> = None;
-        while std::time::Instant::now() < observe_until {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let now = session.capture_pane(5).unwrap_or_default();
-            assert!(
-                !now.to_lowercase().contains("ask anything"),
-                "the pane printed the marker before the test released it: {now:?}"
-            );
-            if now.trim().len() > 20 && last.as_deref() == Some(now.as_str()) {
-                settled += 1;
-            }
-            last = Some(now);
-        }
+        assert!(
+            premature.is_none(),
+            "the pane printed the marker before the test released it: {premature:?}"
+        );
         assert!(
             settled >= 2,
             "pane never held a screen the settle fallback would accept: {last:?}"
         );
         assert!(
-            matches!(
-                returned_rx.try_recv(),
-                Err(std::sync::mpsc::TryRecvError::Empty)
-            ),
+            matches!(early, Err(std::sync::mpsc::TryRecvError::Empty)),
             "returned on the static screen, before the marker appeared"
         );
-
-        std::fs::write(&release, b"").expect("release the pane");
-        // Well inside the 20s budget, so returning here is the marker firing
-        // rather than the wait giving up.
-        returned_rx
-            .recv_timeout(std::time::Duration::from_secs(5))
-            .expect("did not return once the marker appeared");
-        waiter.join().expect("waiter thread");
+        released.expect("did not return promptly once the marker appeared");
     }
-
     #[test]
     fn chrome_rows_accounts_for_status_bar_and_ignores_splits() {
         // #2766: the reporter's tmux yields a pane one row shorter than the

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2716,11 +2716,11 @@ mod tests {
         }
     }
 
-    /// Direct, timing-based proof that `wait_until_ready` with a known
-    /// marker actually blocks until that marker appears, rather than
-    /// returning early on a merely-static pane -- the gap in the generic
-    /// content-settle fallback (a short "still loading" screen can look
-    /// "settled" long before the agent is really listening).
+    /// Direct proof that `wait_until_ready` with a known marker actually
+    /// blocks until that marker appears, rather than returning early on a
+    /// merely-static pane -- the gap in the generic content-settle fallback
+    /// (a "still loading" screen can look "settled" long before the agent is
+    /// really listening).
     #[test]
     fn wait_until_ready_blocks_until_the_marker_appears() {
         if !tmux_available() {
@@ -2729,12 +2729,19 @@ mod tests {
         }
         let guard = TmuxTestSession::new("aoe_test_ready_marker");
         let name = guard.name().to_string();
-        // A short, static "booting" line appears immediately and would
-        // satisfy the generic settle heuristic well under 700ms; the real
-        // marker text only appears after the sleep. The trailing `set-option
-        // pane-base-index 0` chain mirrors `append_pane_base_index_args` so the
-        // `^.0` capture target resolves on hosts with `pane-base-index 1` set
-        // globally (#488, #2231).
+        let temp = tempfile::tempdir().expect("release tempdir");
+        let release = temp.path().join("release");
+        // The pane holds a screen the generic fallback would accept (over 20
+        // characters, unchanging) and prints the marker only once this test
+        // creates the release file, so the marker's arrival is caused here
+        // rather than timed against a sleep in the pane. The trailing
+        // `set-option pane-base-index 0` chain mirrors
+        // `append_pane_base_index_args` so the `^.0` capture target resolves
+        // on hosts with `pane-base-index 1` set globally (#488, #2231).
+        let script = format!(
+            "echo 'booting, please wait ...'; while [ ! -f '{}' ]; do sleep 0.02; done; echo 'ask anything...'; sleep 30",
+            release.display()
+        );
         let status = crate::tmux::tmux_command()
             .args([
                 "new-session",
@@ -2747,7 +2754,7 @@ mod tests {
                 "24",
                 "sh",
                 "-c",
-                "echo booting; sleep 0.7; echo 'ask anything...'; sleep 30",
+                &script,
                 ";",
                 "set-option",
                 "-t",
@@ -2760,19 +2767,52 @@ mod tests {
         assert!(status.success());
         refresh_session_cache();
 
-        let session = Session::from_name(&name);
-        let start = std::time::Instant::now();
-        session.wait_until_ready(std::time::Duration::from_secs(3), Some("ask anything"));
-        let elapsed = start.elapsed();
+        let (returned_tx, returned_rx) = std::sync::mpsc::channel();
+        let waiter_name = name.clone();
+        let waiter = std::thread::spawn(move || {
+            Session::from_name(&waiter_name)
+                .wait_until_ready(std::time::Duration::from_secs(20), Some("ask anything"));
+            let _ = returned_tx.send(());
+        });
 
+        let session = Session::from_name(&name);
+        // Negative claim, so it needs a window: hold the settled markerless
+        // screen past several of the waiter's 200ms polls, which is the state
+        // an early return would key on.
+        let observe_until = std::time::Instant::now() + std::time::Duration::from_millis(1500);
+        let mut settled = 0;
+        let mut last: Option<String> = None;
+        while std::time::Instant::now() < observe_until {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            let now = session.capture_pane(5).unwrap_or_default();
+            assert!(
+                !now.to_lowercase().contains("ask anything"),
+                "the pane printed the marker before the test released it: {now:?}"
+            );
+            if now.trim().len() > 20 && last.as_deref() == Some(now.as_str()) {
+                settled += 1;
+            }
+            last = Some(now);
+        }
         assert!(
-            elapsed >= std::time::Duration::from_millis(600),
-            "returned before the marker could plausibly have appeared: {elapsed:?}"
+            settled >= 2,
+            "pane never held a screen the settle fallback would accept: {last:?}"
         );
         assert!(
-            elapsed < std::time::Duration::from_secs(2),
-            "should have returned promptly once the marker appeared, not idled toward the bound: {elapsed:?}"
+            matches!(
+                returned_rx.try_recv(),
+                Err(std::sync::mpsc::TryRecvError::Empty)
+            ),
+            "returned on the static screen, before the marker appeared"
         );
+
+        std::fs::write(&release, b"").expect("release the pane");
+        // Well inside the 20s budget, so returning here is the marker firing
+        // rather than the wait giving up.
+        returned_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("did not return once the marker appeared");
+        waiter.join().expect("waiter thread");
     }
 
     #[test]


### PR DESCRIPTION
## Description

`tmux::session::tests::wait_until_ready_blocks_until_the_marker_appears` is intermittently red on macOS. The pane printed the ready marker 700ms in and the test asserted the wait took at least 600ms. That floor is a proxy for "it did not return on the static screen", and it holds only while the waiter's polls stay in phase with the pane's sleep.

They fall out of phase on macOS. Each poll forks `capture-pane`, roughly 80ms there against a few ms on Linux, so the effective poll interval is nearer 280ms than 200ms. `refresh_session_cache` alone measured 160-183ms on the failing runners, shifting the waiter's start past the pane's. The second poll then lands around 720-740ms, just past the marker, and the wait returns at 561ms. Correct behavior, failed assertion.

This is not a regression from #3759, which changed only `src/tmux/vt.rs`; `capture_pane` forks tmux directly and never touches the VT path. The same assertion failed on macOS on 2026-09-04 (`a5bdb7bca`, 567.8ms) and 2026-09-05 (`8876585ee`, 568.2ms), days before that merge. The two consecutive failures at 18:30 were `bf875fecb` and `e012f15e0`, and only the second one failed on this test; `bf875fecb`'s Tests failure was Playwright (live), with its macOS cargo job green.

The old floor was also blind to the regression it was named for, and worse than blind: its pane printed `booting`, 7 characters, below `wait_until_ready`'s own `now.trim().len() > 20` gate. The settle fallback it claimed to guard was unreachable by construction. Deleting the `continue` that keeps the marker path off that fallback leaves the old test passing; the rewrite fails on it.

The test now drives the pane instead of racing it: the pane holds a screen the generic settle fallback would accept and prints the marker only once the test creates a release file. Observe the settled markerless screen across several of the waiter's polls, assert it has not returned, then release and require the return. The surviving wall-clock values are deadlines rather than floors: a 2s promptness bound after release, and a waiter budget that only has to outlast the window.

**Relation to #3806 / #3807.** #3806 covers this class repo-wide and @jerome-benoit's #3807 converts 21 tests, but not this one: this test's body is byte-identical between `main` and `fix/3806-flaky-wall-clock`, so there is no overlap to collide. This PR touches only this test and no production code, no helper, and no shared fixture, so it should merge cleanly either way.

**macOS is not exercised by PR CI.** `Cargo Test (macos)` skips its real steps on pull requests, so this fix first runs on its target platform after merge, on a main push. Pre-merge evidence is Linux-only.

**Review follow-ups.** The test is now `#[serial_test::serial]`: it was the only one in the module forking tmux from the parallel pool, and the rewrite doubled its overlap with the 35 serialized tmux tests, which is the contention the diagnosis rests on. Observations are collected and asserted after `thread::scope` joins, so a failed assertion no longer detaches a waiter that forks against the killed session for the rest of its budget; the mutated run now fails in 3.3s. The observation window counts samples instead of wall time, so a host slower than ~650ms per iteration lengthens the window rather than starving the count-based assertion and false-failing for the same reason as the original bug. A drop guard releases the pane on every path out of the scope, since `expect` on the capture panics before the release write; an injected panic mid-window unwinds in 0.44s instead of idling to the deadline. The waiter budget is 60s: it is only a failure deadline and must dominate the sample-bounded window rather than race it.

**Evidence.** Injecting a setup latency into the unchanged body reproduces the failure deterministically: pass at 0/100/180/250ms, fail from 300ms, where elapsed drops 600ms to 400ms as a poll moves off the fourth interval onto the third. The rewritten test passes 20/20 idle and 15/15 with every core saturated, and fails on the `continue` mutation the old one missed. The macOS phase itself is not reproducible on this Linux box, where the unchanged test returns at a stable 820-833ms (15/15 under the same load).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No user-facing change; screenshots are not applicable.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

This PR is itself a test correction. `wait_until_ready`'s production behavior is unchanged, and the rewritten test covers it more tightly than the version it replaces.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:** Investigation, latency sweep, mutation check and repetition runs were executed and reviewed by @njbrake.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Reworked the readiness test to use a test-controlled release file instead of timing delays.
- Added cleanup that releases the waiter on every exit path, including assertion failures.
- Extended the failure deadline to 60 seconds and clarified capture failure handling.
- Kept production code, helpers, and shared fixtures unchanged.

## Benefits

- Reduces intermittent macOS failures caused by timing assumptions.
- Makes the test more deterministic and easier to understand.
- Prevents a failed test from leaving the waiter blocked unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->