### PR TITLE
fix(server): hold the passphrase wall against unforwarded proxied requests

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -184,7 +184,7 @@ aoe serve \
 
 The upstream must set `X-Forwarded-For` (or `cf-connecting-ip`); aoe reads the last value as the client IP. The trust check fires only when the socket peer is loopback, so a misconfigured upstream that lets requests reach aoe directly cannot spoof the IP.
 
-With `--auth=passphrase --behind-proxy` the passphrase wall applies to loopback callers too. Proxied traffic arrives on a loopback socket, so an upstream that forgets the header would otherwise hand every visitor the same-host bypass. The local TUI on such a daemon signs in like any other client.
+With `--auth=passphrase --behind-proxy` the passphrase wall applies to loopback callers too. Proxied traffic arrives on a loopback socket, so an upstream that forgets the header would otherwise hand every visitor the same-host bypass. A browser on the same host signs in with the passphrase like any other client. The TUI structured view has no passphrase exchange, so it cannot attach to a `--behind-proxy` passphrase daemon; use `--auth=token` on daemons you also drive from the local TUI.
 
 `--behind-proxy` requires at least one `--allowed-host <public-hostname>`: aoe cannot infer the hostname your proxy forwards, and the [DNS-rebinding gate](#dns-rebinding) rejects any `Host` it does not recognize. If the proxy listens on a nonstandard port, also pass the exact origin, e.g. `--allowed-origin https://aoe.example.com:8443`. The daemon refuses to start (with an explicit message) if `--behind-proxy` is set without `--allowed-host`.
 

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -184,6 +184,8 @@ aoe serve \
 
 The upstream must set `X-Forwarded-For` (or `cf-connecting-ip`); aoe reads the last value as the client IP. The trust check fires only when the socket peer is loopback, so a misconfigured upstream that lets requests reach aoe directly cannot spoof the IP.
 
+With `--auth=passphrase --behind-proxy` the passphrase wall applies to loopback callers too. Proxied traffic arrives on a loopback socket, so an upstream that forgets the header would otherwise hand every visitor the same-host bypass. The local TUI on such a daemon signs in like any other client.
+
 `--behind-proxy` requires at least one `--allowed-host <public-hostname>`: aoe cannot infer the hostname your proxy forwards, and the [DNS-rebinding gate](#dns-rebinding) rejects any `Host` it does not recognize. If the proxy listens on a nonstandard port, also pass the exact origin, e.g. `--allowed-origin https://aoe.example.com:8443`. The daemon refuses to start (with an explicit message) if `--behind-proxy` is set without `--allowed-host`.
 
 ## Security

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -37,7 +37,11 @@ stay in sync.
 - **`--auth=passphrase` daemons**: the local TUI attaches to a same-host
   daemon without the passphrase exchange (loopback callers are protected
   by the 0600 serve files on disk). Remote callers proxied through a
-  tunnel still hit the passphrase wall.
+  tunnel still hit the passphrase wall. Adding `--behind-proxy` withdraws
+  the same-host carve-out (see
+  [Behind a reverse proxy](../guides/web-dashboard.md#behind-a-reverse-proxy)),
+  and the TUI has no passphrase exchange to fall back on, so it cannot
+  attach to that daemon.
 
 ### TUI structured view keybinds
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -26,7 +26,7 @@ impl AuthMode {
     /// match arms are kept in lockstep with clap's `value(rename_all =
     /// "lowercase")` derive by the `auth_mode_cli_str_matches_clap`
     /// unit test, which round-trips each string through `ValueEnum`.
-    fn as_cli_str(self) -> &'static str {
+    pub(crate) fn as_cli_str(self) -> &'static str {
         match self {
             AuthMode::Token => "token",
             AuthMode::Passphrase => "passphrase",
@@ -1096,7 +1096,7 @@ pub async fn run(profile: &str, mut args: ServeArgs) -> Result<()> {
         profile,
         host: &host,
         port: args.resolved_port(),
-        no_auth: matches!(auth_mode, AuthMode::Passphrase | AuthMode::None),
+        auth_mode,
         read_only: args.read_only,
         remote: args.remote,
         tunnel_name: args.tunnel_name.as_deref(),

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -310,7 +310,10 @@ enum PassphraseWallEntryAction {
 
 /// Resolve the entry decision for `run_passphrase_wall`. Extracted so
 /// the bypass policy is table-testable without standing up the full
-/// axum middleware. See #1525.
+/// axum middleware. `behind_ingress` is `state.behind_tunnel`;
+/// `auth_middleware` withholds `LoopbackTrusted` under the same
+/// condition so elevation does not restore what this denies. See
+/// #1525 and #3843.
 fn passphrase_wall_entry_action(
     path: &str,
     client_ip: IpAddr,
@@ -669,7 +672,14 @@ pub async fn auth_middleware(
     // elevation gates see the #1168 carve-out no matter which path
     // (token, session, passphrase wall, loopback bypass) handled the
     // request. See `LoopbackTrusted`.
-    if is_local_trusted(client_ip) {
+    //
+    // Withheld wherever the passphrase wall itself stops trusting
+    // loopback, or a caller who signed in through the wall would keep
+    // the elevation carve-out the wall just denied them. See #3843.
+    let wall_covers_loopback = state.behind_tunnel
+        && state.token_manager.is_no_auth().await
+        && state.login_manager.is_enabled();
+    if !wall_covers_loopback && is_local_trusted(client_ip) {
         request.extensions_mut().insert(LoopbackTrusted);
     }
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -72,6 +72,11 @@ pub(crate) fn resolve_client_ip(
 /// the local-TUI-to-local-daemon flow; remote callers proxied via a
 /// tunnel are unaffected because [`resolve_client_ip`] resolves them
 /// to the real remote IP, not loopback. See #1168.
+///
+/// That last clause holds only while the upstream sets those headers.
+/// [`passphrase_wall_entry_action`], which grants access on loopback
+/// alone, therefore drops the carve-out behind an external ingress.
+/// See #3843.
 fn is_local_trusted(client_ip: IpAddr) -> bool {
     client_ip.is_loopback()
 }
@@ -291,13 +296,13 @@ enum PassphraseWallEntryAction {
     /// `/login`, `/api/login`, static assets, etc. stay reachable
     /// even without a session.
     BypassExempt,
-    /// Caller is on loopback. fs-perm boundary on
-    /// `~/.agent-of-empires/serve.*` already protects same-host
-    /// access, so layering the passphrase factor on top adds friction
-    /// without strengthening the trust boundary. Mirrors the token-
-    /// auth path's `is_local_trusted` carve-out from #1168 so the
-    /// local TUI works against an `--auth=passphrase` daemon. See
-    /// #1525.
+    /// Caller is on loopback and no external ingress fronts the
+    /// daemon. fs-perm boundary on `~/.agent-of-empires/serve.*`
+    /// already protects same-host access, so layering the passphrase
+    /// factor on top adds friction without strengthening the trust
+    /// boundary. Mirrors the token-auth path's `is_local_trusted`
+    /// carve-out from #1168 so the local TUI works against an
+    /// `--auth=passphrase` daemon. See #1525.
     BypassLoopback,
     /// Run the full session + device-binding + elevation flow.
     Continue,
@@ -306,11 +311,15 @@ enum PassphraseWallEntryAction {
 /// Resolve the entry decision for `run_passphrase_wall`. Extracted so
 /// the bypass policy is table-testable without standing up the full
 /// axum middleware. See #1525.
-fn passphrase_wall_entry_action(path: &str, client_ip: IpAddr) -> PassphraseWallEntryAction {
+fn passphrase_wall_entry_action(
+    path: &str,
+    client_ip: IpAddr,
+    behind_ingress: bool,
+) -> PassphraseWallEntryAction {
     if is_login_session_exempt(path) {
         return PassphraseWallEntryAction::BypassExempt;
     }
-    if is_local_trusted(client_ip) {
+    if !behind_ingress && is_local_trusted(client_ip) {
         return PassphraseWallEntryAction::BypassLoopback;
     }
     PassphraseWallEntryAction::Continue
@@ -551,10 +560,10 @@ pub(crate) async fn handler_elevated(
 /// mirrors the token-auth path's #1168 carve-out so the local TUI can
 /// attach to a same-host `--auth=passphrase` daemon without going
 /// through a passphrase exchange. The fs-perm boundary on
-/// `~/.agent-of-empires/serve.*` already protects same-host access,
-/// and remote callers proxied through a tunnel come in with the real
-/// remote IP via `resolve_client_ip`, so they still hit the wall as
-/// expected. See #1525.
+/// `~/.agent-of-empires/serve.*` already protects same-host access.
+/// Behind an external ingress a loopback peer may be proxied public
+/// traffic instead, so the carve-out is off there and the passphrase
+/// holds for everyone. See #1525 and #3843.
 ///
 /// Rate-limit lockout is intentionally not consulted here: the only
 /// authentication attempt that can fail in this path is the passphrase
@@ -572,7 +581,7 @@ async fn run_passphrase_wall(
     let path = request.uri().path().to_string();
     let method = request.method().clone();
 
-    match passphrase_wall_entry_action(&path, client_ip) {
+    match passphrase_wall_entry_action(&path, client_ip, state.behind_tunnel) {
         PassphraseWallEntryAction::BypassExempt => return next.run(request).await,
         PassphraseWallEntryAction::BypassLoopback => {
             log_loopback_bypass_passphrase(client_ip, &path);
@@ -1223,15 +1232,15 @@ mod tests {
         // wall entirely. This is the #1525 fix: same-host TUI attach
         // must not require a passphrase exchange.
         assert_eq!(
-            passphrase_wall_entry_action("/api/sessions", loopback),
+            passphrase_wall_entry_action("/api/sessions", loopback, false),
             PassphraseWallEntryAction::BypassLoopback
         );
         assert_eq!(
-            passphrase_wall_entry_action("/sessions/abc/acp/ws", loopback),
+            passphrase_wall_entry_action("/sessions/abc/acp/ws", loopback, false),
             PassphraseWallEntryAction::BypassLoopback
         );
         assert_eq!(
-            passphrase_wall_entry_action("/api/settings", loopback_v6),
+            passphrase_wall_entry_action("/api/settings", loopback_v6, false),
             PassphraseWallEntryAction::BypassLoopback
         );
 
@@ -1239,26 +1248,46 @@ mod tests {
         // is the case the passphrase wall was built for; the bypass
         // must not leak through here.
         assert_eq!(
-            passphrase_wall_entry_action("/api/sessions", remote),
+            passphrase_wall_entry_action("/api/sessions", remote, false),
             PassphraseWallEntryAction::Continue
         );
         assert_eq!(
-            passphrase_wall_entry_action("/sessions/abc/acp/ws", remote),
+            passphrase_wall_entry_action("/sessions/abc/acp/ws", remote, false),
             PassphraseWallEntryAction::Continue
         );
 
         // Login-bootstrap allow-list wins regardless of IP, so the
         // SPA can pull assets and POST to `/api/login` from any peer.
         assert_eq!(
-            passphrase_wall_entry_action("/login", remote),
+            passphrase_wall_entry_action("/login", remote, false),
             PassphraseWallEntryAction::BypassExempt
         );
         assert_eq!(
-            passphrase_wall_entry_action("/api/login", remote),
+            passphrase_wall_entry_action("/api/login", remote, false),
             PassphraseWallEntryAction::BypassExempt
         );
         assert_eq!(
-            passphrase_wall_entry_action("/assets/index.css", loopback),
+            passphrase_wall_entry_action("/assets/index.css", loopback, false),
+            PassphraseWallEntryAction::BypassExempt
+        );
+
+        // #3843: behind an external ingress the loopback rows run the
+        // full session check. This is the reported bypass: with
+        // `--auth=passphrase --behind-proxy` and an upstream that does
+        // not set `X-Forwarded-For`, every internet request arrived as
+        // loopback and walked straight past the only gate.
+        assert_eq!(
+            passphrase_wall_entry_action("/api/sessions", loopback, true),
+            PassphraseWallEntryAction::Continue
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/sessions/abc/acp/ws", loopback_v6, true),
+            PassphraseWallEntryAction::Continue
+        );
+        // The login surfaces stay exempt, otherwise nobody could reach
+        // the wall to get past it.
+        assert_eq!(
+            passphrase_wall_entry_action("/api/login", loopback, true),
             PassphraseWallEntryAction::BypassExempt
         );
     }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1,6 +1,7 @@
 //! Bringing the server up: auth mode, fd limits, the listener, and the
 //! background loops it owns.
 
+use crate::cli::serve::AuthMode;
 use crate::file_watch::FileWatchService;
 use crate::server::push::{PushState, STATUS_CHANNEL_CAPACITY};
 use crate::server::rate_limit::RateLimiter;
@@ -144,7 +145,12 @@ pub struct ServerConfig<'a> {
     pub profile: &'a str,
     pub host: &'a str,
     pub port: u16,
-    pub no_auth: bool,
+    /// Auth mode the operator asked for. Carried whole rather than
+    /// flattened to a "no token" bool so `start_server` can tell
+    /// `--auth=passphrase` (token off, passphrase wall on) apart from
+    /// `--auth=none` (no gate) and refuse to bind when the requested
+    /// mode's gate is missing. See #3843.
+    pub auth_mode: AuthMode,
     pub read_only: bool,
     pub remote: bool,
     pub tunnel_name: Option<&'a str>,
@@ -182,12 +188,40 @@ pub(crate) async fn resolve_auth_mode(
     }
 }
 
+/// Refuse to bind when the requested [`AuthMode`] has no live gate.
+///
+/// Each mode names one thing that must exist: `token` a URL token,
+/// `passphrase` the login wall. `none` is the only mode allowed to have
+/// neither, and the CLI already confines it to a loopback bind or an
+/// explicit `--behind-proxy`. Asking for a stronger mode must never
+/// resolve to a weaker one than the default, so an unwired gate is a
+/// startup failure rather than a warning over an open port. See #3843.
+fn check_auth_gate(
+    auth_mode: AuthMode,
+    token_gate: bool,
+    passphrase_wall: bool,
+) -> anyhow::Result<()> {
+    let installed = match auth_mode {
+        AuthMode::Token => token_gate,
+        AuthMode::Passphrase => passphrase_wall,
+        AuthMode::None => true,
+    };
+    if installed {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "--auth={} was requested but its gate did not come up; refusing to serve \
+         unauthenticated. Use --auth=none if an unauthenticated port is intended.",
+        auth_mode.as_cli_str()
+    )
+}
+
 pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let ServerConfig {
         profile,
         host,
         port,
-        no_auth,
+        auth_mode,
         read_only,
         remote,
         tunnel_name,
@@ -218,16 +252,18 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
 
     let instances = load_all_instances(&file_watch)?;
 
-    // Load or generate auth token
-    let auth_token = if no_auth {
+    // Only `--auth=token` issues a URL token. The other two modes are
+    // separated below, once the login wall they depend on exists.
+    let auth_token = match auth_mode {
+        AuthMode::Token => Some(load_or_generate_token().await?),
+        AuthMode::Passphrase | AuthMode::None => None,
+    };
+    if matches!(auth_mode, AuthMode::None) {
         eprintln!(
             "WARNING: Running without authentication. \
              Anyone with network access to this port can control your agent sessions."
         );
-        None
-    } else {
-        Some(load_or_generate_token().await?)
-    };
+    }
 
     let token_lifetime = test_token_lifetime_override().unwrap_or_else(|| {
         if remote {
@@ -272,6 +308,17 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         login::LoginManager::new(passphrase)
     });
     let rate_limiter = Arc::new(RateLimiter::new());
+
+    // Fail closed before anything binds: check the gates that actually
+    // came up against the mode that was asked for. See #3843.
+    check_auth_gate(auth_mode, auth_token.is_some(), login_manager.is_enabled())?;
+
+    if matches!(auth_mode, AuthMode::Passphrase) {
+        eprintln!(
+            "Passphrase authentication: no URL token is issued. Callers reaching \
+             this port sign in with the passphrase."
+        );
+    }
 
     if login_manager.is_enabled() {
         info!("Passphrase login enabled (second-factor authentication)");
@@ -1147,6 +1194,32 @@ async fn remote_rotation_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Every arm of the mode -> gate mapping, including the two that
+    // were never the reported bug: a mode may only start when the gate
+    // it names is live. #3843 was `passphrase` resolving to an open
+    // port, so the passphrase row is the load-bearing one, but the
+    // token row guards the same class of mistake.
+    #[test]
+    fn check_auth_gate_requires_the_gate_each_mode_names() {
+        let cases = [
+            (AuthMode::Token, true, false, true),
+            (AuthMode::Token, true, true, true),
+            (AuthMode::Token, false, true, false),
+            (AuthMode::Passphrase, false, true, true),
+            (AuthMode::Passphrase, false, false, false),
+            (AuthMode::Passphrase, true, false, false),
+            (AuthMode::None, false, false, true),
+        ];
+        for (mode, token_gate, wall, expected_ok) in cases {
+            let got = check_auth_gate(mode, token_gate, wall);
+            assert_eq!(
+                got.is_ok(),
+                expected_ok,
+                "mode={mode:?} token_gate={token_gate} wall={wall} gave {got:?}"
+            );
+        }
+    }
 
     #[test]
     fn remote_serve_url_contents_keeps_public_primary_and_loopback_alternate() {

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -353,6 +353,24 @@ fn cli_serve_auth_passphrase_login_round_trip() {
             ));
         }
 
+        // `/api/sessions` is the surface #3843 reported as readable
+        // without a credential: session ids, titles, and filesystem
+        // paths. Assert it directly rather than trusting that the wall
+        // covers it because `/api/about` is covered.
+        let sessions_unauth = client
+            .get(format!("{base}/api/sessions"))
+            .header("x-forwarded-for", "10.0.0.5")
+            .send()
+            .await
+            .map_err(|e| format!("GET /api/sessions (unauth): {e}"))?;
+        if sessions_unauth.status() != reqwest::StatusCode::UNAUTHORIZED {
+            let s = sessions_unauth.status();
+            let b = sessions_unauth.text().await.unwrap_or_default();
+            return Err(format!(
+                "remote /api/sessions must 401 under --auth=passphrase, got status={s} body={b}"
+            ));
+        }
+
         // 2. POST /api/login with matching passphrase + device binding.
         let login = client
             .post(format!("{base}/api/login"))
@@ -514,6 +532,98 @@ fn cli_serve_auth_passphrase_loopback_bypass() {
             return Err(format!(
                 "loopback /api/sessions should 200 under --auth=passphrase, got status={s} body={b}"
             ));
+        }
+
+        Ok(())
+    });
+
+    let _ = h.run_cli(&["serve", "--stop"]);
+
+    if let Err(e) = result {
+        panic!("{e}");
+    }
+}
+
+/// Regression test for #3843. `--auth=passphrase --behind-proxy` is the
+/// documented "TLS terminated upstream, passphrase is the only human
+/// gate" deployment. The proxy runs on the same host, so its requests
+/// arrive from a loopback socket; the #1525 loopback carve-out then
+/// waved them all through, and an upstream that does not set
+/// `X-Forwarded-For` (a bare nginx `proxy_pass`) turned the whole API
+/// into an unauthenticated public surface.
+///
+/// Flow: start a `--behind-proxy` passphrase daemon, then send exactly
+/// what such a proxy sends: loopback socket, the public `Host`, no
+/// forwarding header, no credential. `/api/sessions` must 401. Before
+/// the fix it returned 200 with the session list.
+#[test]
+#[parallel]
+fn cli_serve_auth_passphrase_behind_proxy_gates_unforwarded_requests() {
+    let h = TuiTestHarness::new("serve_auth_passphrase_behind_proxy");
+    let port = pick_free_port();
+    let port_s = port.to_string();
+
+    let start = h.run_cli(&[
+        "serve",
+        "--daemon",
+        "--port",
+        &port_s,
+        "--auth",
+        "passphrase",
+        "--passphrase",
+        "e2e-pass",
+        "--behind-proxy",
+        "--allowed-host",
+        "aoe.example.test",
+    ]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon --auth=passphrase --behind-proxy failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let result: Result<(), String> = rt.block_on(async {
+        let base = format!("http://127.0.0.1:{port}");
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| format!("build client: {e}"))?;
+
+        for path in ["/api/sessions", "/api/projects"] {
+            let res = client
+                .get(format!("{base}{path}"))
+                .header("host", "aoe.example.test")
+                .send()
+                .await
+                .map_err(|e| format!("GET {path}: {e}"))?;
+            if res.status() != reqwest::StatusCode::UNAUTHORIZED {
+                let s = res.status();
+                let b = res.text().await.unwrap_or_default();
+                return Err(format!(
+                    "{path} must 401 for an unforwarded proxied request under \
+                     --auth=passphrase --behind-proxy, got status={s} body={b}"
+                ));
+            }
+        }
+
+        // The login surfaces stay reachable, otherwise a real user
+        // behind the proxy could never get past the wall.
+        let login_page = client
+            .get(format!("{base}/api/login/status"))
+            .header("host", "aoe.example.test")
+            .send()
+            .await
+            .map_err(|e| format!("GET /api/login/status: {e}"))?;
+        if !login_page.status().is_success() {
+            let s = login_page.status();
+            return Err(format!("/api/login/status must stay reachable, got {s}"));
         }
 
         Ok(())

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -556,6 +556,12 @@ fn cli_serve_auth_passphrase_loopback_bypass() {
 /// what such a proxy sends: loopback socket, the public `Host`, no
 /// forwarding header, no credential. `/api/sessions` must 401. Before
 /// the fix it returned 200 with the session list.
+///
+/// Then sign in over that same unforwarded shape and confirm a
+/// step-up-gated route still demands elevation: the request used to
+/// carry `LoopbackTrusted`, which would have handed a proxied visitor
+/// who knew the passphrase the skill and plugin mutation routes with
+/// no re-prompt.
 #[test]
 #[parallel]
 fn cli_serve_auth_passphrase_behind_proxy_gates_unforwarded_requests() {
@@ -624,6 +630,73 @@ fn cli_serve_auth_passphrase_behind_proxy_gates_unforwarded_requests() {
         if !login_page.status().is_success() {
             let s = login_page.status();
             return Err(format!("/api/login/status must stay reachable, got {s}"));
+        }
+
+        // Signing in must not restore through elevation what the wall
+        // denied. The same unforwarded request used to be stamped
+        // `LoopbackTrusted`, which `handler_elevated` reads as an
+        // elevated session, so a proxied visitor who knew the
+        // passphrase reached the step-up-gated routes (plugin and
+        // skill mutation: arbitrary code on the host) with no
+        // re-prompt. `SkillMutationGuard` runs before the handler, so
+        // the directory below is never touched.
+        let binding_raw: [u8; 32] = [0x5Au8; 32];
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+        let binding_b64 = URL_SAFE_NO_PAD.encode(binding_raw);
+
+        let login = client
+            .post(format!("{base}/api/login"))
+            .header("host", "aoe.example.test")
+            .json(&serde_json::json!({
+                "passphrase": "e2e-pass",
+                "device_binding_secret": binding_b64,
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("POST /api/login: {e}"))?;
+        if !login.status().is_success() {
+            let s = login.status();
+            let b = login.text().await.unwrap_or_default();
+            return Err(format!("login failed: status={s} body={b}"));
+        }
+        let session_cookie = login
+            .headers()
+            .get_all(reqwest::header::SET_COOKIE)
+            .iter()
+            .find_map(|v| {
+                let s = v.to_str().ok()?;
+                let first = s.split(';').next()?.trim();
+                if first.starts_with("aoe_session=") {
+                    Some(first.to_string())
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| "login response missing aoe_session Set-Cookie".to_string())?;
+
+        let mutation = client
+            .delete(format!("{base}/api/skills/e2e-nonexistent"))
+            .header("host", "aoe.example.test")
+            .header("cookie", &session_cookie)
+            .header("x-aoe-device-binding", &binding_b64)
+            .send()
+            .await
+            .map_err(|e| format!("DELETE /api/skills: {e}"))?;
+        if mutation.status() != reqwest::StatusCode::FORBIDDEN {
+            let s = mutation.status();
+            let b = mutation.text().await.unwrap_or_default();
+            return Err(format!(
+                "a signed-in proxied caller must still step up for a skill \
+                 mutation, got status={s} body={b}"
+            ));
+        }
+        let body: serde_json::Value = mutation
+            .json()
+            .await
+            .map_err(|e| format!("decode mutation body: {e}"))?;
+        if body.get("error").and_then(|v| v.as_str()) != Some("elevation_required") {
+            return Err(format!("expected elevation_required, got {body}"));
         }
 
         Ok(())


### PR DESCRIPTION
## Description

Running `aoe serve` behind a reverse proxy with `--auth=passphrase` could leave the whole API open to the internet with no password. The proxy sits on the same machine as aoe, so its traffic arrives looking like it came from that machine, and aoe used to treat anything from the same machine as already trusted and let it straight through. That shortcut exists so the local terminal app does not have to keep typing the passphrase. It only stays safe if the proxy tells aoe who the real visitor is, and a proxy that is not configured to do that (which is the default for a plain nginx setup) leaves aoe unable to tell a stranger on the internet apart from the owner sitting at the keyboard. Everyone got waved through. Now the passphrase is required from everyone whenever a proxy is in front. The trade-off is that the terminal app can no longer attach to such a server at all, because it has no way to type a passphrase; run `--auth=token` on servers you also drive from the terminal.

The report that started this (#3843) saw the API answer without a password and a startup line reading "Running without authentication", and read it as `--auth=passphrase` installing no gate at all. That startup line was wrong, and it is fixed here too, but the gate itself was real: a genuinely remote caller was always refused. What was not real was the gate holding behind a proxy.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

### What changed

`passphrase_wall_entry_action` no longer grants the loopback carve-out when an external ingress fronts the daemon.

The token path's `is_local_trusted` carve-out (#1168) is deliberately unchanged. It fires only after a valid token, so an upstream that drops the forwarding header costs a skipped second factor there, not an open port; withdrawing it would break local TUI attach against every `--remote` daemon, which is too much to bundle into a security fix.

Two supporting changes on the same defect:

- `ServerConfig` carries the requested `AuthMode` instead of a `no_auth` bool. `start_server` could not previously tell `passphrase` from `none`, which is the lossy mapping this looked like from the outside. `check_auth_gate` now refuses to bind when the requested mode's gate did not come up, instead of serving unauthenticated behind a warning.
- `--auth=passphrase` prints what it actually installs. "Running without authentication" is now reachable only from `--auth=none`.

### Modes verified

| mode | gate | behavior |
|---|---|---|
| `token` (default) | URL token | unchanged; 401 without a token, on a nonexistent route too |
| `passphrase` | login wall | remote 401 (unchanged); loopback bypass kept on a direct daemon; **withdrawn under `--behind-proxy`** |
| `none` (and `--no-auth`) | none | unchanged; keeps the warning, still confined by the CLI to a loopback bind or explicit `--behind-proxy` |

`--auth=passphrase` with `--remote` is refused by `validate_auth_combination`, so the withdrawal reaches only `--behind-proxy` daemons.

### Elevation, same misconfiguration

`auth_middleware` stamped `LoopbackTrusted` on every loopback peer before any auth branch, and `handler_elevated` reads that as an elevated session. A proxied visitor who knew the passphrase therefore signed in and reached the step-up-gated skill and plugin mutation routes, which install code on the host, with no re-prompt: the wall denied the carve-out and elevation returned it. The mark is now withheld under the same condition, scoped the same way. The wall's own path-shape gate was never affected; it requires a real elevated session.

### Known caveat

`build_login_cookie` sets `; Secure` whenever `behind_tunnel` is on. A local browser pointed straight at `http://127.0.0.1:<port>` of a `--behind-proxy` daemon now needs a session cookie where it previously needed none. Chrome and Firefox treat loopback as a secure context and store it; Safari historically does not. Worth one manual check. Loosening the flag would weaken the proxied case, so I have not touched it.

### Two judgement calls

`src/server/startup.rs` is now the only `use crate::cli::…` in `src/server/`, so `pub ServerConfig` carries a clap `ValueEnum`. Moving `AuthMode` down a layer would touch `ServeLaunch`'s persisted representation, which is not what I want to churn in a security patch.

`check_auth_gate`'s failure branch is unreachable from the current CLI, which already rejects `--auth=passphrase` without a passphrase. It is kept deliberately: the invariant lives in `src/cli/`, the code that depends on it lives in `src/server/`, and `ServerConfig` is public. A mode that cannot install its gate should not bind.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

`cli_serve_auth_passphrase_behind_proxy_gates_unforwarded_requests` sends what an unconfigured proxy sends (loopback socket, public `Host`, no forwarding header, no credential) and requires a 401, then signs in over that same shape and requires a step-up-gated route to still demand elevation. Both halves verified failing against the pre-fix predicates: `status=200 OK body={"sessions":[...]}` and `status=404 body={"error":"skill_not_found"}`, the latter meaning the mutation guard had already been passed. `cli_serve_auth_passphrase_login_round_trip` gained the `/api/sessions` assertion, the surface the report named. `cli_serve_auth_passphrase_loopback_bypass` is unchanged and still passes, pinning local TUI attach on a direct daemon. Unit tables cover the wall entry rows and every `check_auth_gate` mode.

`cargo fmt`, `cargo clippy --all-targets`, `cargo test`, and `cargo test --features e2e-tests --test e2e -- serve` all pass. Two `serve::` e2e cases (`daemon_starts_and_stops_cleanly`, `restart_replays_launch_state`) fail in my sandbox only: PID 1 there is `sleep`, so exited daemons stay unreaped and `kill(pid, 0)` reports a zombie as alive. Confirmed `State: Z` on each reported PID.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Reproduced against a local daemon before and after the change; the mode table above is from observed responses, not reading. A separate fresh-context agent reviewed the branch and found the false TUI claim in the docs and the elevation neighbour, both addressed in the second commit.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqqwP2oh5H9muExvfEoBq9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Enforces passphrase authentication behind reverse proxies.
- Prevents loopback trust and same-host elevation from bypassing passphrase checks.
- Preserves the requested `AuthMode` and refuses startup when its authentication gate is missing.
- Limits unauthenticated warnings and token generation to their correct modes.
- Adds end-to-end coverage for proxied authentication and mutation protection.
- Updates documentation for proxy deployments and TUI limitations.

These changes prevent silent authentication downgrades and protect proxied server endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->