### PR TITLE
fix(acp): stop a cancel overtaking the prompt it is meant to stop

### DIFF
--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -570,22 +570,24 @@ async fn sessions_turn_send(
         // it cannot answer `agent_busy` for a session the caller may not see
         // (#3685).
         // Ownership is checked before the wake so a foreign session is never
-        // touched. The wake clears an idle-dormant (or manually stopped)
-        // park the same way a user prompt does: a turn is intent to continue,
-        // so the host resumes rather than refusing (#3686).
-        deps.session_service
-            .admits_turn(&caller, &req.session_id)
+        // touched, and the guard is claimed before it too, as the user prompt
+        // handlers do, so a Stop cannot overtake a turn the host just started
+        // (see `acp_cancel`). The wake clears an idle-dormant (or manually
+        // stopped) park the same way a user prompt does: a turn is intent to
+        // continue, so the host resumes rather than refusing (#3686).
+        let _submission = deps
+            .session_service
+            .admit_prompt_submission(&caller, &req.session_id)
             .await
             .map_err(|e| map_send_error(e.into()))?;
         let woke_idle_dormant = deps
             .session_service
             .touch_and_wake_on_prompt(&req.session_id)
             .await;
-        let (_submission, dispatch) = deps
+        let dispatch = deps
             .session_service
-            .begin_prompt_submission(&caller, &req.session_id, woke_idle_dormant)
-            .await
-            .map_err(|e| map_send_error(e.into()))?;
+            .prompt_dispatch_under_submission(&req.session_id, woke_idle_dormant)
+            .await;
         // A cold worker is not a refusal on this path: `send_turn` resumes it
         // and waits, which is how a scheduler wakes a session it created. The
         // turn gates are, because a second prompt at a busy non-steerable

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -34,6 +34,12 @@ const MAX_ATTACHMENT_BYTES: usize = 10 * 1024 * 1024;
 /// Maximum decoded size of all attachments on one prompt (20 MiB).
 const MAX_TOTAL_ATTACHMENT_BYTES: usize = 20 * 1024 * 1024;
 
+/// How long `acp_cancel` may wait on the session's prompt submission before it
+/// says so. Well over the sub-millisecond claim on an idle daemon and over a
+/// same-gesture prompt's own handler on a loaded one, so this fires for a Stop
+/// queued behind something else. See `acp_cancel`.
+const CANCEL_SUBMISSION_WAIT_WARN: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Startup-error banner text for a failed detached structured-view spawn,
 /// shared by the create-path (`create_session`) and enable-path
 /// (`acp_enable`). `CapacityFull` is transient and user-actionable, so its
@@ -1243,21 +1249,10 @@ pub async fn acp_prompt(
         Ok(j) => j,
         Err(rej) => return rej.into_response(),
     };
-    // Claim the session's prompt-submission authority FIRST, before the wake
-    // and before any other await. Two things ride on the position:
-    //
-    // 1. `/acp/cancel` claims the same guard, so a Stop pressed right after
-    //    Enter can no longer overtake its own prompt. The two are separate
-    //    concurrent requests reaching the agent by very different routes, and
-    //    everything this handler does before it hands `ClientCmd::Prompt` to
-    //    the connection task (a disk-backed wake, a control-state fold, the
-    //    `UserPromptSent` publish, worker readiness) is window in which cancel
-    //    can pass it: ~1ms idle, ~200ms on a loaded host. The agent then saw
-    //    `session/cancel` with nothing in flight followed by the very prompt
-    //    it named, and ran that turn to completion with the UI still on Stop.
-    // 2. `prompt_submission` documents submission-before-`instance_lock` as
-    //    the order every other holder takes (#3621); the wake takes
-    //    `instance_lock`, so claiming after it inverted that here alone.
+    // Claimed before the wake, not after it: everything below is window a
+    // concurrent `/acp/cancel` could pass through, and the wake takes
+    // `instance_lock`, which `prompt_submission` orders under this guard. See
+    // `acp_cancel`.
     let Some(_submission) = state
         .session_service
         .prompt_submission_for_session(&id)
@@ -1436,8 +1431,8 @@ pub async fn acp_prompt_diff_comments(
     };
     // This opens a turn (`UserDiffCommentsPrompt` folds to `turn_active`) just
     // as an ordinary prompt does, so it takes the same submission authority
-    // and settles the same disposition under it (#3621, #3649), claimed on
-    // entry for the reasons `acp_prompt` gives.
+    // and settles the same disposition under it (#3621, #3649), claimed before
+    // the wake for the reasons `acp_cancel` gives.
     let Some(_submission) = state
         .session_service
         .prompt_submission_for_session(&id)
@@ -1569,14 +1564,25 @@ pub async fn acp_attachment(
 /// the UI still showing Stop. The gap is the prompt handler's own duration,
 /// so a loaded host widens it from ~1ms to hundreds.
 ///
-/// `prompt_submission_for_session` is the same guard `begin_prompt_submission`
-/// claims, which `send_turn` documents as the session's per-caller ordering
-/// primitive. Taking it here restores the user's gesture order end-to-end for
-/// every surface (web, TUI, plugins) instead of the web composer alone. It
-/// costs nothing on the common path, where no submission is in flight; the
-/// worst case is a submission parked on `WORKER_READY_TIMEOUT`, which cancel's
-/// own `ready_client` already waits out. `force_end_turn` deliberately stays
-/// unguarded: it is the escape hatch for a wedged UI and must never queue.
+/// `prompt_submission_for_session` is the same guard every prompt-submitting
+/// surface claims, which `prompt_submission` documents as the session's
+/// ordering primitive. Taking it here restores the user's gesture order for every
+/// cancel client (the web composer, and `acp::client::http` for the TUI) at
+/// once, and the prompt handlers claim it before their wake so the whole
+/// submission sits inside the hold. It costs nothing on the common path, where
+/// no submission is in flight.
+///
+/// The guard is not only held by the user's own prompt, though: a queue drain
+/// can park on `WORKER_READY_TIMEOUT`, and a rename holds it across a worktree
+/// move. A cancel queued behind one of those publishes nothing while it waits,
+/// so the composer shows an unchanged spinner and no Force stop hatch (that
+/// needs `CancelRequested`, which only the connection task emits). Hence the
+/// warn below: a Stop that stalls should be legible in the log rather than
+/// arrive as a bug report. Dropping the guard early would shave the stall but
+/// reopen a window for a drain's prompt to slip in and be cancelled instead.
+///
+/// `force_end_turn` deliberately stays unguarded: it is the escape hatch for a
+/// wedged UI and must never queue.
 pub async fn acp_cancel(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1584,10 +1590,21 @@ pub async fn acp_cancel(
     if let Some(resp) = read_only_block(&state) {
         return resp;
     }
+    let waited_from = std::time::Instant::now();
     let _submission = state
         .session_service
         .prompt_submission_for_session(&id)
         .await;
+    let waited = waited_from.elapsed();
+    if waited >= CANCEL_SUBMISSION_WAIT_WARN {
+        tracing::warn!(
+            target: "http.api.acp",
+            session = %id,
+            waited_ms = waited.as_millis(),
+            "cancel waited on the session's prompt submission; the UI showed no \
+             progress for that long"
+        );
+    }
     match state.acp_supervisor.cancel_prompt(&id).await {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
         Err(e) => supervisor_error_response("cancel failed", &e),
@@ -3601,11 +3618,15 @@ mod tests {
         let state = crate::server::test_support::build_test_app_state(vec![inst]);
 
         // A worker-less session with no park parks the prompt, as ever.
-        let (guard, dispatch) = state
+        let guard = state
             .session_service
-            .begin_prompt_submission(&SessionCaller::User, &id, false)
+            .admit_prompt_submission(&SessionCaller::User, &id)
             .await
             .expect("session exists");
+        let dispatch = state
+            .session_service
+            .prompt_dispatch_under_submission(&id, false)
+            .await;
         assert_eq!(
             dispatch,
             crate::acp::dispatch::PromptDispatch::Queued {
@@ -3619,11 +3640,15 @@ mod tests {
             crate::server::acp_reconciler::RATE_LIMIT_EXHAUSTED_RETRIES_REASON,
             0,
         ));
-        let (_guard, dispatch) = state
+        let _guard = state
             .session_service
-            .begin_prompt_submission(&SessionCaller::User, &id, false)
+            .admit_prompt_submission(&SessionCaller::User, &id)
             .await
             .expect("session exists");
+        let dispatch = state
+            .session_service
+            .prompt_dispatch_under_submission(&id, false)
+            .await;
         assert_eq!(
             dispatch,
             crate::acp::dispatch::PromptDispatch::Sent,

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1243,13 +1243,29 @@ pub async fn acp_prompt(
         Ok(j) => j,
         Err(rej) => return rej.into_response(),
     };
+    // Claim the session's prompt-submission authority FIRST, before the wake
+    // and before any other await. Two things ride on the position:
+    //
+    // 1. `/acp/cancel` claims the same guard, so a Stop pressed right after
+    //    Enter can no longer overtake its own prompt. The two are separate
+    //    concurrent requests reaching the agent by very different routes, and
+    //    everything this handler does before it hands `ClientCmd::Prompt` to
+    //    the connection task (a disk-backed wake, a control-state fold, the
+    //    `UserPromptSent` publish, worker readiness) is window in which cancel
+    //    can pass it: ~1ms idle, ~200ms on a loaded host. The agent then saw
+    //    `session/cancel` with nothing in flight followed by the very prompt
+    //    it named, and ran that turn to completion with the UI still on Stop.
+    // 2. `prompt_submission` documents submission-before-`instance_lock` as
+    //    the order every other holder takes (#3621); the wake takes
+    //    `instance_lock`, so claiming after it inverted that here alone.
+    let Some(_submission) = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await
+    else {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    };
     let woke_idle_dormant = state.session_service.touch_and_wake_on_prompt(&id).await;
-    {
-        let instances = state.instances.read().await;
-        if !instances.iter().any(|i| i.id == id) {
-            return (StatusCode::NOT_FOUND, "session not found").into_response();
-        }
-    }
     // Decode + validate + capability-gate attachments BEFORE publishing
     // so a rejected prompt never leaves a half-rendered attachment in
     // the transcript (the publish path is otherwise authoritative). See
@@ -1259,21 +1275,18 @@ pub async fn acp_prompt(
         Ok(a) => a,
         Err((code, msg)) => return (code, msg).into_response(),
     };
-    // Claim the session's prompt-submission authority and decide under it, so
-    // every client follows the same send, steer, or queue rules and the
-    // decision and the dispatch it picks are one atomic step. Releasing
-    // between them let a queue drain read a fold this prompt had not published
-    // into yet, so both delivered and whichever lost the agent's race came
-    // back `agent_busy` after its queue row was already retired (#3621).
-    // `woke_idle_dormant` is passed rather than re-read: the wake above
-    // already cleared the marker, so the instance now says "awake".
-    let Ok((_submission, dispatch)) = state
+    // Decide the disposition under the guard we already hold, so every client
+    // follows the same send, steer, or queue rules and the decision and the
+    // dispatch it picks are one atomic step. Releasing between them let a
+    // queue drain read a fold this prompt had not published into yet, so both
+    // delivered and whichever lost the agent's race came back `agent_busy`
+    // after its queue row was already retired (#3621). `woke_idle_dormant` is
+    // passed rather than re-read: the wake above already cleared the marker,
+    // so the instance now says "awake".
+    let dispatch = state
         .session_service
-        .begin_prompt_submission(&SessionCaller::User, &id, woke_idle_dormant)
-        .await
-    else {
-        return (StatusCode::NOT_FOUND, "session not found").into_response();
-    };
+        .prompt_dispatch_under_submission(&id, woke_idle_dormant)
+        .await;
     // A fresh user prompt supersedes any queued rate-limit resume
     // continuation, so drop it before sending: otherwise the reconciler could
     // later replay the older interrupted prompt after this newer one (#3028).
@@ -1421,17 +1434,22 @@ pub async fn acp_prompt_diff_comments(
         Ok(j) => j,
         Err(rej) => return rej.into_response(),
     };
-    let woke_idle_dormant = state.session_service.touch_and_wake_on_prompt(&id).await;
     // This opens a turn (`UserDiffCommentsPrompt` folds to `turn_active`) just
     // as an ordinary prompt does, so it takes the same submission authority
-    // and settles the same disposition under it (#3621, #3649).
-    let Ok((_submission, dispatch)) = state
+    // and settles the same disposition under it (#3621, #3649), claimed on
+    // entry for the reasons `acp_prompt` gives.
+    let Some(_submission) = state
         .session_service
-        .begin_prompt_submission(&SessionCaller::User, &id, woke_idle_dormant)
+        .prompt_submission_for_session(&id)
         .await
     else {
         return (StatusCode::NOT_FOUND, "session not found").into_response();
     };
+    let woke_idle_dormant = state.session_service.touch_and_wake_on_prompt(&id).await;
+    let dispatch = state
+        .session_service
+        .prompt_dispatch_under_submission(&id, woke_idle_dormant)
+        .await;
     // A typed diff-comments prompt has no queue row to park on, so anything
     // but send-or-steer is refused here rather than published and then
     // rejected asynchronously as `agent_busy`, which would strand the card in
@@ -1537,6 +1555,28 @@ pub async fn acp_attachment(
     }
 }
 
+/// Cancel the session's in-flight turn.
+///
+/// Ordered behind any prompt submission still in flight for this session.
+/// `/acp/prompt` and `/acp/cancel` are separate requests served on separate
+/// tasks, and they reach the agent by very different routes: the prompt path
+/// resumes the worker, awaits readiness and publishes `UserPromptSent` before
+/// it hands `ClientCmd::Prompt` to the connection task, while cancel goes
+/// almost straight to the command channel. A Stop pressed shortly after Enter
+/// therefore overtook its own prompt, and the agent saw `session/cancel` with
+/// nothing in flight followed by the `session/prompt` it was meant to stop:
+/// per ACP a cancel names no prompt, so the turn then ran to completion with
+/// the UI still showing Stop. The gap is the prompt handler's own duration,
+/// so a loaded host widens it from ~1ms to hundreds.
+///
+/// `prompt_submission_for_session` is the same guard `begin_prompt_submission`
+/// claims, which `send_turn` documents as the session's per-caller ordering
+/// primitive. Taking it here restores the user's gesture order end-to-end for
+/// every surface (web, TUI, plugins) instead of the web composer alone. It
+/// costs nothing on the common path, where no submission is in flight; the
+/// worst case is a submission parked on `WORKER_READY_TIMEOUT`, which cancel's
+/// own `ready_client` already waits out. `force_end_turn` deliberately stays
+/// unguarded: it is the escape hatch for a wedged UI and must never queue.
 pub async fn acp_cancel(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1544,6 +1584,10 @@ pub async fn acp_cancel(
     if let Some(resp) = read_only_block(&state) {
         return resp;
     }
+    let _submission = state
+        .session_service
+        .prompt_submission_for_session(&id)
+        .await;
     match state.acp_supervisor.cancel_prompt(&id).await {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
         Err(e) => supervisor_error_response("cancel failed", &e),
@@ -3458,6 +3502,90 @@ mod tests {
                 .any(|(_, e)| matches!(e, Event::UserPromptSent { .. })),
             "a prompt no worker ever received must not reach the event store"
         );
+    }
+
+    /// A Stop pressed right after Enter must not overtake its own prompt.
+    ///
+    /// `/acp/prompt` and `/acp/cancel` are concurrent requests that reach the
+    /// agent by very different routes: the prompt path wakes, folds, publishes
+    /// and awaits worker readiness before it hands `ClientCmd::Prompt` to the
+    /// connection task, while cancel goes almost straight to the command
+    /// channel. Whenever cancel passed it, the agent saw `session/cancel` with
+    /// nothing in flight and then the very prompt it named; per ACP a cancel
+    /// names no prompt, so the turn ran to completion with the UI still on
+    /// Stop. The window is the prompt handler's own duration, so a loaded host
+    /// stretched it from ~1ms to hundreds and the live `composer-stop` spec
+    /// failed on whichever case clicked Stop without waiting for output first.
+    ///
+    /// Both halves of the ordering are pinned here, against a held guard
+    /// rather than a live agent: cancel must wait for it, and the prompt
+    /// handler must claim it before its first side effect (the wake, which is
+    /// what `last_accessed_at` records). A handler that claims later leaves
+    /// exactly that much window for a cancel to pass through.
+    #[tokio::test]
+    async fn cancel_and_prompt_serialize_on_the_submission_guard() {
+        use std::time::Duration;
+
+        let mut inst = crate::session::Instance::new("stop-order", "/tmp/aoe-stop-order");
+        inst.id = "sess-stop-order".to_string();
+        inst.view = crate::session::View::Structured;
+        assert!(
+            inst.last_accessed_at.is_none(),
+            "fresh instance is untouched"
+        );
+        let id = inst.id.clone();
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+
+        // Stand in for a submission already in flight. There is no worker, so
+        // every path below fails fast once it gets past the guard.
+        let submission = state
+            .session_service
+            .prompt_submission_for_session(&id)
+            .await
+            .expect("seeded session must admit a submission");
+
+        let cancel = tokio::spawn({
+            let state = Arc::clone(&state);
+            let id = id.clone();
+            async move { acp_cancel(State(state), Path(id)).await.into_response() }
+        });
+        let prompt = tokio::spawn({
+            let state = Arc::clone(&state);
+            let id = id.clone();
+            async move {
+                acp_prompt(
+                    State(state),
+                    Path(id),
+                    Ok(Json(PromptRequest {
+                        text: "think about this".to_string(),
+                        attachments: Vec::new(),
+                        prompt_id: None,
+                    })),
+                )
+                .await
+                .into_response()
+            }
+        });
+
+        // 500ms is orders of magnitude over the microseconds either handler
+        // needs to reach the agent-facing work once it is past the guard.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(
+            !cancel.is_finished(),
+            "acp_cancel must wait for the in-flight submission instead of racing ahead of it"
+        );
+        assert!(
+            state.instances.read().await[0].last_accessed_at.is_none(),
+            "acp_prompt must claim the submission guard before it wakes the session"
+        );
+
+        drop(submission);
+        for handler in [cancel, prompt] {
+            tokio::time::timeout(Duration::from_secs(10), handler)
+                .await
+                .expect("both handlers must finish once the guard drops")
+                .expect("handler task must not panic");
+        }
     }
 
     /// #3688: the recovery lives in `dispatch::decide`, not in one handler,

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -474,9 +474,9 @@ impl SessionService {
     /// any archive, snooze or idle-dormant park, in memory and on disk,
     /// under the instance lock so it serializes with other lifecycle edits.
     /// Returns whether the session was idle-dormant, which callers pass to
-    /// `begin_prompt_submission` and `send_turn` so the wake forces a
+    /// `prompt_dispatch_under_submission` and `send_turn` so the wake forces a
     /// resume. Shared by the user prompt handlers and the plugin turn path
-    /// (#3686).
+    /// (#3686), which all run it under their submission guard.
     pub(crate) async fn touch_and_wake_on_prompt(&self, id: &str) -> bool {
         let inst_lock = self.instance_lock(id).await;
         let _guard = inst_lock.lock().await;
@@ -1453,15 +1453,11 @@ impl SessionService {
     ///    the resume it waits for builds its spawn request under `instance_lock`
     ///    (`acp_reconciler::build_spawn_request`). A submitter that held that
     ///    lock would stall the very resume it is waiting for and give up after
-    ///    `WORKER_READY_TIMEOUT`. This lock is deliberately distinct so the two
-    ///    never overlap; where both are genuinely needed, take this one first.
-    ///
-    /// One input escapes the hold: `acp_prompt` samples `woke_idle_dormant`
-    /// from `touch_and_wake_on_prompt` before claiming the guard,
-    /// because that helper takes `instance_lock`. A stale `true` only forces
-    /// `send_turn`'s resume trigger, which answers `AlreadyResuming` or
-    /// `AlreadyRunning` for a worker that is already there, so it costs a
-    /// lookup rather than a wrong disposition.
+    ///    `WORKER_READY_TIMEOUT`. Where both are genuinely needed, take this
+    ///    one first and release `instance_lock` before the wait: the prompt
+    ///    handlers claim this guard on entry and wake under it, and
+    ///    `touch_and_wake_on_prompt` drops `instance_lock` before returning.
+    ///    Never the reverse order.
     pub(crate) async fn prompt_submission(&self, id: &str) -> tokio::sync::OwnedMutexGuard<()> {
         #[cfg(test)]
         if let Some(tap) = self.submission_claims.get() {
@@ -1496,7 +1492,7 @@ impl SessionService {
     /// teardown and removes the session row before dropping its lock, so both
     /// a waiter parked on that lock and one that vivified a fresh entry after
     /// `forget_prompt_lock` observe the removal and decline.
-    async fn admit_prompt_submission(
+    pub(crate) async fn admit_prompt_submission(
         &self,
         caller: &SessionCaller,
         id: &str,
@@ -1551,36 +1547,15 @@ impl SessionService {
             .ok()
     }
 
-    /// Claim the session's submission authority and settle the prompt's
-    /// disposition under it, so every turn-starting surface decides and
-    /// dispatches as one step instead of dispatching unconditionally after
-    /// the wait (#3649). Admission is decided first, so the disposition is
-    /// only ever computed for a caller entitled to see it.
-    pub(crate) async fn begin_prompt_submission(
-        &self,
-        caller: &SessionCaller,
-        id: &str,
-        idle_dormant: bool,
-    ) -> Result<
-        (
-            tokio::sync::OwnedMutexGuard<()>,
-            crate::acp::dispatch::PromptDispatch,
-        ),
-        TurnAdmissionError,
-    > {
-        let guard = self.admit_prompt_submission(caller, id).await?;
-        let dispatch = self
-            .prompt_dispatch_under_submission(id, idle_dormant)
-            .await;
-        Ok((guard, dispatch))
-    }
-
-    /// [`Self::begin_prompt_submission`]'s second half, for a caller that
-    /// already holds the guard. The user prompt handlers claim submission
-    /// authority on entry (before the wake, so `/acp/cancel` cannot overtake
-    /// the prompt it is meant to stop, and so they take the two locks in the
-    /// order [`Self::prompt_submission`] documents) and only then have an
-    /// `idle_dormant` to decide with.
+    /// Settle the prompt's disposition under a submission guard the caller
+    /// already holds, so every turn-starting surface decides and dispatches as
+    /// one step instead of dispatching unconditionally after the wait (#3649).
+    ///
+    /// Separate from the claim because the two are not adjacent: every caller
+    /// takes [`Self::admit_prompt_submission`] on entry (a `/acp/cancel` must
+    /// not be able to overtake the prompt it is meant to stop, see
+    /// `api::acp::acp_cancel`) and only has an `idle_dormant` to decide with
+    /// after the wake it runs under the hold.
     pub(crate) async fn prompt_dispatch_under_submission(
         &self,
         id: &str,

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -1569,6 +1569,23 @@ impl SessionService {
         TurnAdmissionError,
     > {
         let guard = self.admit_prompt_submission(caller, id).await?;
+        let dispatch = self
+            .prompt_dispatch_under_submission(id, idle_dormant)
+            .await;
+        Ok((guard, dispatch))
+    }
+
+    /// [`Self::begin_prompt_submission`]'s second half, for a caller that
+    /// already holds the guard. The user prompt handlers claim submission
+    /// authority on entry (before the wake, so `/acp/cancel` cannot overtake
+    /// the prompt it is meant to stop, and so they take the two locks in the
+    /// order [`Self::prompt_submission`] documents) and only then have an
+    /// `idle_dormant` to decide with.
+    pub(crate) async fn prompt_dispatch_under_submission(
+        &self,
+        id: &str,
+        idle_dormant: bool,
+    ) -> crate::acp::dispatch::PromptDispatch {
         let running = self.acp_supervisor.is_running(id).await;
         // Settled here, under the guard, rather than probed by each handler
         // before it claims one: a reconciler park landing between a handler's
@@ -1582,8 +1599,7 @@ impl SessionService {
             idle_dormant,
             rate_limit_exhausted,
         };
-        let dispatch = crate::acp::dispatch::decide(&self.fold_control_state(id).await, liveness);
-        Ok((guard, dispatch))
+        crate::acp::dispatch::decide(&self.fold_control_state(id).await, liveness)
     }
 
     /// Whether the session is parked on the redelivery cap (#3688). Off the

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -3,16 +3,6 @@ import { test, expect } from "./helpers/mockedTest";
 const NEW_SESSION_PANE_NAME = /New session Pick a project, then launch a new session/i;
 
 test.describe("Dashboard layout", () => {
-  test("loads and shows header", async ({ page }) => {
-    await page.goto("/");
-    await expect(page.locator("header")).toBeVisible();
-  });
-
-  test("shows branded home screen with logo text", async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByText("empires", { exact: false })).toBeVisible();
-  });
-
   test("shows branded home screen with action panes", async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("empires", { exact: false })).toBeVisible();
@@ -32,11 +22,6 @@ test.describe("Sidebar", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await expect(page.getByLabel("New project session")).toBeVisible();
-  });
-
-  test("sidebar toggle button exists", async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByRole("button", { name: "Toggle sidebar" })).toBeVisible();
   });
 
   test("sidebar Projects section lists a no-session saved project with an add button", async ({ page }) => {
@@ -138,11 +123,6 @@ test.describe("Create session from home screen", () => {
 });
 
 test.describe("Settings", () => {
-  test("settings gear button visible", async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
-  });
-
   test("settings opens on click", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("button", { name: "Settings" }).click();
@@ -201,11 +181,13 @@ test.describe("Mobile responsive", () => {
     await expect(page.getByText("empires", { exact: false })).toBeVisible();
   });
 
-  test("mobile home screen shows sidebar toggle between title and panes", async ({ page }) => {
+  test("mobile home screen's Show sessions button opens the sidebar", async ({ page }) => {
+    // Dashboard.tsx's own `md:hidden` trigger, not TopBar's "Toggle sidebar":
+    // the two are separate elements and nothing else in web/ drives this one.
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
-    await expect(page.getByText("Show sessions")).toBeVisible();
-    await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).toBeVisible();
+    await page.getByText("Show sessions").click();
+    await expect(page.getByLabel("New project session")).toBeInViewport();
   });
 
   test("mobile home offers the five most recent sessions while desktop keeps them hidden", async ({ page }) => {
@@ -287,45 +269,10 @@ test.describe("Mobile responsive", () => {
     await expect(page.getByLabel("New project session")).not.toBeInViewport();
   });
 
-  test("settings gear accessible on mobile", async ({ page }) => {
-    await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/");
-    await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
-  });
-
   test("create modal works on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByRole("button", { name: NEW_SESSION_PANE_NAME }).click();
     await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
-  });
-});
-
-test.describe("Design system", () => {
-  test("uses dark surface background", async ({ page }) => {
-    await page.goto("/");
-    const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
-    // surface-900 = #1c1c1f = rgb(28, 28, 31)
-    expect(bg).toContain("28");
-    expect(bg).not.toBe("rgb(255, 255, 255)");
-  });
-
-  test("loads Geist Sans body font", async ({ page }) => {
-    await page.goto("/");
-    const fonts = await page.evaluate(() => getComputedStyle(document.body).fontFamily);
-    expect(fonts.toLowerCase()).toContain("geist");
-  });
-
-  test("focus-visible ring appears on keyboard navigation", async ({ page }) => {
-    await page.setViewportSize({ width: 1280, height: 720 });
-    await page.goto("/");
-    // Tab to the first button
-    await page.keyboard.press("Tab");
-    const outline = await page.evaluate(() => {
-      const el = document.activeElement;
-      return el ? getComputedStyle(el).outlineColor : "";
-    });
-    // Should have a brand-colored outline
-    expect(outline).not.toBe("");
   });
 });


### PR DESCRIPTION
## Description

The live `composer-stop` spec fails on `Stop while reasoning` because a cancel can overtake the prompt it is meant to stop. It is a product bug, not a test problem.

`/acp/prompt` and `/acp/cancel` are separate concurrent requests reaching the agent by different routes. The prompt path wakes the session (a disk write), folds control state, publishes `UserPromptSent` and awaits worker readiness before handing `ClientCmd::Prompt` to the connection task; cancel goes almost straight to the command channel. All of that is window. The agent then sees `session/cancel` with nothing in flight followed by the very prompt it named, and since an ACP cancel names no prompt, the turn runs to completion with the composer still showing Stop.

Evidence from the failing run's own artifacts (`Tests` 34287159752, shard 1/2), fake-agent log:

```
457147 session/prompt   (turn 1)
457828 session/cancel   (turn 1 Stop, during the prompt)
458032 session/cancel   (turn 2 Stop)   <- 118ms before its prompt
458150 session/prompt   (turn 2)
```

Turn 2's prompt POST left the browser 62ms before its cancel POST; the daemon took 182ms to reach `sending prompt` and 2ms to reach the cancel. The window is the prompt handler's own duration, so it is load-scaled: ~1ms idle, ~200ms on a loaded runner. `Stop while reasoning` is the only case that clicks Stop without first waiting for rendered output, which is why it is the one that lands inside the window.

Both handlers now claim the session's prompt-submission authority, and the prompt handlers claim it on entry rather than after the wake. That also puts them on the submission-before-`instance_lock` order every other holder already documents and takes. `force_end_turn` stays unguarded: it is the escape hatch for a wedged UI and must never queue.

Second commit removes eight `dashboard.spec.ts` cases that assert rendering or design-token constants with no asserted behavior and rewrites a ninth as a behavior test. It is independent of the fix and revertible on its own.

Third commit is review follow-up: the plugin turn path now claims on entry too, the now-callerless `begin_prompt_submission` is gone, a cancel that queues behind a non-prompt holder warns past 500ms (it publishes nothing while it waits, so the composer shows no progress and no Force stop hatch), and `prompt_submission`'s doc no longer states the pre-fix lock order.

Not fixed here: `Tests` run 34285833527 on `a604ed390` failed on `acp-compaction-phase` and `queue-follow-up-with-nav`, unrelated symptoms. Live-shard instability is broader than this one race.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The existing `web/tests/live/acp-stories/composer-stop.spec.ts` is the user story and already fails on the bug; the durable regression test is `cancel_and_prompt_serialize_on_the_submission_guard` in `src/server/api/acp.rs`, which pins both halves of the ordering deterministically without a live agent. Reverting either half fails it (re-verified after the review changes). `coverage-matrix.json` needs no change: it names `tests/dashboard.spec.ts` rather than case titles, and every behavior it maps there still has a surviving case.

Rate measurement, via a throwaway probe that POSTs a prompt, waits N ms, POSTs a cancel and asserts the agent saw them in that order, 20 runs per delay:

| delay | before | after |
|---|---|---|
| 0ms | 20/20 reordered | 0/20 |
| 1ms | 20/20 | 0/20 |
| 2ms | 19/20 | 0/20 |
| 4ms | 2/20 | 0/20 |
| 8ms | 0/20 | 0/20 |

Also run: full live suite (163 passed; the one failure, `acp-view-switch` keep-context, reproduces 3/3 on clean `main` in the same sandbox and is a local tmux/shim issue), `composer-stop` 40x under CPU load, `cargo test --features web`, `cargo fmt`, `cargo clippy --features web --all-targets`, and web `format:check` / `lint` / `tsc -b`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Diagnosis and fix drafted in a back-and-forth session; the failing run's Playwright trace and fake-agent log supplied the ordering evidence.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EguYWwG3aDaa26yv9sJLv2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Serialized prompt and cancellation requests to prevent `session/cancel` from overtaking its prompt.
- Applied the same ordering guard to plugin turns.
- Added warnings when cancellation waits longer than 500 ms.
- Simplified the prompt submission API and updated related documentation.
- Added a deterministic regression test for prompt and cancellation ordering.
- Removed dashboard tests that checked only visibility or styling constants.
- Reworked one mobile dashboard test to verify user behavior.

## Benefits

This prevents premature cancellation during “Stop while reasoning” and makes session behavior more reliable. The new warning helps identify slow cancellation waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->