### PR TITLE
fix(pi): keep a Pi conversation when its transcript is gone

### DIFF
--- a/docs/guides/session-resume.md
+++ b/docs/guides/session-resume.md
@@ -81,9 +81,15 @@ State lives in `sessions.json` in your AoE config directory:
 - **Linux**: `$XDG_CONFIG_HOME/agent-of-empires/profiles/<profile>/sessions.json`
 - **macOS/Windows**: `~/.agent-of-empires/profiles/<profile>/sessions.json`
 
-Three relevant fields:
+Four relevant fields:
 
 - `agent_session_id`: the observed conversation ID. Auto-managed; do not edit.
 - `resume_intent`: your intent (`Default`, `Use(id)`, `Cleared`). Set via the CLI above. Absent when `Default`.
 - `resume_probe_failed_sid`: the last pinned ID whose resume probe failed ambiguously.
   This loop-breaker prevents startup recovery from retrying that same ID automatically until user action changes the resume state.
+- `pi_session_path`: for Pi sessions, the transcript path the pane published.
+  Pi indexes conversations by the directory they started in, so this is what
+  resumes one whose worktree has since moved. Pi writes a transcript lazily,
+  so when this names a file that is not there, an unpinned launch starts fresh
+  and keeps the ID rather than handing `--session` an argument that would fail.
+  Auto-managed; do not edit.

--- a/docs/guides/session-resume.md
+++ b/docs/guides/session-resume.md
@@ -89,7 +89,9 @@ Four relevant fields:
   This loop-breaker prevents startup recovery from retrying that same ID automatically until user action changes the resume state.
 - `pi_session_path`: for Pi sessions, the transcript path the pane published.
   Pi indexes conversations by the directory they started in, so this is what
-  resumes one whose worktree has since moved. Pi writes a transcript lazily,
-  so when this names a file that is not there, an unpinned launch starts fresh
-  and keeps the ID rather than handing `--session` an argument that would fail.
-  Auto-managed; do not edit.
+  resumes one whose worktree has since moved. Pi writes a transcript lazily, so
+  this can name a file that does not exist yet. A launch that would otherwise
+  pass that conversation to `pi --session`, which fails outright on an ID it
+  cannot resolve, starts fresh instead and lets the pane's next conversation
+  take over. Launches that pin with `--session-id` are unaffected, since that
+  flag creates the conversation rather than failing. Auto-managed; do not edit.

--- a/src/server/session_identity.rs
+++ b/src/server/session_identity.rs
@@ -31,6 +31,10 @@ pub(super) fn apply_drained_identity_if_unchanged(
     {
         live.agent_session_id = drained.agent_session_id.clone();
         live.omp_capture_generation = drained.omp_capture_generation.clone();
+        // The drain also records the transcript path a Pi pane published.
+        // Guarded by the same sid baseline: the path names a conversation, so
+        // carrying it onto a row whose sid moved would pair two conversations.
+        live.pi_session_path = drained.pi_session_path.clone();
         if live.resume_probe_failed_sid == *baseline_marker {
             live.resume_probe_failed_sid = drained.resume_probe_failed_sid.clone();
         }

--- a/src/session/anchored_fs.rs
+++ b/src/session/anchored_fs.rs
@@ -178,13 +178,28 @@ impl AnchoredDir {
         self.modified(relative, true)
     }
 
+    /// What `relative` names: `Some(true)` a regular file, `Some(false)`
+    /// something that is not one, `None` nothing at all. `Err` when the
+    /// lookup itself could not be made, which callers that treat absence as
+    /// evidence must keep distinct from `None`.
+    ///
+    /// Inspects with `fstatat` rather than opening, so an entry this process
+    /// may stat but not read still answers `Some(true)`. A sandbox writes its
+    /// files as the container's user, and the host side only needs to know
+    /// they are there.
+    pub(crate) fn regular_lookup(&self, relative: &Path) -> Result<Option<bool>> {
+        let (parent, leaf) = self.open_parent(relative)?;
+        match fstatat(&parent, leaf.as_os_str(), AtFlags::AT_SYMLINK_NOFOLLOW) {
+            Ok(stat) => Ok(Some(
+                (stat.st_mode & nix::libc::S_IFMT) == nix::libc::S_IFREG,
+            )),
+            Err(Errno::ENOENT) => Ok(None),
+            Err(error) => Err(error).context("inspecting anchored file"),
+        }
+    }
+
     pub(crate) fn regular_exists(&self, relative: &Path) -> bool {
-        self.open_parent(relative)
-            .ok()
-            .and_then(|(parent, leaf)| {
-                fstatat(&parent, leaf.as_os_str(), AtFlags::AT_SYMLINK_NOFOLLOW).ok()
-            })
-            .is_some_and(|stat| (stat.st_mode & nix::libc::S_IFMT) == nix::libc::S_IFREG)
+        matches!(self.regular_lookup(relative), Ok(Some(true)))
     }
 
     pub(crate) fn remove_file(&self, relative: &Path) -> Result<()> {

--- a/src/session/instance/kill.rs
+++ b/src/session/instance/kill.rs
@@ -18,12 +18,7 @@ impl Instance {
         if self.pi_session_path.as_deref() == Some(path.as_str()) {
             return;
         }
-        let _ = storage.update(|instances, _| {
-            if let Some(inst) = instances.iter_mut().find(|i| i.id == self.id) {
-                inst.pi_session_path = Some(path.clone());
-            }
-            Ok(())
-        });
+        self.store_pi_session_path(storage, &path);
     }
 
     /// [`flush_pi_sidecar_conversation`] against this session's own storage,

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -669,7 +669,7 @@ pub struct Instance {
     /// whose managed worktree has since moved; the id alone would resolve to
     /// nothing there.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pi_session_path: Option<String>,
+    pub(crate) pi_session_path: Option<String>,
 
     #[serde(skip)]
     pub last_error: Option<String>,

--- a/src/session/instance/session_id.rs
+++ b/src/session/instance/session_id.rs
@@ -4,6 +4,16 @@ use super::*;
 
 const PI_SIDECAR_MAX_BYTES: usize = 4096;
 
+/// What a recorded Pi transcript path resolves to. `Unreadable` means the
+/// store could not be inspected, which is a statement about our view rather
+/// than about the conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PiTranscriptState {
+    Present,
+    Absent,
+    Unreadable,
+}
+
 impl Instance {
     /// Acquire a pre-launch session ID for the agent.
     ///
@@ -467,41 +477,82 @@ impl Instance {
         Some(self.pi_config_bind_dir()?.join(rest))
     }
 
+    /// What this row's recorded transcript path resolves to on disk.
+    ///
+    /// `Unreadable` is the answer whenever the store directory that would
+    /// hold the file could not itself be listed: a bind that no longer
+    /// resolves, a moved store, a namespace the path does not belong to. It
+    /// is deliberately distinct from `Absent`, because only `Absent` is
+    /// evidence about the conversation rather than about our own view.
+    fn pi_recorded_transcript_state(&self, path: &str) -> PiTranscriptState {
+        let relative = if self.is_sandboxed() {
+            match path.strip_prefix("/root/.pi/") {
+                Some(relative) => Path::new(relative),
+                None => return PiTranscriptState::Unreadable,
+            }
+        } else {
+            match self.pi_host_view_of(path) {
+                Some(host_path) => {
+                    return match host_path.parent().map(std::path::Path::is_dir) {
+                        Some(true) if host_path.is_file() => PiTranscriptState::Present,
+                        Some(true) => PiTranscriptState::Absent,
+                        _ => PiTranscriptState::Unreadable,
+                    }
+                }
+                None => return PiTranscriptState::Unreadable,
+            }
+        };
+        let Some(parent) = relative.parent() else {
+            return PiTranscriptState::Unreadable;
+        };
+        let readable = self
+            .pi_config_bind_dir()
+            .and_then(|root| crate::session::AnchoredDir::open(&root).ok())
+            .and_then(|root| root.directory_modified(parent).ok())
+            .flatten()
+            .is_some();
+        if !readable {
+            return PiTranscriptState::Unreadable;
+        }
+        if self.pi_sandbox_regular_exists(relative) {
+            PiTranscriptState::Present
+        } else {
+            PiTranscriptState::Absent
+        }
+    }
+
     /// The recorded transcript path when it belongs to the conversation this
-    /// row currently owns, paired with whether that file is still there.
-    fn pi_recorded_transcript(&self) -> Option<(&str, bool)> {
+    /// row currently owns, paired with what that path resolves to.
+    fn pi_recorded_transcript(&self) -> Option<(&str, PiTranscriptState)> {
         let path = self.pi_session_path.as_deref()?;
         let id = self.agent_session_id.as_deref()?;
         let name = std::path::Path::new(path).file_name()?.to_str()?;
         name.rsplit_once('_')
             .and_then(|(_, tail)| tail.strip_suffix(".jsonl"))
             .filter(|uuid| *uuid == id)?;
-        let exists = if self.is_sandboxed() {
-            path.strip_prefix("/root/.pi/")
-                .is_some_and(|relative| self.pi_sandbox_regular_exists(Path::new(relative)))
-        } else {
-            self.pi_host_view_of(path)
-                .is_some_and(|host_path| host_path.is_file())
-        };
-        Some((path, exists))
+        Some((path, self.pi_recorded_transcript_state(path)))
     }
 
     fn pi_resumable_transcript(&self) -> Option<String> {
-        let (path, exists) = self.pi_recorded_transcript()?;
-        exists.then(|| path.to_string())
+        let (path, state) = self.pi_recorded_transcript()?;
+        (state == PiTranscriptState::Present).then(|| path.to_string())
     }
 
     /// Whether the conversation this row owns is known to have no transcript.
     ///
     /// Positive evidence only, and only from what the pane itself published:
-    /// a recorded path for exactly this conversation whose file is gone. Pi
-    /// writes a transcript lazily, so a conversation that was never prompted
-    /// has none, and pi's store layout is never reconstructed to guess.
+    /// a recorded path for exactly this conversation, in a store directory we
+    /// can read, with no file at it. Pi writes a transcript lazily, so a
+    /// conversation that was never prompted has none. A store we cannot read
+    /// says nothing, and pi's layout is never reconstructed to guess.
     fn pi_recorded_transcript_missing(&self) -> bool {
-        matches!(self.pi_recorded_transcript(), Some((_, false)))
+        matches!(
+            self.pi_recorded_transcript(),
+            Some((_, PiTranscriptState::Absent))
+        )
     }
 
-    pub(super) fn absorb_published_pi_session(&mut self) {
+    pub(crate) fn absorb_published_pi_session(&mut self) {
         if self.resolved_capture_backend() != Some(crate::agents::SessionCaptureBackend::Pi) {
             return;
         }
@@ -856,18 +907,19 @@ impl Instance {
                 return Ok(true);
             }
         }
-        // Pi's `--session <sid>` arm is its hard-failing selector: it exits 1
-        // when the id resolves to nothing, and `remain-on-exit` then leaves a
-        // dead pane that the resume probe reads as a failed resume, so the
-        // next launch discards the conversation. Pi writes a transcript
-        // lazily, so an id AoE holds for a conversation that was never
-        // prompted resolves to nothing. Start fresh instead, keeping the id
-        // for a later launch that can pin it. The `--session-id` arm creates
-        // the conversation rather than failing, which is why it is exempt. An
-        // explicit pin is left to fail: the user named that conversation and
-        // pi's own message in the pane is the answer they asked for.
+        // Pi's `--session` arm exits 1 when its argument resolves to nothing,
+        // and `remain-on-exit` then leaves a dead pane that the resume probe
+        // reads as a failed resume, so the next launch discards the
+        // conversation. Pi writes a transcript lazily, so an id AoE holds for
+        // a conversation that was never prompted resolves to nothing. Start
+        // fresh instead, keeping the id for a later launch that can pin it.
+        // The `--session-id` arm creates the conversation rather than failing,
+        // which is why it is exempt. An explicit pin is left to fail: the user
+        // named that conversation and pi's own message in the pane is the
+        // answer they asked for.
         if flag_arm_is_existing
             && !explicitly_pinned
+            && session_id.is_some()
             && self.resolved_capture_backend() == Some(crate::agents::SessionCaptureBackend::Pi)
             && self.pi_recorded_transcript_missing()
         {
@@ -1572,6 +1624,64 @@ pi = "~/.pi-personal"
             host_inst.pi_host_view_of("/home/u/.pi/x.jsonl"),
             Some(std::path::PathBuf::from("/home/u/.pi/x.jsonl"))
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pi_only_calls_a_transcript_missing_when_its_store_was_readable() {
+        // The gate destroys a conversation, so it must fire on evidence about
+        // the conversation and never on a store AoE could not inspect. This
+        // covers the sandboxed shape, which is the one that can lose its
+        // store dir under a live row (a moved or reclaimed bind).
+        let _guard = crate::session::test_support::isolate_app_dir();
+        let id = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+        let leaf = format!("2026-01-01T00-00-00-000Z_{id}.jsonl");
+
+        let mut inst = Instance::new("pi-store", "/tmp/pi-store");
+        inst.tool = "pi".to_string();
+        inst.agent_session_id = Some(id.to_string());
+        inst.sandbox_info = Some(crate::session::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "aoe-pi-store".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            container_workdir: None,
+            before_start_env: Vec::new(),
+        });
+        inst.pi_session_path = Some(format!("/root/.pi/agent/sessions/--proj--/{leaf}"));
+
+        // No store dir on the host side of the bind yet: unreadable, so the
+        // launch keeps whatever it would have done without this gate.
+        assert!(
+            !inst.pi_recorded_transcript_missing(),
+            "an uninspectable store is not evidence the conversation is gone"
+        );
+        assert_eq!(inst.pi_resumable_transcript(), None);
+
+        let store = inst.sandbox_capture_store_dir().expect("bind dir");
+        let sessions = store.join("agent").join("sessions").join("--proj--");
+        std::fs::create_dir_all(&sessions).unwrap();
+
+        // The store now reads, and the conversation has no file in it.
+        assert!(
+            inst.pi_recorded_transcript_missing(),
+            "a readable store with no file is the pane's own answer"
+        );
+
+        std::fs::write(sessions.join(&leaf), "{}\n").unwrap();
+        assert!(!inst.pi_recorded_transcript_missing());
+        assert_eq!(
+            inst.pi_resumable_transcript(),
+            Some(format!("/root/.pi/agent/sessions/--proj--/{leaf}")),
+            "the pane resumes its own transcript by the path it published"
+        );
+
+        // A recorded host path on a row that has since been sandboxed names
+        // nothing inside the container, so it stays evidence-free.
+        inst.pi_session_path = Some(format!("/home/u/.pi/agent/sessions/--proj--/{leaf}"));
+        assert!(!inst.pi_recorded_transcript_missing());
     }
 
     #[test]

--- a/src/session/instance/session_id.rs
+++ b/src/session/instance/session_id.rs
@@ -14,6 +14,27 @@ enum PiTranscriptState {
     Unreadable,
 }
 
+/// Classify a transcript path the host filesystem can be asked about
+/// directly.
+///
+/// Only a miss under a directory that reads back is `Absent`. `Path::is_file`
+/// folds a denied or failing lookup into `false`, and the launch gate reads
+/// `Absent` as proof about the conversation, so an error must never arrive
+/// there.
+fn host_transcript_state(host_path: &Path) -> PiTranscriptState {
+    match std::fs::metadata(host_path) {
+        Ok(metadata) if metadata.is_file() => PiTranscriptState::Present,
+        Ok(_) => PiTranscriptState::Unreadable,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match host_path.parent().map(std::fs::metadata) {
+                Some(Ok(parent)) if parent.is_dir() => PiTranscriptState::Absent,
+                _ => PiTranscriptState::Unreadable,
+            }
+        }
+        Err(_) => PiTranscriptState::Unreadable,
+    }
+}
+
 impl Instance {
     /// Acquire a pre-launch session ID for the agent.
     ///
@@ -491,33 +512,27 @@ impl Instance {
                 None => return PiTranscriptState::Unreadable,
             }
         } else {
-            match self.pi_host_view_of(path) {
-                Some(host_path) => {
-                    return match host_path.parent().map(std::path::Path::is_dir) {
-                        Some(true) if host_path.is_file() => PiTranscriptState::Present,
-                        Some(true) => PiTranscriptState::Absent,
-                        _ => PiTranscriptState::Unreadable,
-                    }
-                }
-                None => return PiTranscriptState::Unreadable,
-            }
+            let Some(host_path) = self.pi_host_view_of(path) else {
+                return PiTranscriptState::Unreadable;
+            };
+            return host_transcript_state(&host_path);
         };
         let Some(parent) = relative.parent() else {
             return PiTranscriptState::Unreadable;
         };
-        let readable = self
+        let Some(root) = self
             .pi_config_bind_dir()
             .and_then(|root| crate::session::AnchoredDir::open(&root).ok())
-            .and_then(|root| root.directory_modified(parent).ok())
-            .flatten()
-            .is_some();
-        if !readable {
+        else {
+            return PiTranscriptState::Unreadable;
+        };
+        if !matches!(root.directory_modified(parent), Ok(Some(_))) {
             return PiTranscriptState::Unreadable;
         }
-        if self.pi_sandbox_regular_exists(relative) {
-            PiTranscriptState::Present
-        } else {
-            PiTranscriptState::Absent
+        match root.regular_lookup(relative) {
+            Ok(Some(true)) => PiTranscriptState::Present,
+            Ok(None) => PiTranscriptState::Absent,
+            Ok(Some(false)) | Err(_) => PiTranscriptState::Unreadable,
         }
     }
 
@@ -912,11 +927,12 @@ impl Instance {
         // reads as a failed resume, so the next launch discards the
         // conversation. Pi writes a transcript lazily, so an id AoE holds for
         // a conversation that was never prompted resolves to nothing. Start
-        // fresh instead, keeping the id for a later launch that can pin it.
-        // The `--session-id` arm creates the conversation rather than failing,
-        // which is why it is exempt. An explicit pin is left to fail: the user
-        // named that conversation and pi's own message in the pane is the
-        // answer they asked for.
+        // fresh instead: the pane comes up on a new conversation and the
+        // poller adopts it, which is what the old id would have named anyway
+        // once pi had written to it. The `--session-id` arm creates the
+        // conversation rather than failing, which is why it is exempt. An
+        // explicit pin is left to fail: the user named that conversation and
+        // pi's own message in the pane is the answer they asked for.
         if flag_arm_is_existing
             && !explicitly_pinned
             && session_id.is_some()
@@ -928,7 +944,8 @@ impl Instance {
                 instance = %self.id,
                 sid = ?session_id,
                 "the conversation this Pi session owns has no transcript; \
-                 starting fresh rather than failing the launch on `--session`",
+                 starting fresh rather than failing the launch on `--session`. \
+                 The pane's next conversation replaces it",
             );
             session_id = None;
         }
@@ -1020,6 +1037,7 @@ mod tests {
     use crate::session::instance::test_helpers::*;
     use crate::session::test_support::EnvGuard;
     use serial_test::serial;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn self_heal_eligibility_rejects_owned_and_inactive_rows() {
@@ -1685,6 +1703,58 @@ pi = "~/.pi-personal"
     }
 
     #[test]
+    fn pi_never_calls_a_transcript_missing_on_a_store_it_could_not_ask_about() {
+        // The host side answers from the filesystem directly, where every
+        // failed lookup looks like `false`. Only a miss under a directory
+        // that reads back is evidence about the conversation.
+        let temp = tempfile::tempdir().unwrap();
+        let id = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+        let leaf = format!("2026-01-01T00-00-00-000Z_{id}.jsonl");
+        let store = temp.path().join("sessions");
+
+        let mut inst = Instance::new("pi-host-store", "/tmp/pi-host-store");
+        inst.tool = "pi".to_string();
+        inst.agent_session_id = Some(id.to_string());
+        inst.pi_session_path = Some(store.join(&leaf).to_string_lossy().into_owned());
+
+        assert!(
+            !inst.pi_recorded_transcript_missing(),
+            "a store directory that is not there says nothing about the conversation"
+        );
+
+        std::fs::create_dir_all(&store).unwrap();
+        assert!(
+            inst.pi_recorded_transcript_missing(),
+            "a readable store with no file is the pane's own answer"
+        );
+
+        std::fs::write(store.join(&leaf), "{}\n").unwrap();
+        assert!(!inst.pi_recorded_transcript_missing());
+
+        // A lookup that fails for any reason other than a miss is not
+        // evidence. A regular file standing in for the store directory is the
+        // one shape every uid sees the same way; root bypasses mode bits.
+        let not_a_dir = temp.path().join("occupied");
+        std::fs::write(&not_a_dir, "").unwrap();
+        inst.pi_session_path = Some(not_a_dir.join(&leaf).to_string_lossy().into_owned());
+        assert!(
+            !inst.pi_recorded_transcript_missing(),
+            "a store path that is not a directory says nothing about the conversation"
+        );
+        inst.pi_session_path = Some(store.join(&leaf).to_string_lossy().into_owned());
+
+        if !nix::unistd::Uid::effective().is_root() {
+            std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o600)).unwrap();
+            let denied = !inst.pi_recorded_transcript_missing();
+            std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o700)).unwrap();
+            assert!(
+                denied,
+                "a transcript AoE is not allowed to stat must not read as gone"
+            );
+        }
+    }
+
+    #[test]
     #[serial_test::serial]
     fn pi_launch_drops_the_failing_session_selector_when_the_transcript_is_gone() {
         // `--session <sid>` exits 1 on an id that resolves to nothing, which
@@ -1725,7 +1795,7 @@ pi = "~/.pi-personal"
         assert_eq!(
             inst.agent_session_id.as_deref(),
             Some(id),
-            "the id stays on the row for a later launch that can pin it"
+            "acquisition leaves the row's id alone; only the selector is dropped"
         );
 
         // The same row resumes by path once the transcript is there.

--- a/src/session/instance/session_id.rs
+++ b/src/session/instance/session_id.rs
@@ -467,14 +467,15 @@ impl Instance {
         Some(self.pi_config_bind_dir()?.join(rest))
     }
 
-    fn pi_resumable_transcript(&self) -> Option<String> {
+    /// The recorded transcript path when it belongs to the conversation this
+    /// row currently owns, paired with whether that file is still there.
+    fn pi_recorded_transcript(&self) -> Option<(&str, bool)> {
         let path = self.pi_session_path.as_deref()?;
         let id = self.agent_session_id.as_deref()?;
         let name = std::path::Path::new(path).file_name()?.to_str()?;
-        let names_this_conversation = name
-            .rsplit_once('_')
+        name.rsplit_once('_')
             .and_then(|(_, tail)| tail.strip_suffix(".jsonl"))
-            .is_some_and(|uuid| uuid == id);
+            .filter(|uuid| *uuid == id)?;
         let exists = if self.is_sandboxed() {
             path.strip_prefix("/root/.pi/")
                 .is_some_and(|relative| self.pi_sandbox_regular_exists(Path::new(relative)))
@@ -482,15 +483,63 @@ impl Instance {
             self.pi_host_view_of(path)
                 .is_some_and(|host_path| host_path.is_file())
         };
-        (names_this_conversation && exists).then(|| path.to_string())
+        Some((path, exists))
+    }
+
+    fn pi_resumable_transcript(&self) -> Option<String> {
+        let (path, exists) = self.pi_recorded_transcript()?;
+        exists.then(|| path.to_string())
+    }
+
+    /// Whether the conversation this row owns is known to have no transcript.
+    ///
+    /// Positive evidence only, and only from what the pane itself published:
+    /// a recorded path for exactly this conversation whose file is gone. Pi
+    /// writes a transcript lazily, so a conversation that was never prompted
+    /// has none, and pi's store layout is never reconstructed to guess.
+    fn pi_recorded_transcript_missing(&self) -> bool {
+        matches!(self.pi_recorded_transcript(), Some((_, false)))
     }
 
     pub(super) fn absorb_published_pi_session(&mut self) {
         if self.resolved_capture_backend() != Some(crate::agents::SessionCaptureBackend::Pi) {
             return;
         }
-        if let Some(path) = self.pi_published_session_path() {
-            self.pi_session_path = Some(path);
+        let Some(path) = self.pi_published_session_path() else {
+            return;
+        };
+        if self.pi_session_path.as_deref() == Some(path.as_str()) {
+            return;
+        }
+        self.pi_session_path = Some(path.clone());
+        // The sidecar this came from lives in the host temp directory, which a
+        // reboot clears. Only the durable copy survives to tell the next launch
+        // which conversation the pane was on and whether it has a transcript.
+        if let Ok(storage) = crate::session::storage::Storage::new(
+            &self.effective_profile(),
+            self.resolve_file_watch(),
+        ) {
+            self.store_pi_session_path(&storage, &path);
+        }
+    }
+
+    /// Record a published transcript path on this row's durable state.
+    pub(super) fn store_pi_session_path(
+        &self,
+        storage: &crate::session::storage::Storage,
+        path: &str,
+    ) {
+        if let Err(error) = storage.update(|instances, _| {
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == self.id) {
+                inst.pi_session_path = Some(path.to_string());
+            }
+            Ok(())
+        }) {
+            tracing::warn!(
+                target: "session.store",
+                instance = %self.id,
+                "could not persist the Pi transcript path the pane published: {error}",
+            );
         }
     }
 
@@ -806,6 +855,30 @@ impl Instance {
                 tracing::debug!(target: "session.store", "Added resume flags to {} command: {}", context, flags);
                 return Ok(true);
             }
+        }
+        // Pi's `--session <sid>` arm is its hard-failing selector: it exits 1
+        // when the id resolves to nothing, and `remain-on-exit` then leaves a
+        // dead pane that the resume probe reads as a failed resume, so the
+        // next launch discards the conversation. Pi writes a transcript
+        // lazily, so an id AoE holds for a conversation that was never
+        // prompted resolves to nothing. Start fresh instead, keeping the id
+        // for a later launch that can pin it. The `--session-id` arm creates
+        // the conversation rather than failing, which is why it is exempt. An
+        // explicit pin is left to fail: the user named that conversation and
+        // pi's own message in the pane is the answer they asked for.
+        if flag_arm_is_existing
+            && !explicitly_pinned
+            && self.resolved_capture_backend() == Some(crate::agents::SessionCaptureBackend::Pi)
+            && self.pi_recorded_transcript_missing()
+        {
+            tracing::info!(
+                target: "session.store",
+                instance = %self.id,
+                sid = ?session_id,
+                "the conversation this Pi session owns has no transcript; \
+                 starting fresh rather than failing the launch on `--session`",
+            );
+            session_id = None;
         }
         let resume_tool = self
             .resolved_agent()
@@ -1499,6 +1572,57 @@ pi = "~/.pi-personal"
             host_inst.pi_host_view_of("/home/u/.pi/x.jsonl"),
             Some(std::path::PathBuf::from("/home/u/.pi/x.jsonl"))
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pi_launch_drops_the_failing_session_selector_when_the_transcript_is_gone() {
+        // `--session <sid>` exits 1 on an id that resolves to nothing, which
+        // kills the pane and costs the row its conversation on the retry. Pi
+        // writes a transcript lazily, so a conversation that was never
+        // prompted has none. The launch must start fresh and keep the id.
+        let (_hooks, _base, _hooks_tmp) = crate::hooks::test_support::BaseGuard::ready();
+        let temp = tempfile::tempdir().unwrap();
+        let _home = crate::session::test_support::isolate_app_dir_at(temp.path());
+
+        // A profile `PATH` assignment means AoE cannot vouch for which `pi`
+        // the pane runs, so the launch takes the `--session` arm rather than
+        // the `--session-id` arm that would create the conversation.
+        let profile = "pi-missing-transcript";
+        let profile_dir = crate::session::get_profile_dir(profile).unwrap();
+        std::fs::write(
+            profile_dir.join("config.toml"),
+            "environment = [\"PATH=/usr/bin\"]\n",
+        )
+        .unwrap();
+
+        let id = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+        let transcript = temp
+            .path()
+            .join(format!("2026-01-01T00-00-00-000Z_{id}.jsonl"));
+
+        let mut inst = Instance::new("pi-gone", "/tmp/pi-gone");
+        inst.tool = "pi".to_string();
+        inst.command = "pi".to_string();
+        inst.source_profile = profile.to_string();
+        inst.agent_session_id = Some(id.to_string());
+        inst.pi_session_path = Some(transcript.to_string_lossy().into_owned());
+
+        let mut cmd = "pi".to_string();
+        let resumed = inst.apply_session_flags(&mut cmd, "test").unwrap();
+        assert_eq!(cmd, "pi", "no selector may be handed to a doomed resume");
+        assert!(!resumed, "nothing was resumed");
+        assert_eq!(
+            inst.agent_session_id.as_deref(),
+            Some(id),
+            "the id stays on the row for a later launch that can pin it"
+        );
+
+        // The same row resumes by path once the transcript is there.
+        std::fs::write(&transcript, "{}\n").unwrap();
+        let mut cmd = "pi".to_string();
+        assert!(inst.apply_session_flags(&mut cmd, "test").unwrap());
+        assert_eq!(cmd, format!("pi --session '{}'", transcript.display()));
     }
 
     #[test]

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -95,6 +95,7 @@ fn drain_and_persist_session_ids_inner(
 ) -> SessionIdSyncOutcome {
     let mut updates: Vec<Update> = Vec::with_capacity(instances.len());
     let mut filtered_ids: HashSet<String> = HashSet::with_capacity(instances.len());
+    let mut already_current: Vec<String> = Vec::new();
 
     // Frozen pre-update ownership snapshot. Collision checks must read this,
     // never a map mutated mid-loop: with two pollers that transiently cross
@@ -190,6 +191,12 @@ fn drain_and_persist_session_ids_inner(
         }
         if inst.agent_session_id.as_deref() == Some(sid.as_str()) && !confirms_omp_pin {
             acknowledge_poller_observation(inst, &observation);
+            // The pane published the id this row already holds, so there is no
+            // sid to write. Its transcript path may still be new: a launch
+            // that pre-minted its id never sees one of these observations
+            // reach the write below, and that path is the only durable record
+            // of which file the conversation lives in.
+            already_current.push(inst.id.clone());
             continue;
         }
         updates.push(Update {
@@ -229,6 +236,12 @@ fn drain_and_persist_session_ids_inner(
             true
         }
     });
+
+    for id in &already_current {
+        if let Some(inst) = instances.iter_mut().find(|i| i.id == *id) {
+            inst.absorb_published_pi_session();
+        }
+    }
 
     if updates.is_empty() && filtered_ids.is_empty() {
         return SessionIdSyncOutcome::default();
@@ -1344,6 +1357,53 @@ mod tests {
         assert!(
             instances[0].session_id_poller.is_some(),
             "a sidecar poller keeps watching for the next switch"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn pi_records_its_transcript_path_when_the_observation_repeats_its_own_id() {
+        // A host Pi launch that pre-mints its id sees every poller
+        // observation match the row, so nothing is ever written through the
+        // sid path. The transcript path still has to land: it is the only
+        // durable record of which file the conversation lives in, and the
+        // sidecar it comes from does not survive a reboot.
+        let (_hooks, _base, _hooks_tmp) = crate::hooks::test_support::BaseGuard::ready();
+        let temp = tempdir().unwrap();
+        let _guard = storage_home_guard(&temp);
+
+        let profile = "sync-pi-same-sid";
+        let sid = "01a05234-8889-72e2-a7c9-7ebc27b25b78";
+        let mut inst = Instance::new("pi-same-sid-title", "/tmp/pi-same-sid");
+        inst.source_profile = profile.to_string();
+        inst.tool = "pi".to_string();
+        inst.agent_session_id = Some(sid.to_string());
+        inst.mark_pi_extension_launched_for_test();
+        seed_instance_on_disk(profile, &inst);
+
+        let published = "/home/u/.pi/agent/sessions/--proj--/2026-01-01T00-00-00-000Z_01a05234-8889-72e2-a7c9-7ebc27b25b78.jsonl";
+        crate::hooks::write_session_id_via_guard(&inst.id, sid).unwrap();
+        let dir = crate::hooks::ensure_instance_dir_path(&inst.id).unwrap();
+        std::fs::write(dir.join("session_path"), format!("{published}\n")).unwrap();
+
+        let poller = SessionPoller::new(format!("test-tmux-{}", inst.id));
+        poller.inject_test_sidecar_update(&inst.id, sid);
+        inst.session_id_poller = Some(Arc::new(Mutex::new(poller)));
+
+        let file_watch = FileWatchService::noop();
+        let mut instances = [inst];
+        drain_and_persist_session_ids(&mut instances, &file_watch);
+
+        assert_eq!(
+            instances[0].agent_session_id.as_deref(),
+            Some(sid),
+            "an observation that repeats the row's own id changes no sid"
+        );
+        let stored = Storage::new_unwatched(profile).unwrap().load().unwrap();
+        assert_eq!(
+            stored[0].pi_session_path.as_deref(),
+            Some(published),
+            "the transcript path must be durable before any teardown runs"
         );
     }
 

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -400,6 +400,11 @@ fn drain_and_persist_session_ids_inner(
             } else {
                 inst.resume_probe_failed_sid = None;
             }
+            // The transcript path belongs with the id it names. Recording it
+            // here is what makes it durable while the pane is still running:
+            // the sidecar it comes from lives in the host temp directory, and
+            // the only other writer is teardown, which a reboot never reaches.
+            inst.absorb_published_pi_session();
         }
     }
     for rb in &to_rollback {


### PR DESCRIPTION
## Description

A Pi session's transcript path is recorded in memory when the pane publishes it, but only written to disk at stop. A reboot skips that write, so the next launch has an id and no path. It falls back to `--session <sid>`, which pi treats as a hard-failing selector: it exits 1 on an id that resolves to nothing. `remain-on-exit` holds the dead pane, the resume probe reads it as a failed resume, and the retry starts a new conversation under the same row. That is the "red X, and entering it gives a new session" in #3809.

Pi writes a transcript lazily, so a conversation that was never prompted has no file, and that is the common case for a session sitting idle when the machine goes down.

Two changes:

- persist the published transcript path when the pane publishes it, not only at stop
- skip the `--session` arm when the recorded transcript for this row's conversation is confirmed absent, keeping the id for a later launch that can pin it

The evidence is the pane's own published path; pi's store layout is never reconstructed to guess. `--session-id` creates the conversation rather than failing and is exempt, as is an explicit user pin.

Not the same path as #3784 / #3785. That was a sandbox container failing to start on a missing `/tmp` hook bind mount. This is a host Pi launch whose selector resolves to nothing.

Verified against a real `pi` 0.85.1: reboot simulation (tmux server killed, `/tmp/aoe-hooks-*` removed) left a dead pane before the change and a live pane after, and a session with a real transcript still resumes it by path. Also verified for a session launched under a live `aoe serve` and never stopped, which is the case teardown-only persistence missed.

Closes #3809

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the decision is in the launch line `apply_session_flags` builds, and the unit test drives that directly. An e2e test would need a real `pi` on the runner plus a lazily-written transcript, and the harness auto-skips when the tool is absent, so it would assert nothing in CI.

## Verification

- `cargo fmt --check`
- `cargo clippy`
- `cargo test --lib`: 6859 passed, 2 ignored, over 5 consecutive runs
- `cargo test --bins --tests`: 12 integration failures in `acp_runner_control`, `acp_runner_orphan`, and `plugin_install`, all reproducing on clean `8f0cece81` in this sandbox

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5

**Any Additional AI Details you'd like to share:** Claude reproduced the failure against a real pi binary, wrote the patch and the regression test, and ran validation. Reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154qwGbN5tRHKpwiPoWqZqu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Persist published Pi transcript paths before shutdown.
- Recover Pi conversations after reboot when the transcript exists.
- Start a fresh unpinned conversation when the recorded transcript is missing.
- Preserve the conversation ID for future launches.
- Keep explicit pins and `--session-id` launches unchanged.
- Distinguish missing transcripts from unreadable storage.
- Carry `pi_session_path` through daemon reapplication.
- Add documentation and unit tests for the new behavior.

These changes prevent recoverable Pi conversations from appearing lost after restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->