### PR TITLE
fix(vt): map the seeded cursor onto the grid the capture actually filled

### DIFF
--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -1387,13 +1387,11 @@ fn split_seed_capture(raw: &[u8]) -> (&[u8], &str) {
 /// the full pane height, so the parser's visible screen is a pixel-for-pixel
 /// replica of the pane. Only the single trailing line terminator is dropped:
 /// with it, the final `\n` would push the whole screen up one row (the top row
-/// scrolls into history) and misplace every cell. Because the visible screen is
-/// faithful, the CUP is a plain 1-based `#{cursor_y}` / `#{cursor_x}`, which
-/// addresses the visible screen regardless of how much scrollback sits behind
-/// it (that is the coordinate space tmux reports the cursor in). Without this,
-/// the parser's cursor lands after the last replayed glyph, bottom-right for a
-/// full-screen app, until the first live chunk carries the app's own escapes
-/// (issue #2902).
+/// scrolls into history) and misplace every cell. The CUP that follows carries
+/// `#{cursor_x}` and the row [`seeded_cursor_row`] maps `#{cursor_y}` onto.
+/// Without it the parser's cursor lands after the last replayed glyph,
+/// bottom-right for a full-screen app, until the first live chunk carries the
+/// app's own escapes (issue #2902).
 fn assemble_seed_stream(body: &[u8], state: &PaneSeedState, rows: u16) -> Vec<u8> {
     let mut out: Vec<u8> = Vec::with_capacity(body.len() + 32);
     if state.alt {
@@ -1418,10 +1416,9 @@ fn assemble_seed_stream(body: &[u8], state: &PaneSeedState, rows: u16) -> Vec<u8
         out.extend_from_slice(b"\x1b[?1h");
     }
     out.extend_from_slice(&lf_to_crlf(strip_trailing_row_terminator(body)));
-    // 1-based CUP in visible-screen coordinates, clamped to the grid so a stale
-    // query (the pane moved between the state read and this seed) can't push the
-    // cursor off-screen; the first live chunk re-syncs it either way.
-    let cy = state.cursor_y.min(rows.saturating_sub(1)) + 1;
+    // 1-based CUP, clamped to the grid so a state read this far off can't push
+    // the cursor off-screen; the first live chunk re-syncs it either way.
+    let cy = seeded_cursor_row(body, state, rows).min(rows.saturating_sub(1)) + 1;
     let cx = state.cursor_x + 1;
     out.extend_from_slice(format!("\x1b[{cy};{cx}H").as_bytes());
     out.extend_from_slice(if state.cursor_visible {
@@ -1430,6 +1427,37 @@ fn assemble_seed_stream(body: &[u8], state: &PaneSeedState, rows: u16) -> Vec<u8
         b"\x1b[?25l"
     });
     out
+}
+
+/// The seeded grid's own row for the pane cursor tmux reported at
+/// `state.cursor_y`.
+///
+/// tmux counts `cursor_y` from the top of the pane's visible screen, so that is
+/// the grid's row only while the grid is exactly as tall as the pane the body
+/// came from. A reseed racing a `resize-window` breaks that: the capture reads
+/// the pane at its old, taller height, the surplus rows scroll off the top of
+/// the shorter grid and carry the pane's content up with them, and a bare
+/// `cursor_y` leaves the cursor parked that many rows BELOW the content. The
+/// app's next redraw prints its prompt there, so the grid ends up holding two
+/// prompt rows where the pane has one, and no reconcile can see it: grid and
+/// pane still agree on geometry and on the cursor, only the cells differ.
+///
+/// Counting from the pane's bottom row instead survives a mismatch either way,
+/// and reduces to `cursor_y` whenever the two heights agree. A `pane_height` of
+/// 0 means the probe carried no geometry, so keep the plain mapping there.
+fn seeded_cursor_row(body: &[u8], state: &PaneSeedState, rows: u16) -> u16 {
+    if state.pane_height == 0 {
+        return state.cursor_y;
+    }
+    let fed = strip_trailing_row_terminator(body);
+    let body_rows = if fed.is_empty() {
+        0
+    } else {
+        u16::try_from(fed.iter().filter(|&&b| b == b'\n').count() + 1).unwrap_or(u16::MAX)
+    };
+    // Rows of the body the grid still shows; the rest scrolled into history.
+    let visible = body_rows.min(rows);
+    visible.saturating_sub(state.pane_height.saturating_sub(state.cursor_y))
 }
 
 /// Drop the single trailing line terminator (`\n` or `\r\n`) from a
@@ -3749,6 +3777,7 @@ mod tests {
             cursor_x: 3,
             cursor_y: 1,
             cursor_visible: true,
+            pane_height: rows,
             ..Default::default()
         };
         let mut p = vt100::Parser::new(rows, cols, SCROLLBACK_LINES);
@@ -3809,6 +3838,7 @@ mod tests {
             cursor_x: 2,
             cursor_y: 1,
             cursor_visible: true,
+            pane_height: rows,
             ..Default::default()
         };
         let mut p = vt100::Parser::new(rows, cols, SCROLLBACK_LINES);
@@ -3825,6 +3855,90 @@ mod tests {
             "newest row must be on the visible screen:\n{}",
             p.screen().contents()
         );
+    }
+
+    #[test]
+    fn seed_keeps_cursor_on_the_prompt_when_the_pane_outgrows_the_grid() {
+        // #3824. A reseed that runs before `resize-window` lands captures the
+        // pane at its OLD height, so the body is taller than the grid being
+        // built and its top rows scroll into history, carrying the content up.
+        // The cursor has to travel with them; left at a bare `#{cursor_y}` it
+        // parks below the prompt, and the app's next SIGWINCH redraw prints a
+        // second prompt row there that no reconcile can see (grid and pane
+        // agree on geometry and cursor, only the cells differ).
+        let rows: u16 = 6;
+        let cols: u16 = 20;
+        // Pane is two rows taller than the grid: three content rows, a prompt,
+        // and the blank rows capture-pane pads to the pane height.
+        let pane_height: u16 = 8;
+        let mut body = Vec::new();
+        for i in 0..3 {
+            body.extend_from_slice(format!("line-{i}\n").as_bytes());
+        }
+        body.extend_from_slice(b"READY> \n");
+        for _ in 4..pane_height {
+            body.extend_from_slice(b"\n");
+        }
+        let state = PaneSeedState {
+            cursor_x: 7,
+            cursor_y: 3,
+            cursor_visible: true,
+            pane_height,
+            ..Default::default()
+        };
+        let mut p = vt100::Parser::new(rows, cols, SCROLLBACK_LINES);
+        p.process(&assemble_seed_stream(&body, &state, rows));
+
+        // Two body rows scrolled off, so the prompt sits on row 1 and the
+        // cursor must be on it, not two rows below on row 3.
+        assert_eq!(
+            p.screen().cursor_position(),
+            (1, 7),
+            "cursor must follow the prompt row the taller body pushed up:\n{}",
+            p.screen().contents()
+        );
+        assert!(
+            p.screen().contents().contains("READY>"),
+            "prompt must be on the visible screen:\n{}",
+            p.screen().contents()
+        );
+    }
+
+    #[test]
+    fn seeded_cursor_row_reduces_to_cursor_y_when_heights_agree() {
+        // The mapping must be the identity on the normal path (any scrollback
+        // depth, grid as tall as the pane) and fall back to it when the probe
+        // reported no geometry at all.
+        let body = |rows: usize| -> Vec<u8> {
+            let mut out = Vec::new();
+            for i in 0..rows {
+                out.extend_from_slice(format!("r{i}\n").as_bytes());
+            }
+            out
+        };
+        // (body rows, pane_height, cursor_y, grid rows, expected row)
+        let cases: [(usize, u16, u16, u16, u16); 4] = [
+            (4, 4, 2, 4, 2),
+            // Six rows of scrollback ahead of a 4-row pane.
+            (10, 4, 2, 4, 2),
+            // No geometry in the probe: keep the plain mapping.
+            (4, 0, 2, 4, 2),
+            // Grid taller than the pane, so nothing scrolled off: the body's
+            // own history still offsets the cursor by its depth.
+            (4, 2, 1, 6, 3),
+        ];
+        for (body_rows, pane_height, cursor_y, rows, want) in cases {
+            let state = PaneSeedState {
+                cursor_y,
+                pane_height,
+                ..Default::default()
+            };
+            assert_eq!(
+                seeded_cursor_row(&body(body_rows), &state, rows),
+                want,
+                "body_rows={body_rows} pane_height={pane_height} cursor_y={cursor_y} rows={rows}"
+            );
+        }
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -773,7 +773,9 @@ fn sh_quote(s: &str) -> String {
 
 /// The pane's geometry AND cursor in one `display-message` fork:
 /// `(pane_width, pane_height, cursor_x, cursor_y)`, the cursor 0-based in
-/// visible-screen coordinates (the space `assemble_seed_stream`'s CUP uses).
+/// visible-screen coordinates, the space [`reconcile_step`] compares the grid's
+/// cursor in once the two agree on geometry. [`seeded_cursor_row`] is what maps
+/// it onto a grid whose height differs.
 ///
 /// Folded into the geometry probe rather than run as a second fork because
 /// [`VtChannel::reconcile_grid`] needs both on the same once-a-second budget:
@@ -1097,8 +1099,7 @@ fn seed_parser(
     guard: SeedGuard<'_>,
     fence: SeedInstallFence<'_>,
 ) -> VtRefreshResult {
-    let (_, rows) = size;
-    let Some(stream) = capture_seed_stream(target, rows, deadline) else {
+    let Some(stream) = capture_seed_stream(target, size, deadline) else {
         return VtRefreshResult::Failed;
     };
     install_seeded_parser(sink, since, &stream, size, guard, fence)
@@ -1156,10 +1157,11 @@ fn install_seeded_parser(
 /// generation check `swap_seeded_parser` needs.
 fn capture_seed_stream(
     target: &str,
-    rows: u16,
+    size: (u16, u16),
     deadline: &crate::tmux::TmuxCommandDeadline,
 ) -> Option<Vec<u8>> {
-    let (body, state) = capture_seed_snapshot(target, deadline)?;
+    let (cols, rows) = size;
+    let (body, state) = capture_seed_snapshot(target, (cols, rows), deadline)?;
     Some(assemble_seed_stream(&body, &state, rows))
 }
 
@@ -1238,10 +1240,11 @@ fn swap_drained_seeded_parser(
     swap_seeded_parser(sink, since, stream, size, drained_guard.guard)
 }
 /// How many times [`capture_seed_snapshot`] re-runs the probe/capture/probe
-/// round before settling for its last (possibly raced) snapshot. Each retry
-/// costs two forks plus a short settle sleep, and only fires while the pane is
-/// actively changing under the seed, so the bound is about capping seed latency
-/// on a pane that streams continuously, not about a steady state.
+/// round before settling for its last (possibly raced or off-geometry)
+/// snapshot. Each retry costs two forks plus a short settle sleep, and only
+/// fires while the pane is changing or is not yet at the size being seeded, so
+/// the bound is about capping seed latency on a pane that streams continuously
+/// or is mid-resize, not about a steady state.
 const SEED_PROBE_ATTEMPTS: usize = 3;
 
 /// Pause between disagreeing seed attempts, letting a mid-flight burst (a
@@ -1275,6 +1278,7 @@ const SEED_INSTALL_RETRY: Duration = Duration::from_millis(20);
 /// residue).
 fn capture_seed_snapshot(
     target: &str,
+    want: (u16, u16),
     deadline: &crate::tmux::TmuxCommandDeadline,
 ) -> Option<(Vec<u8>, PaneSeedState)> {
     let seed_start = format!("-{SCROLLBACK_LINES}");
@@ -1326,16 +1330,24 @@ fn capture_seed_snapshot(
         }
         let post = parse_seed_state(probe_line);
         let agreed = pre == post;
+        // A capture taken at the geometry we are seeding at needs no mapping and
+        // lays its cells out for the grid that will hold them, so it is worth
+        // one more probe. Bounded by the same attempt budget and only ever
+        // entered while the pane disagrees, so the settled case still returns on
+        // the first pass.
+        let at_want = (post.pane_width, post.pane_height) == want;
         last = Some((body.to_vec(), post));
-        if agreed {
+        if agreed && at_want {
             return last;
         }
     }
-    if last.is_some() {
+    if let Some((_, state)) = last.as_ref() {
         tracing::debug!(
             %target,
             attempts = SEED_PROBE_ATTEMPTS,
-            "vt seed: bracketing probes never agreed; seeding from last snapshot"
+            probe = ?(state.pane_width, state.pane_height),
+            want = ?want,
+            "vt seed: no settled snapshot at the target geometry; seeding from last"
         );
     }
     last
@@ -1386,8 +1398,10 @@ fn split_seed_capture(raw: &[u8]) -> (&[u8], &str) {
 /// absolute CUP and the DECTCEM show/hide.
 ///
 /// The body is fed faithfully, including the blank rows capture-pane pads out to
-/// the full pane height, so the parser's visible screen is a pixel-for-pixel
-/// replica of the pane. Only the single trailing line terminator is dropped:
+/// the full pane height, so the parser's visible screen replicates the pane
+/// whenever the two are the same height. When they are not, the surplus rows
+/// scroll into the grid's history and [`seeded_cursor_row`] carries the cursor
+/// with them; the cells stay offset until a reseed at matching geometry. Only the single trailing line terminator is dropped:
 /// with it, the final `\n` would push the whole screen up one row (the top row
 /// scrolls into history) and misplace every cell. The CUP that follows carries
 /// `#{cursor_x}` and the row [`seeded_cursor_row`] maps `#{cursor_y}` onto.
@@ -1444,9 +1458,12 @@ fn assemble_seed_stream(body: &[u8], state: &PaneSeedState, rows: u16) -> Vec<u8
 /// prompt rows where the pane has one, and no reconcile can see it: grid and
 /// pane still agree on geometry and on the cursor, only the cells differ.
 ///
-/// Counting from the pane's bottom row instead survives a mismatch either way,
-/// and reduces to `cursor_y` whenever the two heights agree. A `pane_height` of
-/// 0 means the probe carried no geometry, so keep the plain mapping there.
+/// Bottom-anchoring the row survives a mismatch either way, and reduces to
+/// `cursor_y` whenever the two heights agree. A `pane_height` of 0 means the
+/// probe carried no geometry, so keep the plain mapping there.
+///
+/// `tui::home::render::map_live_preview_cursor` bottom-anchors the same pane
+/// cursor onto the TUI preview rect (#2742, #3515); keep the two in step.
 fn seeded_cursor_row(body: &[u8], state: &PaneSeedState, rows: u16) -> u16 {
     if state.pane_height == 0 {
         return state.cursor_y;
@@ -5369,6 +5386,79 @@ mod tests {
         )
     }
 
+    /// The unit tests hand-build a `PaneSeedState`; this drives the real
+    /// probe/capture/seed path against a live pane whose height differs from
+    /// the grid being seeded, which is the shape #3824 turned on. Skips when
+    /// tmux is unavailable, like the OSC 8 test below.
+    #[test]
+    #[serial_test::serial]
+    fn real_tmux_seed_lands_the_cursor_on_the_prompt_at_a_shorter_grid() {
+        if crate::tmux::tmux_command().arg("-V").output().is_err() {
+            eprintln!("Skipping test: tmux unavailable");
+            return;
+        }
+        let guard = crate::tmux::test_helpers::TmuxTestSession::new("aoe_test_seed_geom");
+        // The live spec's fixture: scrollback, then a prompt the cursor parks on.
+        let script = "for i in $(seq 1 20); do echo \"line-$i\"; done; printf 'READY> '; sleep 30";
+        let out = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                guard.name(),
+                "-x",
+                "80",
+                "-y",
+                "40",
+                script,
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(out.status.success());
+        let target = format!("{}:^.0", guard.name());
+        let deadline = crate::tmux::TmuxCommandDeadline::new();
+
+        // Wait for the prompt to be painted before seeding.
+        let mut probe = PaneSeedState::default();
+        for _ in 0..50 {
+            probe = pane_seed_state(&target, &deadline).unwrap_or_default();
+            if probe.cursor_y == 20 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        assert_eq!(
+            (probe.pane_height, probe.cursor_y),
+            (40, 20),
+            "fixture must park the cursor on the prompt row of a 40-row pane"
+        );
+
+        // Seed a grid SHORTER than the pane, the racing shape: the body's top
+        // rows scroll into history and take the prompt with them.
+        let rows: u16 = 24;
+        let stream =
+            capture_seed_stream(&target, (80, rows), &deadline).expect("capture seed stream");
+        let mut p = vt100::Parser::new(rows, 80, SCROLLBACK_LINES);
+        p.process(&stream);
+
+        let (cy, cx) = p.screen().cursor_position();
+        let contents = p.screen().contents();
+        let prompt_row = contents
+            .lines()
+            .position(|l| l.contains("READY>"))
+            .expect("prompt must be on the visible screen");
+        assert_eq!(
+            (cy as usize, cx),
+            (prompt_row, 7),
+            "cursor must sit on the prompt row the shorter grid pushed up:\n{contents}"
+        );
+        assert_eq!(
+            contents.lines().filter(|l| l.contains("READY>")).count(),
+            1,
+            "one prompt row only:\n{contents}"
+        );
+    }
+
     /// The seed and the capture fallback both read `capture-pane -e`, and the
     /// whole fix rests on tmux re-emitting a stored hyperlink there. Assert it
     /// against a real tmux rather than a hand-built fixture, so a change in how
@@ -5409,7 +5499,7 @@ mod tests {
         let deadline = crate::tmux::TmuxCommandDeadline::new();
         let mut stream = Vec::new();
         for _ in 0..50 {
-            stream = capture_seed_stream(&target, 24, &deadline).unwrap_or_default();
+            stream = capture_seed_stream(&target, (80, 24), &deadline).unwrap_or_default();
             if !crate::tmux::osc8::extract_links(&stream).is_empty() {
                 break;
             }

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -890,8 +890,9 @@ fn reconcile_step(
 /// state before and after the `capture-pane` fork and retries while the two
 /// disagree, so a pane that scrolled, moved its cursor, or flipped screens
 /// mid-seed can't stamp a stale position into the fresh grid. `history_size`
-/// and `pane_height` exist for that comparison alone, mirroring the drift
-/// fields `merge_cursor_probes` trusts on the legacy capture path.
+/// exists for that comparison alone, mirroring the drift fields
+/// `merge_cursor_probes` trusts on the legacy capture path; `pane_height` also
+/// anchors [`seeded_cursor_row`].
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 struct PaneSeedState {
     alt: bool,
@@ -916,7 +917,8 @@ struct PaneSeedState {
     /// pane that scrolled between the probes grew its history, even when the
     /// cursor stayed pinned to the same bottom row.
     history_size: u32,
-    /// `#{pane_height}`: resize detector for the same check; a resize mid-seed
+    /// `#{pane_height}`: resize detector for the same check, and the height
+    /// [`seeded_cursor_row`] counts `cursor_y` back from; a resize mid-seed
     /// invalidates the coordinate space `cursor_y` was reported in.
     pane_height: u16,
     /// `#{pane_width}`: the other resize axis. A width-only resize rewraps the

--- a/web/tests/live/live-size-owner-takeover.spec.ts
+++ b/web/tests/live/live-size-owner-takeover.spec.ts
@@ -25,28 +25,35 @@ async function openLiveView(page: Page, baseUrl: string) {
   await expect.poll(() => page.locator("[data-live-content]").innerText(), { timeout: 15_000 }).toContain(PROMPT);
 }
 
-/** How many rendered rows carry the prompt, and whether the cursor overlay sits
- *  on the first of them (within a pixel of its top).
+/** How many rendered rows carry the prompt, and where the cursor overlay sits
+ *  relative to the first of them, as a phrase rather than a boolean: an
+ *  asserted-equal object reports its mismatched value, so the offset that
+ *  identifies the fault survives into the failure message.
  *
  *  The count is asserted, not navigated around: the agent redraws its prompt in
  *  place on every SIGWINCH, so a second prompt row means the grid put the
  *  cursor somewhere the pane never had it and the redraw landed there (#3824).
  *  Picking the last row instead would have hidden that. */
-async function promptAlignment(page: Page): Promise<{ promptRows: number; aligned: boolean }> {
+async function promptAlignment(page: Page): Promise<{ promptRows: number; cursor: string }> {
   return page.evaluate((prompt) => {
     const content = document.querySelector("[data-live-content]");
     const cursor = document.querySelector("[data-live-cursor]");
-    if (!content || !cursor) return { promptRows: -1, aligned: false };
+    if (!content || !cursor) return { promptRows: -1, cursor: "no live content" };
     const rows = Array.from(content.children).filter((el) => !el.hasAttribute("data-live-cursor"));
     const promptRows = rows.filter((el) => (el.textContent ?? "").includes(prompt));
     const promptRow = promptRows[0];
-    if (!promptRow) return { promptRows: 0, aligned: false };
-    const delta = cursor.getBoundingClientRect().top - promptRow.getBoundingClientRect().top;
-    return { promptRows: promptRows.length, aligned: Math.abs(delta) < 2 };
+    if (!promptRow) return { promptRows: 0, cursor: "no prompt row" };
+    const rect = promptRow.getBoundingClientRect();
+    const delta = cursor.getBoundingClientRect().top - rect.top;
+    const offBy = rect.height > 0 ? Math.round(delta / rect.height) : Number.NaN;
+    return {
+      promptRows: promptRows.length,
+      cursor: Math.abs(delta) < 2 ? "on the prompt row" : `${offBy} rows off (${delta.toFixed(1)}px)`,
+    };
   }, PROMPT);
 }
 
-const ON_PROMPT = { promptRows: 1, aligned: true };
+const ON_PROMPT = { promptRows: 1, cursor: "on the prompt row" };
 
 async function takeOver(page: Page) {
   const banner = page.locator("[data-live-takeover]");

--- a/web/tests/live/live-size-owner-takeover.spec.ts
+++ b/web/tests/live/live-size-owner-takeover.spec.ts
@@ -25,31 +25,28 @@ async function openLiveView(page: Page, baseUrl: string) {
   await expect.poll(() => page.locator("[data-live-content]").innerText(), { timeout: 15_000 }).toContain(PROMPT);
 }
 
-/** Vertical distance (px) between the cursor overlay and the top of the
- *  rendered row containing the live prompt. 0 means perfectly aligned.
+/** How many rendered rows carry the prompt, and whether the cursor overlay sits
+ *  on the first of them (within a pixel of its top).
  *
- *  The *last* matching row, not the first. A hand-off resizes the pane, the
- *  agent redraws its prompt on SIGWINCH, and when the pane grows the redraw
- *  lands on a new row while the pre-resize prompt stays behind in the
- *  scrollback. Both rows then contain the prompt, and measuring against the
- *  stale one reports the distance between the two prompts rather than any
- *  cursor drift. That is a fixed 76.75px here, so it never converges and the
- *  poll always times out. A cursor that really did sit one row off the live
- *  prompt is still one row height away, well over the threshold. */
-async function cursorToPromptDelta(page: Page): Promise<number> {
+ *  The count is asserted, not navigated around: the agent redraws its prompt in
+ *  place on every SIGWINCH, so a second prompt row means the grid put the
+ *  cursor somewhere the pane never had it and the redraw landed there (#3824).
+ *  Picking the last row instead would have hidden that. */
+async function promptAlignment(page: Page): Promise<{ promptRows: number; aligned: boolean }> {
   return page.evaluate((prompt) => {
     const content = document.querySelector("[data-live-content]");
     const cursor = document.querySelector("[data-live-cursor]");
-    if (!content || !cursor) return Number.NaN;
+    if (!content || !cursor) return { promptRows: -1, aligned: false };
     const rows = Array.from(content.children).filter((el) => !el.hasAttribute("data-live-cursor"));
     const promptRows = rows.filter((el) => (el.textContent ?? "").includes(prompt));
-    const promptRow = promptRows[promptRows.length - 1];
-    if (!promptRow) return Number.NaN;
-    const c = cursor.getBoundingClientRect();
-    const r = promptRow.getBoundingClientRect();
-    return c.top - r.top;
+    const promptRow = promptRows[0];
+    if (!promptRow) return { promptRows: 0, aligned: false };
+    const delta = cursor.getBoundingClientRect().top - promptRow.getBoundingClientRect().top;
+    return { promptRows: promptRows.length, aligned: Math.abs(delta) < 2 };
   }, PROMPT);
 }
+
+const ON_PROMPT = { promptRows: 1, aligned: true };
 
 async function takeOver(page: Page) {
   const banner = page.locator("[data-live-takeover]");
@@ -108,25 +105,25 @@ test("ownership ping-pong keeps the cursor on the prompt row", async ({ browser 
     await openLiveView(a, serve.baseUrl);
     // First client owns; no banner.
     await expect(a.locator("[data-live-takeover]")).toHaveCount(0);
-    await expect.poll(async () => Math.abs(await cursorToPromptDelta(a)), { timeout: 10_000 }).toBeLessThan(2);
+    await expect.poll(() => promptAlignment(a), { timeout: 10_000 }).toEqual(ON_PROMPT);
 
     await openLiveView(b, serve.baseUrl);
 
     // B takes over; A is demoted (banner) and B aligns.
     await takeOver(b);
     await a.locator("[data-live-takeover]").waitFor({ state: "visible", timeout: 10_000 });
-    await expect.poll(async () => Math.abs(await cursorToPromptDelta(b)), { timeout: 10_000 }).toBeLessThan(2);
+    await expect.poll(() => promptAlignment(b), { timeout: 10_000 }).toEqual(ON_PROMPT);
 
     // Two full take-back cycles: the reported bug was the cursor drifting
     // one row below the prompt on every take-back.
     for (let cycle = 0; cycle < 2; cycle++) {
       await takeOver(a);
       await b.locator("[data-live-takeover]").waitFor({ state: "visible", timeout: 10_000 });
-      await expect.poll(async () => Math.abs(await cursorToPromptDelta(a)), { timeout: 10_000 }).toBeLessThan(2);
+      await expect.poll(() => promptAlignment(a), { timeout: 10_000 }).toEqual(ON_PROMPT);
 
       await takeOver(b);
       await a.locator("[data-live-takeover]").waitFor({ state: "visible", timeout: 10_000 });
-      await expect.poll(async () => Math.abs(await cursorToPromptDelta(b)), { timeout: 10_000 }).toBeLessThan(2);
+      await expect.poll(() => promptAlignment(b), { timeout: 10_000 }).toEqual(ON_PROMPT);
     }
 
     await ctxA.close();
@@ -168,7 +165,7 @@ test("released lock auto-reclaims without another take-over tap", async ({ brows
     // NO tap; the cursor re-aligns once A's grid is re-asserted.
     await ctxB.close();
     await a.locator("[data-live-takeover]").waitFor({ state: "detached", timeout: 15_000 });
-    await expect.poll(async () => Math.abs(await cursorToPromptDelta(a)), { timeout: 10_000 }).toBeLessThan(2);
+    await expect.poll(() => promptAlignment(a), { timeout: 10_000 }).toEqual(ON_PROMPT);
 
     await ctxA.close();
   } finally {

--- a/web/tests/live/live-size-owner-takeover.spec.ts
+++ b/web/tests/live/live-size-owner-takeover.spec.ts
@@ -30,10 +30,16 @@ async function openLiveView(page: Page, baseUrl: string) {
  *  asserted-equal object reports its mismatched value, so the offset that
  *  identifies the fault survives into the failure message.
  *
- *  The count is asserted, not navigated around: the agent redraws its prompt in
- *  place on every SIGWINCH, so a second prompt row means the grid put the
- *  cursor somewhere the pane never had it and the redraw landed there (#3824).
- *  Picking the last row instead would have hidden that. */
+ *  The count is asserted, not navigated around. The fixture's WINCH handler
+ *  redraws with a bare carriage return and never a newline, so the pane cannot
+ *  hold two prompt rows; a second one means the grid put the cursor on a row the
+ *  pane never had and the redraw landed there (#3824).
+ *
+ *  This supersedes #3826, which read that second row as a pre-resize prompt left
+ *  behind in the scrollback and measured against the last match instead. It is
+ *  not scrollback: at the failing checkpoint tmux reports history_size=0 and a
+ *  single prompt row while the grid shows two. Measuring against the last match
+ *  made this spec pass with the grid-side duplicate still live. */
 async function promptAlignment(page: Page): Promise<{ promptRows: number; cursor: string }> {
   return page.evaluate((prompt) => {
     const content = document.querySelector("[data-live-content]");


### PR DESCRIPTION
## Description

When you have the live terminal open on your phone and hand control back and forth between two devices, the app sometimes drew the agent's input prompt twice, with the blinking cursor sitting on the lower, phantom copy instead of the real one. The real terminal only ever had one prompt; the app's own copy of the screen had drifted.

It happened because of a timing gap. Each time a device takes control it resizes the terminal, and the app rebuilds its picture of the screen by asking tmux for a fresh snapshot. If the snapshot came back describing the terminal at its old, taller size, the extra rows scrolled off the top of the smaller picture and pulled the content up with them, but the cursor was left behind at the row number tmux had reported. The next time the agent redrew its prompt it printed it wherever the cursor was stranded, and that stray copy is what you saw. Nothing noticed, because every check the app runs compares the screen's size and the cursor position, and by then those matched again; only the text was wrong.

This change places the cursor by counting up from the bottom of the snapshot rather than down from the top, so it moves with the content whenever the two sizes disagree. When they agree, which is the normal case, nothing changes. It also asks tmux again, briefly, for a snapshot taken at the size being rebuilt, so the picture matches the screen rather than merely being self-consistent. The test that was supposed to catch this now checks that only one prompt is on screen, which is the part that had stopped being checked.

Fixes #3824

### Root cause

`assemble_seed_stream` emitted tmux's `#{cursor_y}` as the seeded grid's row directly. That is correct only while the grid is as tall as the pane the `capture-pane` body came from. A reseed racing `resize-window` breaks it: the capture reads the pane at its old height, the surplus rows scroll off the top of the shorter grid and carry the content up, and the cursor stays parked that many rows below where the content landed. The agent's SIGWINCH redraw then prints its prompt at the stranded cursor, and the grid holds two prompt rows where the pane has one.

The divergence is invisible to every existing guard. `reconcile_step` compares geometry and cursor; once the resize settles, both agree and only the cells differ.

`seeded_cursor_row` maps the row from the pane's bottom instead. It reduces to `cursor_y` whenever the heights agree, and a probe carrying no geometry keeps the old mapping.

### Evidence

Instrumenting the seed across 36 runs of the spec: the height mismatch fired on 19 of 248 seeds, 15 of them shifting the cursor by 8 rows. At the spec's 9.6px line height that is 76.8px, matching the 76.75px delta the CI failures reported.

A capture at a failing checkpoint, showing the duplicate is grid-side and not fixture- or tmux-side:

```
tmux:    78x57  cur=7,30  hist=0   -> one READY> row, at 30
grid:    rows=57 hist=8 lines=65   -> READY> at DOM rows 30 AND 38
cursor:  cur=7,30 -> row=38
```

tmux has no scrollback and one prompt; the grid claims 8 lines of history and two.

### Supersedes #3826

#3826 landed on main eight minutes before this branch's first commit and changed the same oracle in the opposite direction, to `promptRows[promptRows.length - 1]`, on the reading that the second prompt row is the pre-resize prompt left behind in the scrollback. Issue #3824 had explicitly asked that this swap not be made until the duplicate's origin was known.

It is not scrollback. At the failing checkpoint tmux reports `history_size=0` and a single prompt row while the grid shows two, and the fixture's WINCH handler is `printf '\r READY> '`, a bare carriage return with no newline, so the pane cannot produce a second row on its own.

#3826 made this spec pass with the grid-side duplicate still live in the product. This PR restores the count assertion and fixes the cause, so rebasing onto #3826 reverts its oracle change deliberately. That is recorded in the spec's own comment so the next reader is not left with two merged changes asserting opposite things about the same three lines.

The before/after flake numbers below were first measured against the pre-#3826 merge base and have been re-measured on the rebased branch.

### Candidate causes from the issue

All three were leads, and all three are ruled out by the capture above.

1. **Incoherent VT seed** (three discordant probes returning the last snapshot). Ruled out: the probes agreed. Every seed logged in the failing runs came back on a probe pair that matched, and the body/probe pair is self-consistent. The corruption is downstream of the snapshot, in how its cursor row is mapped onto a grid of a different height.
2. **Non-atomic geometry/parser publication** (a snapshot mixing old geometry with new cells). Ruled out as the cause of this failure: the published frame is internally consistent (57 rows of cells, geometry 57), and the failure persists past the 10s poll rather than resolving on the next frame, which a transient mixed publication would.
3. **Incomplete capture probes** (`session.rs` reconciling on `history_size`/`pane_height` only, no width or y). Ruled out for this failure: the failing frames are served by the VT grid transport, not `capture_pane_with_cursor`. `transport=grid` in the debug overlay on every captured failure. The legacy path's probe coverage is untouched by this bug.

### Still latent after this

Candidate cause 3 named a real gap that is not this bug and is not fixed here: `merge_cursor_probes` (`src/tmux/session.rs:229`) reconciles on `history_size` and `pane_height` but never `pane_width`, though `CURSOR_FMT` already collects it. A width-only resize between the probes rewraps the pane and still reports `position_reliable: true`. That is the legacy `capture_pane_with_cursor` path, not the grid transport these failures came through.

The width axis of the seed itself is now handled: `capture_seed_snapshot` prefers a snapshot taken at the geometry being seeded, so an over-wide body is retried rather than remapped. `seeded_cursor_row` remains the fallback when the pane will not settle there, and it counts logical rows, so an over-wide body still undercounts.

Correcting an earlier version of this description: a width mismatch confined to the capture does NOT trip `reconcile_step`'s geometry branch. That compares tmux's geometry against the grid's stored geometry, and `set_grid_size_with_deadline` stores the resize target, so once the resize settles both equal the target. It heals through the slower cursor-drift branch, which by design does not fire while output is flowing.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

`live-size-owner-takeover.spec.ts` now asserts the prompt row count alongside the cursor alignment. Its `terminal.live-size-owner` matrix entry already lists the spec, so no matrix edit was needed. Two unit tests cover the mapping: one reproducing the taller-pane seed (fails without the fix), one pinning the identity cases.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

### Verification

The flake rate on this branch's base was 2/6, so repeated runs, not a single green one:

- Before (pre-#3826 base, where the oracle still detected the duplicate): 1 failure in 6 runs of the spec, then 2 in 6 on a rerun; 2 failures in 9 runs of an instrumented copy at the same checkpoints.
- After, on the rebased branch: 36/36 runs of the spec green, plus 12/12 on a re-run after the last comment change, all at 3 workers. Instrumentation confirms the race still fired 19 times across 36 green runs and was corrected rather than avoided.
- The mapping is covered end to end, not only by hand-built state: a real-tmux test seeds a live 40-row pane into a 24-row grid and fails without the fix (cursor at row 20 rather than 4).
- 30/30 green across the neighbouring live specs (`live-grid-transport`, `live-frame-compression`, `mobile-live-no-flutter`, `mobile-live-scrollback-buffer`, `theme-switch-live`).
- `cargo test --features web`: 7153 passed, 0 failed. CI's exact rustdoc gate (`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --features web`) clean. `cargo fmt --check`, `cargo clippy --features web --all-targets` clean. Web `format:check`, `lint`, `tsc -b` clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Root cause was found by instrumenting the seed path and capturing DOM, cursor, WS frames and tmux state together at the failing checkpoint, per the discrimination protocol in #3824.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Pa5NEKgMq7uByVajxEFgW



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed a terminal resize race that could place the cursor on the wrong prompt row and create duplicate `READY>` prompts.
- Updated cursor mapping to account for height changes during snapshot capture.
- Requested snapshots at the target terminal size before rebuilding the grid.
- Strengthened the live-size takeover tests to require one prompt and correct cursor alignment.
- Added unit tests for resize races, matching heights, and shorter grids.

## Benefits

- Improves prompt and cursor consistency during terminal resizing.
- Reduces flaky live tests and prevents stale prompt rows.
- Keeps existing behavior when terminal heights match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->