### PR TITLE
fix(sandbox): share one Claude credential file across sandboxes

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1117,13 +1117,13 @@ Inspect and reclaim per-session sandbox agent stores
 
 ###### **Subcommands:**
 
-* `reclaim` — Report per-session agent stores whose session no longer exists in any profile, and how much disk they hold. Reports only unless `--delete` is given: each store holds a copy of that agent's credentials
+* `reclaim` — Report per-session agent stores whose session no longer exists in any profile, and how much disk they hold. Reports only unless `--delete` is given: a store can hold a copy of that agent's credentials
 
 
 
 ## `aoe sandbox reclaim`
 
-Report per-session agent stores whose session no longer exists in any profile, and how much disk they hold. Reports only unless `--delete` is given: each store holds a copy of that agent's credentials
+Report per-session agent stores whose session no longer exists in any profile, and how much disk they hold. Reports only unless `--delete` is given: a store can hold a copy of that agent's credentials
 
 **Usage:** `aoe sandbox reclaim [OPTIONS]`
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -16,7 +16,8 @@ Docker sandboxing runs your AI coding agents (Claude Code, OpenCode, Mistral Vib
 
 Agent credentials are seeded from the host config into a private per-session
 sandbox directory, so agents authenticate without re-login. Containers do not
-share a writable agent store.
+share a writable agent store; Claude Code's credential file is the one
+exception, see [Shared credentials](#shared-credentials).
 
 ## CLI vs TUI Behavior
 
@@ -341,6 +342,24 @@ one of them is started or brought back.
 container is still running carries on unaffected, on the shared store. One
 whose container is stopped cannot start until its store has moved, so drop the
 variable or run `aoe migrate` before launching it.
+
+### Shared credentials
+
+Claude Code rotates its refresh token every time it refreshes, and the old
+token stops working. A per-session copy of `.credentials.json` therefore logs
+out as soon as any other copy refreshes, and logging in inside one container
+would fix only that container. So every Claude Code session mounts the one
+`sandbox-v2/.credentials.json` at its config path instead of keeping a copy in
+its store, and a refresh or login in any container is seen by the rest.
+
+Each start folds the freshest credential into that file: the Keychain entry on
+macOS, `~/.claude/.credentials.json` elsewhere, and any copy left in the
+session's store by an earlier layout, each taken only when its expiry is later
+than what the file holds. Logging in on the host and starting or restarting
+one sandboxed session re-authenticates all of them; a login made inside a
+container is never overwritten by a staler host copy. A container created
+before this layout mounts only its store, so it is recreated at its next
+start, as it was for the store move.
 
 ### Reclaiming stores
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -151,6 +151,8 @@ volume_ignores_strategy = "named"
 | `~/.gitconfig` | `/root/.gitconfig` | RO | Git config |
 | `~/.ssh/` | `/root/.ssh/` | RO | SSH keys |
 | `~/.config/opencode/` | `/root/.config/opencode/` | RO | OpenCode config |
+| `<agent config>/sandbox-v2/<instance-id>/` | the agent's config path, e.g. `/root/.claude/` | RW | [Per-session agent store](#per-session-agent-stores) |
+| `~/.claude/sandbox-v2/.credentials.json` | `/root/.claude/.credentials.json` | RW | [Shared Claude Code credential](#shared-credentials) |
 
 ## Environment Variables
 
@@ -357,12 +359,14 @@ macOS, `~/.claude/.credentials.json` elsewhere, and any copy left in the
 session's store by an earlier layout, each taken only when its expiry is later
 than what the file holds. Logging in on the host and starting or restarting
 one sandboxed session re-authenticates all of them; a login made inside a
-container is never overwritten by a staler host copy. A container created
-before this layout mounts only its store, so it is recreated at its next
-start, as it was for the store move; restart any that is still running to put
-it on the shared file too. Running `/logout` inside a sandbox revokes the token
-for every sandbox but cannot remove the mounted file, so the revoked token
-stays there until the next login.
+container is never overwritten by a staler host copy. The host itself stays a
+separate chain: a refresh inside a sandbox still rotates the token the host
+holds, as it did before. A container created before this layout mounts only
+its store, so a stopped one is recreated at its next start, as it was for the
+store move, and a running one refuses to relaunch until it is stopped. Running
+`/logout` inside a sandbox revokes the token for every sandbox but cannot
+remove the mounted file, so the revoked token stays there until the next
+login.
 
 ### Reclaiming stores
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -359,7 +359,10 @@ than what the file holds. Logging in on the host and starting or restarting
 one sandboxed session re-authenticates all of them; a login made inside a
 container is never overwritten by a staler host copy. A container created
 before this layout mounts only its store, so it is recreated at its next
-start, as it was for the store move.
+start, as it was for the store move; restart any that is still running to put
+it on the shared file too. Running `/logout` inside a sandbox revokes the token
+for every sandbox but cannot remove the mounted file, so the revoked token
+stays there until the next login.
 
 ### Reclaiming stores
 
@@ -382,7 +385,9 @@ while a store move is in flight.
 
 A session still on the shared legacy store has no private store of its own, so
 deleting it removes its container but leaves that shared store to the
-migration.
+migration. The Claude Code credential file at `sandbox-v2/.credentials.json`
+belongs to no session and is not reclaimed; remove it yourself once the last
+Claude Code sandbox is gone.
 
 ## Worktrees and Sandboxing
 

--- a/src/cli/sandbox.rs
+++ b/src/cli/sandbox.rs
@@ -11,7 +11,7 @@ use crate::session::sandbox_store_reclaim as reclaim;
 pub enum SandboxCommands {
     /// Report per-session agent stores whose session no longer exists in any
     /// profile, and how much disk they hold. Reports only unless `--delete`
-    /// is given: each store holds a copy of that agent's credentials.
+    /// is given: a store can hold a copy of that agent's credentials.
     Reclaim(ReclaimArgs),
 }
 

--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -131,8 +131,15 @@ pub struct ContainerConfig {
     pub selinux_relabel: bool,
     /// Runtime-only evidence that this config installed an identity publisher.
     pub identity_publisher_installed: bool,
+    /// Container paths of the credential files every store of the agent
+    /// shares, one bind mount each. Labelled at create, so a container built
+    /// before a file was shared, which mounts only the store, can be told apart.
+    pub shared_credential_mounts: Vec<String>,
     pub run_policy: RunPolicy,
 }
+
+pub(crate) const SHARED_CREDENTIAL_MOUNTS_LABEL: &str =
+    "com.agent-of-empires.shared-credential-mounts";
 
 impl ContainerConfig {
     pub(crate) fn mount_fingerprint(&self) -> String {
@@ -158,6 +165,10 @@ impl ContainerConfig {
             .iter()
             .map(|byte| format!("{byte:02x}"))
             .collect()
+    }
+
+    pub(crate) fn shared_credential_label(&self) -> String {
+        self.shared_credential_mounts.join(",")
     }
 
     pub(crate) fn path_is_mounted(

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -191,6 +191,11 @@ impl DockerContainer {
         self.runtime.sandbox_store_generation_matches(&self.name)
     }
 
+    pub fn shared_credential_mounts_match(&self, config: &ContainerConfig) -> Result<Option<bool>> {
+        self.runtime
+            .shared_credential_mounts_match(&self.name, config)
+    }
+
     pub fn mount_fingerprint_matches(&self, config: &ContainerConfig) -> Result<Option<bool>> {
         self.runtime
             .mount_fingerprint_matches(&self.name, &config.mount_fingerprint())

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -382,6 +382,29 @@ impl ContainerRuntime {
         ))
     }
 
+    /// Whether `name` was created with the shared credential mounts `config`
+    /// carries. An agent that shares none matches every container.
+    pub fn shared_credential_mounts_match(
+        &self,
+        name: &str,
+        config: &ContainerConfig,
+    ) -> Result<Option<bool>> {
+        if config.shared_credential_mounts.is_empty() {
+            return Ok(Some(true));
+        }
+        if !self.base.supports_labels {
+            return Ok(None);
+        }
+        let expected = config.shared_credential_label();
+        Ok(Some(
+            self.inspect_container_label(
+                name,
+                crate::containers::container_interface::SHARED_CREDENTIAL_MOUNTS_LABEL,
+            )?
+            .is_some_and(|value| value == expected),
+        ))
+    }
+
     pub fn mount_fingerprint_matches(&self, name: &str, expected: &str) -> Result<Option<bool>> {
         if !self.base.supports_labels {
             return Ok(None);

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -461,6 +461,14 @@ impl RuntimeBase {
                 "com.agent-of-empires.mount-fingerprint={}",
                 config.mount_fingerprint()
             ));
+            if !config.shared_credential_mounts.is_empty() {
+                args.push("--label".to_string());
+                args.push(format!(
+                    "{}={}",
+                    crate::containers::container_interface::SHARED_CREDENTIAL_MOUNTS_LABEL,
+                    config.shared_credential_label()
+                ));
+            }
         }
 
         for vol in &config.volumes {
@@ -1803,6 +1811,14 @@ mod tests {
     #[test]
     fn store_generation_label_is_emitted_by_supported_runtimes() {
         let config = ContainerConfig::default();
+        let shared = ContainerConfig {
+            shared_credential_mounts: vec!["/root/.claude/.credentials.json".to_string()],
+            ..Default::default()
+        };
+        let credential_label = [
+            "--label",
+            "com.agent-of-empires.shared-credential-mounts=/root/.claude/.credentials.json",
+        ];
         for base in [
             RuntimeBase::DOCKER,
             RuntimeBase::PODMAN,
@@ -1812,6 +1828,9 @@ mod tests {
             assert!(args.windows(2).any(|pair| {
                 pair == ["--label", "com.agent-of-empires.sandbox-store-generation=2"]
             }));
+            assert!(!args.windows(2).any(|pair| pair == credential_label));
+            let args = base.build_create_args("c", "image", &shared);
+            assert!(args.windows(2).any(|pair| pair == credential_label));
         }
     }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -928,7 +928,7 @@ fn with_config_lock<T>(
 /// planted at the lock path by a process in the container fails the open and
 /// the write it guards never runs, rather than the lock landing on a host file
 /// outside the bind.
-fn with_config_lock_policy<T>(
+pub(crate) fn with_config_lock_policy<T>(
     path: &Path,
     lock_extension: &str,
     policy: SymlinkPolicy,
@@ -987,7 +987,7 @@ impl SymlinkPolicy {
     /// link would pull an arbitrary host file into a config the container
     /// reads. The type check and the read share one `O_NOFOLLOW` descriptor,
     /// so a link swapped in after the check cannot be the thing read.
-    fn read(self, path: &Path) -> Result<Option<String>> {
+    pub(crate) fn read(self, path: &Path) -> Result<Option<String>> {
         match self {
             Self::Follow => match std::fs::read_to_string(path) {
                 Ok(content) => Ok(Some(content)),

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -12,6 +12,7 @@ use crate::containers::{ContainerConfig, EnvEntry, NamedVolumeMount, RunPolicy, 
 use crate::git::GitWorktree;
 use crate::session::config::VolumeIgnoresStrategy;
 
+use crate::hooks::SymlinkPolicy;
 use crate::session::environment::collect_environment;
 use crate::session::instance::SandboxInfo;
 
@@ -51,10 +52,14 @@ struct AgentConfigMount {
     /// Each (filename, content) pair is written to the sandbox dir root and mounted as
     /// a separate file at CONTAINER_HOME/filename (write-once).
     home_seed_files: &'static [(&'static str, &'static str)],
-    /// Files that should only be copied from the host if they don't already exist in the
-    /// sandbox. Protects credentials placed by the v002 migration or by in-container
-    /// authentication from being overwritten by stale host copies.
+    /// Files copied from the host only when the sandbox lacks them, so what the
+    /// container wrote survives a refresh.
     preserve_files: &'static [&'static str],
+    /// Credential files every sandbox of this agent shares as one file at the
+    /// store root, bind-mounted over the store's own path. The agent rotates
+    /// its refresh token on every refresh, so a per-store copy that misses a
+    /// rotation is logged out. See [`sync_shared_credential`].
+    shared_credential_files: &'static [&'static str],
     /// Files to delete from the sandbox dir before each launch. Prevents stale state
     /// (e.g. leftover lock/cache files) from causing failures when the container image
     /// is updated. Do NOT use this for sandbox-owned session state (e.g. opencode's
@@ -76,8 +81,8 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         // is copied as a top-level file, so without the scripts it points at, every
         // referenced hook errors in-container ("No such file or directory"). See #3014.
         copy_dirs: &["plugins", "skills", "hooks"],
-        // On macOS, OAuth tokens live in the Keychain. Extract and write as .credentials.json
-        // so the container can authenticate without re-login.
+        // On macOS the OAuth token lives in the Keychain; it seeds the shared
+        // .credentials.json so the container authenticates without re-login.
         keychain_credential: Some(("Claude Code-credentials", ".credentials.json")),
         // Claude Code reads ~/.claude.json (home level, NOT inside ~/.claude/) for onboarding
         // state. Seeding hasCompletedOnboarding skips the first-run wizard.
@@ -92,7 +97,8 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
             (".claude.json", r#"{"hasCompletedOnboarding":true}"#),
             (".sandbox-gitconfig", SANDBOX_GITCONFIG_SEED),
         ],
-        preserve_files: &[".credentials.json", "history.jsonl"],
+        preserve_files: &["history.jsonl"],
+        shared_credential_files: &[".credentials.json"],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -117,6 +123,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -129,6 +136,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -141,6 +149,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -153,6 +162,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -165,6 +175,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -177,6 +188,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -189,6 +201,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -201,6 +214,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -213,6 +227,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -241,6 +256,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         // on every session, but we preserve it in case the user has
         // additional approvals beyond the AoE-managed ones.
         preserve_files: &["shell-hooks-allowlist.json"],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -253,6 +269,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -265,6 +282,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -277,6 +295,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -289,6 +308,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &["antigravity-oauth-token"],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -303,6 +323,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
     AgentConfigMount {
@@ -320,6 +341,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
+        shared_credential_files: &[],
         clean_files: &[],
     },
 ];
@@ -348,8 +370,8 @@ fn sync_agent_config(
 
     // If the sandbox already has a "projects/" subdirectory, a prior container
     // session ran and created state we must not overwrite (e.g. settings.json,
-    // statsig/, session metadata). Only seed files, copy_dirs, and keychain
-    // credentials are still synced; the general top-level file copy is skipped.
+    // statsig/, session metadata). Only seed files, copy_dirs and shared
+    // credential files are still synced; the general top-level file copy is skipped.
     //
     // Why "projects/"? Claude Code creates this directory on first run to store
     // per-project session data. Its presence reliably indicates the container
@@ -632,7 +654,6 @@ fn copy_dir_recursive_inner(
 
 /// Parse the `expiresAt` timestamp from a Claude Code credential JSON string.
 /// Returns `None` if the JSON is malformed or the field is missing/wrong type.
-#[cfg(any(target_os = "macos", test))]
 fn parse_credential_expires_at(content: &str) -> Option<u64> {
     let value: serde_json::Value = serde_json::from_str(content).ok()?;
     value.get("claudeAiOauth")?.get("expiresAt")?.as_u64()
@@ -641,7 +662,6 @@ fn parse_credential_expires_at(content: &str) -> Option<u64> {
 /// Decide whether an incoming credential should overwrite the existing one,
 /// based on `expiresAt` timestamps. Returns `true` if the incoming credential
 /// should be written.
-#[cfg(any(target_os = "macos", test))]
 fn should_overwrite_credential(existing_content: &str, incoming_content: &str) -> bool {
     let existing_exp = parse_credential_expires_at(existing_content);
     let incoming_exp = parse_credential_expires_at(incoming_content);
@@ -653,10 +673,10 @@ fn should_overwrite_credential(existing_content: &str, incoming_content: &str) -
     }
 }
 
-/// Extract credentials from the macOS Keychain and write to a file.
-/// Returns Ok(true) if credentials were written, Ok(false) if not available.
+/// Read a credential from the macOS Keychain. `None` when there is no usable
+/// entry.
 #[cfg(target_os = "macos")]
-fn extract_keychain_credential(service: &str, dest: &Path) -> Result<bool> {
+fn read_keychain_credential(service: &str) -> Result<Option<String>> {
     use std::process::Command;
 
     let user = std::env::var("USER").unwrap_or_default();
@@ -695,7 +715,7 @@ fn extract_keychain_credential(service: &str, dest: &Path) -> Result<bool> {
                 stderr.trim()
             );
         }
-        return Ok(false);
+        return Ok(None);
     }
 
     let content = String::from_utf8_lossy(&output.stdout);
@@ -705,35 +725,140 @@ fn extract_keychain_credential(service: &str, dest: &Path) -> Result<bool> {
             "Keychain entry for service '{}' exists but has empty content",
             service
         );
-        return Ok(false);
+        return Ok(None);
     }
-
-    // Only overwrite if the keychain credential is fresher than what the sandbox already has.
-    if dest.exists() {
-        if let Ok(existing_content) = std::fs::read_to_string(dest) {
-            if !should_overwrite_credential(&existing_content, trimmed) {
-                tracing::debug!(target: "session.profile",
-                    "Keychain credential for '{}' is not fresher than sandbox, keeping sandbox",
-                    service,
-                );
-                return Ok(false);
-            }
-        }
-    }
-
-    std::fs::write(dest, trimmed)?;
-    tracing::debug!(target: "session.profile",
-        "Extracted keychain credential for '{}' -> {}",
-        service,
-        dest.display()
-    );
-    Ok(true)
+    Ok(Some(trimmed.to_string()))
 }
 
 #[cfg(not(target_os = "macos"))]
-fn extract_keychain_credential(_service: &str, _dest: &Path) -> Result<bool> {
-    Ok(false)
+fn read_keychain_credential(_service: &str) -> Result<Option<String>> {
+    Ok(None)
 }
+
+/// The shared credential file for the store root `sandbox_dir` sits under, or
+/// `None` for the legacy single shared store, whose parent is the host config.
+fn shared_credential_path(sandbox_dir: &Path, name: &str) -> Option<PathBuf> {
+    let root = sandbox_dir.parent()?;
+    (root.file_name()? == SANDBOX_PRIVATE_SUBDIR).then(|| root.join(name))
+}
+
+/// A file's content, or `None` when it is absent or empty (the placeholder a
+/// runtime leaves under a file mount). The store is container-writable, so a
+/// link planted there is not followed; the host file is the user's own.
+fn read_credential_file(dir: &Path, name: &str, follow: SymlinkPolicy) -> Option<String> {
+    let content = match follow {
+        SymlinkPolicy::Follow => std::fs::read_to_string(dir.join(name)).ok(),
+        SymlinkPolicy::Never => crate::session::read_file_no_follow(dir, Path::new(name))
+            .ok()
+            .flatten(),
+    };
+    content.filter(|content| !content.trim().is_empty())
+}
+
+/// Fold the freshest credential into the file every store of this agent
+/// mounts. The store's own copy is left for a container built before the file
+/// was shared, which still reads it; [`remove_shadowed_credential_copies`]
+/// drops it once a container mounting the shared file exists.
+///
+/// Candidates are the store's private copy (left by the v027 move or by a
+/// login before the file was shared), the host file and the macOS Keychain;
+/// each replaces the current content only when its `expiresAt` is newer, so a
+/// login made inside a container survives a stale host copy and a host
+/// re-login reaches every container at its next start. The file is written in
+/// place: a rename would leave every running container's bind mount on the
+/// old inode. An absent file is created empty-but-valid so the mount has a
+/// source; the agent's own login fills it.
+fn sync_shared_credential(
+    mount: &AgentConfigMount,
+    host_dir: &Path,
+    sandbox_dir: &Path,
+    name: &str,
+) -> Result<Option<PathBuf>> {
+    let Some(shared) = shared_credential_path(sandbox_dir, name) else {
+        return Ok(None);
+    };
+    let Some(root) = shared.parent() else {
+        return Ok(None);
+    };
+    std::fs::create_dir_all(root)?;
+    let existing = read_credential_file(root, name, SymlinkPolicy::Never);
+
+    let mut candidates = Vec::new();
+    candidates.extend(read_credential_file(
+        sandbox_dir,
+        name,
+        SymlinkPolicy::Never,
+    ));
+    candidates.extend(read_credential_file(host_dir, name, SymlinkPolicy::Follow));
+    if let Some((service, _)) = mount
+        .keychain_credential
+        .filter(|(_, filename)| *filename == name)
+    {
+        match read_keychain_credential(service) {
+            Ok(content) => candidates.extend(content),
+            Err(e) => tracing::warn!(target: "session.profile",
+                "Failed to read keychain credential for {}: {}", mount.host_rel, e),
+        }
+    }
+
+    let mut chosen = existing.clone();
+    for candidate in candidates {
+        let fresher = chosen
+            .as_deref()
+            .is_none_or(|current| should_overwrite_credential(current, &candidate));
+        if fresher {
+            chosen = Some(candidate);
+        }
+    }
+    let chosen = chosen.unwrap_or_else(|| "{}".to_string());
+    if existing.as_deref() != Some(chosen.as_str()) {
+        write_credential_in_place(&shared, &chosen)?;
+    }
+    Ok(Some(shared))
+}
+
+/// Drop each store's own copy of a credential the container mounts the shared
+/// file over. Runs once the container exists: one built before the file was
+/// shared reads that copy instead, and is recreated rather than stripped.
+pub(crate) fn remove_shadowed_credential_copies(config: &ContainerConfig) {
+    for container_path in &config.shared_credential_mounts {
+        let path = Path::new(container_path);
+        let (Some(dir), Some(name)) = (path.parent(), path.file_name()) else {
+            continue;
+        };
+        let Some(store) = config
+            .volumes
+            .iter()
+            .find(|volume| Path::new(&volume.container_path) == dir)
+        else {
+            continue;
+        };
+        let copy = Path::new(&store.host_path).join(name);
+        match std::fs::remove_file(&copy) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::warn!(target: "session.profile",
+                "Failed to remove shadowed credential copy {}: {}", copy.display(), e),
+        }
+    }
+}
+
+/// Truncate-and-write, never rename: containers bind-mount this inode.
+fn write_credential_in_place(path: &Path, content: &str) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .with_context(|| format!("opening shared credential {}", path.display()))?;
+    file.write_all(content.as_bytes())
+        .with_context(|| format!("writing shared credential {}", path.display()))
+}
+
 /// Return a sandbox config path. A supplied instance ID creates the physically
 /// isolated store mounted into that pane; no live conversation store is shared.
 fn sandbox_dir_for(
@@ -949,10 +1074,16 @@ fn prepare_sandbox_dir_from(
             None
         };
 
+        let skip_entries: Vec<&str> = mount
+            .skip_entries
+            .iter()
+            .chain(mount.shared_credential_files)
+            .copied()
+            .collect();
         sync_agent_config(
             &host_dir,
             &sandbox_dir,
-            mount.skip_entries,
+            &skip_entries,
             mount.seed_files,
             mount.copy_dirs,
             mount.preserve_files,
@@ -987,18 +1118,15 @@ fn prepare_sandbox_dir_from(
                 );
             }
         }
-
-        if let Some((service, filename)) = mount.keychain_credential {
-            if let Err(e) = extract_keychain_credential(service, &sandbox_dir.join(filename)) {
-                tracing::warn!(target: "session.profile",
-                    "Failed to extract keychain credential for {}: {}",
-                    mount.host_rel,
-                    e
-                );
-            }
-        }
     } else {
         std::fs::create_dir_all(&sandbox_dir)?;
+    }
+
+    for &name in mount.shared_credential_files {
+        if let Err(e) = sync_shared_credential(mount, &host_dir, &sandbox_dir, name) {
+            tracing::warn!(target: "session.profile",
+                "Failed to sync shared credential {} for {}: {}", name, mount.host_rel, e);
+        }
     }
 
     for &(filename, content) in mount.home_seed_files {
@@ -2021,6 +2149,7 @@ pub(crate) fn build_container_config(
         profile_session_config.agent_config_dir_for(agent_selection.tool, &home);
     // Agent definitions are in AGENT_CONFIG_MOUNTS. Add new agents there.
     let mut active_sandbox_config: Option<(&AgentConfigMount, PathBuf)> = None;
+    let mut shared_credential_mounts = Vec::new();
     let mut identity_publisher_installed = false;
     let mut identity_publisher_path: Option<(PathBuf, String)> = None;
     let mut identity_output_path: Option<(PathBuf, String)> = None;
@@ -2058,6 +2187,20 @@ pub(crate) fn build_container_config(
             sandbox_dir.display(),
             container_path
         );
+        for &name in mount.shared_credential_files {
+            let Some(shared) = shared_credential_path(&sandbox_dir, name) else {
+                continue;
+            };
+            if shared.is_file() {
+                let container_path = format!("{container_path}/{name}");
+                shared_credential_mounts.push(container_path.clone());
+                volumes.push(VolumeMount {
+                    host_path: shared.to_string_lossy().to_string(),
+                    container_path,
+                    read_only: false,
+                });
+            }
+        }
         volumes.push(VolumeMount {
             host_path: sandbox_dir.to_string_lossy().to_string(),
             container_path,
@@ -2419,6 +2562,7 @@ pub(crate) fn build_container_config(
         network: sanitize_network(sandbox_config.network.as_deref()),
         selinux_relabel: sandbox_config.selinux_relabel,
         identity_publisher_installed,
+        shared_credential_mounts,
         run_policy: RunPolicy {
             privileged: sandbox_config.privileged,
             cap_add: sandbox_config.cap_add.clone(),
@@ -4110,6 +4254,137 @@ mod tests {
     fn test_should_overwrite_when_only_keychain_parseable() {
         let keychain = r#"{"claudeAiOauth":{"expiresAt":1000}}"#;
         assert!(should_overwrite_credential("not-json", keychain));
+    }
+
+    fn credential(expires_at: u64) -> String {
+        format!(r#"{{"claudeAiOauth":{{"expiresAt":{expires_at}}}}}"#)
+    }
+
+    /// The Claude mount without its Keychain source, so a developer's own
+    /// login never reaches the assertions on macOS.
+    fn claude_mount_without_keychain() -> AgentConfigMount {
+        AgentConfigMount {
+            tool_name: "claude",
+            host_rel: ".claude",
+            container_suffix: ".claude",
+            skip_entries: &["sandbox", "projects"],
+            seed_files: &[],
+            copy_dirs: &[],
+            keychain_credential: None,
+            home_seed_files: &[],
+            preserve_files: &["history.jsonl"],
+            shared_credential_files: &[".credentials.json"],
+            clean_files: &[],
+        }
+    }
+
+    #[test]
+    fn shared_credential_follows_the_freshest_copy_across_starts() {
+        let home = TempDir::new().unwrap();
+        let host = home.path().join(".claude");
+        fs::create_dir_all(&host).unwrap();
+        let mount = claude_mount_without_keychain();
+        let root = host.join(SANDBOX_PRIVATE_SUBDIR);
+        let store = root.join("aaaaaaaaaaaaaaaa");
+        let shared = root.join(".credentials.json");
+        let private = store.join(".credentials.json");
+        let prepare =
+            || prepare_sandbox_dir_from(&mount, host.clone(), store.clone(), home.path()).unwrap();
+
+        // Nothing to seed: the mount source still has to exist.
+        prepare();
+        assert_eq!(fs::read_to_string(&shared).unwrap(), "{}");
+        assert!(!private.exists());
+
+        // A host login reaches the shared file and never the store.
+        fs::write(host.join(".credentials.json"), credential(100)).unwrap();
+        prepare();
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
+        assert!(!private.exists());
+
+        // A store with prior data still picks up a fresher host login.
+        fs::create_dir_all(store.join("projects")).unwrap();
+        fs::write(host.join(".credentials.json"), credential(200)).unwrap();
+        prepare();
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(200));
+
+        // A stale host copy does not clobber a login made in a container.
+        fs::write(host.join(".credentials.json"), credential(150)).unwrap();
+        prepare();
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(200));
+
+        // A private copy left by the v027 move is folded in and left for a
+        // container that still mounts only the store.
+        fs::write(&private, credential(300)).unwrap();
+        prepare();
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(300));
+        assert_eq!(fs::read_to_string(&private).unwrap(), credential(300));
+
+        // The empty placeholder a runtime creates for the file mount is ignored.
+        fs::write(&private, "").unwrap();
+        prepare();
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(300));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn claude_sandboxes_share_one_credential_mount() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        let host = temp_home.path().join(".claude");
+        fs::create_dir_all(&host).unwrap();
+        // Beats any real credential the macOS Keychain contributes.
+        let cred = credential(9_999_999_999_999_999);
+        fs::write(host.join(".credentials.json"), &cred).unwrap();
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+        let sandbox_info = crate::session::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        };
+        let shared = host.join(SANDBOX_PRIVATE_SUBDIR).join(".credentials.json");
+        for instance_id in ["shared-cred-a", "shared-cred-b"] {
+            let store = host.join(SANDBOX_PRIVATE_SUBDIR).join(instance_id);
+            // A copy the v027 move left behind, folded in and shadowed.
+            fs::create_dir_all(&store).unwrap();
+            fs::write(store.join(".credentials.json"), credential(1)).unwrap();
+            let config = build_container_config(
+                project_dir.path().to_str().unwrap(),
+                &sandbox_info,
+                ContainerAgentSelection::new("claude", None),
+                false,
+                instance_id,
+                None,
+                "",
+            )
+            .unwrap();
+            let mount = config
+                .volumes
+                .iter()
+                .find(|v| v.container_path == "/root/.claude/.credentials.json")
+                .expect("credential file mount");
+            assert_eq!(mount.host_path, shared.to_string_lossy());
+            assert!(!mount.read_only);
+            assert_eq!(
+                config.shared_credential_mounts,
+                vec!["/root/.claude/.credentials.json".to_string()]
+            );
+            assert!(store.join(".credentials.json").exists());
+            remove_shadowed_credential_copies(&config);
+            assert!(!store.join(".credentials.json").exists());
+            crate::hooks::cleanup_hook_status_dir(instance_id);
+        }
+        assert_eq!(fs::read_to_string(&shared).unwrap(), cred);
     }
 
     /// End-to-end test: repo-level sandbox config (environment, volume_ignores,
@@ -6624,6 +6899,7 @@ volume_ignores = ["target"]
             keychain_credential: None,
             home_seed_files: &[],
             preserve_files: &[],
+            shared_credential_files: &[],
             clean_files: &["opencode.db", "opencode.db-wal", "opencode.db-shm"],
         };
 
@@ -6661,6 +6937,7 @@ volume_ignores = ["target"]
             keychain_credential: None,
             home_seed_files: &[],
             preserve_files: &[],
+            shared_credential_files: &[],
             clean_files: &[],
         };
 
@@ -6692,6 +6969,7 @@ volume_ignores = ["target"]
             keychain_credential: None,
             home_seed_files: &[],
             preserve_files: &[],
+            shared_credential_files: &[],
             clean_files: &["opencode.db", "opencode.db-wal", "opencode.db-shm"],
         };
 

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -821,18 +821,26 @@ fn sync_shared_credential(
 /// file over. Runs once the container exists: one built before the file was
 /// shared reads that copy instead, and is recreated rather than stripped.
 pub(crate) fn remove_shadowed_credential_copies(config: &ContainerConfig) {
+    let volume_at = |target: &Path| {
+        config
+            .volumes
+            .iter()
+            .find(|volume| Path::new(&volume.container_path) == target)
+    };
     for container_path in &config.shared_credential_mounts {
         let path = Path::new(container_path);
         let (Some(dir), Some(name)) = (path.parent(), path.file_name()) else {
             continue;
         };
-        let Some(store) = config
-            .volumes
-            .iter()
-            .find(|volume| Path::new(&volume.container_path) == dir)
-        else {
+        let (Some(shared), Some(store)) = (volume_at(path), volume_at(dir)) else {
             continue;
         };
+        // Only a store beside the shared file holds a shadowed copy. A user
+        // extra_volumes entry at the config path replaces the store mount, and
+        // the credential under it is the user's own login.
+        if Path::new(&store.host_path).parent() != Path::new(&shared.host_path).parent() {
+            continue;
+        }
         let copy = Path::new(&store.host_path).join(name);
         match std::fs::remove_file(&copy) {
             Ok(()) => {}
@@ -4385,6 +4393,41 @@ mod tests {
             crate::hooks::cleanup_hook_status_dir(instance_id);
         }
         assert_eq!(fs::read_to_string(&shared).unwrap(), cred);
+    }
+
+    #[test]
+    fn shadowed_credential_copy_is_removed_only_from_a_store() {
+        let home = TempDir::new().unwrap();
+        let host = home.path().join(".claude");
+        let root = host.join(SANDBOX_PRIVATE_SUBDIR);
+        let store = root.join("aaaaaaaaaaaaaaaa");
+        let shared = root.join(".credentials.json");
+        fs::create_dir_all(&store).unwrap();
+        fs::write(&shared, "{}").unwrap();
+        let config_for = |dir: &Path| ContainerConfig {
+            shared_credential_mounts: vec!["/root/.claude/.credentials.json".to_string()],
+            volumes: vec![
+                VolumeMount {
+                    host_path: shared.to_string_lossy().to_string(),
+                    container_path: "/root/.claude/.credentials.json".to_string(),
+                    read_only: false,
+                },
+                VolumeMount {
+                    host_path: dir.to_string_lossy().to_string(),
+                    container_path: "/root/.claude".to_string(),
+                    read_only: false,
+                },
+            ],
+            ..Default::default()
+        };
+        // A user extra_volumes entry at the config path replaces the store
+        // mount; its host copy is the user's own login, not a shadowed one.
+        for (dir, removed) in [(&store, true), (&host, false)] {
+            let copy = dir.join(".credentials.json");
+            fs::write(&copy, "token").unwrap();
+            remove_shadowed_credential_copies(&config_for(dir));
+            assert_eq!(!copy.exists(), removed, "{}", dir.display());
+        }
     }
 
     /// End-to-end test: repo-level sandbox config (environment, volume_ignores,

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -659,12 +659,31 @@ fn parse_credential_expires_at(content: &str) -> Option<u64> {
     value.get("claudeAiOauth")?.get("expiresAt")?.as_u64()
 }
 
+/// The furthest `expiresAt` a real token carries. The shared file is writable
+/// from inside every sandbox, so a planted timestamp beyond this would
+/// otherwise outrank every later login for good.
+const CREDENTIAL_EXPIRY_HORIZON: std::time::Duration =
+    std::time::Duration::from_secs(400 * 24 * 60 * 60);
+
+fn plausible_credential_expires_at(content: &str, now_ms: u64) -> Option<u64> {
+    parse_credential_expires_at(content).filter(|expires_at| {
+        *expires_at <= now_ms.saturating_add(CREDENTIAL_EXPIRY_HORIZON.as_millis() as u64)
+    })
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_millis() as u64)
+}
+
 /// Decide whether an incoming credential should overwrite the existing one,
 /// based on `expiresAt` timestamps. Returns `true` if the incoming credential
 /// should be written.
 fn should_overwrite_credential(existing_content: &str, incoming_content: &str) -> bool {
-    let existing_exp = parse_credential_expires_at(existing_content);
-    let incoming_exp = parse_credential_expires_at(incoming_content);
+    let now = now_ms();
+    let existing_exp = plausible_credential_expires_at(existing_content, now);
+    let incoming_exp = plausible_credential_expires_at(incoming_content, now);
 
     match (existing_exp, incoming_exp) {
         (Some(existing), Some(incoming)) => incoming > existing,
@@ -746,28 +765,29 @@ fn shared_credential_path(sandbox_dir: &Path, name: &str) -> Option<PathBuf> {
 /// runtime leaves under a file mount). The store is container-writable, so a
 /// link planted there is not followed; the host file is the user's own.
 fn read_credential_file(dir: &Path, name: &str, follow: SymlinkPolicy) -> Option<String> {
-    let content = match follow {
-        SymlinkPolicy::Follow => std::fs::read_to_string(dir.join(name)).ok(),
-        SymlinkPolicy::Never => crate::session::read_file_no_follow(dir, Path::new(name))
-            .ok()
-            .flatten(),
-    };
-    content.filter(|content| !content.trim().is_empty())
+    follow
+        .read(&dir.join(name))
+        .ok()
+        .flatten()
+        .filter(|content| !content.trim().is_empty())
 }
 
 /// Fold the freshest credential into the file every store of this agent
-/// mounts. The store's own copy is left for a container built before the file
-/// was shared, which still reads it; [`remove_shadowed_credential_copies`]
-/// drops it once a container mounting the shared file exists.
+/// mounts. This is a come-up fold rather than a migration because a container
+/// built before the file was shared keeps refreshing its store copy while it
+/// runs, so which copy is freshest is only known at come-up. That copy is left
+/// for such a container; [`remove_shadowed_credential_copies`] drops it once a
+/// container mounting the shared file exists.
 ///
 /// Candidates are the store's private copy (left by the v027 move or by a
 /// login before the file was shared), the host file and the macOS Keychain;
 /// each replaces the current content only when its `expiresAt` is newer, so a
 /// login made inside a container survives a stale host copy and a host
-/// re-login reaches every container at its next start. The file is written in
-/// place: a rename would leave every running container's bind mount on the
-/// old inode. An absent file is created empty-but-valid so the mount has a
-/// source; the agent's own login fills it.
+/// re-login reaches every container at its next start. Only the winner's
+/// `claudeAiOauth` replaces the file's, so what the agent keeps beside it
+/// survives. The file is written in place: a rename would leave every running
+/// container's bind mount on the old inode. An absent file is created
+/// empty-but-valid so the mount has a source; the agent's own login fills it.
 fn sync_shared_credential(
     mount: &AgentConfigMount,
     host_dir: &Path,
@@ -781,7 +801,6 @@ fn sync_shared_credential(
         return Ok(None);
     };
     std::fs::create_dir_all(root)?;
-    let existing = read_credential_file(root, name, SymlinkPolicy::Never);
 
     let mut candidates = Vec::new();
     candidates.extend(read_credential_file(
@@ -801,20 +820,43 @@ fn sync_shared_credential(
         }
     }
 
-    let mut chosen = existing.clone();
-    for candidate in candidates {
-        let fresher = chosen
-            .as_deref()
-            .is_none_or(|current| should_overwrite_credential(current, &candidate));
-        if fresher {
-            chosen = Some(candidate);
+    // The candidates are gathered outside the lock (the Keychain read is a
+    // subprocess); the file is read again under it, right before the write,
+    // so another come-up or a container's own refresh in between is seen.
+    crate::hooks::with_config_lock_policy(&shared, "lock", SymlinkPolicy::Never, || {
+        let existing = read_credential_file(root, name, SymlinkPolicy::Never);
+        let mut winner: Option<&str> = None;
+        for candidate in &candidates {
+            let current = winner.or(existing.as_deref());
+            if current.is_none_or(|current| should_overwrite_credential(current, candidate)) {
+                winner = Some(candidate);
+            }
         }
-    }
-    let chosen = chosen.unwrap_or_else(|| "{}".to_string());
-    if existing.as_deref() != Some(chosen.as_str()) {
-        write_credential_in_place(&shared, &chosen)?;
-    }
+        match (existing.as_deref(), winner) {
+            (None, None) => write_credential_in_place(&shared, "{}"),
+            (_, None) => Ok(()),
+            (existing, Some(winner)) => {
+                write_credential_in_place(&shared, &merge_credential(existing, winner))
+            }
+        }
+    })?;
     Ok(Some(shared))
+}
+
+/// `winner` with everything `existing` held beside `claudeAiOauth` kept, so a
+/// host copy that wins on expiry does not drop what the agent stored in the
+/// file inside a container. Anything that is not two JSON objects is replaced
+/// whole.
+fn merge_credential(existing: Option<&str>, winner: &str) -> String {
+    let parsed = |content: &str| {
+        serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(content).ok()
+    };
+    let merged = existing.and_then(parsed).and_then(|mut merged| {
+        let oauth = parsed(winner)?.remove("claudeAiOauth")?;
+        merged.insert("claudeAiOauth".to_string(), oauth);
+        serde_json::to_string(&merged).ok()
+    });
+    merged.unwrap_or_else(|| winner.to_string())
 }
 
 /// Drop each store's own copy of a credential the container mounts the shared
@@ -851,19 +893,23 @@ pub(crate) fn remove_shadowed_credential_copies(config: &ContainerConfig) {
     }
 }
 
-/// Truncate-and-write, never rename: containers bind-mount this inode.
+/// Write in place, never rename: containers bind-mount this inode. The new
+/// content lands before the old tail is cut, so a concurrent reader never
+/// sees an empty file.
 fn write_credential_in_place(path: &Path, content: &str) -> Result<()> {
     use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
     let mut file = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
-        .truncate(true)
+        .truncate(false)
         .mode(0o600)
         .custom_flags(libc::O_NOFOLLOW)
         .open(path)
         .with_context(|| format!("opening shared credential {}", path.display()))?;
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     file.write_all(content.as_bytes())
+        .and_then(|()| file.set_len(content.len() as u64))
         .with_context(|| format!("writing shared credential {}", path.display()))
 }
 
@@ -4268,6 +4314,27 @@ mod tests {
         format!(r#"{{"claudeAiOauth":{{"expiresAt":{expires_at}}}}}"#)
     }
 
+    #[test]
+    fn an_implausible_expiry_never_outranks_a_real_one() {
+        let far = credential(now_ms() + 2 * CREDENTIAL_EXPIRY_HORIZON.as_millis() as u64);
+        let real = credential(now_ms());
+        assert!(!should_overwrite_credential(&real, &far));
+        assert!(should_overwrite_credential(&far, &real));
+    }
+
+    #[test]
+    fn merge_keeps_what_the_file_held_beside_the_oauth_token() {
+        let existing = r#"{"claudeAiOauth":{"expiresAt":1},"designOauth":{"k":"v"}}"#;
+        let winner = r#"{"claudeAiOauth":{"expiresAt":2}}"#;
+        let merged: serde_json::Value =
+            serde_json::from_str(&merge_credential(Some(existing), winner)).unwrap();
+        assert_eq!(merged["claudeAiOauth"]["expiresAt"], 2);
+        assert_eq!(merged["designOauth"]["k"], "v");
+        assert_eq!(merge_credential(Some("{}"), winner), winner);
+        assert_eq!(merge_credential(Some("not json"), winner), winner);
+        assert_eq!(merge_credential(None, winner), winner);
+    }
+
     /// The Claude mount without its Keychain source, so a developer's own
     /// login never reaches the assertions on macOS.
     fn claude_mount_without_keychain() -> AgentConfigMount {
@@ -4344,8 +4411,9 @@ mod tests {
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         let host = temp_home.path().join(".claude");
         fs::create_dir_all(&host).unwrap();
-        // Beats any real credential the macOS Keychain contributes.
-        let cred = credential(9_999_999_999_999_999);
+        // Beats any real credential the macOS Keychain contributes while
+        // staying inside the horizon a real token can carry.
+        let cred = credential(now_ms() + 300 * 24 * 60 * 60 * 1000);
         fs::write(host.join(".credentials.json"), &cred).unwrap();
 
         let project_dir = TempDir::new().unwrap();

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -761,15 +761,33 @@ fn shared_credential_path(sandbox_dir: &Path, name: &str) -> Option<PathBuf> {
     (root.file_name()? == SANDBOX_PRIVATE_SUBDIR).then(|| root.join(name))
 }
 
-/// A file's content, or `None` when it is absent or empty (the placeholder a
-/// runtime leaves under a file mount). The store is container-writable, so a
-/// link planted there is not followed; the host file is the user's own.
-fn read_credential_file(dir: &Path, name: &str, follow: SymlinkPolicy) -> Option<String> {
-    follow
-        .read(&dir.join(name))
-        .ok()
-        .flatten()
-        .filter(|content| !content.trim().is_empty())
+/// A file's content, or `None` when it is absent, empty (the placeholder a
+/// runtime leaves under a file mount) or not a plain file. A plain file that
+/// cannot be read is an error, never `None`: the caller would take absence as
+/// leave to write over it. The store is container-writable, so a link planted
+/// there is not followed; the host file is the user's own.
+fn read_credential_file(dir: &Path, name: &str, follow: SymlinkPolicy) -> Result<Option<String>> {
+    let path = dir.join(name);
+    if let Some(content) = follow.read(&path)? {
+        return Ok(Some(content).filter(|content| !content.trim().is_empty()));
+    }
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.is_file() => {
+            anyhow::bail!("{} exists but could not be read", path.display())
+        }
+        Ok(_) => Ok(None),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("inspecting {}", path.display())),
+    }
+}
+
+/// A candidate that cannot be read is skipped; the file it would replace is
+/// still the one every sandbox mounts.
+fn read_credential_candidate(dir: &Path, name: &str, follow: SymlinkPolicy) -> Option<String> {
+    read_credential_file(dir, name, follow).unwrap_or_else(|e| {
+        tracing::warn!(target: "session.profile", "Skipping credential candidate: {}", e);
+        None
+    })
 }
 
 /// Fold the freshest credential into the file every store of this agent
@@ -803,12 +821,16 @@ fn sync_shared_credential(
     std::fs::create_dir_all(root)?;
 
     let mut candidates = Vec::new();
-    candidates.extend(read_credential_file(
+    candidates.extend(read_credential_candidate(
         sandbox_dir,
         name,
         SymlinkPolicy::Never,
     ));
-    candidates.extend(read_credential_file(host_dir, name, SymlinkPolicy::Follow));
+    candidates.extend(read_credential_candidate(
+        host_dir,
+        name,
+        SymlinkPolicy::Follow,
+    ));
     if let Some((service, _)) = mount
         .keychain_credential
         .filter(|(_, filename)| *filename == name)
@@ -824,7 +846,7 @@ fn sync_shared_credential(
     // subprocess); the file is read again under it, right before the write,
     // so another come-up or a container's own refresh in between is seen.
     crate::hooks::with_config_lock_policy(&shared, "lock", SymlinkPolicy::Never, || {
-        let existing = read_credential_file(root, name, SymlinkPolicy::Never);
+        let existing = read_credential_file(root, name, SymlinkPolicy::Never)?;
         let mut winner: Option<&str> = None;
         for candidate in &candidates {
             let current = winner.or(existing.as_deref());
@@ -4312,6 +4334,36 @@ mod tests {
 
     fn credential(expires_at: u64) -> String {
         format!(r#"{{"claudeAiOauth":{{"expiresAt":{expires_at}}}}}"#)
+    }
+
+    #[test]
+    fn an_unreadable_shared_file_is_never_overwritten() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = TempDir::new().unwrap();
+        let host = home.path().join(".claude");
+        let mount = claude_mount_without_keychain();
+        let store = host.join(SANDBOX_PRIVATE_SUBDIR).join("aaaaaaaaaaaaaaaa");
+        let shared = host.join(SANDBOX_PRIVATE_SUBDIR).join(".credentials.json");
+        fs::create_dir_all(&store).unwrap();
+        // A failed sync is logged and the launch goes on; the file must be
+        // left exactly as it was.
+        let prepare =
+            || prepare_sandbox_dir_from(&mount, host.clone(), store.clone(), home.path()).unwrap();
+
+        // Root reads a write-only file regardless, so the case cannot fail there.
+        if !nix::unistd::geteuid().is_root() {
+            fs::write(&shared, credential(5)).unwrap();
+            fs::set_permissions(&shared, fs::Permissions::from_mode(0o200)).unwrap();
+            prepare();
+            fs::set_permissions(&shared, fs::Permissions::from_mode(0o600)).unwrap();
+            assert_eq!(fs::read_to_string(&shared).unwrap(), credential(5));
+            fs::remove_file(&shared).unwrap();
+        }
+
+        // A path that is not a plain file is not seeded over either.
+        fs::create_dir(&shared).unwrap();
+        prepare();
+        assert!(shared.is_dir());
     }
 
     #[test]

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -177,6 +177,14 @@ impl Instance {
                 Some(detect_as.as_str()),
             );
             let config = self.build_container_config()?;
+            // Still refreshing its own store copy, which rotates the token
+            // away from every sandbox on the shared file.
+            if container.shared_credential_mounts_match(&config)? == Some(false) {
+                anyhow::bail!(
+                    "running sandbox {} predates the shared credential file; stop it, then relaunch to rebuild it",
+                    self.id
+                );
+            }
             self.identity_publisher_launched = config.identity_publisher_installed
                 && identity_publisher_mount_matches(&container, &config)?
                 && identity_publisher_dependencies_available(&container)
@@ -200,14 +208,9 @@ impl Instance {
             );
         }
 
+        let mut recreate = false;
         if container.exists()? {
-            let legacy_store = container.sandbox_store_generation_matches()? == Some(false);
-            // Built before its agent shared a credential file, so it mounts
-            // only the store, whose copy the come-up no longer refreshes.
-            let unshared_credentials = !legacy_store
-                && container.shared_credential_mounts_match(&self.build_container_config()?)?
-                    == Some(false);
-            if legacy_store || unshared_credentials {
+            if container.sandbox_store_generation_matches()? == Some(false) {
                 container.remove(false)?;
             } else {
                 // Restart of a stopped container is a come-up: refresh so a
@@ -220,21 +223,29 @@ impl Instance {
                     Some(detect_as.as_str()),
                 );
                 let config = self.build_container_config()?;
-                container.start()?;
-                self.identity_publisher_launched = config.identity_publisher_installed
-                    && identity_publisher_mount_matches(&container, &config)?
-                    && identity_publisher_dependencies_available(&container)
-                    && self.hook_session_publisher_allowed_by_argv();
-                self.backfill_container_workdir(&container);
-                container_config::ensure_folder_trust_config_for_active_agent(
-                    &self.tool,
-                    Some(detect_as.as_str()),
-                    &self.source_profile,
-                    &self.id,
-                    &self.container_workdir(),
-                    self.is_yolo_mode(),
-                );
-                return Ok(container);
+                // Built before its agent shared a credential file, so it
+                // mounts only the store, whose copy the come-up no longer
+                // refreshes.
+                recreate = container.shared_credential_mounts_match(&config)? == Some(false);
+                if recreate {
+                    container.remove(false)?;
+                } else {
+                    container.start()?;
+                    self.identity_publisher_launched = config.identity_publisher_installed
+                        && identity_publisher_mount_matches(&container, &config)?
+                        && identity_publisher_dependencies_available(&container)
+                        && self.hook_session_publisher_allowed_by_argv();
+                    self.backfill_container_workdir(&container);
+                    container_config::ensure_folder_trust_config_for_active_agent(
+                        &self.tool,
+                        Some(detect_as.as_str()),
+                        &self.source_profile,
+                        &self.id,
+                        &self.container_workdir(),
+                        self.is_yolo_mode(),
+                    );
+                    return Ok(container);
+                }
             }
         }
 
@@ -244,7 +255,10 @@ impl Instance {
 
         // Mint before building the container config so the docker-run env also
         // carries the values (leak-safe via the inherit path in run_create).
-        self.ensure_before_start_env(true)?;
+        // A container just removed for its credential mount was minted above.
+        if !recreate {
+            self.ensure_before_start_env(true)?;
+        }
         let config = self.build_container_config()?;
         // Still the workdir the *previous* container was created with; the pin below
         // is what moves it forward.

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -201,7 +201,13 @@ impl Instance {
         }
 
         if container.exists()? {
-            if container.sandbox_store_generation_matches()? == Some(false) {
+            let legacy_store = container.sandbox_store_generation_matches()? == Some(false);
+            // Built before its agent shared a credential file, so it mounts
+            // only the store, whose copy the come-up no longer refreshes.
+            let unshared_credentials = !legacy_store
+                && container.shared_credential_mounts_match(&self.build_container_config()?)?
+                    == Some(false);
+            if legacy_store || unshared_credentials {
                 container.remove(false)?;
             } else {
                 // Restart of a stopped container is a come-up: refresh so a
@@ -251,6 +257,7 @@ impl Instance {
         );
         container.remove_stranded_named_ignore_volumes(&self.id, &stranded);
         let container_id = container.create(&config)?;
+        container_config::remove_shadowed_credential_copies(&config);
         self.identity_publisher_launched = config.identity_publisher_installed
             && identity_publisher_dependencies_available(&container)
             && self.hook_session_publisher_allowed_by_argv();


### PR DESCRIPTION
## Description

Claude Code rotates its refresh token on every refresh and the old one stops working. The v027 store isolation gave each sandboxed session its own copy of `.credentials.json`, so every container became its own chain: the first to refresh logged all the others out, a login inside one container fixed only that one, and a restart never re-read the host credential because the store sync skips top-level files once a store has prior data.

Every Claude sandbox now bind-mounts one `sandbox-v2/.credentials.json` over its store's path. Each come-up folds the freshest of the Keychain entry, the host file and any legacy per-store copy into it by `expiresAt`. Claude Code 2.1.263 writes the file in place when a rename hits the bind mount, refuses symlinks and reloads on mtime. Containers created before the file was shared are told apart by a create-time label and recreated at their next start.

The fold runs at come-up rather than as a migration: a container built before the file was shared keeps refreshing its store copy while it runs, so which copy is freshest is only known when a session starts. The host stays a separate chain from the sandboxes, as before. Injecting `CLAUDE_CODE_OAUTH_TOKEN` from the host instead would leave containers unable to refresh, so a mounted file it is.

Untested here: Apple Container with a file mount nested in a directory mount. Codex and Gemini keep per-store copies until their writers are checked the same way.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behaviour is in the store sync and the mount list, both covered by unit tests; the container recreation needs a runtime the e2e harness skips without.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Fable 5.1 via Claude Code

**Any Additional AI Details you'd like to share:**
Diagnosis, design and code drafted by the model in discussion with @njbrake, who owns the decisions.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Fable 5.1 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHEbGF3z4uAJxvY3KX18Fa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Shared Claude credentials across all sandboxes through one synchronized file.
- Selected the freshest valid credential and protected unreadable files from overwrite.
- Recreated older sandboxes when credential mounts did not match.
- Kept Codex and Gemini credentials per store.
- Updated cleanup behavior, tests, and documentation.

## Benefits

- Claude sessions can reuse rotating refresh tokens reliably.
- Concurrent starts preserve credential consistency.
- Existing sandboxes migrate safely.

Runtime recreation and nested Apple Container mounts remain untested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->