### PR TITLE
fix(web): keep terminal selection through streamed frames and bracket toolbar pastes

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -852,6 +852,8 @@ export function MobileLiveTerminal({
     const rows: AnsiSegment[][] = [];
     // Visual row index where each pane line starts (for cursor math).
     const lineStartRow: number[] = new Array(lines.length);
+    // Pane line and wrap offset of each visual row (for row identity).
+    const source: Array<{ line: number; wrap: number }> = [];
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
       let wrapped = wrapCache.get(line);
@@ -860,9 +862,12 @@ export function MobileLiveTerminal({
         wrapCache.set(line, wrapped);
       }
       lineStartRow[i] = rows.length;
-      for (const row of wrapped.rows) rows.push(row);
+      for (let wrap = 0; wrap < wrapped.rows.length; wrap++) {
+        rows.push(wrapped.rows[wrap]!);
+        source.push({ line: i, wrap });
+      }
     }
-    return { rows, lineStartRow };
+    return { rows, lineStartRow, source };
   }, [lines, renderCols, wrapCache]);
   const screenRows = frame?.rows ?? 0;
   const history = frame?.history ?? 0;
@@ -2041,18 +2046,18 @@ export function MobileLiveTerminal({
             padLines > 0 ? (
               <div key={`pad-${block}`} style={{ height: `${padLines * lineH}px` }} aria-hidden="true" />
             ) : null,
-            // Rows are keyed by ABSOLUTE buffer position (spacer + window
-            // row), which is invariant as the agent appends: history grows by
-            // k, the capture window slides by k, and a given content line
-            // keeps spacer+index. The pads sit beside them in one flat list
-            // because any wrapper keyed on the mounted range would remount
-            // every row (and drop the user's selection) each time the range
-            // moved by a line.
+            // Rows are keyed by pane line (spacer + window line, invariant as
+            // the agent appends: history grows by k and the window slides by
+            // k) plus wrap offset, so a wrapped row keeps its identity too.
+            // The pads sit beside them in one flat list because any wrapper
+            // keyed on the mounted range would remount every row (and drop
+            // the user's selection) each time the range moved by a line.
             ...visual.rows.slice(start, end).map((segs, j) => {
               const i = start + j;
+              const src = visual.source[i]!;
               return (
                 <Row
-                  key={effectiveSpacerLines + i}
+                  key={`${effectiveSpacerLines + src.line}:${src.wrap}`}
                   segs={segs}
                   cursorCol={i === cursorRow ? live.col : null}
                   focused={i === cursorRow && focused}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -13,7 +13,7 @@ import {
 } from "../lib/liveTermLines";
 import { cursorLineIndex, pointerPaneCell, wheelNotches } from "../lib/liveMouse";
 import { registerMobileKeyboardProxyReceiver, type MobileKeyboardProxyInput } from "../lib/mobileKeyboardProxy";
-import { writeClipboard } from "../lib/clipboard";
+import { bracketedPaste, writeClipboard } from "../lib/clipboard";
 import type { LiveFrame, LiveStats } from "../hooks/useLiveTerminal";
 import { useWebSettings } from "../hooks/useWebSettings";
 import { useIsCoarsePointer } from "../hooks/useIsCoarsePointer";
@@ -1675,12 +1675,7 @@ export function MobileLiveTerminal({
           typedWordRef.current = dropLastCodePoint(run);
           break;
         case "insertFromPaste": {
-          const text = input.data ?? "";
-          if (text) {
-            // Bracketed paste so agents treat embedded newlines as
-            // pasted text, not per-line submits.
-            sendData(`\x1b[200~${text}\x1b[201~`);
-          }
+          if (input.data) sendData(bracketedPaste(input.data));
           break;
         }
         default:
@@ -1783,8 +1778,7 @@ export function MobileLiveTerminal({
       e.preventDefault();
 
       if (imageFiles.length === 0) {
-        // Bracketed paste so agents treat embedded newlines as pasted text.
-        if (text) sendData(`\x1b[200~${text}\x1b[201~`);
+        if (text) sendData(bracketedPaste(text));
         return;
       }
 
@@ -1799,7 +1793,7 @@ export function MobileLiveTerminal({
         if (parts.length === 0) return;
         // Leading and trailing spaces keep the path from gluing onto queued
         // text or the user's next keystroke. No newline: never auto-submit.
-        sendData(`\x1b[200~ ${parts.join(" ")} \x1b[201~`);
+        sendData(bracketedPaste(` ${parts.join(" ")} `));
       })();
     },
     [sendData, uploadPastedImage],
@@ -2043,30 +2037,29 @@ export function MobileLiveTerminal({
             opt out (`bottomAlign=false`) so a near-empty bash prompt sits at
             the top like a normal terminal. */}
         <div className={`relative whitespace-pre ${bottomAlign ? "mt-auto" : ""}`} data-live-content>
-          {mounted.blocks.map(({ padLines, start, end }) => {
-            return (
-              <Fragment key={`${start}-${end}`}>
-                {padLines > 0 && <div style={{ height: `${padLines * lineH}px` }} aria-hidden="true" />}
-                {visual.rows.slice(start, end).map((segs, j) => {
-                  const i = start + j;
-                  // Keyed by ABSOLUTE buffer position (spacer + window row),
-                  // which is invariant as the agent appends: history grows by
-                  // k, the capture window slides by k, and a given content
-                  // line keeps spacer+index. With a viewport-relative key an
-                  // append shifted every row onto a new key and re-rendered
-                  // the entire mounted slice per streamed frame.
-                  return (
-                    <Row
-                      key={effectiveSpacerLines + i}
-                      segs={segs}
-                      cursorCol={i === cursorRow ? live.col : null}
-                      focused={i === cursorRow && focused}
-                    />
-                  );
-                })}
-              </Fragment>
-            );
-          })}
+          {mounted.blocks.flatMap(({ padLines, start, end }, block) => [
+            padLines > 0 ? (
+              <div key={`pad-${block}`} style={{ height: `${padLines * lineH}px` }} aria-hidden="true" />
+            ) : null,
+            // Rows are keyed by ABSOLUTE buffer position (spacer + window
+            // row), which is invariant as the agent appends: history grows by
+            // k, the capture window slides by k, and a given content line
+            // keeps spacer+index. The pads sit beside them in one flat list
+            // because any wrapper keyed on the mounted range would remount
+            // every row (and drop the user's selection) each time the range
+            // moved by a line.
+            ...visual.rows.slice(start, end).map((segs, j) => {
+              const i = start + j;
+              return (
+                <Row
+                  key={effectiveSpacerLines + i}
+                  segs={segs}
+                  cursorCol={i === cursorRow ? live.col : null}
+                  focused={i === cursorRow && focused}
+                />
+              );
+            }),
+          ])}
           {bottomPadLines > 0 && <div style={{ height: `${bottomPadLines * lineH}px` }} aria-hidden="true" />}
         </div>
       </div>

--- a/web/src/components/MobileTerminalToolbar.tsx
+++ b/web/src/components/MobileTerminalToolbar.tsx
@@ -1,44 +1,8 @@
 import { useCallback, useState } from "react";
 import type { RefObject } from "react";
 import { useLongPressDrag, type DragAxis } from "../hooks/useLongPressDrag";
+import { bracketedPaste, readClipboardText } from "../lib/clipboard";
 import { toastBus } from "../lib/toastBus";
-
-const CLIPBOARD_TEXT_TYPES = ["text/plain", "text/uri-list", "text/html"] as const;
-
-// Normalize clipboard payloads to plain text. Necessary because GitHub's
-// "Copy link" buttons (and many Mac copy-link UIs) write text/uri-list
-// only, no text/plain, so the browser's default paste handler ends up
-// with an empty payload.
-function normalizeClipboardData(type: string, raw: string): string {
-  if (type === "text/uri-list") {
-    // text/uri-list permits multiple URLs separated by CRLF, with
-    // comments starting with #. Drop comments, join with newlines.
-    return raw
-      .split(/\r?\n/)
-      .filter((l) => l && !l.startsWith("#"))
-      .join("\n");
-  }
-  if (type === "text/html") {
-    const doc = new DOMParser().parseFromString(raw, "text/html");
-    const anchor = doc.querySelector("a[href]");
-    const href = anchor?.getAttribute("href");
-    if (href) return href;
-    return doc.body?.textContent?.trim() ?? "";
-  }
-  return raw;
-}
-
-function extractClipboardText(cd: DataTransfer | null): string {
-  if (!cd) return "";
-  for (const ty of CLIPBOARD_TEXT_TYPES) {
-    const raw = cd.getData(ty);
-    if (raw) {
-      const normalized = normalizeClipboardData(ty, raw);
-      if (normalized) return normalized;
-    }
-  }
-  return "";
-}
 
 interface Props {
   sendData: (data: string) => void;
@@ -154,101 +118,12 @@ export function MobileTerminalToolbar({ sendData, keyboardOpen, ctrlActive, onCt
         className={btnBase}
         onClick={async () => {
           haptic();
+          const text = await readClipboardText();
+          if (text) {
+            sendData(bracketedPaste(text));
+            return;
+          }
           const t = toastBus.handler;
-
-          // Path A: Clipboard API. Doesn't require focus, so it doesn't
-          // pop the soft keyboard. Tries every MIME type the source app
-          // wrote (e.g. GitHub's Copy Link writes text/uri-list only,
-          // not text/plain, which is why the old execCommand path read
-          // empty). HTTPS-only on iOS.
-          if (window.isSecureContext) {
-            try {
-              if (navigator.clipboard?.read) {
-                const items = await navigator.clipboard.read();
-                for (const item of items) {
-                  for (const ty of CLIPBOARD_TEXT_TYPES) {
-                    if (!item.types.includes(ty)) continue;
-                    const blob = await item.getType(ty);
-                    const raw = await blob.text();
-                    const text = normalizeClipboardData(ty, raw);
-                    if (text) {
-                      sendData(text);
-                      return;
-                    }
-                  }
-                }
-              } else if (navigator.clipboard?.readText) {
-                const text = await navigator.clipboard.readText();
-                if (text) {
-                  sendData(text);
-                  return;
-                }
-              }
-            } catch {
-              // Permission denied, no focus, etc. Fall through to path B.
-            }
-          }
-
-          // Path B: execCommand-based fallback for insecure contexts.
-          //
-          // Keyboard-open branch: reuse whatever editable element is
-          // already focused as the paste target. We never call focus(),
-          // so iOS sees no focus transition and the soft keyboard stays
-          // up. execCommand("paste") fires the paste event on the active
-          // element, our listener reads clipboardData directly.
-          //
-          // Keyboard-closed branch: there's no editable focused, so we
-          // have to focus the terminal textarea ourselves. Flip it to
-          // readonly first so iOS doesn't pop the keyboard, then blur
-          // afterward so the next FAB tap is a real focus transition.
-          const activeEl = document.activeElement;
-          const activeIsEditable = activeEl instanceof HTMLTextAreaElement || activeEl instanceof HTMLInputElement;
-
-          if (keyboardOpen && activeIsEditable) {
-            let recovered = "";
-            const onPaste: EventListener = (e: Event) => {
-              recovered = extractClipboardText((e as ClipboardEvent).clipboardData);
-            };
-            activeEl.addEventListener("paste", onPaste, { once: true });
-            try {
-              document.execCommand("paste");
-            } catch {
-              // continue to error toast
-            }
-            activeEl.removeEventListener("paste", onPaste);
-            if (recovered) {
-              sendData(recovered);
-              return;
-            }
-          } else {
-            const ta = inputElRef.current;
-            if (ta) {
-              let recovered = "";
-              const onPaste = (e: ClipboardEvent) => {
-                recovered = extractClipboardText(e.clipboardData);
-              };
-              ta.addEventListener("paste", onPaste, { once: true });
-              // Attribute (not property) toggles keep the react-hooks
-              // immutability lint happy about ref-derived elements.
-              const prevReadOnly = ta.hasAttribute("readonly");
-              ta.setAttribute("readonly", "");
-              try {
-                ta.focus({ preventScroll: true });
-                document.execCommand("paste");
-              } catch {
-                // continue to error toast
-              }
-              if (!prevReadOnly) ta.removeAttribute("readonly");
-              ta.blur();
-              ta.removeEventListener("paste", onPaste);
-              if (recovered) {
-                sendData(recovered);
-                return;
-              }
-            }
-          }
-
-          // All paths failed. Tell the user what to try next.
           if (!window.isSecureContext) {
             t?.error("Paste needs HTTPS. Run `aoe serve --remote` for a Tailscale or Cloudflare HTTPS URL.");
           } else {

--- a/web/src/components/MobileTerminalToolbar.tsx
+++ b/web/src/components/MobileTerminalToolbar.tsx
@@ -4,6 +4,14 @@ import { useLongPressDrag, type DragAxis } from "../hooks/useLongPressDrag";
 import { bracketedPaste, readClipboardText } from "../lib/clipboard";
 import { toastBus } from "../lib/toastBus";
 
+function execCommandPaste(): boolean {
+  try {
+    return document.execCommand("paste");
+  } catch {
+    return false;
+  }
+}
+
 interface Props {
   sendData: (data: string) => void;
   keyboardOpen: boolean;
@@ -118,17 +126,25 @@ export function MobileTerminalToolbar({ sendData, keyboardOpen, ctrlActive, onCt
         className={btnBase}
         onClick={async () => {
           haptic();
+          const t = toastBus.handler;
+          if (!window.isSecureContext) {
+            // No Clipboard API on a plain-HTTP origin. WebKit still honours
+            // execCommand("paste") from a tap, behind its own Paste prompt,
+            // when an editable is focused: the paste event lands on the
+            // terminal's input, whose handler brackets it. Other engines
+            // return false. Must run before any await to stay in the gesture.
+            const active = document.activeElement;
+            const editable = active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement;
+            if (keyboardOpen && editable && execCommandPaste()) return;
+            t?.error("Paste needs HTTPS. Run `aoe serve --remote` for a Tailscale or Cloudflare HTTPS URL.");
+            return;
+          }
           const text = await readClipboardText();
           if (text) {
             sendData(bracketedPaste(text));
             return;
           }
-          const t = toastBus.handler;
-          if (!window.isSecureContext) {
-            t?.error("Paste needs HTTPS. Run `aoe serve --remote` for a Tailscale or Cloudflare HTTPS URL.");
-          } else {
-            t?.error("Couldn't read clipboard. Try copying again, or open this dashboard in Safari.");
-          }
+          t?.error("Couldn't read clipboard. Try copying again, or open this dashboard in Safari.");
         }}
       >
         <svg

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -20,7 +20,8 @@ vi.mock("../../hooks/useWebSettings", () => ({
 }));
 
 const writeClipboard = vi.fn();
-vi.mock("../../lib/clipboard", () => ({
+vi.mock("../../lib/clipboard", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../lib/clipboard")>()),
   writeClipboard: (text: string) => writeClipboard(text),
 }));
 

--- a/web/src/components/__tests__/MobileLiveTerminal.rowIdentity.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.rowIdentity.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+//
+// Select-to-copy on a streaming pane depends on the row DOM nodes surviving
+// the frames that arrive while the selection is being made: a remounted row
+// collapses the browser selection, and on iOS also dismisses the Copy callout.
+
+import { createRef } from "react";
+import { beforeAll, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+import type { LiveFrame } from "../../hooks/useLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+function frame(lines: string[], rows: number): LiveFrame {
+  return {
+    content: lines.join("\n") + "\n",
+    lines,
+    rows,
+    history: Math.max(0, lines.length - rows),
+    cursor: null,
+    altScreen: false,
+    mouse: false,
+    mouseSgr: false,
+  };
+}
+
+function terminal(f: LiveFrame) {
+  return (
+    <MobileLiveTerminal
+      frame={f}
+      connected
+      active
+      reading={false}
+      sendResize={vi.fn()}
+      setWindow={vi.fn()}
+      setCadence={vi.fn()}
+      enterReading={vi.fn()}
+      returnToLive={vi.fn()}
+      sendData={vi.fn()}
+      typedWordRef={{ current: "" }}
+      uploadPastedImage={vi.fn()}
+      forwardWheel={vi.fn()}
+      forwardButton={vi.fn()}
+      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+      clearCtrl={vi.fn()}
+      inputRef={createRef<HTMLTextAreaElement>()}
+      onInputFocusChange={vi.fn()}
+      bottomAlign
+      keyboardOpen={false}
+    />
+  );
+}
+
+it("keeps unchanged row nodes when the agent appends lines", () => {
+  const { rerender } = render(terminal(frame(["alpha", "beta", "$ "], 3)));
+  const alpha = screen.getByText("alpha").parentElement;
+  const beta = screen.getByText("beta").parentElement;
+
+  rerender(terminal(frame(["alpha", "beta", "gamma", "delta", "$ "], 3)));
+
+  expect(screen.getByText("alpha").parentElement).toBe(alpha);
+  expect(screen.getByText("beta").parentElement).toBe(beta);
+  expect(screen.getByText("delta")).toBeTruthy();
+});

--- a/web/src/components/__tests__/MobileLiveTerminal.rowIdentity.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.rowIdentity.test.tsx
@@ -5,8 +5,8 @@
 // collapses the browser selection, and on iOS also dismisses the Copy callout.
 
 import { createRef } from "react";
-import { beforeAll, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
 import { MobileLiveTerminal } from "../MobileLiveTerminal";
 import type { LiveFrame } from "../../hooks/useLiveTerminal";
 
@@ -14,20 +14,46 @@ vi.mock("../../hooks/useWebSettings", () => ({
   useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
 }));
 
+// jsdom has no layout: charW falls back to fontSize * 0.6, so this width
+// renders 28 columns once the sizing effect has run.
+const WIDTH = 240;
+const COLS = Math.floor(WIDTH / (14 * 0.6));
+const RESIZE_DEBOUNCE_MS = 150;
+let roCallbacks: Array<() => void> = [];
+
 beforeAll(() => {
   globalThis.ResizeObserver = class {
-    observe() {}
+    private cb: () => void;
+    constructor(cb: () => void) {
+      this.cb = cb;
+    }
+    observe() {
+      roCallbacks.push(this.cb);
+    }
     unobserve() {}
-    disconnect() {}
+    disconnect() {
+      roCallbacks = roCallbacks.filter((c) => c !== this.cb);
+    }
   } as unknown as typeof ResizeObserver;
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", { configurable: true, get: () => WIDTH });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get: () => 600 });
 });
 
-function frame(lines: string[], rows: number): LiveFrame {
+beforeEach(() => {
+  vi.useFakeTimers();
+  roCallbacks = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function frame(lines: string[], rows: number, history = Math.max(0, lines.length - rows)): LiveFrame {
   return {
     content: lines.join("\n") + "\n",
     lines,
     rows,
-    history: Math.max(0, lines.length - rows),
+    history,
     cursor: null,
     altScreen: false,
     mouse: false,
@@ -62,6 +88,10 @@ function terminal(f: LiveFrame) {
   );
 }
 
+function rowCount(container: HTMLElement) {
+  return container.querySelectorAll("[data-live-content] > div:not([aria-hidden])").length;
+}
+
 it("keeps unchanged row nodes when the agent appends lines", () => {
   const { rerender } = render(terminal(frame(["alpha", "beta", "$ "], 3)));
   const alpha = screen.getByText("alpha").parentElement;
@@ -72,4 +102,23 @@ it("keeps unchanged row nodes when the agent appends lines", () => {
   expect(screen.getByText("alpha").parentElement).toBe(alpha);
   expect(screen.getByText("beta").parentElement).toBe(beta);
   expect(screen.getByText("delta")).toBeTruthy();
+});
+
+it("keeps row nodes when the window slides past wrapped lines", () => {
+  // Two lines wider than the pane sit above the text being selected; the
+  // live edge then slides the window by two lines, so those wrapped rows
+  // drop off the top while the history count grows to match.
+  const wide = (tag: string) => `${tag} `.repeat(20).trimEnd();
+  const { container, rerender } = render(terminal(frame([wide("one"), wide("two"), "alpha", "beta", "$ "], 3)));
+  act(() => {
+    for (const cb of roCallbacks) cb();
+    vi.advanceTimersByTime(RESIZE_DEBOUNCE_MS);
+  });
+  expect(COLS).toBe(28);
+  expect(rowCount(container)).toBeGreaterThan(5);
+  const alpha = screen.getByText("alpha").parentElement;
+
+  rerender(terminal(frame(["alpha", "beta", "gamma", "delta", "$ "], 3, 4)));
+
+  expect(screen.getByText("alpha").parentElement).toBe(alpha);
 });

--- a/web/src/components/__tests__/MobileTerminalToolbar.test.tsx
+++ b/web/src/components/__tests__/MobileTerminalToolbar.test.tsx
@@ -71,6 +71,35 @@ describe("MobileTerminalToolbar", () => {
     await waitFor(() => expect(sendData).toHaveBeenCalledWith("\x1b[200~line 1\nline 2\x1b[201~"));
   });
 
+  it("on a plain-HTTP origin pastes through execCommand into the focused input, else explains HTTPS", async () => {
+    secureContext(false);
+    const error = vi.fn();
+    toastBus.handler = { push: vi.fn(), error, info: vi.fn(), openLink: vi.fn() };
+    const editable = document.createElement("textarea");
+    document.body.appendChild(editable);
+    editable.focus();
+    const paste = screen.getByLabelText.bind(screen);
+
+    for (const [granted, toasts] of [
+      [true, 0],
+      [false, 1],
+    ] as const) {
+      error.mockClear();
+      const execCommand = vi.fn(() => granted);
+      Object.defineProperty(document, "execCommand", { value: execCommand, configurable: true });
+      const { sendData, unmount } = renderToolbar({ keyboardOpen: true });
+      fireEvent.click(paste("Paste from clipboard"));
+      await new Promise((r) => setTimeout(r, 0));
+      expect(execCommand).toHaveBeenCalledWith("paste");
+      // The focused input's own paste handler sends; the toolbar never does.
+      expect(sendData).not.toHaveBeenCalled();
+      expect(error).toHaveBeenCalledTimes(toasts);
+      unmount();
+    }
+    document.body.removeChild(editable);
+    toastBus.handler = null;
+  });
+
   it("reports an unreadable clipboard instead of sending anything", async () => {
     secureContext(true);
     Object.defineProperty(navigator, "clipboard", {

--- a/web/src/components/__tests__/MobileTerminalToolbar.test.tsx
+++ b/web/src/components/__tests__/MobileTerminalToolbar.test.tsx
@@ -2,21 +2,25 @@
 //
 // Unit tests for MobileTerminalToolbar's keyboard wiring (#1432). The strip
 // is never rendered under the chromium Playwright coverage run (pointer:coarse
-// does not match there), so these exercise it directly: the keyboard-open
-// paste fallback branch and the Ctrl latch. The parent (a live terminal
+// does not match there), so these exercise it directly: the paste button and
+// the Ctrl latch. The parent (a live terminal
 // view) always owns the keyboard inset now, so the strip carries none.
 
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MobileTerminalToolbar } from "../MobileTerminalToolbar";
+import { toastBus } from "../../lib/toastBus";
 
 afterEach(() => {
   cleanup();
-  // Drop the per-test isSecureContext override (set in the paste-branch test)
-  // so it falls back to the default and does not leak into other tests.
   delete (window as { isSecureContext?: boolean }).isSecureContext;
+  delete (navigator as { clipboard?: unknown }).clipboard;
 });
+
+function secureContext(value: boolean) {
+  Object.defineProperty(window, "isSecureContext", { value, configurable: true });
+}
 
 interface Overrides {
   keyboardOpen?: boolean;
@@ -51,25 +55,36 @@ describe("MobileTerminalToolbar", () => {
     expect(screen.getByLabelText("Ctrl")).toBeTruthy();
   });
 
-  it("takes the keyboard-open paste branch when an editable is focused", async () => {
-    // Force the execCommand fallback path: skip the Clipboard API branch.
-    Object.defineProperty(window, "isSecureContext", {
-      value: false,
+  it("bracket-pastes clipboard text so multi-line pastes are not per-line submits", async () => {
+    secureContext(true);
+    const item = {
+      types: ["text/html", "text/plain"],
+      getType: async () => new Blob(["line 1\nline 2"], { type: "text/plain" }),
+    };
+    Object.defineProperty(navigator, "clipboard", {
+      value: { read: async () => [item] },
       configurable: true,
     });
     const { sendData } = renderToolbar({ keyboardOpen: true });
 
-    const editable = document.createElement("textarea");
-    document.body.appendChild(editable);
-    editable.focus();
+    fireEvent.click(screen.getByLabelText("Paste from clipboard"));
+    await waitFor(() => expect(sendData).toHaveBeenCalledWith("\x1b[200~line 1\nline 2\x1b[201~"));
+  });
+
+  it("reports an unreadable clipboard instead of sending anything", async () => {
+    secureContext(true);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { read: async () => Promise.reject(new Error("denied")) },
+      configurable: true,
+    });
+    const error = vi.fn();
+    toastBus.handler = { push: vi.fn(), error, info: vi.fn(), openLink: vi.fn() };
+    const { sendData } = renderToolbar();
 
     fireEvent.click(screen.getByLabelText("Paste from clipboard"));
-    // The onClick handler is async; let its microtasks settle. With no
-    // clipboard data recovered it falls through without sending anything.
-    await new Promise((r) => setTimeout(r, 0));
-
+    await waitFor(() => expect(error).toHaveBeenCalledWith(expect.stringContaining("Couldn't read clipboard")));
     expect(sendData).not.toHaveBeenCalled();
-    document.body.removeChild(editable);
+    toastBus.handler = null;
   });
 });
 

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { armClipboardWrite } from "./clipboard";
+import { armClipboardWrite, readClipboardText } from "./clipboard";
 
 class FakeClipboardItem {
   constructor(public readonly data: Record<string, Promise<Blob>>) {}
@@ -67,5 +67,42 @@ describe("armClipboardWrite", () => {
     const armed = armClipboardWrite();
     expect(armed.resolve("fallback")).toBe(true);
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("fallback"));
+  });
+});
+
+describe("readClipboardText", () => {
+  afterEach(() => {
+    delete (navigator as { clipboard?: unknown }).clipboard;
+  });
+
+  it("normalises whichever text type the source app wrote", async () => {
+    Object.defineProperty(window, "isSecureContext", { configurable: true, value: true });
+    const cases: Array<[string, string, string]> = [
+      ["text/plain", "plain\ntext", "plain\ntext"],
+      [
+        "text/uri-list",
+        "# comment\r\nhttps://a.example\r\nhttps://b.example\r\n",
+        "https://a.example\nhttps://b.example",
+      ],
+      ["text/html", '<p><a href="https://x.example/pr/1">PR</a></p>', "https://x.example/pr/1"],
+      ["text/html", '<a href="">click here</a>', "click here"],
+      ["text/html", "<p> just text </p>", "just text"],
+    ];
+    for (const [type, raw, expected] of cases) {
+      const item = { types: [type], getType: async () => new Blob([raw], { type }) };
+      Object.defineProperty(navigator, "clipboard", { configurable: true, value: { read: async () => [item] } });
+      expect(await readClipboardText(), `${type}: ${raw}`).toBe(expected);
+    }
+  });
+
+  it("returns empty text outside a secure context or when the read is refused", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { read: async () => Promise.reject(new Error("denied")) },
+    });
+    Object.defineProperty(window, "isSecureContext", { configurable: true, value: true });
+    expect(await readClipboardText()).toBe("");
+    Object.defineProperty(window, "isSecureContext", { configurable: true, value: false });
+    expect(await readClipboardText()).toBe("");
   });
 });

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,5 +1,10 @@
 /** Wrap pasted text in bracketed-paste markers so an agent treats embedded
- *  newlines as part of one paste rather than per-line submits. */
+ *  newlines as part of one paste rather than per-line submits.
+ *
+ *  The web input path cannot see whether the pane enabled DECSET 2004, so a
+ *  raw shell or simple REPL receives the markers as text and shows `00~` /
+ *  `01~` around the paste. The TUI avoids this by pasting through tmux
+ *  (`Session::paste_text`); routing web pastes the same way is the fix. */
 export function bracketedPaste(text: string): string {
   return `\x1b[200~${text}\x1b[201~`;
 }
@@ -20,15 +25,15 @@ function normalizeClipboardData(type: string, raw: string): string {
   if (type === "text/html") {
     const doc = new DOMParser().parseFromString(raw, "text/html");
     const href = doc.querySelector("a[href]")?.getAttribute("href");
-    return href ?? doc.body?.textContent?.trim() ?? "";
+    return href || (doc.body?.textContent?.trim() ?? "");
   }
   return raw;
 }
 
 /** Read the clipboard as plain text from a user gesture, or "" when the
- *  browser refuses. Only the async Clipboard API can read without a native
- *  paste gesture, and it exists only in secure contexts; iOS shows its own
- *  Paste confirmation and rejects if the user dismisses it. */
+ *  browser refuses or it is empty. The async Clipboard API exists only in
+ *  secure contexts; iOS shows its own Paste confirmation and rejects if the
+ *  user dismisses it. */
 export async function readClipboardText(): Promise<string> {
   if (!window.isSecureContext) return "";
   try {

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,10 +1,59 @@
+/** Wrap pasted text in bracketed-paste markers so an agent treats embedded
+ *  newlines as part of one paste rather than per-line submits. */
+export function bracketedPaste(text: string): string {
+  return `\x1b[200~${text}\x1b[201~`;
+}
+
+const CLIPBOARD_TEXT_TYPES = ["text/plain", "text/uri-list", "text/html"] as const;
+
+// GitHub's "Copy link" buttons (and many Mac copy-link UIs) write
+// text/uri-list only, no text/plain, so a text/plain-only reader sees an
+// empty clipboard.
+function normalizeClipboardData(type: string, raw: string): string {
+  if (type === "text/uri-list") {
+    // CRLF-separated URLs with `#` comment lines.
+    return raw
+      .split(/\r?\n/)
+      .filter((l) => l && !l.startsWith("#"))
+      .join("\n");
+  }
+  if (type === "text/html") {
+    const doc = new DOMParser().parseFromString(raw, "text/html");
+    const href = doc.querySelector("a[href]")?.getAttribute("href");
+    return href ?? doc.body?.textContent?.trim() ?? "";
+  }
+  return raw;
+}
+
+/** Read the clipboard as plain text from a user gesture, or "" when the
+ *  browser refuses. Only the async Clipboard API can read without a native
+ *  paste gesture, and it exists only in secure contexts; iOS shows its own
+ *  Paste confirmation and rejects if the user dismisses it. */
+export async function readClipboardText(): Promise<string> {
+  if (!window.isSecureContext) return "";
+  try {
+    if (navigator.clipboard?.read) {
+      for (const item of await navigator.clipboard.read()) {
+        for (const type of CLIPBOARD_TEXT_TYPES) {
+          if (!item.types.includes(type)) continue;
+          const text = normalizeClipboardData(type, await (await item.getType(type)).text());
+          if (text) return text;
+        }
+      }
+      return "";
+    }
+    return (await navigator.clipboard?.readText?.()) ?? "";
+  } catch {
+    return "";
+  }
+}
+
 /** Write `text` to the clipboard, returning whether it succeeded.
  *
  *  Prefers the async Clipboard API, but that is only defined in secure
  *  contexts (HTTPS or `localhost`). `aoe serve` is frequently reached
  *  over plain HTTP on a LAN or Tailscale IP, where `navigator.clipboard`
- *  is `undefined`, so fall back to a hidden-textarea `execCommand("copy")`
- *  (same approach the mobile terminal toolbar uses for its paste path). */
+ *  is `undefined`, so fall back to a hidden-textarea `execCommand("copy")`. */
 export async function writeClipboard(text: string): Promise<boolean> {
   if (window.isSecureContext && navigator.clipboard?.writeText) {
     try {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -215,12 +215,15 @@
         "src/lib/clipboard.test.ts",
         "src/hooks/useLiveTerminal.forward.test.ts",
         "src/components/__tests__/MobileLiveTerminal.paste.test.tsx",
-        "src/components/__tests__/MobileLiveTerminal.clipboard.test.tsx"
+        "src/components/__tests__/MobileLiveTerminal.clipboard.test.tsx",
+        "src/components/__tests__/MobileLiveTerminal.rowIdentity.test.tsx",
+        "src/components/__tests__/MobileTerminalToolbar.test.tsx"
       ],
       "components": [
         "web/src/lib/clipboard.ts",
         "web/src/hooks/useLiveTerminal.ts",
-        "web/src/components/MobileLiveTerminal.tsx"
+        "web/src/components/MobileLiveTerminal.tsx",
+        "web/src/components/MobileTerminalToolbar.tsx"
       ]
     },
     {


### PR DESCRIPTION
## Description

Copy and paste in the mobile web terminal, seen on an iOS PWA with Claude Code.

**Copy.** Mounted rows were wrapped in a `Fragment` keyed by the visible range, so each appended line or scrolled row remounted every row and collapsed the selection. On iOS this dismisses the Copy callout mid-gesture. Rows and pads now render as one flat list; rows are keyed by pane line plus wrap offset, which is invariant as the window slides. jsdom tests assert the row nodes survive both an append and a slide past wrapped lines.

**Paste.** The toolbar paste button sent clipboard text raw, so a multi-line paste submitted each line as its own prompt. It now shares `bracketedPaste()` with the keyboard paths. On a plain-HTTP origin it tries `execCommand("paste")` into the focused input, which WebKit permits behind its Paste prompt; other engines get the HTTPS toast. The old fallback's listener juggling is gone.

Known tradeoff: web pastes hand-roll the bracketed-paste markers, so a pane that never enabled DECSET 2004 shows `00~`/`01~` debris. Pre-existing for the keyboard paths; the fix is routing web pastes through tmux `paste-buffer` server-side, as the TUI does.

Clipboard MIME normalisation moved to `web/src/lib/clipboard.ts` as `readClipboardText()`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (no visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json` (Vitest: `MobileLiveTerminal.rowIdentity.test.tsx`, `MobileTerminalToolbar.test.tsx`; matrix entry `terminal.clipboard-chords`)
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5.1 via Claude Code

**Any Additional AI Details you'd like to share:**
Investigation, fix, and tests by the model; direction and review by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR was drafted by Claude Fable 5.1 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Ci5HXGh2TUgjNmt4tffV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserves terminal row elements during streaming, scrolling, and wrapped-line changes. This keeps mobile text selection stable.
- Improves paste handling for multiline content by using bracketed paste.
- Supports clipboard paste on plain HTTP through the WebKit paste flow, with a secure HTTPS fallback.
- Centralizes clipboard reading and format normalization.
- Adds coverage for row stability, paste behavior, clipboard formats, and related coverage tracking.

## Benefits

These changes provide more reliable mobile terminal selection and paste behavior across browsers and connection types. They also simplify clipboard handling and improve regression protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->