### PR TITLE
docs: drop the experimental label from the web dashboard title

### DIFF
--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -71,7 +71,7 @@ const PAGES = [
   {
     source: "docs/guides/web-dashboard.md",
     dest: "guides/web-dashboard.md",
-    title: "Web Dashboard (Experimental)",
+    title: "Web Dashboard",
     description:
       "Remote access to AI coding agent sessions from any browser with Agent of Empires.",
   },


### PR DESCRIPTION
## Description

The docs sync map still titled the web dashboard guide "Web Dashboard (Experimental)". That title is stamped into the generated page frontmatter, so it was the site page heading and browser tab title. The guide's own H1 and the `docsNav.ts` entry already say plain "Web Dashboard".

A repo-wide sweep for experimental/beta/preview/alpha framing around the dashboard found no other occurrences. Remaining matches are unrelated: the CityHall labs badge, `node --experimental-strip-types`, the experimental ACP `session/delete` RPC, and test fixtures named `alpha`/`beta`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Sweep and edit done by the model; the decision to drop the label is mine.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E127YMSt93vei1eGnhWXP3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Renamed the synced web dashboard documentation title from “Web Dashboard (Experimental)” to “Web Dashboard.”
- Updated generated frontmatter, page headings, and browser tab titles.
- Removed the outdated experimental label for a clearer, consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->