### PR TITLE
fix(web): hold the painted frame while a terminal selection is live

### DIFF
--- a/docs/guides/web/terminal.md
+++ b/docs/guides/web/terminal.md
@@ -19,7 +19,7 @@ The terminal uses tmux for scrollback and selection, so copy and scroll work wit
 - **Scroll** with the mouse wheel (or a one-finger swipe on touch) through tmux scrollback. Touch scrolling follows the finger like any native list: drag down to look back through history, drag up to head back toward the live tail.
 - **Select** by click-dragging across the text. Dragging upward past the top edge scrolls into scrollback and extends the selection. Releasing the drag copies to your system clipboard automatically; no Ctrl/Cmd+C needed.
 
-While a selection touches the terminal the pane stops repainting, so the agent cannot rewrite the text under it mid-gesture. The agent keeps running; the **Back to live** button appears for as long as the view is held, and clearing the selection (or clicking that button) catches it back up.
+While a selection touches the terminal the pane stops repainting, so the agent cannot rewrite the text under it mid-gesture. Dragging upward still reaches older scrollback: newly captured history loads in above the held rows. The agent keeps running; the **Back to live** button appears for as long as the view is held, and clearing the selection (or clicking that button) catches it back up. A full-screen mouse agent also gives up its grip on touch gestures while a selection is live, so the selection handles can be dragged.
 
 Mouse-enabled full-screen agents copy through OSC 52 instead: AoE forwards the agent's clipboard event through the live connection to the same browser clipboard path.
 

--- a/docs/guides/web/terminal.md
+++ b/docs/guides/web/terminal.md
@@ -19,6 +19,8 @@ The terminal uses tmux for scrollback and selection, so copy and scroll work wit
 - **Scroll** with the mouse wheel (or a one-finger swipe on touch) through tmux scrollback. Touch scrolling follows the finger like any native list: drag down to look back through history, drag up to head back toward the live tail.
 - **Select** by click-dragging across the text. Dragging upward past the top edge scrolls into scrollback and extends the selection. Releasing the drag copies to your system clipboard automatically; no Ctrl/Cmd+C needed.
 
+While a selection touches the terminal the pane stops repainting, so the agent cannot rewrite the text under it mid-gesture. The agent keeps running; the **Back to live** button appears for as long as the view is held, and clearing the selection (or clicking that button) catches it back up.
+
 Mouse-enabled full-screen agents copy through OSC 52 instead: AoE forwards the agent's clipboard event through the live connection to the same browser clipboard path.
 
 Copy relies on the browser Clipboard API, which only works in a secure context: HTTPS (the remote-access tunnel modes) or `http://localhost`. On a plain-HTTP LAN/VPN origin the browser blocks clipboard writes, so the selection stays visible but is not copied. Firefox is best-effort (it lacks the async clipboard write); Chromium and Safari copy reliably.

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -18,6 +18,7 @@ import type { LiveFrame, LiveStats } from "../hooks/useLiveTerminal";
 import { useWebSettings } from "../hooks/useWebSettings";
 import { useIsCoarsePointer } from "../hooks/useIsCoarsePointer";
 import { useTerminalGestureBoundary } from "../hooks/useTerminalGestureBoundary";
+import { useSelectionHold } from "../hooks/useSelectionHold";
 
 // Mobile rendering of a tmux agent pane, mirroring the TUI's live mode:
 // the server streams `capture-pane` snapshots (src/server/live_ws.rs)
@@ -591,7 +592,7 @@ export const Row = memo(function Row({
 });
 
 export function MobileLiveTerminal({
-  frame,
+  frame: streamFrame,
   liveStats,
   transport,
   armAgentClipboard,
@@ -644,6 +645,11 @@ export function MobileLiveTerminal({
     setFontSize(configuredFontSize);
   }
   const scrollerRef = useRef<HTMLDivElement>(null);
+  // A selection anywhere in the grid pins the painted frame until the user
+  // lets go, so no row is rewritten out from under the range. Everything
+  // below renders that held frame; only the stream acknowledgements read
+  // `streamFrame`.
+  const frame = useSelectionHold(streamFrame, scrollerRef);
   const measureRef = useRef<HTMLSpanElement>(null);
   const keyboardLayoutRef = useRef<KeyboardLayoutReader | null>(null);
   useEffect(() => {
@@ -1167,8 +1173,8 @@ export function MobileLiveTerminal({
   // is a transport event, not derived state, so an effect is the right hook.
   useEffect(() => {
     // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
-    if (frame) notchPacer.onFrame();
-  }, [frame, notchPacer]);
+    if (streamFrame) notchPacer.onFrame();
+  }, [streamFrame, notchPacer]);
 
   const onWheel = useCallback(
     (e: React.WheelEvent) => {
@@ -1605,8 +1611,8 @@ export function MobileLiveTerminal({
 
   const [frameTiming] = useState(() => new FrameTimingProbe());
   useLayoutEffect(() => {
-    if (LIVE_DEBUG && frame) frameTiming.record(performance.now(), frame.receivedAt);
-  }, [frame, frameTiming]);
+    if (LIVE_DEBUG && streamFrame) frameTiming.record(performance.now(), streamFrame.receivedAt);
+  }, [streamFrame, frameTiming]);
 
   // --- bottom pinning ---------------------------------------------------------
   useLayoutEffect(() => {

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -645,11 +645,11 @@ export function MobileLiveTerminal({
     setFontSize(configuredFontSize);
   }
   const scrollerRef = useRef<HTMLDivElement>(null);
-  // A selection anywhere in the grid pins the painted frame until the user
-  // lets go, so no row is rewritten out from under the range. Everything
-  // below renders that held frame; only the stream acknowledgements read
-  // `streamFrame`.
-  const frame = useSelectionHold(streamFrame, scrollerRef);
+  // A selection touching the grid pins the painted frame until the user lets
+  // go, so no row is rewritten out from under the range (see the hook).
+  // Everything below renders that held frame; only the stream
+  // acknowledgements read `streamFrame`.
+  const { value: frame, held: selectionHeld } = useSelectionHold(streamFrame, scrollerRef);
   const measureRef = useRef<HTMLSpanElement>(null);
   const keyboardLayoutRef = useRef<KeyboardLayoutReader | null>(null);
   useEffect(() => {
@@ -703,8 +703,8 @@ export function MobileLiveTerminal({
   }, [remeasure]);
 
   // --- frame geometry -------------------------------------------------------
-  // `frame` always tracks the live stream; reading scrollback just widens
-  // the capture window (the hook owns that). Nothing is frozen.
+  // `frame` tracks the live stream except while a selection holds it; reading
+  // scrollback just widens the capture window (the hook owns that).
   const rowsRef = useRef(0);
   const readingRef = useRef(reading);
   useEffect(() => {
@@ -1078,6 +1078,9 @@ export function MobileLiveTerminal({
     const el = scrollerRef.current;
     if (el) el.scrollTop = liveScrollTarget(el);
     liveDetachedRef.current = false;
+    // Dropping the selection is what releases a held frame; a selection the
+    // user has stopped caring about would otherwise pin the view silently.
+    document.getSelection()?.removeAllRanges();
     returnToLive(rowsRef.current * LIVE_WINDOW_SCREENS);
   }, [returnToLive, liveScrollTarget]);
 
@@ -2098,7 +2101,7 @@ export function MobileLiveTerminal({
         </div>
       )}
 
-      {reading && (
+      {(reading || selectionHeld) && (
         <button
           type="button"
           onClick={jumpToLatest}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -458,6 +458,15 @@ function specialKeySequence(e: TerminalKeyLike): string | null {
   }
 }
 
+/** A frame's rows as raw strings. `lines` is authoritative when present (a
+ *  patched frame never re-splits its window); `content` carries a
+ *  terminating newline that is not a row. */
+function frameLines(frame: LiveFrame): string[] {
+  if (frame.lines) return frame.lines;
+  const content = frame.content.endsWith("\n") ? frame.content.slice(0, -1) : frame.content;
+  return content.split("\n");
+}
+
 export const Row = memo(function Row({
   segs,
   cursorCol,
@@ -649,7 +658,27 @@ export function MobileLiveTerminal({
   // go, so no row is rewritten out from under the range (see the hook).
   // Everything below renders that held frame; only the stream
   // acknowledgements read `streamFrame`.
-  const { value: frame, held: selectionHeld } = useSelectionHold(streamFrame, scrollerRef);
+  const { value: heldFrame, held: selectionHeld } = useSelectionHold(streamFrame, scrollerRef);
+  // Dragging a selection upward past the top edge scrolls into scrollback,
+  // which asks the server for a wider capture window. Holding that response
+  // whole would extend the drag into the blank history spacer instead of the
+  // text it just requested, so newly captured lines ABOVE the held window are
+  // spliced in front of it. They are older scrollback: immutable, and no row
+  // already on screen changes. Keeping the held frame's `history` shrinks the
+  // spacer by exactly the spliced count, so every held row keeps its key
+  // (spacer + line) and its pixel position, and the selection with them.
+  const frame = useMemo(() => {
+    // Reading mode is the only thing that widens the window, and it is also
+    // what mounts every row: outside it the debounced row count lags a
+    // sudden jump in height and virtualization would unmount the selected
+    // row, which is the collapse this whole change exists to prevent.
+    if (!selectionHeld || !reading || !heldFrame || !streamFrame || heldFrame === streamFrame) return heldFrame;
+    const held = frameLines(heldFrame);
+    const next = frameLines(streamFrame);
+    const older = heldFrame.history - held.length - (streamFrame.history - next.length);
+    if (older <= 0) return heldFrame;
+    return { ...heldFrame, lines: next.slice(0, Math.min(older, next.length)).concat(held) };
+  }, [selectionHeld, reading, heldFrame, streamFrame]);
   const measureRef = useRef<HTMLSpanElement>(null);
   const keyboardLayoutRef = useRef<KeyboardLayoutReader | null>(null);
   useEffect(() => {
@@ -888,7 +917,19 @@ export function MobileLiveTerminal({
   const forwardMode = altScreen && (frame?.mouse ?? false);
   const mouseSgr = frame?.mouseSgr ?? false;
   const effectiveSpacerLines = forwardMode ? 0 : spacerLines;
-  const { forwardModeRef, mouseSgrRef } = useTerminalGestureBoundary({ scrollerRef, forwardMode, mouseSgr });
+  // Gesture forwarding, unlike the layout above, yields to a live selection.
+  // Forward mode owns every touch (touch-action: none plus a non-passive
+  // preventDefault) so a drag becomes wheel notches instead of a page pan;
+  // that is also what WebKit needs left alone to drag a selection's handles,
+  // so with it on the callout comes up and its handles will not move. The
+  // layout keeps using `forwardMode` on purpose: `effectiveSpacerLines` feeds
+  // the row keys, and flipping it mid-selection would remount every row.
+  const forwardGestures = forwardMode && !selectionHeld;
+  const { forwardModeRef, mouseSgrRef } = useTerminalGestureBoundary({
+    scrollerRef,
+    forwardMode: forwardGestures,
+    mouseSgr,
+  });
   // Sub-notch scroll remainder (px) carried across events, and the last
   // touch Y while forwarding a single-finger drag.
   const wheelAccumRef = useRef(0);
@@ -2019,7 +2060,7 @@ export function MobileLiveTerminal({
             // wheel scrolls the app, the double-scroll clunk. touch-action:
             // none stops the browser from starting any pan or zoom for
             // touches on the terminal; JS still receives every touch event.
-            touchAction: forwardMode ? "none" : undefined,
+            touchAction: forwardGestures ? "none" : undefined,
             // Do NOT set `-webkit-overflow-scrolling: touch` here. It promotes
             // this opaque scroll region to a composited layer that macOS/iOS
             // Safari rasterizes at 1x, making the DOM terminal text look

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -658,27 +658,33 @@ export function MobileLiveTerminal({
   // go, so no row is rewritten out from under the range (see the hook).
   // Everything below renders that held frame; only the stream
   // acknowledgements read `streamFrame`.
-  const { value: heldFrame, held: selectionHeld } = useSelectionHold(streamFrame, scrollerRef);
   // Dragging a selection upward past the top edge scrolls into scrollback,
   // which asks the server for a wider capture window. Holding that response
-  // whole would extend the drag into the blank history spacer instead of the
-  // text it just requested, so newly captured lines ABOVE the held window are
-  // spliced in front of it. They are older scrollback: immutable, and no row
-  // already on screen changes. Keeping the held frame's `history` shrinks the
-  // spacer by exactly the spliced count, so every held row keeps its key
-  // (spacer + line) and its pixel position, and the selection with them.
-  const frame = useMemo(() => {
-    // Reading mode is the only thing that widens the window, and it is also
-    // what mounts every row: outside it the debounced row count lags a
-    // sudden jump in height and virtualization would unmount the selected
-    // row, which is the collapse this whole change exists to prevent.
-    if (!selectionHeld || !reading || !heldFrame || !streamFrame || heldFrame === streamFrame) return heldFrame;
-    const held = frameLines(heldFrame);
-    const next = frameLines(streamFrame);
-    const older = heldFrame.history - held.length - (streamFrame.history - next.length);
-    if (older <= 0) return heldFrame;
-    return { ...heldFrame, lines: next.slice(0, Math.min(older, next.length)).concat(held) };
-  }, [selectionHeld, reading, heldFrame, streamFrame]);
+  // out would extend the drag into the blank history spacer instead of the
+  // text it just requested, so lines newly exposed ABOVE the held window are
+  // folded into the held frame. Folded in, not re-derived per frame: a capped
+  // VT scrollback evicts its oldest line on every append, which slides the
+  // exposed text under unchanged row keys, and re-deriving would rewrite the
+  // very rows the selection was extended onto. Keeping the held frame's
+  // `history` shrinks the spacer by exactly the folded count, so every row
+  // keeps its key and its pixel position; the fold settles because it leaves
+  // nothing older outstanding.
+  const absorbExposedHistory = useCallback(
+    (held: LiveFrame | null, next: LiveFrame | null) => {
+      // Reading mode is the only thing that widens the window, and the only
+      // state that mounts every row: outside it the debounced row count lags
+      // a sudden jump in height and virtualization would unmount the selected
+      // row, the collapse this whole change exists to prevent.
+      if (!reading || !held || !next) return null;
+      const heldLines = frameLines(held);
+      const nextLines = frameLines(next);
+      const older = held.history - heldLines.length - (next.history - nextLines.length);
+      if (older <= 0) return null;
+      return { ...held, lines: nextLines.slice(0, Math.min(older, nextLines.length)).concat(heldLines) };
+    },
+    [reading],
+  );
+  const { value: frame, held: selectionHeld } = useSelectionHold(streamFrame, scrollerRef, absorbExposedHistory);
   const measureRef = useRef<HTMLSpanElement>(null);
   const keyboardLayoutRef = useRef<KeyboardLayoutReader | null>(null);
   useEffect(() => {

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -679,8 +679,13 @@ export function MobileLiveTerminal({
       const heldLines = frameLines(held);
       const nextLines = frameLines(next);
       const older = held.history - heldLines.length - (next.history - nextLines.length);
-      if (older <= 0) return null;
-      return { ...held, lines: nextLines.slice(0, Math.min(older, nextLines.length)).concat(heldLines) };
+      // A frame too short to carry the whole exposed prefix would fold part of
+      // it and leave the rest outstanding, folding the same lines again on
+      // every following pass until React's re-render limit trips. The pane's
+      // scrollback collapsing mid-selection (a `clear`, or the window gaining
+      // a second pane, both of which report history 0) is what reaches this.
+      if (older <= 0 || older > nextLines.length) return null;
+      return { ...held, lines: nextLines.slice(0, older).concat(heldLines) };
     },
     [reading],
   );

--- a/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
@@ -64,13 +64,34 @@ function altFrame(n: number): LiveFrame {
   };
 }
 
-function terminal(f: LiveFrame) {
+// A normal-buffer pane whose capture window is far smaller than its history:
+// `captured` screen rows plus one line of scrollback at first, then the full
+// history once reading widens the window.
+function historyFrame(captured: number): LiveFrame {
+  const rows = 3;
+  const history = 10;
+  const lines = [];
+  for (let i = history - captured + 1; i <= history; i++) lines.push(`h${String(i).padStart(3, "0")}`);
+  lines.push("s1", "s2", "s3");
+  return {
+    content: lines.join("\n") + "\n",
+    lines,
+    rows,
+    history,
+    cursor: null,
+    altScreen: false,
+    mouse: false,
+    mouseSgr: false,
+  };
+}
+
+function terminal(f: LiveFrame, reading = false) {
   return (
     <MobileLiveTerminal
       frame={f}
       connected
       active
-      reading={false}
+      reading={reading}
       sendResize={vi.fn()}
       setWindow={vi.fn()}
       setCadence={vi.fn()}
@@ -159,4 +180,22 @@ it("offers the back-to-live control while a frame is held, and releasing catches
 
   expect(document.getSelection()?.isCollapsed ?? true).toBe(true);
   expect(container.querySelector("[data-live-content]")?.textContent).toContain("line 5");
+});
+
+it("lets uncaptured scrollback populate under a live selection", () => {
+  // Selecting at the live edge and dragging upward past the top scrolls into
+  // scrollback (enterReading widens the capture window). The hold must not
+  // swallow that wider frame, or the drag extends into the blank spacer
+  // instead of the older text it just asked for.
+  const { container, rerender } = mount(historyFrame(1));
+  const selection = selectRowText("s2");
+
+  // Scrolling up flips the pane into reading mode first; the wider capture
+  // window lands a frame later.
+  rerender(terminal(historyFrame(1), true));
+  rerender(terminal(historyFrame(10), true));
+
+  const text = container.querySelector("[data-live-content]")?.textContent ?? "";
+  expect(text).toContain("h001");
+  expect(selection.toString()).toBe("s2");
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
@@ -104,6 +104,37 @@ function evictedFrame(): LiveFrame {
   };
 }
 
+/** A pane whose scrollback is far deeper than the live capture window, and
+ *  the same pane after that scrollback goes away: tmux reports history 0 for
+ *  a `clear` (ED3) and for a window that has gained a second pane. */
+function deepFrame(): LiveFrame {
+  const lines = ["h1999", "h2000", "s1", "s2", "s3"];
+  return {
+    content: lines.join("\n") + "\n",
+    lines,
+    rows: 3,
+    history: 2000,
+    cursor: null,
+    altScreen: false,
+    mouse: false,
+    mouseSgr: false,
+  };
+}
+
+function clearedFrame(): LiveFrame {
+  const lines = ["s1", "s2", "s3"];
+  return {
+    content: lines.join("\n") + "\n",
+    lines,
+    rows: 3,
+    history: 0,
+    cursor: null,
+    altScreen: false,
+    mouse: false,
+    mouseSgr: false,
+  };
+}
+
 function terminal(f: LiveFrame, reading = false) {
   return (
     <MobileLiveTerminal
@@ -236,4 +267,17 @@ it("holds newly exposed history once the selection can reach it", () => {
 
   expect(selection.toString()).toBe("h005");
   expect(container.querySelector("[data-live-content]")?.textContent).toContain("h001");
+});
+
+it("holds through the pane's scrollback collapsing mid-selection", () => {
+  // A selection taken at the live edge holds a window far shallower than the
+  // history, so the fold is waiting on a prefix that a cleared pane can never
+  // send. Folding what did arrive would leave the rest outstanding and repeat
+  // every pass, past React's re-render limit.
+  const { rerender } = mount(deepFrame());
+  const selection = selectRowText("s2");
+  rerender(terminal(deepFrame(), true));
+  rerender(terminal(clearedFrame(), true));
+
+  expect(selection.toString()).toBe("s2");
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
@@ -85,6 +85,25 @@ function historyFrame(captured: number): LiveFrame {
   };
 }
 
+/** The same pane once the VT scrollback is FULL: appending a line evicts the
+ *  oldest, so the reported history depth and the captured length both stay
+ *  put while every line shifts up one. */
+function evictedFrame(): LiveFrame {
+  const lines = [];
+  for (let i = 2; i <= 10; i++) lines.push(`h${String(i).padStart(3, "0")}`);
+  lines.push("s1", "s2", "s3", "s4");
+  return {
+    content: lines.join("\n") + "\n",
+    lines,
+    rows: 3,
+    history: 10,
+    cursor: null,
+    altScreen: false,
+    mouse: false,
+    mouseSgr: false,
+  };
+}
+
 function terminal(f: LiveFrame, reading = false) {
   return (
     <MobileLiveTerminal
@@ -198,4 +217,23 @@ it("lets uncaptured scrollback populate under a live selection", () => {
   const text = container.querySelector("[data-live-content]")?.textContent ?? "";
   expect(text).toContain("h001");
   expect(selection.toString()).toBe("s2");
+});
+
+it("holds newly exposed history once the selection can reach it", () => {
+  // Once the VT scrollback is capped and full, a new output line evicts the
+  // oldest: history depth and capture length are unchanged, so the exposed
+  // prefix keeps its row keys while its text shifts by a line. Re-deriving
+  // that prefix per frame would rewrite it under a selection extended into
+  // it, which is the collapse the hold exists to prevent.
+  const { container, rerender } = mount(historyFrame(1));
+  selectRowText("s2");
+  rerender(terminal(historyFrame(1), true));
+  rerender(terminal(historyFrame(10), true));
+
+  // Extend into the history the scroll just exposed.
+  const selection = selectRowText("h005");
+  rerender(terminal(evictedFrame(), true));
+
+  expect(selection.toString()).toBe("h005");
+  expect(container.querySelector("[data-live-content]")?.textContent).toContain("h001");
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+//
+// A repainting agent rewrites a mounted row's text node in place, and the
+// DOM collapses any range whose endpoints sit inside it. Keeping the row
+// nodes mounted (#3830) does not help; the paint has to stop for the length
+// of the gesture. A full-screen agent repaints every row of every frame, so
+// without the hold a selection there never survives long enough to copy.
+
+import { createRef } from "react";
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+import type { LiveFrame } from "../../hooks/useLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
+}));
+
+const WIDTH = 240;
+let roCallbacks: Array<() => void> = [];
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    private cb: () => void;
+    constructor(cb: () => void) {
+      this.cb = cb;
+    }
+    observe() {
+      roCallbacks.push(this.cb);
+    }
+    unobserve() {}
+    disconnect() {
+      roCallbacks = roCallbacks.filter((c) => c !== this.cb);
+    }
+  } as unknown as typeof ResizeObserver;
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", { configurable: true, get: () => WIDTH });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get: () => 600 });
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  roCallbacks = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.getSelection()?.removeAllRanges();
+});
+
+// A full-screen agent: no scrollback, and the transcript slides up through a
+// fixed grid, so every screen row holds new text on the next frame.
+function altFrame(n: number): LiveFrame {
+  const lines = [`line ${n}`, `line ${n + 1}`, `line ${n + 2}`, "", "> prompt"];
+  return {
+    content: lines.join("\n") + "\n",
+    lines,
+    rows: 5,
+    history: 0,
+    cursor: null,
+    altScreen: true,
+    mouse: false,
+    mouseSgr: false,
+  };
+}
+
+function terminal(f: LiveFrame) {
+  return (
+    <MobileLiveTerminal
+      frame={f}
+      connected
+      active
+      reading={false}
+      sendResize={vi.fn()}
+      setWindow={vi.fn()}
+      setCadence={vi.fn()}
+      enterReading={vi.fn()}
+      returnToLive={vi.fn()}
+      sendData={vi.fn()}
+      typedWordRef={{ current: "" }}
+      uploadPastedImage={vi.fn()}
+      forwardWheel={vi.fn()}
+      forwardButton={vi.fn()}
+      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+      clearCtrl={vi.fn()}
+      inputRef={createRef<HTMLTextAreaElement>()}
+      onInputFocusChange={vi.fn()}
+      bottomAlign
+      keyboardOpen={false}
+    />
+  );
+}
+
+/** Select a row's whole text with both endpoints INSIDE its text node, the
+ *  way a long-press word selection anchors. Selecting the node's contents
+ *  from the row element instead would leave the range endpoints outside the
+ *  rewritten data and survive a repaint that a real gesture does not. */
+function selectRowText(text: string) {
+  const row = screen.getByText(text);
+  const node = row.firstChild as Text;
+  const range = document.createRange();
+  range.setStart(node, 0);
+  range.setEnd(node, node.data.length);
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}
+
+function mount(f: LiveFrame) {
+  const result = render(terminal(f));
+  act(() => {
+    for (const cb of roCallbacks) cb();
+    vi.advanceTimersByTime(200);
+  });
+  return result;
+}
+
+it("holds the painted frame while a selection is live, then catches up", () => {
+  const { container, rerender } = mount(altFrame(1));
+  const selection = selectRowText("line 2");
+
+  rerender(terminal(altFrame(2)));
+
+  expect(selection.toString()).toBe("line 2");
+  expect(container.querySelector("[data-live-content]")?.textContent).toContain("line 1");
+
+  selection.removeAllRanges();
+  rerender(terminal(altFrame(3)));
+
+  expect(container.querySelector("[data-live-content]")?.textContent).toContain("line 5");
+});
+
+it("keeps painting when the selection is outside the terminal", () => {
+  const outside = document.createElement("p");
+  outside.textContent = "elsewhere";
+  document.body.append(outside);
+  const { container, rerender } = mount(altFrame(1));
+  const range = document.createRange();
+  range.setStart(outside.firstChild!, 0);
+  range.setEnd(outside.firstChild!, 9);
+  document.getSelection()!.addRange(range);
+
+  rerender(terminal(altFrame(2)));
+
+  expect(container.querySelector("[data-live-content]")?.textContent).toContain("line 4");
+  outside.remove();
+});

--- a/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx
@@ -1,10 +1,7 @@
 // @vitest-environment jsdom
 //
-// A repainting agent rewrites a mounted row's text node in place, and the
-// DOM collapses any range whose endpoints sit inside it. Keeping the row
-// nodes mounted (#3830) does not help; the paint has to stop for the length
-// of the gesture. A full-screen agent repaints every row of every frame, so
-// without the hold a selection there never survives long enough to copy.
+// Select-to-copy over a full-screen agent, which repaints every row of every
+// frame. See useSelectionHold for why the paint has to stop.
 
 import { createRef } from "react";
 import { afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest";
@@ -45,7 +42,11 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   document.getSelection()?.removeAllRanges();
+  outside?.remove();
+  outside = null;
 });
+
+let outside: HTMLElement | null = null;
 
 // A full-screen agent: no scrollback, and the transcript slides up through a
 // fixed grid, so every screen row holds new text on the next frame.
@@ -131,7 +132,7 @@ it("holds the painted frame while a selection is live, then catches up", () => {
 });
 
 it("keeps painting when the selection is outside the terminal", () => {
-  const outside = document.createElement("p");
+  outside = document.createElement("p");
   outside.textContent = "elsewhere";
   document.body.append(outside);
   const { container, rerender } = mount(altFrame(1));
@@ -143,5 +144,19 @@ it("keeps painting when the selection is outside the terminal", () => {
   rerender(terminal(altFrame(2)));
 
   expect(container.querySelector("[data-live-content]")?.textContent).toContain("line 4");
-  outside.remove();
+});
+
+it("offers the back-to-live control while a frame is held, and releasing catches up", () => {
+  const { container, rerender } = mount(altFrame(1));
+  expect(screen.queryByLabelText("Back to live")).toBeNull();
+
+  selectRowText("line 2");
+  rerender(terminal(altFrame(2)));
+  const backToLive = screen.getByLabelText("Back to live");
+
+  act(() => backToLive.click());
+  rerender(terminal(altFrame(3)));
+
+  expect(document.getSelection()?.isCollapsed ?? true).toBe(true);
+  expect(container.querySelector("[data-live-content]")?.textContent).toContain("line 5");
 });

--- a/web/src/hooks/useSelectionHold.ts
+++ b/web/src/hooks/useSelectionHold.ts
@@ -1,50 +1,59 @@
-import { useCallback, useState, useSyncExternalStore } from "react";
+import { useCallback, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 import type { RefObject } from "react";
 
 /** Holds the rendered value still while the user holds a text selection
- *  inside `containerRef`, returning the value that was on screen when the
- *  selection began.
+ *  touching `containerRef`, returning the value that was on screen when the
+ *  selection began and whether the hold is in effect.
  *
- *  React updates a row whose text changed by rewriting its existing text
+ *  React updates an element whose text changed by rewriting its existing text
  *  node in place, and the DOM's replace-data steps collapse any range whose
- *  endpoints sit inside that node. Keeping row nodes mounted (#3830) is
- *  therefore not enough: an agent that repaints the row under the finger
- *  still destroys the selection, and on iOS that dismisses the Copy callout
- *  mid-gesture. A full-screen agent repaints every row of every frame, so
- *  there a selection never survives long enough to copy.
- *
- *  Freezing the paint for the length of the gesture is the terminal
- *  convention (tmux copy-mode does the same). The stream itself is
- *  untouched: the agent keeps running and the view catches up on release.
+ *  endpoints sit inside that node. Node identity never enters into it, so
+ *  keeping nodes mounted across a frame (#3830) is not enough on its own:
+ *  repainting the text under the finger destroys the selection, and on iOS
+ *  that dismisses the Copy callout mid-gesture. Freezing the paint for the
+ *  length of the gesture is the terminal convention, tmux copy-mode included.
  */
-export function useSelectionHold<T>(value: T, containerRef: RefObject<HTMLElement | null>): T {
+export function useSelectionHold<T>(
+  value: T,
+  containerRef: RefObject<HTMLElement | null>,
+): { value: T; held: boolean } {
   const subscribe = useCallback((onChange: () => void) => {
     document.addEventListener("selectionchange", onChange);
     return () => document.removeEventListener("selectionchange", onChange);
   }, []);
   // Read through useSyncExternalStore rather than from a selectionchange
-  // handler so the answer is re-derived during the render an arriving frame
+  // handler so the answer is re-derived during the render an arriving value
   // triggers. A handler's state update could still be queued at that point,
-  // and the frame would repaint over a selection made moments earlier.
+  // and that render would repaint over a selection made moments earlier.
+  // Either endpoint inside the container counts, so a drag that ends outside
+  // it is held too.
   const getSnapshot = useCallback(() => {
     const container = containerRef.current;
     const selection = document.getSelection();
     if (!container || !selection || selection.isCollapsed || selection.rangeCount === 0) return false;
-    return container.contains(selection.anchorNode) && container.contains(selection.focusNode);
+    return container.contains(selection.anchorNode) || container.contains(selection.focusNode);
   }, [containerRef]);
   const selecting = useSyncExternalStore(subscribe, getSnapshot, () => false);
 
-  // Adjust-state-during-render, as elsewhere in this tree. `painted` trails
-  // the last value rendered without a selection, so it is the frame the user
-  // selected against even when the selection and a new frame land together.
-  // The wrapper object distinguishes holding a null frame from not holding.
-  const [painted, setPainted] = useState(value);
+  // The last committed value. Trails `shown`, so at the render that first
+  // sees a selection it is the value the user selected against, even when
+  // the selection and a new value land in the same render.
+  const painted = useRef(value);
   const [held, setHeld] = useState<{ value: T } | null>(null);
   if (selecting) {
-    if (held === null) setHeld({ value: painted });
-  } else {
-    if (held !== null) setHeld(null);
-    if (painted !== value) setPainted(value);
+    // Adjust-state-during-render, as elsewhere in this tree. Reading the ref
+    // here is safe and deliberate: it is written only in the layout effect
+    // below, so it holds the same committed value for every pass of a render.
+    // Mirroring it in state instead costs a second render pass per streamed
+    // value, on the path this component is built to keep cheap.
+    // eslint-disable-next-line react-hooks/refs
+    if (held === null) setHeld({ value: painted.current });
+  } else if (held !== null) {
+    setHeld(null);
   }
-  return selecting && held ? held.value : value;
+  const shown = selecting && held ? held.value : value;
+  useLayoutEffect(() => {
+    painted.current = shown;
+  });
+  return { value: shown, held: selecting && held !== null };
 }

--- a/web/src/hooks/useSelectionHold.ts
+++ b/web/src/hooks/useSelectionHold.ts
@@ -16,6 +16,11 @@ import type { RefObject } from "react";
 export function useSelectionHold<T>(
   value: T,
   containerRef: RefObject<HTMLElement | null>,
+  /** Fold context that only became reachable after the hold began into the
+   *  held value, so it is frozen from then on like everything else behind the
+   *  hold. Must return null once there is nothing left to fold: each fold
+   *  re-renders, and a callback that always returns a value will not settle. */
+  absorb?: (held: T, next: T) => T | null,
 ): { value: T; held: boolean } {
   const subscribe = useCallback((onChange: () => void) => {
     document.addEventListener("selectionchange", onChange);
@@ -48,6 +53,10 @@ export function useSelectionHold<T>(
     // value, on the path this component is built to keep cheap.
     // eslint-disable-next-line react-hooks/refs
     if (held === null) setHeld({ value: painted.current });
+    else {
+      const absorbed = absorb?.(held.value, value) ?? null;
+      if (absorbed !== null) setHeld({ value: absorbed });
+    }
   } else if (held !== null) {
     setHeld(null);
   }

--- a/web/src/hooks/useSelectionHold.ts
+++ b/web/src/hooks/useSelectionHold.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState, useSyncExternalStore } from "react";
+import type { RefObject } from "react";
+
+/** Holds the rendered value still while the user holds a text selection
+ *  inside `containerRef`, returning the value that was on screen when the
+ *  selection began.
+ *
+ *  React updates a row whose text changed by rewriting its existing text
+ *  node in place, and the DOM's replace-data steps collapse any range whose
+ *  endpoints sit inside that node. Keeping row nodes mounted (#3830) is
+ *  therefore not enough: an agent that repaints the row under the finger
+ *  still destroys the selection, and on iOS that dismisses the Copy callout
+ *  mid-gesture. A full-screen agent repaints every row of every frame, so
+ *  there a selection never survives long enough to copy.
+ *
+ *  Freezing the paint for the length of the gesture is the terminal
+ *  convention (tmux copy-mode does the same). The stream itself is
+ *  untouched: the agent keeps running and the view catches up on release.
+ */
+export function useSelectionHold<T>(value: T, containerRef: RefObject<HTMLElement | null>): T {
+  const subscribe = useCallback((onChange: () => void) => {
+    document.addEventListener("selectionchange", onChange);
+    return () => document.removeEventListener("selectionchange", onChange);
+  }, []);
+  // Read through useSyncExternalStore rather than from a selectionchange
+  // handler so the answer is re-derived during the render an arriving frame
+  // triggers. A handler's state update could still be queued at that point,
+  // and the frame would repaint over a selection made moments earlier.
+  const getSnapshot = useCallback(() => {
+    const container = containerRef.current;
+    const selection = document.getSelection();
+    if (!container || !selection || selection.isCollapsed || selection.rangeCount === 0) return false;
+    return container.contains(selection.anchorNode) && container.contains(selection.focusNode);
+  }, [containerRef]);
+  const selecting = useSyncExternalStore(subscribe, getSnapshot, () => false);
+
+  // Adjust-state-during-render, as elsewhere in this tree. `painted` trails
+  // the last value rendered without a selection, so it is the frame the user
+  // selected against even when the selection and a new frame land together.
+  // The wrapper object distinguishes holding a null frame from not holding.
+  const [painted, setPainted] = useState(value);
+  const [held, setHeld] = useState<{ value: T } | null>(null);
+  if (selecting) {
+    if (held === null) setHeld({ value: painted });
+  } else {
+    if (held !== null) setHeld(null);
+    if (painted !== value) setPainted(value);
+  }
+  return selecting && held ? held.value : value;
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -234,7 +234,11 @@
         "src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx",
         "tests/live-selection-hold.spec.ts"
       ],
-      "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/hooks/useSelectionHold.ts"]
+      "components": [
+        "web/src/components/MobileLiveTerminal.tsx",
+        "web/src/hooks/useSelectionHold.ts",
+        "web/src/hooks/useTerminalGestureBoundary.ts"
+      ]
     },
     {
       "id": "terminal.mobile-ime-word-commit",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -227,6 +227,16 @@
       ]
     },
     {
+      "id": "terminal.selection-hold",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "src/components/__tests__/MobileLiveTerminal.selectionHold.test.tsx",
+        "tests/live-selection-hold.spec.ts"
+      ],
+      "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/hooks/useSelectionHold.ts"]
+    },
+    {
       "id": "terminal.mobile-ime-word-commit",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live-selection-hold.spec.ts
+++ b/web/tests/live-selection-hold.spec.ts
@@ -30,7 +30,7 @@ function altFrame(n: number) {
 const content = (page: Page) => page.locator("[data-live-content]");
 const selection = (page: Page) => page.evaluate(() => window.getSelection()?.toString() ?? "");
 
-test("a selection over a full-screen agent survives its repaints", async ({ page }) => {
+async function setup(page: Page) {
   await installTerminalSpies(page);
   const handle = await mockTerminalApis(page);
   await page.goto("/");
@@ -40,17 +40,19 @@ test("a selection over a full-screen agent survives its repaints", async ({ page
   await clickSidebarSession(page, "pinch-test");
   await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
   await expect.poll(() => handle.liveMessages.length, { timeout: 5_000 }).toBeGreaterThan(0);
+  // Let the client's opening window/cadence messages settle: the mock answers
+  // each one with a default (normal-screen) frame, which would clobber the
+  // alt-screen frames these tests push.
+  await page.waitForTimeout(400);
+  return handle;
+}
 
-  handle.pushLiveFrame(altFrame(1));
-  await expect.poll(() => content(page).textContent()).toContain("line 1");
-
-  // Both endpoints inside the row's text node, the way a long-press word
-  // selection anchors. Anchoring on the row element instead would put them
-  // outside the rewritten data and survive a repaint a real gesture cannot.
-  await page.evaluate(() => {
-    const row = Array.from(document.querySelectorAll("[data-live-content] > div")).find(
-      (r) => r.textContent === "line 2",
-    );
+// Both endpoints inside the row's text node, the way a long-press word
+// selection anchors. Anchoring on the row element instead would put them
+// outside the rewritten data and survive a repaint a real gesture cannot.
+async function selectRow(page: Page, text: string) {
+  await page.evaluate((t) => {
+    const row = Array.from(document.querySelectorAll("[data-live-content] > div")).find((r) => r.textContent === t);
     if (!row) throw new Error("row not rendered");
     const node = document.createTreeWalker(row, NodeFilter.SHOW_TEXT).nextNode() as Text;
     const range = document.createRange();
@@ -59,7 +61,16 @@ test("a selection over a full-screen agent survives its repaints", async ({ page
     const sel = window.getSelection()!;
     sel.removeAllRanges();
     sel.addRange(range);
-  });
+  }, text);
+}
+
+test("a selection over a full-screen agent survives its repaints", async ({ page }) => {
+  const handle = await setup(page);
+
+  handle.pushLiveFrame(altFrame(1));
+  await expect.poll(() => content(page).textContent()).toContain("line 1");
+
+  await selectRow(page, "line 2");
   expect(await selection(page)).toBe("line 2");
 
   handle.pushLiveFrame(altFrame(2));
@@ -72,4 +83,33 @@ test("a selection over a full-screen agent survives its repaints", async ({ page
   await page.evaluate(() => window.getSelection()?.removeAllRanges());
   handle.pushLiveFrame(altFrame(4));
   await expect.poll(() => content(page).textContent()).toContain("line 6");
+});
+
+// A full-screen MOUSE app additionally owns every touch, so the drag that
+// adjusts a selection's handles never reaches WebKit: the callout comes up
+// and its handles will not move (reported on iOS 26 Safari and the PWA).
+// Forwarding yields while a selection is live; the layout does not, so the
+// row keys are untouched and the hold above still stands.
+test("a live selection releases the full-screen app's grip on touch gestures", async ({ page }) => {
+  const handle = await setup(page);
+  handle.pushLiveFrame({ ...altFrame(1), mouse: true, mouseSgr: true });
+  await expect.poll(() => content(page).textContent()).toContain("line 1");
+
+  const scroller = page.locator("[data-live-terminal] > div").first();
+  const touchMoveCancelled = () =>
+    scroller.evaluate((el) => !el.dispatchEvent(new Event("touchmove", { cancelable: true })));
+  const touchAction = () => scroller.evaluate((el) => getComputedStyle(el).touchAction);
+
+  await expect.poll(touchAction).toBe("none");
+  await expect.poll(touchMoveCancelled).toBe(true);
+
+  await selectRow(page, "line 2");
+
+  await expect.poll(touchAction).not.toBe("none");
+  await expect.poll(touchMoveCancelled).toBe(false);
+
+  // Dropping it hands the app its gestures back.
+  await page.evaluate(() => window.getSelection()?.removeAllRanges());
+  await expect.poll(touchAction).toBe("none");
+  await expect.poll(touchMoveCancelled).toBe(true);
 });

--- a/web/tests/live-selection-hold.spec.ts
+++ b/web/tests/live-selection-hold.spec.ts
@@ -1,13 +1,15 @@
 import { test, expect } from "./helpers/mockedTest";
 import { devices, type Page } from "@playwright/test";
 import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
-import { mockTerminalApis, installTerminalSpies, seedSettings, type MockHandle } from "./helpers/terminal-mocks";
+import { mockTerminalApis, installTerminalSpies, seedSettings } from "./helpers/terminal-mocks";
 
-// Select-to-copy over a full-screen agent. jsdom covers the hold itself
-// (MobileLiveTerminal.selectionHold.test.tsx); this is the real engine
-// agreeing that a range anchored inside a row's text node survives the
-// frames that land during the gesture. On iOS a collapsed range takes the
-// Copy callout down with it, so the selection surviving IS the feature.
+// Select-to-copy over a full-screen agent, driven end to end: a real
+// Selection over the production bundle, fed by frames off the live-ws route.
+// jsdom covers the hold's logic (MobileLiveTerminal.selectionHold.test.tsx)
+// and models the range collapse faithfully, so this is not the cheapest test
+// that catches the bug; it is here because the bug is Selection semantics and
+// jsdom only simulates those. The mocked suite is Chromium, so it says
+// nothing about the WebKit callout this ultimately exists for.
 test.use({ ...devices["iPhone 13"] });
 
 // A full-screen agent: no scrollback, and the transcript slides up through
@@ -39,7 +41,7 @@ test("a selection over a full-screen agent survives its repaints", async ({ page
   await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
   await expect.poll(() => handle.liveMessages.length, { timeout: 5_000 }).toBeGreaterThan(0);
 
-  handle.pushLiveFrame(altFrame(1) as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  handle.pushLiveFrame(altFrame(1));
   await expect.poll(() => content(page).textContent()).toContain("line 1");
 
   // Both endpoints inside the row's text node, the way a long-press word
@@ -60,14 +62,14 @@ test("a selection over a full-screen agent survives its repaints", async ({ page
   });
   expect(await selection(page)).toBe("line 2");
 
-  handle.pushLiveFrame(altFrame(2) as Parameters<MockHandle["pushLiveFrame"]>[0]);
-  handle.pushLiveFrame(altFrame(3) as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  handle.pushLiveFrame(altFrame(2));
+  handle.pushLiveFrame(altFrame(3));
   await page.waitForTimeout(300);
   expect(await selection(page)).toBe("line 2");
   await expect(content(page)).toContainText("line 1");
 
   // Letting go releases the hold and the view catches up to the live edge.
   await page.evaluate(() => window.getSelection()?.removeAllRanges());
-  handle.pushLiveFrame(altFrame(4) as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  handle.pushLiveFrame(altFrame(4));
   await expect.poll(() => content(page).textContent()).toContain("line 6");
 });

--- a/web/tests/live-selection-hold.spec.ts
+++ b/web/tests/live-selection-hold.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+import { mockTerminalApis, installTerminalSpies, seedSettings, type MockHandle } from "./helpers/terminal-mocks";
+
+// Select-to-copy over a full-screen agent. jsdom covers the hold itself
+// (MobileLiveTerminal.selectionHold.test.tsx); this is the real engine
+// agreeing that a range anchored inside a row's text node survives the
+// frames that land during the gesture. On iOS a collapsed range takes the
+// Copy callout down with it, so the selection surviving IS the feature.
+test.use({ ...devices["iPhone 13"] });
+
+// A full-screen agent: no scrollback, and the transcript slides up through
+// a fixed grid, so every screen row holds new text on the next frame.
+function altFrame(n: number) {
+  const lines = [`line ${n}`, `line ${n + 1}`, `line ${n + 2}`, "", "> prompt"];
+  return {
+    content: lines.join("\n") + "\n",
+    rows: 5,
+    history: 0,
+    cursor: null,
+    altScreen: true,
+    mouse: false,
+    mouseSgr: false,
+  };
+}
+
+const content = (page: Page) => page.locator("[data-live-content]");
+const selection = (page: Page) => page.evaluate(() => window.getSelection()?.toString() ?? "");
+
+test("a selection over a full-screen agent survives its repaints", async ({ page }) => {
+  await installTerminalSpies(page);
+  const handle = await mockTerminalApis(page);
+  await page.goto("/");
+  await seedSettings(page, { mobileFontSize: 14 });
+  await page.reload();
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, "pinch-test");
+  await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
+  await expect.poll(() => handle.liveMessages.length, { timeout: 5_000 }).toBeGreaterThan(0);
+
+  handle.pushLiveFrame(altFrame(1) as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  await expect.poll(() => content(page).textContent()).toContain("line 1");
+
+  // Both endpoints inside the row's text node, the way a long-press word
+  // selection anchors. Anchoring on the row element instead would put them
+  // outside the rewritten data and survive a repaint a real gesture cannot.
+  await page.evaluate(() => {
+    const row = Array.from(document.querySelectorAll("[data-live-content] > div")).find(
+      (r) => r.textContent === "line 2",
+    );
+    if (!row) throw new Error("row not rendered");
+    const node = document.createTreeWalker(row, NodeFilter.SHOW_TEXT).nextNode() as Text;
+    const range = document.createRange();
+    range.setStart(node, 0);
+    range.setEnd(node, node.data.length);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+  expect(await selection(page)).toBe("line 2");
+
+  handle.pushLiveFrame(altFrame(2) as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  handle.pushLiveFrame(altFrame(3) as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  await page.waitForTimeout(300);
+  expect(await selection(page)).toBe("line 2");
+  await expect(content(page)).toContainText("line 1");
+
+  // Letting go releases the hold and the view catches up to the live edge.
+  await page.evaluate(() => window.getSelection()?.removeAllRanges());
+  handle.pushLiveFrame(altFrame(4) as Parameters<MockHandle["pushLiveFrame"]>[0]);
+  await expect.poll(() => content(page).textContent()).toContain("line 6");
+});


### PR DESCRIPTION
## Description

Follow-up to #3830, which fixed row identity but not row content.

React rewrites a changed row's existing text node in place, and the DOM's replace-data steps collapse any range whose endpoints sit inside it. Node identity never enters into it, so keeping rows mounted was necessary but not sufficient. A full-screen agent repaints every row of every frame, so a selection there never survived long enough to copy. `altScreen` is not the load-bearing condition, though: a spinner on the selected row collapses a normal-buffer selection the same way. The fix keys off the selection, not the mode, and needs nothing new on the wire.

A selection touching the grid now pins the painted frame until the user lets go, the tmux copy-mode convention. Newly captured scrollback still loads in above the held rows, so dragging upward past the top edge reaches older text rather than the blank spacer. A full-screen mouse app also gives up its grip on touch gestures while a selection is live: its `touch-action: none` and non-passive `preventDefault` are what WebKit needs left alone to drag the selection handles, so with them on the callout came up and its handles would not move. A held pane surfaces the existing **Back to live** control rather than looking hung.

Confirmed working on iOS Safari and the PWA against a build of this branch.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No visual change to capture: the rendered difference is that the grid stops repainting while a selection is held. The tests below assert that directly; the iOS callout it exists for is a device check, done.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

`MobileLiveTerminal.selectionHold.test.tsx` is the regression test: jsdom models the replace-data collapse faithfully, so it goes red on this bug, and it also covers the release, the back-to-live control, a selection outside the terminal, and scrollback populating under a live selection. `live-selection-hold.spec.ts` drives the story over the production bundle with a real Selection, and asserts the gesture release that jsdom cannot see. Every case was confirmed red without its fix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Diagnosed from a live report. The reproduction, the minimisation that ruled out `altScreen` as the cause, and every regression test were driven from a browser loop before any fix was written.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tj5Khfu9ux54CTxc7uXdKE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Keeps selected terminal text stable while live output continues.
- Adds a **Back to live** control and restores live updates when the selection ends.
- Loads new scrollback without moving or changing selected rows.
- Preserves native touch selection gestures during active selections.
- Prevents incomplete scrollback updates from duplicating rows or breaking rendering.
- Adds component and Chromium regression tests, plus documentation and coverage updates.

This prevents selected terminal text from changing or disappearing during live output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->