### PR TITLE
fix(sandbox): keep the host and sandbox Claude credential chains apart

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -359,14 +359,21 @@ macOS, `~/.claude/.credentials.json` elsewhere, and any copy left in the
 session's store by an earlier layout, each taken only when its expiry is later
 than what the file holds. Logging in on the host and starting or restarting
 one sandboxed session re-authenticates all of them; a login made inside a
-container is never overwritten by a staler host copy. The host itself stays a
-separate chain: a refresh inside a sandbox still rotates the token the host
-holds, as it did before. A container created before this layout mounts only
-its store, so a stopped one is recreated at its next start, as it was for the
-store move, and a running one refuses to relaunch until it is stopped. Running
-`/logout` inside a sandbox revokes the token for every sandbox but cannot
-remove the mounted file, so the revoked token stays there until the next
-login.
+container is never overwritten by a staler host copy. Between starts the file
+belongs to the containers: the TUI's periodic refresh only seeds a file that
+holds no credential, so a host refresh never replaces a token the sandboxes
+are rotating mid-session.
+
+The host and the sandboxes are not separate chains once a start has copied
+the host's token in: both then hold the same refresh token, and whichever
+refreshes first logs the other out, as it did before this layout. A login
+made inside a container starts a chain of its own, which the next start
+replaces again if the host's token is fresher by then. A container created
+before this layout mounts only its store, so a stopped one is recreated at its
+next start, as it was for the store move, and a running one refuses to
+relaunch until it is stopped. Running `/logout` inside a sandbox revokes the
+token for every sandbox but cannot remove the mounted file, so the revoked
+token stays there until the next login.
 
 ### Reclaiming stores
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -354,26 +354,24 @@ would fix only that container. So every Claude Code session mounts the one
 `sandbox-v2/.credentials.json` at its config path instead of keeping a copy in
 its store, and a refresh or login in any container is seen by the rest.
 
-Each start folds the freshest credential into that file: the Keychain entry on
-macOS, `~/.claude/.credentials.json` elsewhere, and any copy left in the
-session's store by an earlier layout, each taken only when its expiry is later
-than what the file holds. Logging in on the host and starting or restarting
-one sandboxed session re-authenticates all of them; a login made inside a
-container is never overwritten by a staler host copy. Between starts the file
-belongs to the containers: the TUI's periodic refresh only seeds a file that
-holds no credential, so a host refresh never replaces a token the sandboxes
-are rotating mid-session.
+A file that holds no credential is seeded at the next start or TUI refresh
+from the freshest of the Keychain entry on macOS, `~/.claude/.credentials.json`
+elsewhere, and any copy left in the session's store by an earlier layout. A
+file that holds one is never replaced by the host's again: a token copied from
+the host is the host's own refresh token, so both sides hold it until the
+first of them refreshes and logs the other out, as it did before this layout.
+From that first refresh on the sandboxes are a chain of their own, and a login
+made inside any one of them re-authenticates all of them. A copy left in a
+session's store by an earlier layout is a sandbox chain too, and is folded in
+at that session's next start when it is fresher. To seed the sandboxes from a
+new host login instead, stop them, delete `sandbox-v2/.credentials.json` and
+start one.
 
-The host and the sandboxes are not separate chains once a start has copied
-the host's token in: both then hold the same refresh token, and whichever
-refreshes first logs the other out, as it did before this layout. A login
-made inside a container starts a chain of its own, which the next start
-replaces again if the host's token is fresher by then. A container created
-before this layout mounts only its store, so a stopped one is recreated at its
-next start, as it was for the store move, and a running one refuses to
-relaunch until it is stopped. Running `/logout` inside a sandbox revokes the
-token for every sandbox but cannot remove the mounted file, so the revoked
-token stays there until the next login.
+A container created before this layout mounts only its store, so a stopped
+one is recreated at its next start, as it was for the store move, and a
+running one refuses to relaunch until it is stopped. Running `/logout` inside
+a sandbox revokes the token for every sandbox but cannot remove the mounted
+file, so the revoked token stays there until the next login.
 
 ### Reclaiming stores
 

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -196,6 +196,10 @@ impl DockerContainer {
             .shared_credential_mounts_match(&self.name, config)
     }
 
+    pub fn carries_shared_credential_label(&self) -> Result<Option<bool>> {
+        self.runtime.carries_shared_credential_label(&self.name)
+    }
+
     pub fn mount_fingerprint_matches(&self, config: &ContainerConfig) -> Result<Option<bool>> {
         self.runtime
             .mount_fingerprint_matches(&self.name, &config.mount_fingerprint())

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -405,6 +405,21 @@ impl ContainerRuntime {
         ))
     }
 
+    /// Whether `name` carries the shared credential label at all, as every
+    /// container created since its agent shared a credential file does.
+    pub fn carries_shared_credential_label(&self, name: &str) -> Result<Option<bool>> {
+        if !self.base.supports_labels {
+            return Ok(None);
+        }
+        Ok(Some(
+            self.inspect_container_label(
+                name,
+                crate::containers::container_interface::SHARED_CREDENTIAL_MOUNTS_LABEL,
+            )?
+            .is_some(),
+        ))
+    }
+
     pub fn mount_fingerprint_matches(&self, name: &str, expected: &str) -> Result<Option<bool>> {
         if !self.base.supports_labels {
             return Ok(None);

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -790,15 +790,17 @@ fn read_credential_candidate(dir: &Path, name: &str, follow: SymlinkPolicy) -> O
     })
 }
 
-/// Which credentials a fold may put in the shared file.
+/// Which candidates a fold may put over a credential the shared file holds.
+/// The host file and the Keychain only ever seed a file holding none: a token
+/// copied from the host is the host's own refresh token, and the first side
+/// to refresh would log the other out.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum CredentialFold {
-    /// A come-up, create or start: the freshest candidate replaces what the
-    /// file holds.
+    /// A come-up, create or start: a fresher copy left in the store by an
+    /// earlier layout, a sandbox chain of its own, replaces what the file
+    /// holds.
     Freshest,
-    /// Off a come-up: a file holding a credential is left to the containers'
-    /// own rotation, so a fresher host token never re-couples them to the host
-    /// chain mid-session. Only a file holding none is seeded.
+    /// Off a come-up: nothing replaces what the file holds.
     SeedOnly,
 }
 
@@ -815,10 +817,9 @@ fn holds_credential(content: &str) -> bool {
 /// once a container mounting the shared file exists.
 ///
 /// Candidates are the store's private copy (left by the v027 move or by a
-/// login before the file was shared), the host file and the macOS Keychain;
-/// each replaces the current content only when its `expiresAt` is newer, so a
-/// login made inside a container survives a stale host copy and a host
-/// re-login reaches every container at its next start. Only the winner's
+/// login before the file was shared), the host file and the macOS Keychain,
+/// the freshest by `expiresAt` winning among those `fold` admits; see
+/// [`CredentialFold`]. Only the winner's
 /// `claudeAiOauth` replaces the file's, so what the agent keeps beside it
 /// survives. The file is written in place: a rename would leave every running
 /// container's bind mount on the old inode. An absent file is created
@@ -838,23 +839,20 @@ fn sync_shared_credential(
     };
     std::fs::create_dir_all(root)?;
 
+    // Each candidate with whether it is a sandbox chain of its own.
     let mut candidates = Vec::new();
-    candidates.extend(read_credential_candidate(
-        sandbox_dir,
-        name,
-        SymlinkPolicy::Never,
-    ));
-    candidates.extend(read_credential_candidate(
-        host_dir,
-        name,
-        SymlinkPolicy::Follow,
-    ));
+    candidates.extend(
+        read_credential_candidate(sandbox_dir, name, SymlinkPolicy::Never).map(|c| (c, true)),
+    );
+    candidates.extend(
+        read_credential_candidate(host_dir, name, SymlinkPolicy::Follow).map(|c| (c, false)),
+    );
     if let Some((service, _)) = mount
         .keychain_credential
         .filter(|(_, filename)| *filename == name)
     {
         match read_keychain_credential(service) {
-            Ok(content) => candidates.extend(content),
+            Ok(content) => candidates.extend(content.map(|c| (c, false))),
             Err(e) => tracing::warn!(target: "session.profile",
                 "Failed to read keychain credential for {}: {}", mount.host_rel, e),
         }
@@ -865,10 +863,12 @@ fn sync_shared_credential(
     // so another come-up or a container's own refresh in between is seen.
     crate::hooks::with_config_lock_policy(&shared, "lock", SymlinkPolicy::Never, || {
         let existing = read_credential_file(root, name, SymlinkPolicy::Never)?;
-        let replaceable =
-            fold == CredentialFold::Freshest || !existing.as_deref().is_some_and(holds_credential);
+        let existing_usable = existing.as_deref().is_some_and(holds_credential);
         let mut winner: Option<&str> = None;
-        for candidate in candidates.iter().filter(|_| replaceable) {
+        for (candidate, sandbox_chain) in &candidates {
+            if existing_usable && !(*sandbox_chain && fold == CredentialFold::Freshest) {
+                continue;
+            }
             let current = winner.or(existing.as_deref());
             if current.is_none_or(|current| should_overwrite_credential(current, candidate)) {
                 winner = Some(candidate);
@@ -4566,16 +4566,17 @@ mod tests {
         assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
         assert!(!private.exists());
 
-        // A store with prior data still picks up a fresher host login.
+        // A fresher host login is the host's own chain: seeding it again
+        // would have the first side to refresh log the other out.
         fs::create_dir_all(store.join("projects")).unwrap();
         fs::write(host.join(".credentials.json"), credential(200)).unwrap();
         prepare();
-        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(200));
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
 
-        // A stale host copy does not clobber a login made in a container.
-        fs::write(host.join(".credentials.json"), credential(150)).unwrap();
+        // Nor does a stale host copy clobber a login made in a container.
+        fs::write(host.join(".credentials.json"), credential(50)).unwrap();
         prepare();
-        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(200));
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
 
         // A private copy left by the v027 move is folded in and left for a
         // container that still mounts only the store.
@@ -4617,9 +4618,10 @@ mod tests {
             );
         }
 
-        // A fresher host login waits for a come-up: between starts the file
-        // holds the containers' own rotation.
-        fs::write(host.join(".credentials.json"), credential(200)).unwrap();
+        // A fresher copy in the store, a sandbox chain of its own, waits for
+        // a come-up; a fresher host login never replaces what the file holds.
+        fs::write(host.join(".credentials.json"), credential(300)).unwrap();
+        fs::write(store.join(".credentials.json"), credential(200)).unwrap();
         prepare(CredentialFold::SeedOnly);
         assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
         prepare(CredentialFold::Freshest);

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1564,6 +1564,24 @@ fn compute_workspace_volume_paths(
 }
 
 /// Re-sync the current instance's physically isolated agent config.
+/// Whether the agent `tool` resolves to under `profile` shares a credential
+/// file across its sandboxes.
+pub(crate) fn agent_shares_credential_file(
+    profile: &str,
+    tool: &str,
+    detect_as: Option<&str>,
+) -> bool {
+    let profile_config = super::profile_config::resolve_config_or_warn(profile);
+    resolve_active_agent(tool, detect_as, &profile_config.session)
+        .is_some_and(|agent| agent_mounts_share_credential_file(agent.name))
+}
+
+fn agent_mounts_share_credential_file(agent: &str) -> bool {
+    AGENT_CONFIG_MOUNTS
+        .iter()
+        .any(|mount| mount.tool_name == agent && !mount.shared_credential_files.is_empty())
+}
+
 pub(crate) fn refresh_agent_configs_for_instance(
     profile: &str,
     instance_id: &str,

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -1598,7 +1598,6 @@ fn compute_workspace_volume_paths(
     Ok((volumes, ws_container))
 }
 
-/// Re-sync the current instance's physically isolated agent config.
 /// Whether the agent `tool` resolves to under `profile` shares a credential
 /// file across its sandboxes.
 pub(crate) fn agent_shares_credential_file(
@@ -1617,6 +1616,7 @@ fn agent_mounts_share_credential_file(agent: &str) -> bool {
         .any(|mount| mount.tool_name == agent && !mount.shared_credential_files.is_empty())
 }
 
+/// Re-sync the current instance's physically isolated agent config.
 pub(crate) fn refresh_agent_configs_for_instance(
     profile: &str,
     instance_id: &str,

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -920,17 +920,30 @@ pub(crate) fn place_shadowed_credential_mountpoints(config: &ContainerConfig) {
         if Path::new(&store.host_path).parent() != Path::new(&shared.host_path).parent() {
             continue;
         }
-        let copy = Path::new(&store.host_path).join(name);
-        // Emptying the copy is only safe once the fold has landed a credential
-        // in the shared file; short of that (a failed fold, or the empty seed
-        // `sync_shared_credential` writes when it found none) the copy may be
-        // the only one left, and it already serves as the mountpoint.
-        let folded = std::fs::read_to_string(&shared.host_path)
-            .is_ok_and(|content| !matches!(content.trim(), "" | "{}"));
+        let store_dir = Path::new(&store.host_path);
+        let copy = store_dir.join(name);
+        let folded = Path::new(&shared.host_path)
+            .parent()
+            .zip(name.to_str())
+            .is_some_and(|(root, name)| shadowed_copy_is_folded(root, store_dir, name));
         if let Err(e) = place_credential_mountpoint(&copy, folded) {
             tracing::warn!(target: "session.profile",
                 "Failed to place credential mountpoint {}: {}", copy.display(), e);
         }
+    }
+}
+
+/// Whether the shared file holds a credential at least as fresh as the store's
+/// own copy, so the copy can be emptied. Read now rather than remembered from
+/// the fold: a fold that failed, or a copy it could not read, leaves the copy
+/// the only chain there is, and a plain file already serves as the
+/// mountpoint. Either side that cannot be read keeps the copy.
+fn shadowed_copy_is_folded(shared_root: &Path, store: &Path, name: &str) -> bool {
+    let shared = read_credential_file(shared_root, name, SymlinkPolicy::Never);
+    let copy = read_credential_file(store, name, SymlinkPolicy::Never);
+    match (shared, copy) {
+        (Ok(Some(shared)), Ok(Some(copy))) => !should_overwrite_credential(&shared, &copy),
+        _ => false,
     }
 }
 
@@ -4595,7 +4608,7 @@ mod tests {
         let store = root.join("aaaaaaaaaaaaaaaa");
         let shared = root.join(".credentials.json");
         fs::create_dir_all(&store).unwrap();
-        fs::write(&shared, "shared").unwrap();
+        fs::write(&shared, credential(2)).unwrap();
         let config_for = |dir: &Path| ContainerConfig {
             shared_credential_mounts: vec!["/root/.claude/.credentials.json".to_string()],
             volumes: vec![
@@ -4616,22 +4629,31 @@ mod tests {
         // mount; its host copy is the user's own login, not a shadowed one.
         for (dir, emptied) in [(&store, true), (&host, false)] {
             let copy = dir.join(".credentials.json");
-            fs::write(&copy, "token").unwrap();
+            fs::write(&copy, credential(1)).unwrap();
             place_shadowed_credential_mountpoints(&config_for(dir));
-            let kept = fs::read_to_string(&copy).unwrap() == "token";
+            let kept = fs::read_to_string(&copy).unwrap() == credential(1);
             assert_eq!(!kept, emptied, "{}", dir.display());
         }
 
-        // A shared file the fold landed no credential in leaves the copy alone:
-        // it is still the only one, and already the mountpoint the mount needs.
+        // The copy is kept while it is the only chain there is: the shared
+        // file holds no credential, or one the copy is fresher than because
+        // the fold did not land it. A plain file is already the mountpoint.
         let copy = store.join(".credentials.json");
-        for unfolded in ["", "{}"] {
+        for (unfolded, copy_content) in [
+            ("", credential(1)),
+            ("{}", credential(1)),
+            (&credential(2), credential(3)),
+        ] {
             fs::write(&shared, unfolded).unwrap();
-            fs::write(&copy, "token").unwrap();
+            fs::write(&copy, &copy_content).unwrap();
             place_shadowed_credential_mountpoints(&config_for(&store));
-            assert_eq!(fs::read_to_string(&copy).unwrap(), "token", "{unfolded:?}");
+            assert_eq!(
+                fs::read_to_string(&copy).unwrap(),
+                copy_content,
+                "{unfolded:?}"
+            );
         }
-        fs::write(&shared, "shared").unwrap();
+        fs::write(&shared, credential(2)).unwrap();
 
         // The store is container-writable, so a link planted at the mountpoint
         // is replaced rather than followed.

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -790,6 +790,23 @@ fn read_credential_candidate(dir: &Path, name: &str, follow: SymlinkPolicy) -> O
     })
 }
 
+/// Which credentials a fold may put in the shared file.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum CredentialFold {
+    /// A come-up, create or start: the freshest candidate replaces what the
+    /// file holds.
+    Freshest,
+    /// Off a come-up: a file holding a credential is left to the containers'
+    /// own rotation, so a fresher host token never re-couples them to the host
+    /// chain mid-session. Only a file holding none is seeded.
+    SeedOnly,
+}
+
+/// Whether `content` carries a credential a container could use.
+fn holds_credential(content: &str) -> bool {
+    plausible_credential_expires_at(content, now_ms()).is_some()
+}
+
 /// Fold the freshest credential into the file every store of this agent
 /// mounts. This is a come-up fold rather than a migration because a container
 /// built before the file was shared keeps refreshing its store copy while it
@@ -811,6 +828,7 @@ fn sync_shared_credential(
     host_dir: &Path,
     sandbox_dir: &Path,
     name: &str,
+    fold: CredentialFold,
 ) -> Result<Option<PathBuf>> {
     let Some(shared) = shared_credential_path(sandbox_dir, name) else {
         return Ok(None);
@@ -847,8 +865,10 @@ fn sync_shared_credential(
     // so another come-up or a container's own refresh in between is seen.
     crate::hooks::with_config_lock_policy(&shared, "lock", SymlinkPolicy::Never, || {
         let existing = read_credential_file(root, name, SymlinkPolicy::Never)?;
+        let replaceable =
+            fold == CredentialFold::Freshest || !existing.as_deref().is_some_and(holds_credential);
         let mut winner: Option<&str> = None;
-        for candidate in &candidates {
+        for candidate in candidates.iter().filter(|_| replaceable) {
             let current = winner.or(existing.as_deref());
             if current.is_none_or(|current| should_overwrite_credential(current, candidate)) {
                 winner = Some(candidate);
@@ -1161,10 +1181,11 @@ fn prepare_sandbox_dir(
     mount: &AgentConfigMount,
     home: &Path,
     instance_id: Option<&str>,
+    fold: CredentialFold,
 ) -> Result<PathBuf> {
     let host_dir = home.join(mount.host_rel);
     let sandbox_dir = sandbox_dir_for(mount, home, instance_id)?;
-    prepare_sandbox_dir_from(mount, host_dir, sandbox_dir, home)
+    prepare_sandbox_dir_from(mount, host_dir, sandbox_dir, home, fold)
 }
 
 fn prepare_sandbox_dir_from(
@@ -1172,6 +1193,7 @@ fn prepare_sandbox_dir_from(
     host_dir: PathBuf,
     sandbox_dir: PathBuf,
     home: &Path,
+    fold: CredentialFold,
 ) -> Result<PathBuf> {
     // Remove stale files before syncing. This prevents leftovers from a previous
     // session (e.g. a SQLite database created by an older tool version) from
@@ -1260,7 +1282,7 @@ fn prepare_sandbox_dir_from(
     }
 
     for &name in mount.shared_credential_files {
-        if let Err(e) = sync_shared_credential(mount, &host_dir, &sandbox_dir, name) {
+        if let Err(e) = sync_shared_credential(mount, &host_dir, &sandbox_dir, name, fold) {
             tracing::warn!(target: "session.profile",
                 "Failed to sync shared credential {} for {}: {}", name, mount.host_rel, e);
         }
@@ -1600,6 +1622,7 @@ pub(crate) fn refresh_agent_configs_for_instance(
     instance_id: &str,
     tool: &str,
     detect_as: Option<&str>,
+    fold: CredentialFold,
 ) {
     let Some(home) = dirs::home_dir() else {
         return;
@@ -1619,8 +1642,9 @@ pub(crate) fn refresh_agent_configs_for_instance(
                 directory.clone(),
                 directory.join(SANDBOX_PRIVATE_SUBDIR).join(instance_id),
                 &home,
+                fold,
             ),
-            None => prepare_sandbox_dir(mount, &home, Some(instance_id)),
+            None => prepare_sandbox_dir(mount, &home, Some(instance_id), fold),
         };
         match result {
             Ok(sandbox_dir) => {
@@ -1884,6 +1908,8 @@ pub(crate) struct ContainerAgentSelection<'a> {
     /// running a user's own agent still reports status (Kiro has no global
     /// hooks). `None` for the default / no selection.
     selected_agent: Option<&'a str>,
+    /// How the launch treats the credential file the agent's sandboxes share.
+    credential_fold: CredentialFold,
 }
 
 impl<'a> ContainerAgentSelection<'a> {
@@ -1892,7 +1918,15 @@ impl<'a> ContainerAgentSelection<'a> {
             tool,
             detect_as,
             selected_agent: None,
+            credential_fold: CredentialFold::Freshest,
         }
+    }
+
+    /// Set how the launch treats the shared credential file (see
+    /// [`CredentialFold`]).
+    pub(crate) fn with_credential_fold(mut self, fold: CredentialFold) -> Self {
+        self.credential_fold = fold;
+        self
     }
 
     /// Set the user-selected agent name (see [`Self::selected_agent`]).
@@ -2320,8 +2354,14 @@ pub(crate) fn build_container_config(
                 directory.clone(),
                 directory.join(SANDBOX_PRIVATE_SUBDIR).join(instance_id),
                 &home,
+                agent_selection.credential_fold,
             ),
-            None => prepare_sandbox_dir(mount, &home, Some(instance_id)),
+            None => prepare_sandbox_dir(
+                mount,
+                &home,
+                Some(instance_id),
+                agent_selection.credential_fold,
+            ),
         };
         let sandbox_dir = match sandbox_dir {
             Ok(dir) => dir,
@@ -3437,7 +3477,8 @@ mod tests {
             .iter()
             .find(|m| m.tool_name == "hermes")
             .unwrap();
-        let sandbox = prepare_sandbox_dir(mount, dir.path(), None).unwrap();
+        let sandbox =
+            prepare_sandbox_dir(mount, dir.path(), None, CredentialFold::Freshest).unwrap();
 
         assert!(sandbox.join("config.yaml").exists());
         assert!(sandbox.join(".env").exists());
@@ -3512,7 +3553,7 @@ mod tests {
             .iter()
             .find(|m| m.tool_name == "opencode" && m.host_rel == ".local/share/opencode")
             .expect("opencode data-dir mount");
-        let out = prepare_sandbox_dir(mount, dir.path(), None).unwrap();
+        let out = prepare_sandbox_dir(mount, dir.path(), None, CredentialFold::Freshest).unwrap();
         assert_eq!(out, sandbox);
 
         assert!(
@@ -3911,7 +3952,8 @@ mod tests {
             .iter()
             .find(|m| m.tool_name == "prime-agent")
             .expect("prime-agent mount must exist");
-        let sandbox = prepare_sandbox_dir(prime_mount, home.path(), None).unwrap();
+        let sandbox =
+            prepare_sandbox_dir(prime_mount, home.path(), None, CredentialFold::Freshest).unwrap();
 
         assert_eq!(
             fs::read_to_string(sandbox.join("skills/reviewing/SKILL.md")).unwrap(),
@@ -4426,8 +4468,16 @@ mod tests {
         fs::create_dir_all(&store).unwrap();
         // A failed sync is logged and the launch goes on; the file must be
         // left exactly as it was.
-        let prepare =
-            || prepare_sandbox_dir_from(&mount, host.clone(), store.clone(), home.path()).unwrap();
+        let prepare = || {
+            prepare_sandbox_dir_from(
+                &mount,
+                host.clone(),
+                store.clone(),
+                home.path(),
+                CredentialFold::Freshest,
+            )
+            .unwrap()
+        };
 
         // Root reads a write-only file regardless, so the case cannot fail there.
         if !nix::unistd::geteuid().is_root() {
@@ -4494,8 +4544,16 @@ mod tests {
         let store = root.join("aaaaaaaaaaaaaaaa");
         let shared = root.join(".credentials.json");
         let private = store.join(".credentials.json");
-        let prepare =
-            || prepare_sandbox_dir_from(&mount, host.clone(), store.clone(), home.path()).unwrap();
+        let prepare = || {
+            prepare_sandbox_dir_from(
+                &mount,
+                host.clone(),
+                store.clone(),
+                home.path(),
+                CredentialFold::Freshest,
+            )
+            .unwrap()
+        };
 
         // Nothing to seed: the mount source still has to exist.
         prepare();
@@ -4530,6 +4588,42 @@ mod tests {
         fs::write(&private, "").unwrap();
         prepare();
         assert_eq!(fs::read_to_string(&shared).unwrap(), credential(300));
+    }
+
+    #[test]
+    fn off_a_come_up_the_fold_only_seeds() {
+        let home = TempDir::new().unwrap();
+        let host = home.path().join(".claude");
+        fs::create_dir_all(&host).unwrap();
+        let mount = claude_mount_without_keychain();
+        let root = host.join(SANDBOX_PRIVATE_SUBDIR);
+        let store = root.join("aaaaaaaaaaaaaaaa");
+        let shared = root.join(".credentials.json");
+        fs::create_dir_all(&store).unwrap();
+        let prepare = |fold| {
+            prepare_sandbox_dir_from(&mount, host.clone(), store.clone(), home.path(), fold)
+                .unwrap()
+        };
+
+        // A file holding no usable credential is seeded from the host.
+        fs::write(host.join(".credentials.json"), credential(100)).unwrap();
+        for unusable in ["", "{}", "not json"] {
+            fs::write(&shared, unusable).unwrap();
+            prepare(CredentialFold::SeedOnly);
+            assert_eq!(
+                fs::read_to_string(&shared).unwrap(),
+                credential(100),
+                "{unusable:?}"
+            );
+        }
+
+        // A fresher host login waits for a come-up: between starts the file
+        // holds the containers' own rotation.
+        fs::write(host.join(".credentials.json"), credential(200)).unwrap();
+        prepare(CredentialFold::SeedOnly);
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
+        prepare(CredentialFold::Freshest);
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(200));
     }
 
     #[test]
@@ -5810,6 +5904,7 @@ trust_level = "trusted"
             instance_id,
             "codex",
             None,
+            CredentialFold::Freshest,
         );
         let refreshed: toml::Value =
             toml::from_str(&fs::read_to_string(codex_sandbox.join("config.toml")).unwrap())
@@ -5861,6 +5956,7 @@ trust_level = "trusted"
             "gemini-yolo-refresh-test",
             "gemini",
             None,
+            CredentialFold::Freshest,
         );
         let refreshed: serde_json::Value = serde_json::from_str(
             &fs::read_to_string(gemini_sandbox.join("settings.json")).unwrap(),
@@ -6559,6 +6655,7 @@ trusted_hash = "keep"
             instance_id,
             "codex",
             None,
+            CredentialFold::Freshest,
         );
 
         let config_text = fs::read_to_string(&sandbox_config_path).unwrap();
@@ -6676,7 +6773,13 @@ trusted_hash = "keep"
                 profile,
             )
             .unwrap();
-            refresh_agent_configs_for_instance(profile, instance_id, "codex", None);
+            refresh_agent_configs_for_instance(
+                profile,
+                instance_id,
+                "codex",
+                None,
+                CredentialFold::Freshest,
+            );
         }
 
         for (instance_id, _, expected_status) in instances {
@@ -7188,7 +7291,7 @@ volume_ignores = ["target"]
             clean_files: &["opencode.db", "opencode.db-wal", "opencode.db-shm"],
         };
 
-        prepare_sandbox_dir(&mount, home.path(), None).unwrap();
+        prepare_sandbox_dir(&mount, home.path(), None, CredentialFold::Freshest).unwrap();
 
         assert!(!sandbox_dir.join("opencode.db").exists());
         assert!(!sandbox_dir.join("opencode.db-wal").exists());
@@ -7226,7 +7329,7 @@ volume_ignores = ["target"]
             clean_files: &[],
         };
 
-        prepare_sandbox_dir(&mount, home.path(), None).unwrap();
+        prepare_sandbox_dir(&mount, home.path(), None, CredentialFold::Freshest).unwrap();
 
         assert!(
             !sandbox_dir.join("opencode.db").exists(),
@@ -7259,7 +7362,7 @@ volume_ignores = ["target"]
         };
 
         // Should not panic or error when files don't exist
-        prepare_sandbox_dir(&mount, home.path(), None).unwrap();
+        prepare_sandbox_dir(&mount, home.path(), None, CredentialFold::Freshest).unwrap();
     }
 
     // --- GCP credential mount tests ---

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -170,6 +170,15 @@ impl Instance {
                 self.backfill_container_workdir(&container);
                 return Ok(container);
             }
+            // Still rotating the copy in its store. The refresh below would
+            // fold that copy into the shared file and log every sandbox on
+            // it out at the copy's next rotation, so refuse first.
+            if self.predates_shared_credential(&container, &detect_as)? {
+                anyhow::bail!(
+                    "running sandbox {} predates the shared credential file; stop it, then relaunch to rebuild it",
+                    self.id
+                );
+            }
             container_config::refresh_agent_configs_for_instance(
                 &self.effective_profile(),
                 &self.id,
@@ -177,14 +186,6 @@ impl Instance {
                 Some(detect_as.as_str()),
             );
             let config = self.build_container_config()?;
-            // Still refreshing its own store copy, which rotates the token
-            // away from every sandbox on the shared file.
-            if container.shared_credential_mounts_match(&config)? == Some(false) {
-                anyhow::bail!(
-                    "running sandbox {} predates the shared credential file; stop it, then relaunch to rebuild it",
-                    self.id
-                );
-            }
             self.identity_publisher_launched = config.identity_publisher_installed
                 && identity_publisher_mount_matches(&container, &config)?
                 && identity_publisher_dependencies_available(&container)
@@ -285,6 +286,25 @@ impl Instance {
         }
 
         Ok(container)
+    }
+
+    /// Whether the session's container was created before its agent shared a
+    /// credential file, so the copy in its store is a token chain the
+    /// container is still rotating. Read from the create-time label rather
+    /// than from the config, since building the config folds that copy in.
+    pub(crate) fn predates_shared_credential(
+        &self,
+        container: &DockerContainer,
+        detect_as: &str,
+    ) -> Result<bool> {
+        if !container_config::agent_shares_credential_file(
+            &self.effective_profile(),
+            &self.tool,
+            Some(detect_as),
+        ) {
+            return Ok(false);
+        }
+        Ok(container.carries_shared_credential_label()? == Some(false))
     }
 
     fn ensure_container_hook_mount_source(&self) {

--- a/src/session/instance/container.rs
+++ b/src/session/instance/container.rs
@@ -179,13 +179,17 @@ impl Instance {
                     self.id
                 );
             }
+            // Not a come-up: the credential file stays with the containers'
+            // own rotation, and is only seeded when it holds none.
+            let fold = container_config::CredentialFold::SeedOnly;
             container_config::refresh_agent_configs_for_instance(
                 &self.effective_profile(),
                 &self.id,
                 &self.tool,
                 Some(detect_as.as_str()),
+                fold,
             );
-            let config = self.build_container_config()?;
+            let config = self.build_container_config_with(fold)?;
             self.identity_publisher_launched = config.identity_publisher_installed
                 && identity_publisher_mount_matches(&container, &config)?
                 && identity_publisher_dependencies_available(&container)
@@ -222,6 +226,7 @@ impl Instance {
                     &self.id,
                     &self.tool,
                     Some(detect_as.as_str()),
+                    container_config::CredentialFold::Freshest,
                 );
                 let config = self.build_container_config()?;
                 // Built before its agent shared a credential file, so it
@@ -401,6 +406,15 @@ impl Instance {
     }
 
     pub(super) fn build_container_config(&self) -> Result<crate::containers::ContainerConfig> {
+        self.build_container_config_with(container_config::CredentialFold::Freshest)
+    }
+
+    /// [`Self::build_container_config`] with `fold` deciding what the build
+    /// may put in the credential file the agent's sandboxes share.
+    fn build_container_config_with(
+        &self,
+        fold: container_config::CredentialFold,
+    ) -> Result<crate::containers::ContainerConfig> {
         self.ensure_container_hook_mount_source();
         let detect_as = self.effective_detect_as();
         let sandbox = self
@@ -433,7 +447,8 @@ impl Instance {
             &self.project_path,
             sandbox,
             container_config::ContainerAgentSelection::new(&self.tool, Some(&detect_as))
-                .with_selected_agent(selected_agent.as_deref()),
+                .with_selected_agent(selected_agent.as_deref())
+                .with_credential_fold(fold),
             self.is_yolo_mode(),
             &self.id,
             self.workspace_info.as_ref(),

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -192,14 +192,17 @@ pub(super) fn poll_statuses_once(
             // file is still rotating the copy in its store; folding that in
             // would log every sandbox on the shared file out.
             let container = crate::containers::DockerContainer::from_session_id(&instance.id);
-            let running = state
+            // An absent name is unknown, not stopped: the map is empty for a
+            // runtime that cannot list states and for a failed list. Only a
+            // container known to be stopped skips the check.
+            let stopped = state
                 .container_states
                 .get(&crate::containers::DockerContainer::generate_name(
                     &instance.id,
                 ))
                 .copied()
-                .unwrap_or(false);
-            if running {
+                == Some(false);
+            if !stopped {
                 match instance.predates_shared_credential(&container, &instance.detect_as) {
                     Ok(false) => {}
                     Ok(true) => continue,

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -176,8 +176,10 @@ pub(super) fn poll_statuses_once(
         false
     };
 
-    // Periodically re-sync sandbox credentials from the macOS Keychain
-    // so long-lived sessions don't lose auth mid-run.
+    // Periodically seed a shared credential file that holds no credential,
+    // and refresh the rest of each store. A file holding a credential is
+    // left to the containers' own rotation: pushing a fresher host token
+    // in would put every sandbox back on the host's chain mid-session.
     if has_sandboxed && state.last_credential_refresh.elapsed() >= state.credential_refresh_interval
     {
         state.last_credential_refresh = Instant::now();
@@ -213,6 +215,7 @@ pub(super) fn poll_statuses_once(
                 &instance.id,
                 &instance.tool,
                 Some(&instance.detect_as),
+                crate::session::config::container_config::CredentialFold::SeedOnly,
             );
         }
     }

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -186,6 +186,28 @@ pub(super) fn poll_statuses_once(
                 && inst.sandbox_store_generation
                     >= crate::session::config::container_config::CURRENT_SANDBOX_STORE_GENERATION
         }) {
+            // A running container built before its agent shared a credential
+            // file is still rotating the copy in its store; folding that in
+            // would log every sandbox on the shared file out.
+            let container = crate::containers::DockerContainer::from_session_id(&instance.id);
+            let running = state
+                .container_states
+                .get(&crate::containers::DockerContainer::generate_name(
+                    &instance.id,
+                ))
+                .copied()
+                .unwrap_or(false);
+            if running {
+                match instance.predates_shared_credential(&container, &instance.detect_as) {
+                    Ok(false) => {}
+                    Ok(true) => continue,
+                    Err(error) => {
+                        tracing::warn!(target: "session.profile",
+                            "Skipping credential refresh for {}: {error:#}", instance.id);
+                        continue;
+                    }
+                }
+            }
             crate::session::config::container_config::refresh_agent_configs_for_instance(
                 &instance.effective_profile(),
                 &instance.id,


### PR DESCRIPTION
## Description

Four standalone commits on the shared Claude credential file (#3834, #3846).

1. A running container created before the file was shared is no longer folded. Its store copy is a chain it keeps rotating; folding it logged every sandbox on the shared file out until it stopped.
2. A store copy is emptied only when the shared file holds a credential at least as fresh, compared at placement since a poll can write the file after the fold. A failed or skipped fold used to empty the only fresh copy.
3. The 30-minute TUI refresh and a relaunch of a running container seed only. The guide promises a host login carries over on start or restart; the poll put every live sandbox back on the host's refresh token mid-session.
4. **Open question.** The host file and Keychain never replace a credential the shared file holds, even at start. Ends the host/sandbox coupling (both files hold one refresh token on the reporting machine today) at the cost of "log in on the host, restart a sandbox": log in inside any sandbox instead, or delete `sandbox-v2/.credentials.json` and start one. Droppable without touching 1 to 3.

Not done: rejecting expired candidates. `expiresAt` is the access token's expiry; an idle sandbox's copy is expired with a live refresh token, and rejecting it would let a staler copy over it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the fold rules are unit tested through the store preparation path (`off_a_come_up_the_fold_only_seeds`, `shared_credential_follows_the_freshest_copy_across_starts`, `shadowed_credential_copy_is_emptied_only_in_a_store`); the label skip reads a container label, which needs a runtime the harness skips without.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5.1 via Claude Code

**Any Additional AI Details you'd like to share:** Audit, diagnosis and implementation by the model in discussion with @njbrake, who owns the decisions.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Fable 5.1 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GEwxHbRR8Tg8fYn74Z6Yd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Separate host Claude credentials from sandbox credential chains.
- Preserve existing shared credentials during refreshes and relaunches.
- Prevent older running containers from receiving unintended credential updates.
- Keep legacy stopped-container behavior.
- Add container-label detection and credential-folding rules.
- Update sandbox credential documentation.
- Add unit coverage for credential folding and placement.

## Benefits

This prevents host or Keychain credentials from replacing sandbox credentials. It makes credential refresh behavior safer and more predictable.

## Potential follow-up

Add an end-to-end test for the container-label scenario when the test harness supports it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->