### PR TITLE
test: repair four tmux/xtask tests that could not fail, and make ENV_LOCK the PATH exclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check skill file references valid CLI commands
         run: cargo xtask check-skill
+      # The workspace declares no `default-members`, so every other `cargo
+      # test` in these workflows is scoped to the root package and xtask's own
+      # tests ran nowhere (#3479). This job already builds xtask.
+      - name: Cargo test (xtask)
+        run: cargo test -p xtask
 
   build-cache-selftest:
     name: Build Cache Self-Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,10 @@ jobs:
       - name: Check skill file references valid CLI commands
         run: cargo xtask check-skill
       # The workspace declares no `default-members`, so every other `cargo
-      # test` in these workflows is scoped to the root package and xtask's own
-      # tests ran nowhere (#3479). This job already builds xtask.
-      - name: Cargo test (xtask)
-        run: cargo test -p xtask
+      # test` in these workflows is scoped to the root package and these two
+      # members' tests ran nowhere (#3479). This job already builds xtask.
+      - name: Cargo test (non-default workspace members)
+        run: cargo test -p xtask -p aoe-plugin-api
 
   build-cache-selftest:
     name: Build Cache Self-Test

--- a/src/acp/acp_client/resolve_command.rs
+++ b/src/acp/acp_client/resolve_command.rs
@@ -267,9 +267,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn resolve_agent_command_falls_back_to_bundled_when_not_on_path() {
-        // Tagged `#[serial]` and PATH-scrubbed because the adapter names are
-        // real: a dev machine with a global `claude-agent-acp` would
-        // (correctly) resolve that copy instead of the bundled one.
+        // PATH-scrubbed because the adapter names are real: a dev machine
+        // with a global `claude-agent-acp` would (correctly) resolve that
+        // copy instead of the bundled one.
         let app = tempfile::TempDir::new().unwrap();
         let name = "claude-agent-acp";
         let bin_dir = app
@@ -280,20 +280,9 @@ mod tests {
         std::fs::write(&bin, "#!/usr/bin/env node\n").unwrap();
 
         let empty = tempfile::TempDir::new().unwrap();
-        let prev = std::env::var_os("PATH");
-        // SAFETY: mutates the process-wide PATH; `#[serial]` keeps other
-        // PATH readers out of the way.
-        unsafe {
-            std::env::set_var("PATH", empty.path());
-        }
-        let resolved = resolve_agent_command(name, Some(app.path()));
-        if let Some(prev) = prev {
-            unsafe {
-                std::env::set_var("PATH", prev);
-            }
-        }
-
-        let resolved = resolved.expect("should resolve from the bundled adapter dir");
+        let _path = crate::session::test_support::EnvGuard::set(&[("PATH", empty.path())]);
+        let resolved = resolve_agent_command(name, Some(app.path()))
+            .expect("should resolve from the bundled adapter dir");
         assert_eq!(resolved.path, bin);
         assert_eq!(resolved.prepend_paths.first(), Some(&bin_dir));
     }
@@ -349,9 +338,6 @@ mod tests {
     #[serial_test::serial]
     fn resolve_agent_command_finds_binary_in_path_env() {
         // Build a temp dir with a fake binary, point PATH at it.
-        // Tagged `#[serial]` because the test mutates the process-wide
-        // PATH; any concurrent test that reads PATH (e.g. resolves a
-        // real binary) would race.
         let dir = tempfile::TempDir::new().unwrap();
         let bin = dir.path().join("aoe-test-resolver-fake");
         std::fs::write(&bin, "#!/bin/sh\n").unwrap();
@@ -360,27 +346,9 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
-        let prev = std::env::var_os("PATH");
-        let new_path = format!(
-            "{}:{}",
-            dir.path().display(),
-            prev.as_ref()
-                .map(|p| p.to_string_lossy().into_owned())
-                .unwrap_or_default()
-        );
-        // SAFETY: this test mutates the process-wide PATH. Other PATH
-        // readers in the same test binary would race; `#[serial]` keeps
-        // them apart.
-        unsafe {
-            std::env::set_var("PATH", &new_path);
-        }
-        let resolved = resolve_agent_command("aoe-test-resolver-fake", None);
-        if let Some(prev) = prev {
-            unsafe {
-                std::env::set_var("PATH", prev);
-            }
-        }
-        let resolved = resolved.expect("binary should resolve from PATH");
+        let _path = crate::session::test_support::path_prepended(dir.path());
+        let resolved = resolve_agent_command("aoe-test-resolver-fake", None)
+            .expect("binary should resolve from PATH");
         assert_eq!(resolved.path, bin);
         assert_eq!(resolved.prepend_paths, vec![dir.path().to_path_buf()]);
     }

--- a/src/acp/node.rs
+++ b/src/acp/node.rs
@@ -440,10 +440,9 @@ mod tests {
             eprintln!("skipping: node not on PATH");
             return;
         };
-        std::env::set_var("AOE_ACP_NODE", &p);
+        let _env = crate::session::test_support::EnvGuard::set(&[("AOE_ACP_NODE", &p)]);
         let temp = tempfile::tempdir().unwrap();
         let resolved = resolve("", temp.path()).expect("env var resolves");
-        std::env::remove_var("AOE_ACP_NODE");
         assert!(matches!(resolved.source, NodeSource::Env));
     }
 
@@ -452,17 +451,8 @@ mod tests {
     fn resolve_returns_no_node_with_unmatchable_settings() {
         // No PATH-side node, no env, no settings → NoNode.
         let temp = tempfile::tempdir().unwrap();
-        let saved_path = std::env::var_os("PATH");
-        let saved_env = std::env::var_os("AOE_ACP_NODE");
-        std::env::remove_var("PATH");
-        std::env::remove_var("AOE_ACP_NODE");
+        let _env = crate::session::test_support::EnvGuard::unset(&["PATH", "AOE_ACP_NODE"]);
         let result = resolve("", temp.path());
-        if let Some(p) = saved_path {
-            std::env::set_var("PATH", p);
-        }
-        if let Some(v) = saved_env {
-            std::env::set_var("AOE_ACP_NODE", v);
-        }
         assert!(matches!(result, Err(NodeError::NoNode(_))));
     }
 }

--- a/src/session/instance/launch_command.rs
+++ b/src/session/instance/launch_command.rs
@@ -918,10 +918,8 @@ mod tests {
     /// `working_dir` inside the login shell's own script, after profile
     /// sourcing, so it wins regardless of what those files did.
     ///
-    /// No `#[serial]` key: since #3469 every process-global `PATH` mutation in
-    /// the crate goes through `EnvGuard`, so `ENV_LOCK` excludes them all for
-    /// this test's whole body. The lock is taken before the `which` so the
-    /// resolution is inside that window too.
+    /// Holds `ENV_LOCK` across the `PATH` read, which is why the lock is taken
+    /// before the `which` rather than after it.
     #[test]
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
         let _lock = EnvGuard::read_lock();

--- a/src/session/instance/launch_command.rs
+++ b/src/session/instance/launch_command.rs
@@ -918,17 +918,16 @@ mod tests {
     /// `working_dir` inside the login shell's own script, after profile
     /// sourcing, so it wins regardless of what those files did.
     ///
-    /// `#[serial]` on the default key, not `shell_env`: this resolves `bash`
-    /// through the inherited `PATH`, and every test that mutates `PATH`
-    /// process-globally (`update::install`, `acp::node`, `acp::acp_client`)
-    /// carries the default key, so `shell_env` bought no exclusion against
-    /// them. Since #3421 a scrub racing the `which` is a silent skip rather
-    /// than a failure. The `shell_env` holder this stops excluding touches
-    /// only `TERM`/`COLORTERM`/`FORCE_COLOR`/`NO_COLOR`, and `Command`
-    /// snapshots the environment at spawn, so the exposure is that instant.
+    /// No `#[serial]` key: since #3469 every process-global `PATH` mutation in
+    /// the crate goes through `EnvGuard`, so `ENV_LOCK` excludes them all for
+    /// this test's whole body. The outer guard is taken before the `which` so
+    /// the resolution is inside that window too.
     #[test]
-    #[serial_test::serial]
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
+        // Placeholder value: the guard exists to hold `ENV_LOCK` across the
+        // `PATH` read below, and the inner guard overwrites `SHELL` with the
+        // resolved path a moment later.
+        let _lock = EnvGuard::set(&[("SHELL", "/bin/sh")]);
         // The wrapper execs `$SHELL`, so it has to be a shell that exists here.
         let Ok(bash) = which::which("bash") else {
             eprintln!("skipping: bash not found on PATH");

--- a/src/session/instance/launch_command.rs
+++ b/src/session/instance/launch_command.rs
@@ -920,14 +920,11 @@ mod tests {
     ///
     /// No `#[serial]` key: since #3469 every process-global `PATH` mutation in
     /// the crate goes through `EnvGuard`, so `ENV_LOCK` excludes them all for
-    /// this test's whole body. The outer guard is taken before the `which` so
-    /// the resolution is inside that window too.
+    /// this test's whole body. The lock is taken before the `which` so the
+    /// resolution is inside that window too.
     #[test]
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
-        // Placeholder value: the guard exists to hold `ENV_LOCK` across the
-        // `PATH` read below, and the inner guard overwrites `SHELL` with the
-        // resolved path a moment later.
-        let _lock = EnvGuard::set(&[("SHELL", "/bin/sh")]);
+        let _lock = EnvGuard::read_lock();
         // The wrapper execs `$SHELL`, so it has to be a shell that exists here.
         let Ok(bash) = which::which("bash") else {
             eprintln!("skipping: bash not found on PATH");

--- a/src/session/instance/omp.rs
+++ b/src/session/instance/omp.rs
@@ -789,10 +789,7 @@ mod tests {
         std::env::join_paths(entries).expect("PATH entries contain no separator")
     }
 
-    /// Reads the inherited `PATH` to build the child's, so it holds
-    /// `ENV_LOCK` across that read. Since #3469 every process-global `PATH`
-    /// scrub takes the same lock, which is the exclusion `#[serial]` could not
-    /// give: it covered only the scrubbers sharing its key.
+    /// Holds `ENV_LOCK` across the `PATH` read that builds the child's.
     #[cfg(unix)]
     #[test]
     fn omp_capture_gate_executes_nested_stdin_scripts() {

--- a/src/session/instance/omp.rs
+++ b/src/session/instance/omp.rs
@@ -767,41 +767,21 @@ mod tests {
         assert!(command.find("printf").unwrap() < command.rfind("exec sh -c").unwrap());
     }
 
-    /// The shim dir, then the caller's `PATH`. Shim first, so the fake `tmux`
-    /// wins over any real one; inherited, so a host whose coreutils sit
-    /// outside the FHS layout still resolves them. `OsString` throughout: a
-    /// `PATH` entry need not be UTF-8.
-    #[cfg(unix)]
-    fn test_path_with_shim(bin: &std::path::Path) -> std::ffi::OsString {
-        // An unset or empty PATH is handled separately: `split_paths("")`
-        // yields one EMPTY entry, and an empty PATH element means the current
-        // directory, so joining it would hand the child `<shim>:` and put cwd
-        // on its PATH.
-        let Some(inherited) = std::env::var_os("PATH").filter(|p| !p.is_empty()) else {
-            return bin.as_os_str().to_os_string();
-        };
-        let entries = std::iter::once(bin.to_path_buf())
-            .chain(std::env::split_paths(&inherited))
-            .collect::<Vec<_>>();
-        std::env::join_paths(entries).expect("PATH entries contain no separator")
-    }
-
-    /// `#[serial]` because this reads the inherited PATH, and every test that
-    /// scrubs PATH process-globally carries that same default-key annotation:
-    /// `crate::acp::node`, `crate::acp::acp_client`, and
-    /// `crate::update::install`.
-    /// Not an `EnvGuard` lock: none of them takes `test_support::ENV_LOCK`, so
-    /// a guard would exclude unrelated guard users and leave this window open.
-    /// A future PATH mutator outside the default serial group would reopen it.
+    /// The shim dir goes first on `PATH` so the fake `tmux` wins over any real
+    /// one, and the inherited entries stay so a host whose coreutils sit
+    /// outside the FHS layout still resolves them. Since #3469 the guard both
+    /// applies that and holds `ENV_LOCK`, so the inherited half cannot be read
+    /// while another test has `PATH` scrubbed; `#[serial]` only ever excluded
+    /// the scrubbers that happened to share its key.
     #[cfg(unix)]
     #[test]
-    #[serial_test::serial]
     fn omp_capture_gate_executes_nested_stdin_scripts() {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempfile::tempdir().unwrap();
         let bin = temp.path().join("bin");
         std::fs::create_dir(&bin).unwrap();
+        let _path = crate::session::test_support::path_prepended(&bin);
         let tmux = bin.join("tmux");
         let expected = format!(
             "{}=launch-unit-123",
@@ -822,7 +802,6 @@ mod tests {
         std::fs::write(&script, outer).unwrap();
         let status = std::process::Command::new("sh")
             .arg(&script)
-            .env("PATH", test_path_with_shim(&bin))
             .env("TMUX_PANE", "%1")
             .status()
             .unwrap();
@@ -844,7 +823,6 @@ mod tests {
         std::fs::write(&script, large_outer).unwrap();
         let status = std::process::Command::new("sh")
             .arg(&script)
-            .env("PATH", test_path_with_shim(&bin))
             .env("TMUX_PANE", "%1")
             .status()
             .unwrap();

--- a/src/session/instance/omp.rs
+++ b/src/session/instance/omp.rs
@@ -767,21 +767,41 @@ mod tests {
         assert!(command.find("printf").unwrap() < command.rfind("exec sh -c").unwrap());
     }
 
-    /// The shim dir goes first on `PATH` so the fake `tmux` wins over any real
-    /// one, and the inherited entries stay so a host whose coreutils sit
-    /// outside the FHS layout still resolves them. Since #3469 the guard both
-    /// applies that and holds `ENV_LOCK`, so the inherited half cannot be read
-    /// while another test has `PATH` scrubbed; `#[serial]` only ever excluded
-    /// the scrubbers that happened to share its key.
+    /// The shim dir, then the caller's `PATH`. Shim first, so the fake `tmux`
+    /// wins over any real one; inherited, so a host whose coreutils sit
+    /// outside the FHS layout still resolves them. `OsString` throughout: a
+    /// `PATH` entry need not be UTF-8.
+    ///
+    /// Child-scoped on purpose. Putting the shim on the process `PATH` would
+    /// hand the fake `tmux` to every test resolving a real one concurrently.
+    #[cfg(unix)]
+    fn test_path_with_shim(bin: &std::path::Path) -> std::ffi::OsString {
+        // An unset or empty PATH is handled separately: `split_paths("")`
+        // yields one EMPTY entry, and an empty PATH element means the current
+        // directory, so joining it would hand the child `<shim>:` and put cwd
+        // on its PATH.
+        let Some(inherited) = std::env::var_os("PATH").filter(|p| !p.is_empty()) else {
+            return bin.as_os_str().to_os_string();
+        };
+        let entries = std::iter::once(bin.to_path_buf())
+            .chain(std::env::split_paths(&inherited))
+            .collect::<Vec<_>>();
+        std::env::join_paths(entries).expect("PATH entries contain no separator")
+    }
+
+    /// Reads the inherited `PATH` to build the child's, so it holds
+    /// `ENV_LOCK` across that read. Since #3469 every process-global `PATH`
+    /// scrub takes the same lock, which is the exclusion `#[serial]` could not
+    /// give: it covered only the scrubbers sharing its key.
     #[cfg(unix)]
     #[test]
     fn omp_capture_gate_executes_nested_stdin_scripts() {
         use std::os::unix::fs::PermissionsExt;
 
+        let _env = crate::session::test_support::EnvGuard::read_lock();
         let temp = tempfile::tempdir().unwrap();
         let bin = temp.path().join("bin");
         std::fs::create_dir(&bin).unwrap();
-        let _path = crate::session::test_support::path_prepended(&bin);
         let tmux = bin.join("tmux");
         let expected = format!(
             "{}=launch-unit-123",
@@ -802,6 +822,7 @@ mod tests {
         std::fs::write(&script, outer).unwrap();
         let status = std::process::Command::new("sh")
             .arg(&script)
+            .env("PATH", test_path_with_shim(&bin))
             .env("TMUX_PANE", "%1")
             .status()
             .unwrap();
@@ -823,6 +844,7 @@ mod tests {
         std::fs::write(&script, large_outer).unwrap();
         let status = std::process::Command::new("sh")
             .arg(&script)
+            .env("PATH", test_path_with_shim(&bin))
             .env("TMUX_PANE", "%1")
             .status()
             .unwrap();

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -240,7 +240,6 @@ pub(crate) fn path_prepended(dir: &Path) -> EnvGuard {
 /// Install a PATH command that remains first after the test pane starts its
 /// login shell.
 pub(crate) fn install_login_shell_path_command(root: &Path, name: &str, script: &str) -> EnvGuard {
-    let guard = EnvGuard::read_lock();
     let bin = root.join("bin");
     std::fs::create_dir_all(&bin).expect("create test bin directory");
     let executable = bin.join(name);
@@ -261,17 +260,7 @@ pub(crate) fn install_login_shell_path_command(root: &Path, name: &str, script: 
         ),
     )
     .expect("write test login profile");
-    let path = std::env::join_paths(
-        std::iter::once(bin).chain(
-            std::env::var_os("PATH")
-                .iter()
-                .flat_map(|value| std::env::split_paths(value)),
-        ),
-    )
-    .expect("join test PATH");
-    guard
-        .and_set("PATH", path)
-        .and_set("SHELL", OsString::from("/bin/sh"))
+    path_prepended(&bin).and_set("SHELL", OsString::from("/bin/sh"))
 }
 
 /// Restores the process-global tied-worktree setting even when a test panics.

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -168,6 +168,18 @@ impl EnvGuard {
         guard
     }
 
+    /// Take [`ENV_LOCK`] without mutating anything, for a test that only
+    /// *reads* the process environment and must not observe another guard's
+    /// mutation mid-read. `#[serial]` cannot do that job: it excludes only
+    /// tests sharing its key, which is what left the reads in
+    /// `session::instance::omp` and `tmux::session` open (#3469).
+    pub(crate) fn read_lock() -> Self {
+        Self {
+            prev: Vec::new(),
+            _lock: acquire_env_lock(),
+        }
+    }
+
     fn snapshot(&mut self, key: &'static str) {
         self.prev.push((key, std::env::var_os(key)));
     }
@@ -190,6 +202,25 @@ impl Drop for EnvGuard {
             ENV_LOCK_HELD.with(|held| held.set(false));
         }
     }
+}
+
+/// Put `dir` first on `PATH` for the rest of the scope.
+///
+/// The hand-rolled save/restore pairs this replaces excluded each other by
+/// `#[serial]` key rather than through [`ENV_LOCK`], so a guard user carrying
+/// a different key could read a scrubbed `PATH` mid-test (#3469). They also
+/// restored with `set_var` unconditionally, which leaves an empty `PATH`
+/// behind on a host that inherited none; [`EnvGuard`] removes it instead.
+pub(crate) fn path_prepended(dir: &Path) -> EnvGuard {
+    // An empty `PATH` is dropped rather than split: `split_paths("")` yields
+    // one empty entry, and an empty entry means the current directory, so
+    // keeping it would put the caller's cwd on the test's `PATH`.
+    let inherited = std::env::var_os("PATH").filter(|value| !value.is_empty());
+    let path = std::env::join_paths(
+        std::iter::once(dir.to_path_buf()).chain(inherited.iter().flat_map(std::env::split_paths)),
+    )
+    .expect("join test PATH");
+    EnvGuard::set(&[("PATH", path)])
 }
 
 /// Install a PATH command that remains first after the test pane starts its
@@ -517,6 +548,60 @@ mod tests {
         fn capture(key: &'static str) -> Self {
             Self(key, std::env::var_os(key))
         }
+    }
+
+    /// #3469: [`ENV_LOCK`] must exclude a reader from a peer guard's
+    /// mutation. That is the property a `#[serial]` key could not provide,
+    /// and the reason the process-global `PATH` scrubbers had to move onto
+    /// the guard: a reader carrying one key saw the scrub of a writer
+    /// carrying another.
+    ///
+    /// No `#[serial]` here on purpose. The claim is that the lock alone is
+    /// enough, so an annotation would hide what is being measured.
+    #[test]
+    fn env_lock_excludes_a_reader_from_a_peer_guards_mutation() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let ambient = std::env::var_os("PATH");
+        let shim = TempDir::new().unwrap();
+        let scrubbed = AtomicBool::new(false);
+        let releasing = AtomicBool::new(false);
+        let reader_waiting = AtomicBool::new(false);
+
+        // Collected inside the scope, asserted after it joins, so a failure
+        // cannot leave the peer thread running against a dropped guard.
+        let (observed_path, released_first) = std::thread::scope(|scope| {
+            scope.spawn(|| {
+                let scrub = path_prepended(shim.path());
+                scrubbed.store(true, Ordering::SeqCst);
+                while !reader_waiting.load(Ordering::SeqCst) {
+                    std::thread::yield_now();
+                }
+                // Widens the window rather than timing anything: a reader
+                // that waits for the lock reads the restored value however
+                // long this is, so only a reader that does not wait can lose
+                // here. Both observations below stay valid at any duration.
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                releasing.store(true, Ordering::SeqCst);
+                drop(scrub);
+            });
+
+            while !scrubbed.load(Ordering::SeqCst) {
+                std::thread::yield_now();
+            }
+            reader_waiting.store(true, Ordering::SeqCst);
+            let _read = EnvGuard::read_lock();
+            (std::env::var_os("PATH"), releasing.load(Ordering::SeqCst))
+        });
+
+        assert_eq!(
+            observed_path, ambient,
+            "a peer guard's PATH mutation was visible under ENV_LOCK"
+        );
+        assert!(
+            released_first,
+            "the reader entered ENV_LOCK while a peer guard still held it"
+        );
     }
 
     /// Locks #2751: a non-UTF-8 prior value MUST round-trip through the

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -617,7 +617,16 @@ mod tests {
     /// the old value under [`ENV_LOCK`] as well. Reading first and calling
     /// [`EnvGuard::set`] afterwards leaves the helper racing the very scrub it
     /// exists to be excluded from, and bakes that scrub into what it installs.
+    /// `#[serial]` on the default key, unlike its sibling above: this one
+    /// *removes* `PATH` for the width of the window rather than prepending to
+    /// it, and the tmux tests that resolve a bare `tmux` through `PATH` carry
+    /// that key without taking `ENV_LOCK`. Where tmux lives outside the
+    /// execvp fallback path (Homebrew, Nix), an overlap makes
+    /// `tmux_available()` skip silently. The key does not weaken this test's
+    /// own oracle: `serial_test` orders whole tests, so the peer thread and
+    /// the reader below still need `ENV_LOCK` to exclude each other.
     #[test]
+    #[serial]
     fn path_prepended_derives_its_value_under_the_lock() {
         use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -168,6 +168,21 @@ impl EnvGuard {
         guard
     }
 
+    /// Set `key` on a guard that already holds [`ENV_LOCK`], snapshotting its
+    /// prior value like [`Self::set`] does.
+    ///
+    /// Chains onto [`Self::read_lock`] for a value derived from the process
+    /// env: `set`'s caller must read the old value to build the new one, and
+    /// at that point no lock exists, so a helper built on `set` has the very
+    /// hole the guard exists to close.
+    pub(crate) fn and_set<V: AsRef<OsStr>>(mut self, key: &'static str, value: V) -> Self {
+        self.snapshot(key);
+        // SAFETY (staged for Rust 2024 edition migration): same
+        // invariant as [`restore_or_remove`] below.
+        std::env::set_var(key, value.as_ref());
+        self
+    }
+
     /// Take [`ENV_LOCK`] without mutating anything, for a test that only
     /// *reads* the process environment and must not observe another guard's
     /// mutation mid-read. `#[serial]` cannot do that job: it excludes only
@@ -206,12 +221,11 @@ impl Drop for EnvGuard {
 
 /// Put `dir` first on `PATH` for the rest of the scope.
 ///
-/// The hand-rolled save/restore pairs this replaces excluded each other by
-/// `#[serial]` key rather than through [`ENV_LOCK`], so a guard user carrying
-/// a different key could read a scrubbed `PATH` mid-test (#3469). They also
-/// restored with `set_var` unconditionally, which leaves an empty `PATH`
-/// behind on a host that inherited none; [`EnvGuard`] removes it instead.
+/// Exclusive against every other guard user through [`ENV_LOCK`], which the
+/// hand-rolled save/restore pairs it replaces were not: they excluded only
+/// their own `#[serial]` key (#3469).
 pub(crate) fn path_prepended(dir: &Path) -> EnvGuard {
+    let guard = EnvGuard::read_lock();
     // An empty `PATH` is dropped rather than split: `split_paths("")` yields
     // one empty entry, and an empty entry means the current directory, so
     // keeping it would put the caller's cwd on the test's `PATH`.
@@ -220,12 +234,13 @@ pub(crate) fn path_prepended(dir: &Path) -> EnvGuard {
         std::iter::once(dir.to_path_buf()).chain(inherited.iter().flat_map(std::env::split_paths)),
     )
     .expect("join test PATH");
-    EnvGuard::set(&[("PATH", path)])
+    guard.and_set("PATH", path)
 }
 
 /// Install a PATH command that remains first after the test pane starts its
 /// login shell.
 pub(crate) fn install_login_shell_path_command(root: &Path, name: &str, script: &str) -> EnvGuard {
+    let guard = EnvGuard::read_lock();
     let bin = root.join("bin");
     std::fs::create_dir_all(&bin).expect("create test bin directory");
     let executable = bin.join(name);
@@ -254,7 +269,9 @@ pub(crate) fn install_login_shell_path_command(root: &Path, name: &str, script: 
         ),
     )
     .expect("join test PATH");
-    EnvGuard::set(&[("PATH", path), ("SHELL", OsString::from("/bin/sh"))])
+    guard
+        .and_set("PATH", path)
+        .and_set("SHELL", OsString::from("/bin/sh"))
 }
 
 /// Restores the process-global tied-worktree setting even when a test panics.
@@ -551,18 +568,21 @@ mod tests {
     }
 
     /// #3469: [`ENV_LOCK`] must exclude a reader from a peer guard's
-    /// mutation. That is the property a `#[serial]` key could not provide,
-    /// and the reason the process-global `PATH` scrubbers had to move onto
-    /// the guard: a reader carrying one key saw the scrub of a writer
-    /// carrying another.
+    /// mutation, which is the property a `#[serial]` key cannot provide.
     ///
-    /// No `#[serial]` here on purpose. The claim is that the lock alone is
+    /// No `#[serial]` here on purpose: the claim is that the lock alone is
     /// enough, so an annotation would hide what is being measured.
     #[test]
     fn env_lock_excludes_a_reader_from_a_peer_guards_mutation() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let ambient = std::env::var_os("PATH");
+        // Under the lock: an unrelated guard's mutation live at this instant
+        // would otherwise become the baseline and fail the comparison below
+        // for a reason other than the one being measured.
+        let ambient = {
+            let _read = EnvGuard::read_lock();
+            std::env::var_os("PATH")
+        };
         let shim = TempDir::new().unwrap();
         let scrubbed = AtomicBool::new(false);
         let releasing = AtomicBool::new(false);
@@ -601,6 +621,60 @@ mod tests {
         assert!(
             released_first,
             "the reader entered ENV_LOCK while a peer guard still held it"
+        );
+    }
+
+    /// #3469: a helper that derives its value from the process env has to read
+    /// the old value under [`ENV_LOCK`] as well. Reading first and calling
+    /// [`EnvGuard::set`] afterwards leaves the helper racing the very scrub it
+    /// exists to be excluded from, and bakes that scrub into what it installs.
+    #[test]
+    fn path_prepended_derives_its_value_under_the_lock() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let ambient = {
+            let _read = EnvGuard::read_lock();
+            std::env::var_os("PATH")
+        };
+        let shim = TempDir::new().unwrap();
+        let scrubbed = AtomicBool::new(false);
+        let reader_waiting = AtomicBool::new(false);
+
+        let built = std::thread::scope(|scope| {
+            scope.spawn(|| {
+                let scrub = EnvGuard::unset(&["PATH"]);
+                scrubbed.store(true, Ordering::SeqCst);
+                while !reader_waiting.load(Ordering::SeqCst) {
+                    std::thread::yield_now();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                drop(scrub);
+            });
+
+            while !scrubbed.load(Ordering::SeqCst) {
+                std::thread::yield_now();
+            }
+            reader_waiting.store(true, Ordering::SeqCst);
+            let _path = path_prepended(shim.path());
+            std::env::var_os("PATH")
+        });
+
+        let built = built.expect("path_prepended sets PATH");
+        let entries: Vec<PathBuf> = std::env::split_paths(&built).collect();
+        assert_eq!(
+            entries.first(),
+            Some(&shim.path().to_path_buf()),
+            "the shim must come first"
+        );
+        let inherited: Vec<PathBuf> = ambient
+            .iter()
+            .filter(|value| !value.is_empty())
+            .flat_map(std::env::split_paths)
+            .collect();
+        assert_eq!(
+            &entries[1..],
+            inherited.as_slice(),
+            "a peer guard's scrub was baked into the derived PATH"
         );
     }
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -5161,14 +5161,13 @@ mod tests {
         file.disarm();
     }
 
-    /// `#[serial]` because the assertion reads the inherited PATH, and every
-    /// test that scrubs PATH process-globally carries that same default-key
-    /// annotation: `crate::acp::node`, `crate::acp::acp_client`, and
-    /// `crate::update::install`. Not an `EnvGuard` lock: none of them takes
-    /// `test_support::ENV_LOCK`.
+    /// The assertion reads the inherited PATH and hands it to a child, so it
+    /// holds `ENV_LOCK` for that window. Since #3469 every process-global PATH
+    /// scrub goes through `EnvGuard`, so the lock excludes all of them;
+    /// `#[serial]` only ever excluded the ones sharing its key.
     #[test]
-    #[serial_test::serial]
     fn test_container_env_file_does_not_mutate_host_process_environment() {
+        let _env = crate::session::test_support::EnvGuard::read_lock();
         let temp = tempfile::tempdir().unwrap();
         let host_output = temp.path().join("host-env");
         let payload_output = temp.path().join("container-env");

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2588,6 +2588,117 @@ mod tests {
         }
     }
 
+    /// Block until `pane_id` reports `#{pane_dead}`, so a caller never races
+    /// the pane's own process exit with a fixed sleep.
+    fn wait_for_pane_dead(pane_id: &str) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let out = crate::tmux::tmux_command()
+                .args(["display-message", "-t", pane_id, "-p", "#{pane_dead}"])
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
+            if out == "1" {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "pane {pane_id} never reported dead, last read {out:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    /// Move `session_name`'s only window to index 1 under `base-index 1`, so
+    /// window 0 genuinely does not exist.
+    ///
+    /// Setting `base-index 1` on a live session does not renumber the window it
+    /// was created with, and a `:0.0` target against a session that still has a
+    /// window 0 resolves fine, so the option on its own leaves the base-index
+    /// half of #435 / #488 untested (#3368). Moving the window afterwards
+    /// reproduces what a user with `base-index 1` in their `tmux.conf` has,
+    /// without touching the server-global option every other tmux test shares.
+    ///
+    /// tmux resolves a window index that does not exist to the session's
+    /// current window, so with a second window active a `:0.0` target then
+    /// reads the active window rather than failing loudly. That is the
+    /// regression these callers exist to catch.
+    fn rebase_first_window_to_index_one(session_name: &str) {
+        let set = crate::tmux::tmux_command()
+            .args(["set-option", "-t", session_name, "base-index", "1"])
+            .output()
+            .expect("tmux set-option base-index");
+        assert!(set.status.success(), "failed to set base-index 1");
+
+        let moved = crate::tmux::tmux_command()
+            .args([
+                "move-window",
+                "-d",
+                "-s",
+                &format!("{session_name}:0"),
+                "-t",
+                &format!("{session_name}:1"),
+            ])
+            .output()
+            .expect("tmux move-window");
+        assert!(
+            moved.status.success(),
+            "failed to move the first window off index 0: {}",
+            String::from_utf8_lossy(&moved.stderr)
+        );
+
+        let listed = crate::tmux::tmux_command()
+            .args(["list-windows", "-t", session_name, "-F", "#{window_index}"])
+            .output()
+            .expect("tmux list-windows");
+        let indices = String::from_utf8_lossy(&listed.stdout);
+        assert!(
+            !indices.lines().any(|line| line.trim() == "0"),
+            "window 0 must not exist, or a `:0.0` target still resolves: {indices:?}"
+        );
+    }
+
+    /// Set the server-global `pane-base-index` for the rest of the scope and
+    /// restore the previous value on drop, including on unwind.
+    ///
+    /// Modelling a user who sets `pane-base-index 1` needs the global option:
+    /// aoe pins the session-level one, and a window-level value would take
+    /// precedence over that pin rather than losing to it. Every test in this
+    /// binary that forks `tmux new-session` carries the default
+    /// `#[serial_test::serial]` key, so the global is exclusive for the
+    /// guard's lifetime. Construct it only once a session exists: both
+    /// `set-option -g` and `show-options -g` fail against a stopped server.
+    struct GlobalPaneBaseIndex(String);
+
+    impl GlobalPaneBaseIndex {
+        fn set(value: &str) -> Self {
+            let previous = crate::tmux::tmux_command()
+                .args(["show-options", "-g", "-v", "pane-base-index"])
+                .output()
+                .expect("tmux show-options -g pane-base-index");
+            let previous = String::from_utf8_lossy(&previous.stdout).trim().to_string();
+            let applied = crate::tmux::tmux_command()
+                .args(["set-option", "-g", "pane-base-index", value])
+                .output()
+                .expect("tmux set-option -g pane-base-index");
+            assert!(
+                applied.status.success(),
+                "failed to set a global pane-base-index of {value}"
+            );
+            Self(previous)
+        }
+    }
+
+    impl Drop for GlobalPaneBaseIndex {
+        fn drop(&mut self) {
+            let _ = crate::tmux::tmux_command()
+                .args(["set-option", "-g", "pane-base-index", &self.0])
+                .output();
+        }
+    }
+
     /// Create a detached session for the composite tests, applying the guards
     /// the rest of this module treats as mandatory:
     ///
@@ -4001,8 +4112,13 @@ mod tests {
     }
 
     /// Regression test for #435: with multiple tmux windows, pane health
-    /// checks must target window 0 pane 0 explicitly so that a dead pane in
-    /// a second window does not cause the agent pane to be killed.
+    /// checks must target the first window's pane explicitly so that a dead
+    /// pane in a second window does not cause the agent pane to be killed.
+    ///
+    /// The dead pane has to outlive its process for the active window to stay
+    /// the wrong answer. `remain-on-exit` is a window/pane option, so it is
+    /// set on the second window's pane while that pane still blocks on a
+    /// release file, rather than raced against a command that exits at once.
     #[test]
     #[serial_test::serial]
     fn test_is_pane_dead_targets_window_zero_with_multiple_windows() {
@@ -4038,35 +4154,44 @@ mod tests {
             .expect("tmux new-session");
         assert!(output.status.success());
 
-        // Force base-index 1 and pane-base-index 1 to simulate users who
-        // have both set in their tmux.conf.
-        let output = crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "base-index", "1"])
-            .output()
-            .expect("tmux set-option base-index");
-        assert!(output.status.success());
-        let output = crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "pane-base-index", "1"])
-            .output()
-            .expect("tmux set-option pane-base-index");
-        assert!(output.status.success());
+        rebase_first_window_to_index_one(&session_name);
 
-        // Create a second window with a command that exits immediately
+        // A second window that blocks until this test releases it, so
+        // `remain-on-exit` lands on its pane before the pane can die.
+        let temp = tempfile::tempdir().unwrap();
+        let release = temp.path().join("release");
         let output = crate::tmux::tmux_command()
             .args([
                 "new-window",
                 "-t",
                 &session_name,
-                "true", // exits immediately
+                "-P",
+                "-F",
+                "#{pane_id}",
+                &format!("until [ -e '{}' ]; do sleep 0.02; done", release.display()),
+                ";",
+                "set-option",
+                "-p",
+                "-t",
+                &session_name,
+                "remain-on-exit",
+                "on",
             ])
             .output()
             .expect("tmux new-window");
         assert!(output.status.success());
-
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        let dead_pane = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        assert!(
+            dead_pane.starts_with('%'),
+            "expected a pane id from new-window -P, got {dead_pane:?}"
+        );
+        std::fs::write(&release, b"go").unwrap();
+        wait_for_pane_dead(&dead_pane);
 
         // The agent pane (first window) is still alive, so is_pane_dead should
-        // return false even though the second window's pane has exited.
+        // return false even though the second window's pane has exited. With
+        // no window 0 a `:0.0` target resolves to the active window, which is
+        // that dead second window.
         assert!(
             !is_pane_dead(&session_name),
             "is_pane_dead should check the first window's pane, not the active window"
@@ -4076,6 +4201,11 @@ mod tests {
     /// Regression test: capture_pane must target the first window's pane
     /// regardless of which window is currently active, and regardless of
     /// the user's tmux base-index setting.
+    ///
+    /// The pane prints a marker before exec'ing `sleep`, so the capture has
+    /// something to assert on: `capture_pane` swallows a failed tmux call into
+    /// `Ok(String::new())`, and the `:0.0` regression this guards is exactly
+    /// that silent empty read (#3368).
     #[test]
     #[serial_test::serial]
     fn test_capture_pane_targets_first_window_with_multiple_windows() {
@@ -4098,21 +4228,14 @@ mod tests {
                 "80",
                 "-y",
                 "24",
-                "sleep 30",
+                "sh -c 'echo AOE_FIRST_WINDOW; exec sleep 30'",
             ])
             .output()
             .expect("tmux new-session");
         assert!(output.status.success());
         let agent_pane = only_pane_id(&session_name);
 
-        // Force base-index 1 to simulate users who have set base-index 1 in
-        // their tmux.conf. With base-index 1, window 0 does not exist, so any
-        // target using :0.0 silently fails.
-        let output = crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "base-index", "1"])
-            .output()
-            .expect("tmux set-option base-index");
-        assert!(output.status.success());
+        rebase_first_window_to_index_one(&session_name);
 
         // Open a second window running a shell, and make it the active window
         let output = crate::tmux::tmux_command()
@@ -4127,11 +4250,17 @@ mod tests {
             name: session_name.clone(),
         };
 
-        // capture_pane must succeed -- with base-index 1, a :0.0 target does
-        // not exist and the tmux command fails silently returning empty content.
-        let _content = session
+        // With no window 0, a `:0.0` target resolves to the active window --
+        // the shell opened above -- so `capture_pane` reads the wrong pane or,
+        // when tmux does reject the target, returns `Ok("")`. Asserting the
+        // first window's own marker rejects both.
+        let content = session
             .capture_pane(10)
             .expect("capture_pane should not return an error for a valid session");
+        assert!(
+            content.contains("AOE_FIRST_WINDOW"),
+            "capture_pane must read the first window's pane: {content:?}"
+        );
 
         // The command in the first window is 'sleep', not a shell.
         // is_pane_running_shell must return false even though the active
@@ -4721,14 +4850,7 @@ mod tests {
         assert!(output.status.success());
         let agent_pane = only_pane_id(&session_name);
 
-        // Force base-index 1 to simulate users who have set base-index 1 in
-        // their tmux.conf. With base-index 1, window 0 does not exist, so any
-        // target using :0.0 silently fails.
-        let output = crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "base-index", "1"])
-            .output()
-            .expect("tmux set-option base-index");
-        assert!(output.status.success());
+        rebase_first_window_to_index_one(&session_name);
 
         // Open a second window running a shell and make it active
         let output = crate::tmux::tmux_command()
@@ -4739,10 +4861,9 @@ mod tests {
 
         wait_for_pane_command(&agent_pane, "sleep");
 
-        // Should be false: first window runs 'sleep', not a shell.
-        // Would incorrectly return true if the active second window (sh) were checked.
-        // With base-index 1 and a :0.0 target the call silently fails and
-        // returns false for the wrong reason; ^ correctly reads the first pane.
+        // Should be false: first window runs 'sleep', not a shell. With no
+        // window 0 a `:0.0` target resolves to the active window, so the
+        // reverted targeting reads the second window's `sh` and returns true.
         assert!(
             !is_pane_running_shell(&session_name),
             "is_pane_running_shell should target first window (sleep), not active window (sh)"
@@ -4817,8 +4938,17 @@ mod tests {
         );
     }
 
-    /// Regression test for #488: ensure status checks work correctly when both
-    /// pane-base-index 1 and split panes are in play.
+    /// Regression test for #488: on a host whose global `pane-base-index` is 1,
+    /// the `.0` half of the `^.0` status targets only resolves because
+    /// [`append_pane_base_index_args`] pins `pane-base-index 0` onto every
+    /// session aoe creates. Without that pin the panes number from 1 and `.0`
+    /// falls back to the active pane, which is the split the user just made.
+    ///
+    /// The global option is what a user actually sets: aoe's own pin is
+    /// session-level, and a window-level value would win over it rather than
+    /// lose to it. Before #3368 this test set no `pane-base-index 1` anywhere,
+    /// so it duplicated [`test_status_checks_target_pane_zero_with_split_panes`]
+    /// and covered nothing of its own.
     #[test]
     #[serial_test::serial]
     fn test_status_checks_with_split_panes_and_pane_base_index_1() {
@@ -4830,43 +4960,46 @@ mod tests {
         let guard = TmuxTestSession::new("aoe_test_splitpbi");
         let session_name = guard.name().to_string();
 
-        // Create session with pane-base-index 0 pinned (as aoe does)
+        // Built with the production helpers rather than a hand-written copy of
+        // their arguments, so emptying either one fails here.
+        let mut args: Vec<String> = [
+            "new-session",
+            "-d",
+            "-s",
+            &session_name,
+            "-x",
+            "80",
+            "-y",
+            "24",
+            "sleep 30",
+        ]
+        .iter()
+        .map(|arg| arg.to_string())
+        .collect();
+        append_remain_on_exit_args(&mut args, &session_name);
+        append_pane_base_index_args(&mut args, &session_name);
         let output = crate::tmux::tmux_command()
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &session_name,
-                "-x",
-                "80",
-                "-y",
-                "24",
-                "sleep 30",
-                ";",
-                "set-option",
-                "-p",
-                "-t",
-                &session_name,
-                "remain-on-exit",
-                "on",
-                ";",
-                "set-option",
-                "-t",
-                &session_name,
-                "pane-base-index",
-                "0",
-            ])
+            .args(&args)
             .output()
             .expect("tmux new-session");
         assert!(output.status.success());
         let agent_pane = only_pane_id(&session_name);
 
-        // Simulate a user with pane-base-index 1 globally by setting it on the
-        // window -- but aoe has already pinned pane-base-index 0 on the session,
-        // so pane 0 should still be valid.
-        // Note: we set it on the session to verify our pinning takes precedence.
-        // Actually, set pane-base-index 1 globally to simulate user config, then
-        // verify our session-level override keeps pane 0 valid.
+        // After the create: `set-option -g` needs a running server, and pane
+        // indices are computed from the option on every read, so applying it
+        // to a live session is the same state as a host that had it all along.
+        let _global_pane_base_index = GlobalPaneBaseIndex::set("1");
+
+        let listed = crate::tmux::tmux_command()
+            .args(["list-panes", "-t", &session_name, "-F", "#{pane_index}"])
+            .output()
+            .expect("tmux list-panes");
+        let indices = String::from_utf8_lossy(&listed.stdout);
+        assert!(
+            indices.lines().any(|line| line.trim() == "0"),
+            "the session pin must keep pane 0 addressable under a global \
+             pane-base-index of 1: {indices:?}"
+        );
 
         // Split the window and make the new pane active
         let output = crate::tmux::tmux_command()

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2670,15 +2670,25 @@ mod tests {
     /// `#[serial_test::serial]` key, so the global is exclusive for the
     /// guard's lifetime. Construct it only once a session exists: both
     /// `set-option -g` and `show-options -g` fail against a stopped server.
-    struct GlobalPaneBaseIndex(String);
+    struct GlobalPaneBaseIndex(Option<String>);
 
     impl GlobalPaneBaseIndex {
         fn set(value: &str) -> Self {
-            let previous = crate::tmux::tmux_command()
+            // A failed read would restore an empty string, and
+            // `set-option -g pane-base-index ""` leaves the global at `value`
+            // for the rest of the binary's run: every later unpinned session
+            // then numbers panes from 1 and the `.0` targets fall through to
+            // the active pane.
+            let read = crate::tmux::tmux_command()
                 .args(["show-options", "-g", "-v", "pane-base-index"])
                 .output()
                 .expect("tmux show-options -g pane-base-index");
-            let previous = String::from_utf8_lossy(&previous.stdout).trim().to_string();
+            assert!(
+                read.status.success(),
+                "failed to read the global pane-base-index: {}",
+                String::from_utf8_lossy(&read.stderr)
+            );
+            let previous = String::from_utf8_lossy(&read.stdout).trim().to_string();
             let applied = crate::tmux::tmux_command()
                 .args(["set-option", "-g", "pane-base-index", value])
                 .output()
@@ -2687,15 +2697,19 @@ mod tests {
                 applied.status.success(),
                 "failed to set a global pane-base-index of {value}"
             );
-            Self(previous)
+            Self(Some(previous).filter(|previous| !previous.is_empty()))
         }
     }
 
     impl Drop for GlobalPaneBaseIndex {
         fn drop(&mut self) {
-            let _ = crate::tmux::tmux_command()
-                .args(["set-option", "-g", "pane-base-index", &self.0])
-                .output();
+            // `-u` where the option had no value, so the restore never writes
+            // an empty string tmux would reject.
+            let restore = match &self.0 {
+                Some(previous) => vec!["set-option", "-g", "pane-base-index", previous],
+                None => vec!["set-option", "-gu", "pane-base-index"],
+            };
+            let _ = crate::tmux::tmux_command().args(restore).output();
         }
     }
 
@@ -4946,9 +4960,7 @@ mod tests {
     ///
     /// The global option is what a user actually sets: aoe's own pin is
     /// session-level, and a window-level value would win over it rather than
-    /// lose to it. Before #3368 this test set no `pane-base-index 1` anywhere,
-    /// so it duplicated [`test_status_checks_target_pane_zero_with_split_panes`]
-    /// and covered nothing of its own.
+    /// lose to it.
     #[test]
     #[serial_test::serial]
     fn test_status_checks_with_split_panes_and_pane_base_index_1() {

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2670,7 +2670,7 @@ mod tests {
     /// `#[serial_test::serial]` key, so the global is exclusive for the
     /// guard's lifetime. Construct it only once a session exists: both
     /// `set-option -g` and `show-options -g` fail against a stopped server.
-    struct GlobalPaneBaseIndex(Option<String>);
+    struct GlobalPaneBaseIndex(String);
 
     impl GlobalPaneBaseIndex {
         fn set(value: &str) -> Self {
@@ -2689,6 +2689,13 @@ mod tests {
                 String::from_utf8_lossy(&read.stderr)
             );
             let previous = String::from_utf8_lossy(&read.stdout).trim().to_string();
+            // tmux prints the default rather than nothing, so an empty read
+            // means the option is not what this guard thinks it is; restoring
+            // `""` would leave the global at `value` for the rest of the run.
+            assert!(
+                !previous.is_empty(),
+                "tmux reported no global pane-base-index to restore"
+            );
             let applied = crate::tmux::tmux_command()
                 .args(["set-option", "-g", "pane-base-index", value])
                 .output()
@@ -2697,19 +2704,15 @@ mod tests {
                 applied.status.success(),
                 "failed to set a global pane-base-index of {value}"
             );
-            Self(Some(previous).filter(|previous| !previous.is_empty()))
+            Self(previous)
         }
     }
 
     impl Drop for GlobalPaneBaseIndex {
         fn drop(&mut self) {
-            // `-u` where the option had no value, so the restore never writes
-            // an empty string tmux would reject.
-            let restore = match &self.0 {
-                Some(previous) => vec!["set-option", "-g", "pane-base-index", previous],
-                None => vec!["set-option", "-gu", "pane-base-index"],
-            };
-            let _ = crate::tmux::tmux_command().args(restore).output();
+            let _ = crate::tmux::tmux_command()
+                .args(["set-option", "-g", "pane-base-index", &self.0])
+                .output();
         }
     }
 
@@ -5173,10 +5176,7 @@ mod tests {
         file.disarm();
     }
 
-    /// The assertion reads the inherited PATH and hands it to a child, so it
-    /// holds `ENV_LOCK` for that window. Since #3469 every process-global PATH
-    /// scrub goes through `EnvGuard`, so the lock excludes all of them;
-    /// `#[serial]` only ever excluded the ones sharing its key.
+    /// Holds `ENV_LOCK` across the `PATH` read it hands to a child.
     #[test]
     fn test_container_env_file_does_not_mutate_host_process_environment() {
         let _env = crate::session::test_support::EnvGuard::read_lock();

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -896,19 +896,6 @@ mod tests {
             std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        fn with_path_prepended<F: FnOnce()>(prefix: &Path, f: F) {
-            let prev = std::env::var("PATH").unwrap_or_default();
-            let new_path = format!("{}:{}", prefix.display(), prev);
-            // SAFETY: serial_test ensures no concurrent env mutation.
-            unsafe {
-                std::env::set_var("PATH", &new_path);
-            }
-            f();
-            unsafe {
-                std::env::set_var("PATH", &prev);
-            }
-        }
-
         #[test]
         #[serial]
         fn sudo_replace_moves_then_chmods() {
@@ -922,9 +909,8 @@ mod tests {
             #[cfg(unix)]
             std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-            with_path_prepended(dir.path(), || {
-                sudo_replace(&source, &target).expect("sudo_replace should succeed");
-            });
+            let _path = crate::session::test_support::path_prepended(dir.path());
+            sudo_replace(&source, &target).expect("sudo_replace should succeed");
 
             assert!(!source.exists(), "source should be moved");
             assert_eq!(std::fs::read(&target).unwrap(), b"new");
@@ -945,15 +931,13 @@ mod tests {
             std::fs::write(&source, b"new").unwrap();
             let target = dir.path().join("target");
 
-            with_path_prepended(dir.path(), || {
-                let err =
-                    sudo_replace(&source, &target).expect_err("failing sudo should propagate");
-                let s = err.to_string();
-                assert!(
-                    s.contains("sudo mv failed"),
-                    "expected mv-failed error, got: {s}"
-                );
-            });
+            let _path = crate::session::test_support::path_prepended(dir.path());
+            let err = sudo_replace(&source, &target).expect_err("failing sudo should propagate");
+            let s = err.to_string();
+            assert!(
+                s.contains("sudo mv failed"),
+                "expected mv-failed error, got: {s}"
+            );
         }
     }
 
@@ -1031,26 +1015,14 @@ mod tests {
             log
         }
 
-        fn with_path_prepended<F: FnOnce()>(prefix: &Path, f: F) {
-            let prev = std::env::var("PATH").unwrap_or_default();
-            unsafe {
-                std::env::set_var("PATH", format!("{}:{}", prefix.display(), prev));
-            }
-            f();
-            unsafe {
-                std::env::set_var("PATH", &prev);
-            }
-        }
-
         #[test]
         #[serial]
         fn runs_update_info_then_upgrade_aoe() {
             let dir = TempDir::new().unwrap();
             let log = write_recording_brew_shim(dir.path(), "1.5.2", None);
 
-            with_path_prepended(dir.path(), || {
-                update_via_brew("1.5.2").expect("brew upgrade should succeed");
-            });
+            let _path = crate::session::test_support::path_prepended(dir.path());
+            update_via_brew("1.5.2").expect("brew upgrade should succeed");
 
             let invocations = std::fs::read_to_string(&log).unwrap();
             let lines: Vec<_> = invocations.lines().collect();
@@ -1066,7 +1038,8 @@ mod tests {
             let dir = TempDir::new().unwrap();
             let log = write_recording_brew_shim(dir.path(), "1.5.2", Some("update"));
 
-            let err = with_path_prepended_returning(dir.path(), || update_via_brew("1.5.2"));
+            let _path = crate::session::test_support::path_prepended(dir.path());
+            let err = update_via_brew("1.5.2");
             let err = err.expect_err("brew update failure should propagate");
             assert!(
                 err.to_string().contains("brew update"),
@@ -1088,7 +1061,8 @@ mod tests {
             let dir = TempDir::new().unwrap();
             let log = write_recording_brew_shim(dir.path(), "1.5.2", Some("upgrade"));
 
-            let err = with_path_prepended_returning(dir.path(), || update_via_brew("1.5.2"));
+            let _path = crate::session::test_support::path_prepended(dir.path());
+            let err = update_via_brew("1.5.2");
             let err = err.expect_err("brew upgrade failure should propagate");
             assert!(
                 err.to_string().contains("brew upgrade aoe"),
@@ -1112,7 +1086,8 @@ mod tests {
             // brew has 1.5.1 but we're trying to install 1.5.2
             let log = write_recording_brew_shim(dir.path(), "1.5.1", None);
 
-            let err = with_path_prepended_returning(dir.path(), || update_via_brew("1.5.2"));
+            let _path = crate::session::test_support::path_prepended(dir.path());
+            let err = update_via_brew("1.5.2");
             let err = err.expect_err("formula lag should fail loudly");
             let msg = err.to_string();
             assert!(
@@ -1145,29 +1120,13 @@ mod tests {
             #[cfg(unix)]
             std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-            with_path_prepended(dir.path(), || {
-                update_via_brew("1.5.2").expect("missing JSON should not block upgrade");
-            });
+            let _path = crate::session::test_support::path_prepended(dir.path());
+            update_via_brew("1.5.2").expect("missing JSON should not block upgrade");
 
             let invocations = std::fs::read_to_string(&log).unwrap();
             let lines: Vec<_> = invocations.lines().collect();
             assert_eq!(lines.len(), 3, "upgrade should still run; got {lines:?}");
             assert_eq!(lines[2], "upgrade aoe");
-        }
-
-        // PATH-prepended runner that returns a value (Result, in this case).
-        // The plain `with_path_prepended` upstream is FnOnce() -> () which
-        // is fine for assert! but loses the Result.
-        fn with_path_prepended_returning<R, F: FnOnce() -> R>(prefix: &Path, f: F) -> R {
-            let prev = std::env::var("PATH").unwrap_or_default();
-            unsafe {
-                std::env::set_var("PATH", format!("{}:{}", prefix.display(), prev));
-            }
-            let result = f();
-            unsafe {
-                std::env::set_var("PATH", &prev);
-            }
-            result
         }
     }
 
@@ -1191,19 +1150,11 @@ mod tests {
             #[cfg(unix)]
             std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-            let prev = std::env::var("PATH").unwrap_or_default();
-            let new_path = format!("{}:{}", dir.path().display(), prev);
-            unsafe {
-                std::env::set_var("PATH", &new_path);
-            }
+            let _path = crate::session::test_support::path_prepended(dir.path());
 
             let started = Instant::now();
             let result = probe_brew_aoe_path_with_timeout(Duration::from_millis(300));
             let elapsed = started.elapsed();
-
-            unsafe {
-                std::env::set_var("PATH", &prev);
-            }
 
             assert!(result.is_none(), "hanging brew should return None");
             assert!(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -395,11 +395,20 @@ struct CliTree {
 impl CliTree {
     fn from_command(cmd: &clap::Command) -> Self {
         let mut tree = Self::default();
-        tree.walk(cmd, "");
+        tree.walk(cmd, "", false);
         tree
     }
 
-    fn walk(&mut self, cmd: &clap::Command, prefix: &str) {
+    /// Walks each spelling of each command, so a subcommand is recorded under
+    /// its parent's aliases as well as its parent's name. Recursing only under
+    /// the canonical name leaves `<alias> <sub>` in no set at all, and a parent
+    /// path followed by an unknown word reports as nonexistent: a red check on
+    /// correct documentation.
+    ///
+    /// `aliased` tracks whether any segment so far was an alias. One anywhere
+    /// in the path keeps the whole path out of the advisory, since `aoe grp
+    /// create` is not a documentation gap for `aoe group create`.
+    fn walk(&mut self, cmd: &clap::Command, prefix: &str, aliased: bool) {
         for sub in cmd.get_subcommands() {
             if sub.get_name() == "help" {
                 continue;
@@ -411,19 +420,21 @@ impl CliTree {
                     format!("{prefix} {name}")
                 }
             };
-            let path = join(sub.get_name());
-            if sub.has_subcommands() {
-                self.parents.insert(path.clone());
-            }
-            for alias in sub.get_all_aliases() {
-                let alias_path = join(alias);
+            let spellings = std::iter::once((sub.get_name(), false))
+                .chain(sub.get_all_aliases().map(|alias| (alias, true)));
+            for (name, is_alias) in spellings {
+                let path = join(name);
+                let aliased = aliased || is_alias;
                 if sub.has_subcommands() {
-                    self.parents.insert(alias_path.clone());
+                    self.parents.insert(path.clone());
                 }
-                self.aliases.insert(alias_path);
+                if aliased {
+                    self.aliases.insert(path.clone());
+                } else {
+                    self.commands.insert(path.clone());
+                }
+                self.walk(sub, &path, aliased);
             }
-            self.commands.insert(path.clone());
-            self.walk(sub, &path);
         }
     }
 
@@ -440,14 +451,32 @@ impl CliTree {
 /// `name: aoe` from reading as an invocation of whatever the next line
 /// starts with.
 fn code_spans(content: &str) -> Vec<&str> {
+    // Only a shell fence holds commands. A `json` or `text` fence is data, and
+    // the `#` truncation below would read a payload as a shell comment.
+    fn is_shell_fence(info: &str) -> bool {
+        matches!(
+            info.trim(),
+            "" | "sh" | "bash" | "shell" | "zsh" | "console" | "shell-session"
+        )
+    }
+
     let mut spans = Vec::new();
-    let mut in_fence = false;
+    // `Some(is_shell)` while inside a fence. Tracking "inside" separately from
+    // "is shell" is what keeps a `json` fence's closing marker from reading as
+    // the opening of a shell one and inverting every fence after it.
+    let mut fence: Option<bool> = None;
     for line in content.lines() {
-        if line.trim_start().starts_with("```") {
-            in_fence = !in_fence;
+        if let Some(info) = line.trim_start().strip_prefix("```") {
+            fence = match fence {
+                Some(_) => None,
+                None => Some(is_shell_fence(info)),
+            };
             continue;
         }
-        if in_fence {
+        if let Some(is_shell) = fence {
+            if !is_shell {
+                continue;
+            }
             // Truncated at `#`, which is a comment in every shell fence these
             // files use. Prose naming a command is common there and is not an
             // invocation; dropping the tail can only under-check, never
@@ -700,6 +729,17 @@ mod skill_check_tests {
             // Neither tilde fences nor indented blocks are code context here.
             ("~~~\naoe list\n~~~", &[]),
             ("    aoe list", &[]),
+            // A non-shell fence is data. Reading it as commands turned a
+            // sample payload or a prose block into a red check.
+            ("```json\n\"note\": \"aoe manages sessions\"\n```", &[]),
+            ("```text\naoe makes it easy to run agents\n```", &[]),
+            // Its closing marker must not open a shell fence: that inverts
+            // every fence after it, which silently drops real coverage.
+            (
+                "```json\n{}\n```\nprose aoe here\n```sh\naoe list\n```",
+                &["aoe list"],
+            ),
+            ("```json\n{}\n```\nRun `aoe list`.", &["aoe list"]),
         ];
         for (content, expected) in cases {
             assert_eq!(&code_spans(content), expected, "spans of {content:?}");
@@ -746,6 +786,35 @@ mod skill_check_tests {
             assert_eq!(referenced, set(credited), "credited for {content:?}");
             assert_eq!(reported, set(unknown), "reported for {content:?}");
         }
+    }
+
+    /// A parent reached through an alias still has subcommands. Before this,
+    /// `walk` recursed only under the canonical name, so `grp create` was in
+    /// neither `commands` nor `aliases`, `grp` resolved as a parent, and the
+    /// trailing word reported as a command that does not exist.
+    #[test]
+    fn aliases_expand_into_their_subcommand_paths() {
+        let cmd = clap::Command::new("aoe").subcommand(
+            clap::Command::new("group")
+                .alias("grp")
+                .subcommand(clap::Command::new("create").alias("new")),
+        );
+        let cli = CliTree::from_command(&cmd);
+        for path in ["group", "grp", "group create", "grp create", "grp new"] {
+            assert!(cli.is_known(path), "{path} must resolve");
+        }
+        assert_eq!(
+            cli.commands,
+            set(&["group", "group create"]),
+            "only the fully canonical paths belong in the advisory"
+        );
+        // The parent rule still has to catch a bad subcommand under the alias.
+        let (credited, unknown) = check_invocations("`aoe grp bogusverb`", &cli);
+        assert!(credited.is_empty());
+        assert_eq!(unknown, set(&["grp bogusverb"]));
+        // And a real one through the alias must stay silent.
+        let (credited, unknown) = check_invocations("`aoe grp create mygroup`", &cli);
+        assert!(credited.is_empty() && unknown.is_empty());
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -376,19 +376,163 @@ fn generate_cli_docs() {
     println!("Generated CLI documentation at {}", output_path.display());
 }
 
-fn collect_subcommand_paths(cmd: &clap::Command, prefix: &str, out: &mut BTreeSet<String>) {
-    for sub in cmd.get_subcommands() {
-        if sub.get_name() == "help" {
+/// The clap command tree, flattened into the three questions the skill check
+/// asks of a command path it read out of a skill file.
+#[derive(Default)]
+struct CliTree {
+    /// Canonical `aoe <path>` subcommand paths.
+    commands: BTreeSet<String>,
+    /// Paths that take a subcommand of their own, so a word after one of them
+    /// is a subcommand name. After any other path it is a positional argument.
+    parents: BTreeSet<String>,
+    /// Paths reachable through a `#[command(alias = ...)]`. Accepted as input
+    /// but kept out of the advisory: `aoe ls` in a skill file is not a
+    /// documentation gap for `aoe list`, and aliases are absent from
+    /// `docs/cli/reference.md` on purpose.
+    aliases: BTreeSet<String>,
+}
+
+impl CliTree {
+    fn from_command(cmd: &clap::Command) -> Self {
+        let mut tree = Self::default();
+        tree.walk(cmd, "");
+        tree
+    }
+
+    fn walk(&mut self, cmd: &clap::Command, prefix: &str) {
+        for sub in cmd.get_subcommands() {
+            if sub.get_name() == "help" {
+                continue;
+            }
+            let join = |name: &str| {
+                if prefix.is_empty() {
+                    name.to_string()
+                } else {
+                    format!("{prefix} {name}")
+                }
+            };
+            let path = join(sub.get_name());
+            if sub.has_subcommands() {
+                self.parents.insert(path.clone());
+            }
+            for alias in sub.get_all_aliases() {
+                let alias_path = join(alias);
+                if sub.has_subcommands() {
+                    self.parents.insert(alias_path.clone());
+                }
+                self.aliases.insert(alias_path);
+            }
+            self.commands.insert(path.clone());
+            self.walk(sub, &path);
+        }
+    }
+
+    fn is_known(&self, path: &str) -> bool {
+        self.commands.contains(path) || self.aliases.contains(path)
+    }
+}
+
+/// The spans of a markdown file where `aoe` is a command rather than the
+/// ordinary English word it also is in these files: fenced code blocks, and
+/// inline backtick spans in prose.
+///
+/// Spans are line-local, which is also what keeps the frontmatter's
+/// `name: aoe` from reading as an invocation of whatever the next line
+/// starts with. A line whose backticks do not pair is skipped: its spans
+/// cannot be told from its prose.
+fn code_spans(content: &str) -> Vec<&str> {
+    let mut spans = Vec::new();
+    let mut in_fence = false;
+    for line in content.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
             continue;
         }
-        let path = if prefix.is_empty() {
-            sub.get_name().to_string()
-        } else {
-            format!("{} {}", prefix, sub.get_name())
-        };
-        out.insert(path.clone());
-        collect_subcommand_paths(sub, &path, out);
+        if in_fence {
+            spans.push(line);
+            continue;
+        }
+        let parts: Vec<&str> = line.split('`').collect();
+        if parts.len().is_multiple_of(2) {
+            continue;
+        }
+        spans.extend(parts.iter().skip(1).step_by(2));
     }
+    spans
+}
+
+/// Every `aoe <words>` invocation in `content`'s code spans, as the words that
+/// were read rather than the prefix of them that happened to resolve.
+fn read_invocations(content: &str) -> Vec<Vec<String>> {
+    let re = regex::Regex::new(r"\baoe[ \t]+([a-z][a-z0-9 \t-]*)").unwrap();
+    let mut invocations = Vec::new();
+    for span in code_spans(content) {
+        for cap in re.captures_iter(span) {
+            let words: Vec<String> = cap[1]
+                .split_whitespace()
+                .take_while(|w| w.chars().all(|c| c.is_ascii_lowercase() || c == '-'))
+                .map(str::to_string)
+                .collect();
+            if !words.is_empty() {
+                invocations.push(words);
+            }
+        }
+    }
+    invocations
+}
+
+/// Resolve one invocation against the CLI tree.
+///
+/// `Ok(Some(path))` is a canonical command to credit in the advisory,
+/// `Ok(None)` an alias or a bare prefix with nothing to credit, and `Err` the
+/// command text to report as nonexistent. Before #3479 the caller only ever
+/// recorded paths the tree had already accepted, so the "does not exist" arm
+/// it then checked was unsatisfiable.
+fn resolve_invocation(words: &[String], cli: &CliTree) -> Result<Option<String>, String> {
+    let mut resolved: Option<(String, usize)> = None;
+    let mut path = String::new();
+    for (index, word) in words.iter().enumerate() {
+        if path.is_empty() {
+            path = word.clone();
+        } else {
+            path = format!("{path} {word}");
+        }
+        if cli.is_known(&path) {
+            resolved = Some((path.clone(), index + 1));
+        }
+    }
+
+    let Some((resolved, consumed)) = resolved else {
+        return Err(words[0].clone());
+    };
+    // A word after a leaf command is a positional argument (`aoe group create
+    // mygroup`); after a command that takes subcommands it is a subcommand
+    // name, and an unknown one is the bug this check exists for.
+    if cli.parents.contains(&resolved) {
+        if let Some(next) = words.get(consumed) {
+            return Err(format!("{resolved} {next}"));
+        }
+    }
+    Ok(cli.commands.contains(&resolved).then_some(resolved))
+}
+
+/// Check every `aoe ...` invocation in one skill file, returning the canonical
+/// commands to credit in the advisory and the nonexistent ones to report.
+fn check_invocations(content: &str, cli: &CliTree) -> (BTreeSet<String>, BTreeSet<String>) {
+    let mut referenced = BTreeSet::new();
+    let mut unknown = BTreeSet::new();
+    for words in read_invocations(content) {
+        match resolve_invocation(&words, cli) {
+            Ok(Some(path)) => {
+                referenced.insert(path);
+            }
+            Ok(None) => {}
+            Err(bad) => {
+                unknown.insert(bad);
+            }
+        }
+    }
+    (referenced, unknown)
 }
 
 /// How the skill's published version is sourced, which determines whether a
@@ -408,9 +552,7 @@ fn check_skill() {
     ];
 
     // Build the clap command tree once; shared across every skill file.
-    let cli_cmd = agent_of_empires::cli::Cli::command();
-    let mut cli_commands: BTreeSet<String> = BTreeSet::new();
-    collect_subcommand_paths(&cli_cmd, "", &mut cli_commands);
+    let cli = CliTree::from_command(&agent_of_empires::cli::Cli::command());
 
     let mut has_error = false;
     let mut referenced: BTreeSet<String> = BTreeSet::new();
@@ -425,20 +567,14 @@ fn check_skill() {
 
         let content = fs::read_to_string(skill_path).expect("Failed to read SKILL.md");
 
-        if check_skill_file(
-            path_str,
-            &content,
-            version_rule,
-            &cli_commands,
-            &mut referenced,
-        ) {
+        if check_skill_file(path_str, &content, version_rule, &cli, &mut referenced) {
             has_error = true;
         }
     }
 
     // Advisory: CLI commands not referenced in any skill file.
     let mut missing_from_skill = Vec::new();
-    for cli_cmd in &cli_commands {
+    for cli_cmd in &cli.commands {
         let mentioned = referenced.iter().any(|s| {
             s == cli_cmd
                 || cli_cmd.starts_with(&format!("{} ", s))
@@ -470,7 +606,7 @@ fn check_skill_file(
     path_str: &str,
     content: &str,
     version_rule: &VersionRule,
-    cli_commands: &BTreeSet<String>,
+    cli: &CliTree,
     referenced: &mut BTreeSet<String>,
 ) -> bool {
     let mut has_error = false;
@@ -502,64 +638,125 @@ fn check_skill_file(
         _ => {}
     }
 
-    // Extract `aoe <words>` patterns and match longest valid subcommand path
-    let re = regex::Regex::new(r"aoe\s+([a-z][a-z0-9 -]*)").unwrap();
-    let mut skill_commands: BTreeSet<String> = BTreeSet::new();
-    for cap in re.captures_iter(content) {
-        let raw = cap[1].trim();
-        let words: Vec<&str> = raw
-            .split_whitespace()
-            .take_while(|w| {
-                !w.starts_with('-')
-                    && !w.starts_with('<')
-                    && !w.starts_with('"')
-                    && !w.starts_with('$')
-                    && !w.starts_with('/')
-                    && !w.starts_with('.')
-                    && w.chars().all(|c| c.is_ascii_lowercase() || c == '-')
-            })
-            .collect();
-
-        // Find the longest prefix that is a known CLI command
-        let mut best = String::new();
-        let mut path = String::new();
-        for word in &words {
-            if path.is_empty() {
-                path = word.to_string();
-            } else {
-                path = format!("{} {}", path, word);
-            }
-            if cli_commands.contains(&path) {
-                best = path.clone();
-            }
-        }
-        // If no exact match, use the first word if it's a known top-level command
-        if best.is_empty() && !words.is_empty() && cli_commands.contains(words[0]) {
-            best = words[0].to_string();
-        }
-        if !best.is_empty() {
-            skill_commands.insert(best);
-        }
+    let (found, unknown) = check_invocations(content, cli);
+    for bad in unknown {
+        eprintln!("ERROR: {path_str} references command 'aoe {bad}' which does not exist in CLI");
+        has_error = true;
     }
 
-    // Check for skill references to commands that don't exist
-    for skill_cmd in &skill_commands {
-        if !cli_commands.contains(skill_cmd) {
-            let is_prefix = cli_commands
-                .iter()
-                .any(|c| c.starts_with(&format!("{} ", skill_cmd)));
-            if !is_prefix {
-                eprintln!(
-                    "ERROR: {} references command 'aoe {}' which does not exist in CLI",
-                    path_str, skill_cmd
-                );
-                has_error = true;
-            }
-        }
-    }
-
-    referenced.extend(skill_commands);
+    referenced.extend(found);
     has_error
+}
+
+#[cfg(test)]
+mod skill_check_tests {
+    use super::{check_invocations, code_spans, CliTree};
+    use std::collections::BTreeSet;
+
+    fn set(paths: &[&str]) -> BTreeSet<String> {
+        paths.iter().map(|p| p.to_string()).collect()
+    }
+
+    fn tree() -> CliTree {
+        CliTree {
+            commands: set(&[
+                "list",
+                "session",
+                "session capture",
+                "group",
+                "group create",
+            ]),
+            parents: set(&["session", "group"]),
+            aliases: set(&["ls", "group ls"]),
+        }
+    }
+
+    #[test]
+    fn code_spans_are_fences_and_paired_inline_spans() {
+        let cases: &[(&str, &[&str])] = &[
+            ("```sh\naoe list\n```", &["aoe list"]),
+            ("Run `aoe list` now.", &["aoe list"]),
+            (
+                "Two `aoe list` and `aoe group` spans.",
+                &["aoe list", "aoe group"],
+            ),
+            // Prose is not code: `aoe` is an ordinary word in these files.
+            ("Use aoe list to see sessions.", &[]),
+            // One backtick cannot delimit a span, so the line is skipped.
+            ("A stray ` and aoe list after it.", &[]),
+            // Line-local, so frontmatter cannot join two keys into a command.
+            ("name: aoe\ndescription: something", &[]),
+            // A `#` comment inside a fence is still code.
+            (
+                "```sh\n# aoe list is the listing\n```",
+                &["# aoe list is the listing"],
+            ),
+            // Neither tilde fences nor indented blocks are code context here.
+            ("~~~\naoe list\n~~~", &[]),
+            ("    aoe list", &[]),
+        ];
+        for (content, expected) in cases {
+            assert_eq!(&code_spans(content), expected, "spans of {content:?}");
+        }
+    }
+
+    #[test]
+    fn invocations_resolve_credit_and_reject() {
+        // (content, credited commands, commands reported as nonexistent)
+        let cases: &[(&str, &[&str], &[&str])] = &[
+            ("`aoe list`", &["list"], &[]),
+            ("`aoe session capture`", &["session capture"], &[]),
+            // #3479: none of these three could be reported before, and the
+            // middle one also suppressed every `aoe session *` advisory entry.
+            ("`aoe totallybogus`", &[], &["totallybogus"]),
+            ("`aoe session bogusverb`", &[], &["session bogusverb"]),
+            ("`aoe session pin`", &[], &["session pin"]),
+            // A word after a leaf is a positional argument, not a subcommand.
+            ("`aoe group create mygroup`", &["group create"], &[]),
+            ("`aoe session capture my-id`", &["session capture"], &[]),
+            // An alias is accepted as input but credits no canonical command.
+            ("`aoe ls`", &[], &[]),
+            ("`aoe group ls`", &[], &[]),
+            // Flags and placeholders end the command path.
+            ("`aoe list --json`", &["list"], &[]),
+            ("`aoe session capture <id>`", &["session capture"], &[]),
+            // A bare prefix is a real reference with nothing extra to check.
+            ("`aoe session`", &["session"], &[]),
+            // Repeats report once.
+            (
+                "`aoe totallybogus` and `aoe totallybogus`",
+                &[],
+                &["totallybogus"],
+            ),
+            // Prose is not scanned, so neither half of this is read.
+            ("Use aoe totallybogus freely.", &[], &[]),
+        ];
+        let cli = tree();
+        for (content, credited, unknown) in cases {
+            let (referenced, reported) = check_invocations(content, &cli);
+            assert_eq!(referenced, set(credited), "credited for {content:?}");
+            assert_eq!(reported, set(unknown), "reported for {content:?}");
+        }
+    }
+
+    #[test]
+    fn aliases_are_read_from_the_clap_tree() {
+        use clap::CommandFactory;
+        let cli = CliTree::from_command(&agent_of_empires::cli::Cli::command());
+        // `collect_subcommand_paths` recorded `get_name()` only, so every
+        // `#[command(alias = ...)]` read as a nonexistent command (#3479).
+        assert!(!cli.aliases.is_empty(), "the CLI declares command aliases");
+        assert!(
+            cli.aliases
+                .iter()
+                .all(|alias| !cli.commands.contains(alias)),
+            "an alias must not also be advertised as a canonical command"
+        );
+        assert!(
+            cli.parents.iter().all(|parent| cli.is_known(parent)),
+            "every parent path must resolve"
+        );
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -438,8 +438,7 @@ impl CliTree {
 ///
 /// Spans are line-local, which is also what keeps the frontmatter's
 /// `name: aoe` from reading as an invocation of whatever the next line
-/// starts with. A line whose backticks do not pair is skipped: its spans
-/// cannot be told from its prose.
+/// starts with.
 fn code_spans(content: &str) -> Vec<&str> {
     let mut spans = Vec::new();
     let mut in_fence = false;
@@ -449,14 +448,19 @@ fn code_spans(content: &str) -> Vec<&str> {
             continue;
         }
         if in_fence {
-            spans.push(line);
+            // Truncated at `#`, which is a comment in every shell fence these
+            // files use. Prose naming a command is common there and is not an
+            // invocation; dropping the tail can only under-check, never
+            // redden a documentation edit.
+            spans.push(line.split('#').next().unwrap_or(line));
             continue;
         }
+        // An odd part count means the backticks pair up. Otherwise the spans
+        // on this line cannot be told from its prose, so it is skipped.
         let parts: Vec<&str> = line.split('`').collect();
-        if parts.len().is_multiple_of(2) {
-            continue;
+        if parts.len() % 2 == 1 {
+            spans.extend(parts.iter().skip(1).step_by(2));
         }
-        spans.extend(parts.iter().skip(1).step_by(2));
     }
     spans
 }
@@ -470,7 +474,12 @@ fn read_invocations(content: &str) -> Vec<Vec<String>> {
         for cap in re.captures_iter(span) {
             let words: Vec<String> = cap[1]
                 .split_whitespace()
-                .take_while(|w| w.chars().all(|c| c.is_ascii_lowercase() || c == '-'))
+                // A leading `-` is a flag, not a subcommand: the capture runs
+                // through `--json` and friends because `-` is a legal
+                // character inside a command name too.
+                .take_while(|w| {
+                    !w.starts_with('-') && w.chars().all(|c| c.is_ascii_lowercase() || c == '-')
+                })
                 .map(str::to_string)
                 .collect();
             if !words.is_empty() {
@@ -485,9 +494,7 @@ fn read_invocations(content: &str) -> Vec<Vec<String>> {
 ///
 /// `Ok(Some(path))` is a canonical command to credit in the advisory,
 /// `Ok(None)` an alias or a bare prefix with nothing to credit, and `Err` the
-/// command text to report as nonexistent. Before #3479 the caller only ever
-/// recorded paths the tree had already accepted, so the "does not exist" arm
-/// it then checked was unsatisfiable.
+/// command text to report as nonexistent.
 fn resolve_invocation(words: &[String], cli: &CliTree) -> Result<Option<String>, String> {
     let mut resolved: Option<(String, usize)> = None;
     let mut path = String::new();
@@ -686,11 +693,10 @@ mod skill_check_tests {
             ("A stray ` and aoe list after it.", &[]),
             // Line-local, so frontmatter cannot join two keys into a command.
             ("name: aoe\ndescription: something", &[]),
-            // A `#` comment inside a fence is still code.
-            (
-                "```sh\n# aoe list is the listing\n```",
-                &["# aoe list is the listing"],
-            ),
+            // A `#` comment inside a fence is prose about a command, not an
+            // invocation of one, so the tail is dropped.
+            ("```sh\n# aoe list is the listing\n```", &[""]),
+            ("```sh\naoe list # lists them\n```", &["aoe list "]),
             // Neither tilde fences nor indented blocks are code context here.
             ("~~~\naoe list\n~~~", &[]),
             ("    aoe list", &[]),
@@ -717,8 +723,11 @@ mod skill_check_tests {
             // An alias is accepted as input but credits no canonical command.
             ("`aoe ls`", &[], &[]),
             ("`aoe group ls`", &[], &[]),
-            // Flags and placeholders end the command path.
+            // Flags and placeholders end the command path. A flag after a
+            // command that takes subcommands is still a flag.
             ("`aoe list --json`", &["list"], &[]),
+            ("`aoe group --help`", &["group"], &[]),
+            ("`aoe session --json`", &["session"], &[]),
             ("`aoe session capture <id>`", &["session capture"], &[]),
             // A bare prefix is a real reference with nothing extra to check.
             ("`aoe session`", &["session"], &[]),
@@ -751,10 +760,6 @@ mod skill_check_tests {
                 .iter()
                 .all(|alias| !cli.commands.contains(alias)),
             "an alias must not also be advertised as a canonical command"
-        );
-        assert!(
-            cli.parents.iter().all(|parent| cli.is_known(parent)),
-            "every parent path must resolve"
         );
     }
 }


### PR DESCRIPTION
## Description

Three test-infrastructure issues whose common shape is a test that could not fail. Two more from the same cluster turned out to be already fixed on `main`; evidence at the bottom, no code here for either.

**#3368, tmux targeting.** Setting `base-index 1` on a live session does not renumber the window it was created with, so the three tests justified by "with base-index 1, window 0 does not exist" ran against a session that still had a window 0. The first window now moves to index 1 after the option is set, and the helper asserts window 0 is gone. tmux resolves a missing window index to the session's current window, so `:0.0` then reads the active window rather than failing.

Same file, three more gaps. `capture_pane`'s `.expect(...)` could not fire (the call returns `Ok(String::new())` on a failed tmux invocation) and the content was discarded; the first window's pane now prints a marker and the test asserts the capture contains it. The dead-pane test slept 300 ms and set `remain-on-exit` at a scope the second window never inherited, so that window closed and the active window was the agent's own; its pane now blocks on a release file until `remain-on-exit` is on it, and the test polls `#{pane_dead}`. `test_status_checks_with_split_panes_and_pane_base_index_1` set `pane-base-index 1` nowhere and duplicated the test above it; it now sets the server-global option, which is what a user actually sets, and builds the session through the production `append_*_args` helpers.

**#3479, `xtask check-skill`.** `skill_commands` was only inserted into after `cli_commands` had accepted the value, so the arm asking `!cli_commands.contains(...)` was unsatisfiable. Worse than inert: `aoe session bogusverb` truncated to `session` and, through the advisory's prefix rule, suppressed the twelve `aoe session *` entries. Scoped down per your comment on the issue, following @blueagledev's design: read code context only (fenced blocks and paired inline spans, line-local), record what was read rather than what matched, treat a trailing word as a subcommand only where the resolved path takes subcommands, and collect `get_all_aliases()`. Output on the current tree is byte-identical to before, exit 0, advisory unchanged at 92.

xtask's tests also now run in CI. The workspace declares no `default-members`, so every `cargo test` in the workflows was scoped to the root package and the xtask tests ran only on a contributor's machine. Clippy for xtask is deliberately left out: it needs a second lib build under different features.

**#3469, PATH scrubbers onto `EnvGuard`.** The seven save/restore pairs excluded their readers by `#[serial]` key rather than by `ENV_LOCK`. `git grep 'set_var("PATH"' -- src/` now returns nothing. Three comments documented that as a reason not to reach for the guard; all three are gone, and `#[serial]` comes off the three readers they justified. `path_prepended` also drops an empty inherited `PATH` rather than splitting it: `split_paths("")` yields one empty entry, which means the current directory, so the `format!("{prefix}:{prev}")` it replaces put the caller's cwd on the test's `PATH`.

### How each new assertion was shown to fail

| mutation | result |
| --- | --- |
| `^.0` back to `:0.0` in `is_pane_dead`, `pane_current_command`, `pane_start_command_is_protected`, `Session::capture_pane` | 3 of the 4 targeting tests fail; all 4 passed before this PR |
| `append_pane_base_index_args` appends nothing | `test_status_checks_with_split_panes_and_pane_base_index_1` fails |
| `check-skill` records nothing for an unresolvable word | the extractor test fails |
| trailing word after a parent is not checked | the extractor test fails |
| aliases are not collected | the alias test fails |
| whole file scanned instead of its code spans | the extractor test fails |
| a flag after a parent command is read as a subcommand | the extractor test fails |
| a `#` comment inside a fence is read as an invocation | the extractor test fails |
| the reader takes no `ENV_LOCK` | the exclusion test fails on the visible mutation |
| `path_prepended` restores with a raw `set_var` | the exclusion test fails |
| `path_prepended` reads `PATH` before taking the lock | the derivation test fails |

The one test that stays green under the `^.0` → `:0.0` mutation is `test_status_checks_with_split_panes_and_pane_base_index_1`, correctly: it covers the `.0` half, which that mutation does not touch. It has its own mutation above.

Injected into a fenced block in `contrib/openclaw-skill/SKILL.md`, before and after:

| line | before | after |
| --- | --- | --- |
| `aoe totallybogus` | exit 0, advisory 92 | exit 1, advisory 92 |
| `aoe session bogusverb` | exit 0, advisory 80 | exit 1, advisory 92 |
| `aoe session pin` | exit 0, advisory 80 | exit 1, advisory 92 |
| `aoe ls`, `aoe rm x`, `aoe profile mv a b`, `aoe group create g`, `aoe group ls`, `aoe session capture id` | exit 0 | exit 0 |

The first version of the `ENV_LOCK` exclusion test passed both of its mutations, because the reader's 500 lock/read iterations finished before the peer thread had scrubbed anything. It was rewritten to hold the peer's guard across a real window.

### Review round (commit 4)

A review caught three isolation defects, all reproduced before being fixed. The largest was mine and made things worse than `main`: moving the `omp` capture-gate test from a child-scoped `PATH` to a process-global one and dropping `#[serial]` put a fake `tmux` on every concurrent test's `PATH`. `tmux_available()` reads the shim's exit 0 as tmux being present, so tmux tests ran against the shim rather than skipping. `cargo test --lib -- tmux::session::tests::a_zoomed_pane session::instance::omp::tests::omp_capture_gate --test-threads=8` failed 3/3, and in full-suite runs it also tripped this branch's own new assertion. The override is child-scoped again and the test holds `ENV_LOCK` only for the read that builds it; 3/3 green after.

`path_prepended` also read `PATH` before taking the lock, so the helper written to close that hole had it. `EnvGuard::and_set` chains onto `read_lock` so the derivation happens inside the lock. `GlobalPaneBaseIndex` could leak the global on a failed `show-options`, and `check-skill` had gained two false positives (`aoe group --help`, and a `#` comment inside a fence). Each is now a table case that fails without its fix.

### One thing I could not settle

`session::smart_rename::tests::resolve_smart_rename_config_reads_repo_aware_config_but_not_repo_commands` went red once during the review, on the pre-fix code. It is 0/8 red on the current branch. Its state is `HOME` / `XDG_CONFIG_HOME`, set at `src/session/smart_rename.rs:2547` with a raw unguarded `set_var` behind only `#[serial]` and never restored, while fifteen non-serial tests mutate the same state through `AppDirGuard` under `ENV_LOCK`. That is a pre-existing instance of this PR's own bug class in a file this PR does not touch, and none of the three tests de-serialized here reads or writes `HOME`. I could not build a `main` baseline to prove attribution: the box is at 100% disk with 1.4 GB free and a second debug target directory does not fit. Flagging it rather than claiming it is unrelated.

### #3513 and #3648: already fixed, nothing changed here

**#3513** was fixed by #3750 (`src/tmux/mod.rs`): the 1000 ms sleep is a poll to a 15 second deadline, and `remain-on-exit on` is chained into the create so waiting past the exit cannot lose the output. 5/5 green locally on tmux 3.6. Recommend closing.

**#3648** was fixed by #3678 (`b2569c75e`), incidentally rather than by name. The assertion the issue reports, `assert_eq!(spoofed, expect_continuation)` with `("C", false)`, is the one that commit deleted; `test_batch_output_frames_records_against_a_real_tmux` now asserts only that `parse_batch_output` returns `real-id` for whatever raw form each available locale produced, which is acceptance criteria 1, 2 and 4. Criterion 3's multiline fixtures are in `test_parse_batch_output_ignores_multiline_continuations`; the flattened form has no fixture of its own, which is a one-line gap I have not filled. I could not reproduce the failure: this box has tmux 3.6, where `LC_ALL=C` does flatten the newline to `_`, so even the pre-#3678 assertion holds here. The tmux 3.7c behavior the issue reports is real, and the code that depended on it is gone. Recommend closing.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
  - `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo clippy -p xtask --all-targets -- -D warnings`, `cargo test`: 6872 lib + 289 integration passed, 4/4 repeat runs green. `cargo test -p xtask`: 6 passed, 3 of them new.
- [x] Documentation was updated where necessary
  - No user-facing behavior changes. The three stale `EnvGuard` caveats are corrected where they sit.
- [x] For UI changes: included screenshot or recording
  - No UI changes.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Every change here is to test code or to the check that gates it. No production behavior changes; the mutation table above is the coverage evidence.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:** The mutation runs, the before/after `check-skill` matrix and the tmux target-resolution probes were executed and reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWwvnDwmKNLDnVB1kmcjWi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Strengthened tmux tests for window targeting, pane output, dead-pane handling, and user index settings.
- Improved `xtask check-skill` validation for aliases, subcommands, flags, comments, and code spans.
- Added xtask and `aoe-plugin-api` test coverage to CI.
- Centralized test `PATH` isolation with `EnvGuard` and `path_prepended`.
- Replaced manual environment cleanup and obsolete test serialization.
- Added tests for environment isolation and fixed review-discovered test leaks and false positives.

## Benefits

These changes make regression tests more reliable and improve CI coverage. They also prevent test environment leaks without changing production behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->