### PR TITLE
fix(sandbox): place the mountpoint the shared credential file mounts over

### DIFF
--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -794,8 +794,8 @@ fn read_credential_candidate(dir: &Path, name: &str, follow: SymlinkPolicy) -> O
 /// mounts. This is a come-up fold rather than a migration because a container
 /// built before the file was shared keeps refreshing its store copy while it
 /// runs, so which copy is freshest is only known at come-up. That copy is left
-/// for such a container; [`remove_shadowed_credential_copies`] drops it once a
-/// container mounting the shared file exists.
+/// for such a container; [`place_shadowed_credential_mountpoints`] empties it
+/// once a container mounting the shared file exists.
 ///
 /// Candidates are the store's private copy (left by the v027 move or by a
 /// login before the file was shared), the host file and the macOS Keychain;
@@ -881,10 +881,24 @@ fn merge_credential(existing: Option<&str>, winner: &str) -> String {
     merged.unwrap_or_else(|| winner.to_string())
 }
 
-/// Drop each store's own copy of a credential the container mounts the shared
-/// file over. Runs once the container exists: one built before the file was
-/// shared reads that copy instead, and is recreated rather than stripped.
-pub(crate) fn remove_shadowed_credential_copies(config: &ContainerConfig) {
+/// Place the mountpoint each store needs for the shared credential file
+/// mounted over it, and empty the store's own copy once the shared file holds
+/// it.
+///
+/// The mount is a file nested inside the store's directory mount, so the
+/// runtime resolves its mountpoint through that mount and lands on the host
+/// store. runc refuses to create it there (it is outside the container's
+/// rootfs), so a store without the file fails the first create with
+/// `create mountpoint for ... is outside of rootfs`, and only succeeds on a
+/// retry because the failed attempt left the file behind (#3845). Placing it
+/// ourselves is what makes the first create work.
+///
+/// Empty rather than carrying the copy's old content: [`read_credential_file`]
+/// reads an empty file as no credential, so a copy [`sync_shared_credential`]
+/// already folded in cannot come back as a candidate. Runs before every create
+/// and start, since the runtime needs the mountpoint each time it applies the
+/// mounts.
+pub(crate) fn place_shadowed_credential_mountpoints(config: &ContainerConfig) {
     let volume_at = |target: &Path| {
         config
             .volumes
@@ -906,13 +920,39 @@ pub(crate) fn remove_shadowed_credential_copies(config: &ContainerConfig) {
             continue;
         }
         let copy = Path::new(&store.host_path).join(name);
-        match std::fs::remove_file(&copy) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => tracing::warn!(target: "session.profile",
-                "Failed to remove shadowed credential copy {}: {}", copy.display(), e),
+        // Emptying the copy is only safe once the fold has landed in the
+        // shared file; a fold that failed leaves the copy the freshest
+        // credential there is, and it already serves as the mountpoint.
+        let folded = std::fs::read_to_string(&shared.host_path)
+            .is_ok_and(|content| !content.trim().is_empty());
+        if let Err(e) = place_credential_mountpoint(&copy, folded) {
+            tracing::warn!(target: "session.profile",
+                "Failed to place credential mountpoint {}: {}", copy.display(), e);
         }
     }
+}
+
+/// A plain file at `path` for the runtime to mount over, emptied when
+/// `replace` and left alone otherwise. The store is container-writable, so
+/// anything but a plain file there is replaced rather than mounted through.
+fn place_credential_mountpoint(path: &Path, replace: bool) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() && (!replace || metadata.len() == 0) => return Ok(()),
+        Ok(_) => {
+            std::fs::remove_file(path).with_context(|| format!("removing {}", path.display()))?;
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e).with_context(|| format!("inspecting {}", path.display())),
+    }
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map(|_| ())
+        .with_context(|| format!("creating {}", path.display()))
 }
 
 /// Write in place, never rename: containers bind-mount this inode. The new
@@ -4481,11 +4521,14 @@ mod tests {
             container_workdir: None,
         };
         let shared = host.join(SANDBOX_PRIVATE_SUBDIR).join(".credentials.json");
-        for instance_id in ["shared-cred-a", "shared-cred-b"] {
+        // A store the v027 move left a copy in, and a fresh one with none: both
+        // end up with the empty mountpoint the nested file mount needs (#3845).
+        for (instance_id, stale_copy) in [("shared-cred-a", true), ("shared-cred-b", false)] {
             let store = host.join(SANDBOX_PRIVATE_SUBDIR).join(instance_id);
-            // A copy the v027 move left behind, folded in and shadowed.
             fs::create_dir_all(&store).unwrap();
-            fs::write(store.join(".credentials.json"), credential(1)).unwrap();
+            if stale_copy {
+                fs::write(store.join(".credentials.json"), credential(1)).unwrap();
+            }
             let config = build_container_config(
                 project_dir.path().to_str().unwrap(),
                 &sandbox_info,
@@ -4507,16 +4550,19 @@ mod tests {
                 config.shared_credential_mounts,
                 vec!["/root/.claude/.credentials.json".to_string()]
             );
-            assert!(store.join(".credentials.json").exists());
-            remove_shadowed_credential_copies(&config);
-            assert!(!store.join(".credentials.json").exists());
+            assert_eq!(store.join(".credentials.json").exists(), stale_copy);
+            place_shadowed_credential_mountpoints(&config);
+            assert_eq!(
+                fs::read_to_string(store.join(".credentials.json")).unwrap(),
+                ""
+            );
             crate::hooks::cleanup_hook_status_dir(instance_id);
         }
         assert_eq!(fs::read_to_string(&shared).unwrap(), cred);
     }
 
     #[test]
-    fn shadowed_credential_copy_is_removed_only_from_a_store() {
+    fn shadowed_credential_copy_is_emptied_only_in_a_store() {
         let home = TempDir::new().unwrap();
         let host = home.path().join(".claude");
         let root = host.join(SANDBOX_PRIVATE_SUBDIR);
@@ -4542,12 +4588,32 @@ mod tests {
         };
         // A user extra_volumes entry at the config path replaces the store
         // mount; its host copy is the user's own login, not a shadowed one.
-        for (dir, removed) in [(&store, true), (&host, false)] {
+        for (dir, emptied) in [(&store, true), (&host, false)] {
             let copy = dir.join(".credentials.json");
             fs::write(&copy, "token").unwrap();
-            remove_shadowed_credential_copies(&config_for(dir));
-            assert_eq!(!copy.exists(), removed, "{}", dir.display());
+            place_shadowed_credential_mountpoints(&config_for(dir));
+            let kept = fs::read_to_string(&copy).unwrap() == "token";
+            assert_eq!(!kept, emptied, "{}", dir.display());
         }
+
+        // A shared file the fold never reached leaves the copy alone: it is
+        // still the only credential, and already the mountpoint the mount needs.
+        fs::write(&shared, "").unwrap();
+        let copy = store.join(".credentials.json");
+        fs::write(&copy, "token").unwrap();
+        place_shadowed_credential_mountpoints(&config_for(&store));
+        assert_eq!(fs::read_to_string(&copy).unwrap(), "token");
+        fs::write(&shared, "{}").unwrap();
+
+        // The store is container-writable, so a link planted at the mountpoint
+        // is replaced rather than followed.
+        let outside = home.path().join("outside");
+        fs::write(&outside, "token").unwrap();
+        fs::remove_file(&copy).unwrap();
+        std::os::unix::fs::symlink(&outside, &copy).unwrap();
+        place_shadowed_credential_mountpoints(&config_for(&store));
+        assert!(fs::symlink_metadata(&copy).unwrap().is_file());
+        assert_eq!(fs::read_to_string(&outside).unwrap(), "token");
     }
 
     /// End-to-end test: repo-level sandbox config (environment, volume_ignores,

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -885,13 +885,14 @@ fn merge_credential(existing: Option<&str>, winner: &str) -> String {
 /// mounted over it, and empty the store's own copy once the shared file holds
 /// it.
 ///
-/// The mount is a file nested inside the store's directory mount, so the
-/// runtime resolves its mountpoint through that mount and lands on the host
-/// store. runc refuses to create it there (it is outside the container's
-/// rootfs), so a store without the file fails the first create with
-/// `create mountpoint for ... is outside of rootfs`, and only succeeds on a
-/// retry because the failed attempt left the file behind (#3845). Placing it
-/// ourselves is what makes the first create work.
+/// The mount is a file nested inside the store's directory mount, so a runtime
+/// asked to create the mountpoint resolves it through that mount and lands on
+/// the host store, outside the container's rootfs. Docker Desktop refuses it
+/// there with `create mountpoint for ... is outside of rootfs` yet leaves the
+/// file behind, which is why a store without it failed every first create and
+/// worked on the retry (#3845, upstream docker/for-mac#7853). Placing the
+/// file ourselves is what makes the first create work, and keeps the runtime
+/// from having to create a mountpoint through a bind mount at all.
 ///
 /// Empty rather than carrying the copy's old content: [`read_credential_file`]
 /// reads an empty file as no credential, so a copy [`sync_shared_credential`]
@@ -920,11 +921,12 @@ pub(crate) fn place_shadowed_credential_mountpoints(config: &ContainerConfig) {
             continue;
         }
         let copy = Path::new(&store.host_path).join(name);
-        // Emptying the copy is only safe once the fold has landed in the
-        // shared file; a fold that failed leaves the copy the freshest
-        // credential there is, and it already serves as the mountpoint.
+        // Emptying the copy is only safe once the fold has landed a credential
+        // in the shared file; short of that (a failed fold, or the empty seed
+        // `sync_shared_credential` writes when it found none) the copy may be
+        // the only one left, and it already serves as the mountpoint.
         let folded = std::fs::read_to_string(&shared.host_path)
-            .is_ok_and(|content| !content.trim().is_empty());
+            .is_ok_and(|content| !matches!(content.trim(), "" | "{}"));
         if let Err(e) = place_credential_mountpoint(&copy, folded) {
             tracing::warn!(target: "session.profile",
                 "Failed to place credential mountpoint {}: {}", copy.display(), e);
@@ -933,14 +935,20 @@ pub(crate) fn place_shadowed_credential_mountpoints(config: &ContainerConfig) {
 }
 
 /// A plain file at `path` for the runtime to mount over, emptied when
-/// `replace` and left alone otherwise. The store is container-writable, so
-/// anything but a plain file there is replaced rather than mounted through.
+/// `replace` and left as it is otherwise. The store is container-writable and
+/// a runtime that got as far as making a directory there leaves one, so
+/// anything but a plain file is replaced rather than mounted through.
 fn place_credential_mountpoint(path: &Path, replace: bool) -> Result<()> {
     use std::os::unix::fs::OpenOptionsExt;
     match std::fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_file() && (!replace || metadata.len() == 0) => return Ok(()),
-        Ok(_) => {
-            std::fs::remove_file(path).with_context(|| format!("removing {}", path.display()))?;
+        Ok(metadata) => {
+            if metadata.is_dir() {
+                std::fs::remove_dir_all(path)
+            } else {
+                std::fs::remove_file(path)
+            }
+            .with_context(|| format!("removing {}", path.display()))?;
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(e).with_context(|| format!("inspecting {}", path.display())),
@@ -4569,7 +4577,7 @@ mod tests {
         let store = root.join("aaaaaaaaaaaaaaaa");
         let shared = root.join(".credentials.json");
         fs::create_dir_all(&store).unwrap();
-        fs::write(&shared, "{}").unwrap();
+        fs::write(&shared, "shared").unwrap();
         let config_for = |dir: &Path| ContainerConfig {
             shared_credential_mounts: vec!["/root/.claude/.credentials.json".to_string()],
             volumes: vec![
@@ -4596,14 +4604,16 @@ mod tests {
             assert_eq!(!kept, emptied, "{}", dir.display());
         }
 
-        // A shared file the fold never reached leaves the copy alone: it is
-        // still the only credential, and already the mountpoint the mount needs.
-        fs::write(&shared, "").unwrap();
+        // A shared file the fold landed no credential in leaves the copy alone:
+        // it is still the only one, and already the mountpoint the mount needs.
         let copy = store.join(".credentials.json");
-        fs::write(&copy, "token").unwrap();
-        place_shadowed_credential_mountpoints(&config_for(&store));
-        assert_eq!(fs::read_to_string(&copy).unwrap(), "token");
-        fs::write(&shared, "{}").unwrap();
+        for unfolded in ["", "{}"] {
+            fs::write(&shared, unfolded).unwrap();
+            fs::write(&copy, "token").unwrap();
+            place_shadowed_credential_mountpoints(&config_for(&store));
+            assert_eq!(fs::read_to_string(&copy).unwrap(), "token", "{unfolded:?}");
+        }
+        fs::write(&shared, "shared").unwrap();
 
         // The store is container-writable, so a link planted at the mountpoint
         // is replaced rather than followed.
@@ -4614,6 +4624,12 @@ mod tests {
         place_shadowed_credential_mountpoints(&config_for(&store));
         assert!(fs::symlink_metadata(&copy).unwrap().is_file());
         assert_eq!(fs::read_to_string(&outside).unwrap(), "token");
+
+        // As is a directory left by a runtime that got that far.
+        fs::remove_file(&copy).unwrap();
+        fs::create_dir(&copy).unwrap();
+        place_shadowed_credential_mountpoints(&config_for(&store));
+        assert!(fs::symlink_metadata(&copy).unwrap().is_file());
     }
 
     /// End-to-end test: repo-level sandbox config (environment, volume_ignores,

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -230,6 +230,7 @@ impl Instance {
                 if recreate {
                     container.remove(false)?;
                 } else {
+                    container_config::place_shadowed_credential_mountpoints(&config);
                     container.start()?;
                     self.identity_publisher_launched = config.identity_publisher_installed
                         && identity_publisher_mount_matches(&container, &config)?
@@ -270,8 +271,8 @@ impl Instance {
                 .and_then(|sandbox| sandbox.container_workdir.as_deref()),
         );
         container.remove_stranded_named_ignore_volumes(&self.id, &stranded);
+        container_config::place_shadowed_credential_mountpoints(&config);
         let container_id = container.create(&config)?;
-        container_config::remove_shadowed_credential_copies(&config);
         self.identity_publisher_launched = config.identity_publisher_installed
             && identity_publisher_dependencies_available(&container)
             && self.hook_session_publisher_allowed_by_argv();


### PR DESCRIPTION
## Description

Every new sandboxed Claude Code session has been failing the first time its container is created, and working the second time you ask for it. All Claude sandboxes share one credentials file so they don't log each other out, and that one file gets mounted into each session at the place Claude Code expects to find it, which sits inside the folder that session already has mounted. Nothing on our side ever created a file at that spot, so Docker had to create it, and Docker refuses to create a file there because doing so would write into your home folder from inside the container. It fails, but not before leaving the file behind, which is why the retry works. This change creates that file itself, empty, before the container is created or started, so the first attempt works like the second one always did.

Chosen fix, and what it costs: keep the shared file bind-mounted where it is and make the mountpoint exist, rather than moving the mount out of the store or going back to a per-session copy. Claude Code only reads `~/.claude/.credentials.json`, refuses a symlink there, and that path is inside the per-session store mount, so there is nowhere else to put it; seeding a per-session copy at come-up is the pre-#3834 layout that logged sandboxes out as soon as one of them refreshed. The cost is that the nested file-in-directory mount stays, so Apple Container still has to support it. What changes is that the runtime is now only ever asked to mount over an existing file, never to create one through a bind mount, which is the part Docker refused.

Also fixed by the same change: `remove_shadowed_credential_copies` unlinked the store's copy right after create, so restarting any stopped sandbox created since #3834 would have hit the same refusal. The copy is now emptied instead of unlinked, and the mountpoint is placed before every start as well as every create. An empty file already reads as no credential in the fold, so the emptied copy can never come back as a candidate; a fold that failed to land leaves the copy alone rather than dropping the only credential there is.

Diagnosis: I could not run `aoe add` from inside the sandbox (no Docker daemon, no `aoe` binary, no `CAP_SYS_ADMIN`). Instead I read the failure out of the container the bug produced. `/proc/self/mountinfo` shows mount 1007 (`sandbox-v2/.credentials.json` -> `/root/.claude/.credentials.json`) with mount 995 (`sandbox-v2/<instance-id>` -> `/root/.claude`) as its parent, so the mount does exist and the store directory does hold a dirent for it. No code path in aoe writes that dirent: `sync_agent_config` puts `.credentials.json` in `skip_entries`, `sync_shared_credential` writes only the file at the store root, and the only other reference removed it. The runtime created it, on the create that failed.

Upstream: docker/for-mac#7853 is the same failure with a two-line repro and the same error string, and states the behavior this fix relies on: the failing run "still creates the empty file", and deleting that file reproduces the error while the next run works. It is closed as fixed in Docker Desktop 4.68.0, so a machine still hitting #3845 is on an older build; worth confirming with `docker version`. The change does not depend on which runtime bug caused it: a bind mount needs a mountpoint, and aoe was never creating one.

Fixes #3845

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the failure is a container runtime refusing a mount, which needs a Docker daemon; both container-creating tests in `tests/e2e/sandbox.rs` are already `#[ignore = "requires Docker daemon"]` and do not run in CI. The host-side precondition the runtime failed on is a unit test: `claude_sandboxes_share_one_credential_mount` now covers a fresh store with no copy and asserts the mountpoint is placed, and `shadowed_credential_copy_is_emptied_only_in_a_store` covers emptying, the unfolded-shared-file case, and a link planted at the mountpoint.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Diagnosis and implementation done in discussion with @njbrake; reviewed by a separate fresh-context agent before leaving draft.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ba2L9wbbij5UVH27MFF2e6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Creates the credential mountpoint before each container creation or start.
- Replaces the old credential-copy removal flow with mountpoint preparation.
- Empties valid shadowed credential files instead of deleting them.
- Preserves existing files when credential folding fails.
- Replaces invalid links or directories with secure mountpoint files.
- Adds coverage for fresh stores, existing paths, failed folds, and mountpoint placement.

## Benefits

This prevents intermittent first-attempt failures when creating sandboxed Claude sessions. It also preserves shared credentials across sandboxes and makes retries unnecessary.

## Further enhancement

Consider testing the mount behavior across all supported container runtimes and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
