### PR TITLE
fix(web): drop the retained IME shadow on session switch and out-of-band input

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -882,6 +882,11 @@ function AppContent({
   const transitionKeyboardProxy = useCallback((nextSessionId: string | null) => {
     if (keyboardProxySessionIdRef.current === nextSessionId) return;
     keyboardProxySessionIdRef.current = nextSessionId;
+    // The retained intermediate syllable is a shadow of the old session's
+    // PTY edit. Carrying it into the new session would let the next
+    // deleteContentBackward delete that session's text before the
+    // replacement arrives, so the shadow is dropped with the receiver.
+    if (keyboardProxyRef.current) keyboardProxyRef.current.value = "";
     clearMobileKeyboardProxyInput();
   }, []);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -99,7 +99,11 @@ import { toastBus, reportError } from "./lib/toastBus";
 import { isAbsolutePath, resolveToRepoRelative, type FileRef } from "./lib/fileRef";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
 import { dispatchFocusTerminal, requestSessionInputFocus, setPendingTerminalFocus } from "./lib/terminalFocus";
-import { clearMobileKeyboardProxyInput, deliverMobileKeyboardProxyInput } from "./lib/mobileKeyboardProxy";
+import {
+  clearMobileKeyboardProxyInput,
+  deliverMobileKeyboardProxyInput,
+  forwardTerminalBeforeInput,
+} from "./lib/mobileKeyboardProxy";
 import { hydrateWebUiStateFromServer, initWebUiSync } from "./lib/webUiSync";
 import { WorkspaceSidebar, SnoozeModal } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
@@ -891,24 +895,7 @@ function AppContent({
   useEffect(() => {
     const proxy = keyboardProxy;
     if (!proxy) return;
-    const onBeforeInput = (e: InputEvent) => {
-      switch (e.inputType) {
-        case "insertText":
-        case "insertLineBreak":
-        case "insertParagraph":
-        case "deleteContentBackward":
-        case "insertFromPaste":
-          e.preventDefault();
-          deliverMobileKeyboardProxyInput({
-            inputType: e.inputType,
-            data: e.data,
-            isComposing: e.isComposing,
-          });
-          break;
-        default:
-          break;
-      }
-    };
+    const onBeforeInput = (e: InputEvent) => forwardTerminalBeforeInput(e, deliverMobileKeyboardProxyInput);
     proxy.addEventListener("beforeinput", onBeforeInput);
     return () => proxy.removeEventListener("beforeinput", onBeforeInput);
   }, [keyboardProxy]);
@@ -2409,6 +2396,13 @@ function AppContent({
           // This matches the live terminal's hidden input geometry.
           className="fixed bottom-0 left-0 w-px h-px opacity-0 pointer-events-none"
           style={{ caretColor: "transparent", color: "transparent" }}
+          // Typed text now stays in this textarea as IME context (see
+          // forwardTerminalBeforeInput), so keep the OS from rewriting it
+          // the way the live terminal's own hidden input already does.
+          autoCapitalize="off"
+          autoCorrect="off"
+          autoComplete="off"
+          spellCheck={false}
         />
       </div>
     </AcpPrefsProvider>

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -12,7 +12,11 @@ import {
   type CellRun,
 } from "../lib/liveTermLines";
 import { cursorLineIndex, pointerPaneCell, wheelNotches } from "../lib/liveMouse";
-import { registerMobileKeyboardProxyReceiver, type MobileKeyboardProxyInput } from "../lib/mobileKeyboardProxy";
+import {
+  forwardTerminalBeforeInput,
+  registerMobileKeyboardProxyReceiver,
+  type MobileKeyboardProxyInput,
+} from "../lib/mobileKeyboardProxy";
 import { bracketedPaste, writeClipboard } from "../lib/clipboard";
 import type { LiveFrame, LiveStats } from "../hooks/useLiveTerminal";
 import { useWebSettings } from "../hooks/useWebSettings";
@@ -1751,24 +1755,7 @@ export function MobileLiveTerminal({
     [sendKeys, sendData, typedWordRef],
   );
   const handleBeforeInput = useCallback(
-    (ev: InputEvent) => {
-      switch (ev.inputType) {
-        case "insertText":
-        case "insertLineBreak":
-        case "insertParagraph":
-        case "deleteContentBackward":
-        case "insertFromPaste":
-          ev.preventDefault();
-          handleMobileKeyboardProxyInput({
-            inputType: ev.inputType,
-            data: ev.data,
-            isComposing: ev.isComposing,
-          });
-          break;
-        default:
-          break;
-      }
-    },
+    (ev: InputEvent) => forwardTerminalBeforeInput(ev, handleMobileKeyboardProxyInput),
     [handleMobileKeyboardProxyInput],
   );
   useEffect(() => {
@@ -1785,6 +1772,9 @@ export function MobileLiveTerminal({
       if (seq) {
         e.preventDefault();
         sendData(seq);
+        // Typed text accumulates in the hidden textarea as IME context (see
+        // forwardTerminalBeforeInput); Enter is the safe point to drop it.
+        if (e.key === "Enter" && e.target instanceof HTMLTextAreaElement) e.target.value = "";
         return;
       }
       // Ctrl+Shift+C copies the current terminal selection (the terminal-
@@ -1900,7 +1890,9 @@ export function MobileLiveTerminal({
       // result must not become a run for the next composition to strip.
       if (!rest) typedWordRef.current = run;
       else if (sendKeys(rest) && retroactive) typedWordRef.current = plainRunAfter(run, rest);
-      if (e.currentTarget instanceof HTMLTextAreaElement) e.currentTarget.value = "";
+      // Leave the committed text in the textarea: an IME that re-edits a
+      // committed syllable (delete + reinsert) needs it there for the delete
+      // to surface as a beforeinput. See forwardTerminalBeforeInput.
     },
     [sendKeys, typedWordRef],
   );

--- a/web/src/components/MobileTerminalToolbar.tsx
+++ b/web/src/components/MobileTerminalToolbar.tsx
@@ -3,6 +3,7 @@ import type { RefObject } from "react";
 import { useLongPressDrag, type DragAxis } from "../hooks/useLongPressDrag";
 import { bracketedPaste, readClipboardText } from "../lib/clipboard";
 import { toastBus } from "../lib/toastBus";
+import { invalidateRetainedImeContext } from "../lib/mobileKeyboardProxy";
 
 function execCommandPaste(): boolean {
   try {
@@ -40,23 +41,36 @@ export function MobileTerminalToolbar({ sendData, keyboardOpen, ctrlActive, onCt
     if (keyboardOpen) inputElRef.current?.focus();
   }, [inputElRef, keyboardOpen]);
 
+  // Drag-repeat arrows are the same out-of-band path as the buttons.
+  const sendOutOfBand = useCallback(
+    (data: string) => {
+      invalidateRetainedImeContext(inputElRef.current);
+      sendData(data);
+    },
+    [sendData, inputElRef],
+  );
+
   const send = useCallback(
     (data: string) => {
       haptic();
+      // Out-of-band input bypasses the proxy textarea's beforeinput, so the
+      // retained IME syllable no longer mirrors the PTY line; drop it or the
+      // next Korean keystroke rewrites the stale value into the new prompt.
+      invalidateRetainedImeContext(inputElRef.current);
       sendData(data);
       refocusTerminal();
     },
-    [sendData, refocusTerminal, haptic],
+    [sendData, refocusTerminal, haptic, inputElRef],
   );
 
   const upHandlers = useLongPressDrag({
-    onRepeat: () => sendData(ARROW_UP),
-    onHorizontal: (dir) => sendData(dir === "left" ? ARROW_LEFT : ARROW_RIGHT),
+    onRepeat: () => sendOutOfBand(ARROW_UP),
+    onHorizontal: (dir) => sendOutOfBand(dir === "left" ? ARROW_LEFT : ARROW_RIGHT),
     onAxisChange: setUpAxis,
   });
   const downHandlers = useLongPressDrag({
-    onRepeat: () => sendData(ARROW_DOWN),
-    onHorizontal: (dir) => sendData(dir === "left" ? ARROW_LEFT : ARROW_RIGHT),
+    onRepeat: () => sendOutOfBand(ARROW_DOWN),
+    onHorizontal: (dir) => sendOutOfBand(dir === "left" ? ARROW_LEFT : ARROW_RIGHT),
     onAxisChange: setDownAxis,
   });
 

--- a/web/src/lib/mobileKeyboardProxy.test.ts
+++ b/web/src/lib/mobileKeyboardProxy.test.ts
@@ -1,11 +1,65 @@
+// @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearMobileKeyboardProxyInput,
   deliverMobileKeyboardProxyInput,
+  forwardTerminalBeforeInput,
   registerMobileKeyboardProxyReceiver,
 } from "./mobileKeyboardProxy";
 
 afterEach(clearMobileKeyboardProxyInput);
+
+function beforeInput(target: HTMLTextAreaElement, init: InputEventInit) {
+  const ev = new InputEvent("beforeinput", { bubbles: true, cancelable: true, ...init });
+  const deliver = vi.fn();
+  target.addEventListener("beforeinput", (e) => forwardTerminalBeforeInput(e as InputEvent, deliver), { once: true });
+  target.dispatchEvent(ev);
+  return { ev, deliver };
+}
+
+describe("forwardTerminalBeforeInput", () => {
+  // iOS WebKit's Korean keyboard rewrites the trailing syllable as
+  // deleteContentBackward + insertText with no composition events, and skips
+  // the delete when the textarea is empty. Text edits must therefore land in
+  // the textarea (default NOT prevented) so the next delete is observable.
+  it("forwards insertText and lets it land in the textarea", () => {
+    const ta = document.createElement("textarea");
+    const { ev, deliver } = beforeInput(ta, { inputType: "insertText", data: "ㅎ" });
+    expect(deliver).toHaveBeenCalledWith({ inputType: "insertText", data: "ㅎ", isComposing: false });
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("forwards deleteContentBackward and lets the textarea shrink", () => {
+    const ta = document.createElement("textarea");
+    ta.value = "ㅎ";
+    const { ev, deliver } = beforeInput(ta, { inputType: "deleteContentBackward" });
+    expect(deliver).toHaveBeenCalledWith({ inputType: "deleteContentBackward", data: null, isComposing: false });
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("swallows line breaks and drops the accumulated IME context", () => {
+    const ta = document.createElement("textarea");
+    ta.value = "한국어";
+    const { ev, deliver } = beforeInput(ta, { inputType: "insertLineBreak" });
+    expect(deliver).toHaveBeenCalledWith({ inputType: "insertLineBreak", data: null, isComposing: false });
+    expect(ev.defaultPrevented).toBe(true);
+    expect(ta.value).toBe("");
+  });
+
+  it("swallows pastes so they never enter the textarea", () => {
+    const ta = document.createElement("textarea");
+    const { ev, deliver } = beforeInput(ta, { inputType: "insertFromPaste", data: "a\nb" });
+    expect(deliver).toHaveBeenCalledWith({ inputType: "insertFromPaste", data: "a\nb", isComposing: false });
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("ignores other input types", () => {
+    const ta = document.createElement("textarea");
+    const { ev, deliver } = beforeInput(ta, { inputType: "insertReplacementText", data: "x" });
+    expect(deliver).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+});
 
 describe("mobile keyboard proxy", () => {
   it("delivers input buffered while a session is mounting", () => {

--- a/web/src/lib/mobileKeyboardProxy.ts
+++ b/web/src/lib/mobileKeyboardProxy.ts
@@ -36,3 +36,40 @@ export function clearMobileKeyboardProxyInput() {
   receiver = null;
   pending = [];
 }
+
+/** Translate a native `beforeinput` on a hidden terminal textarea into a
+ * semantic soft-keyboard edit.
+ *
+ * `insertText` and `deleteContentBackward` are forwarded AND left to mutate
+ * the textarea. iOS WebKit fires no composition events for the Korean
+ * keyboard (WebKit bug 274700): every keystroke rewrites the trailing
+ * syllable as `deleteContentBackward` + `insertText` ("ㅎ" -> "하" -> "한").
+ * WebKit dispatches no `beforeinput` for a delete with nothing before the
+ * caret, so with an always-empty textarea the deletes vanish and the PTY
+ * receives every intermediate syllable ("ㅎ하한"). Keeping the typed text in
+ * the textarea is what makes those deletes observable. See #1450 / #1615 for
+ * the soft-keyboard Backspace path this shares.
+ *
+ * Line breaks and pastes never reach the textarea. A line break is also the
+ * safe point to drop the accumulated text: no IME re-edits a syllable across
+ * Enter. */
+export function forwardTerminalBeforeInput(ev: InputEvent, deliver: (input: MobileKeyboardProxyInput) => void) {
+  switch (ev.inputType) {
+    case "insertText":
+    case "deleteContentBackward":
+      deliver({ inputType: ev.inputType, data: ev.data, isComposing: ev.isComposing });
+      break;
+    case "insertLineBreak":
+    case "insertParagraph":
+      ev.preventDefault();
+      deliver({ inputType: ev.inputType, data: ev.data, isComposing: ev.isComposing });
+      if (ev.target instanceof HTMLTextAreaElement) ev.target.value = "";
+      break;
+    case "insertFromPaste":
+      ev.preventDefault();
+      deliver({ inputType: ev.inputType, data: ev.data, isComposing: ev.isComposing });
+      break;
+    default:
+      break;
+  }
+}

--- a/web/src/lib/mobileKeyboardProxy.ts
+++ b/web/src/lib/mobileKeyboardProxy.ts
@@ -37,6 +37,15 @@ export function clearMobileKeyboardProxyInput() {
   pending = [];
 }
 
+/** Out-of-band terminal input (toolbar keys, hardware navigation) reaches
+ * the PTY without a `beforeinput` on the shadow textarea, so the retained
+ * intermediate syllable no longer mirrors the PTY line. Drop it, or the
+ * next Korean keystroke rewrites the stale value as `DEL + replacement`
+ * into whatever prompt the PTY now shows. */
+export function invalidateRetainedImeContext(target: HTMLTextAreaElement | null | undefined) {
+  if (target) target.value = "";
+}
+
 /** Translate a native `beforeinput` on a hidden terminal textarea into a
  * semantic soft-keyboard edit.
  *

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -92,6 +92,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/components/LiveTerminalView.tsx"]
     },
     {
+      "id": "terminal.mobile-ime-syllable-rewrite",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/live-terminal-ime-rewrite.spec.ts"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/lib/mobileKeyboardProxy.ts"]
+    },
+    {
       "id": "dashboard.summary-excludes-trash",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -96,7 +96,11 @@
       "kind": "mocked-playwright",
       "risk": "medium",
       "specs": ["tests/live-terminal-ime-rewrite.spec.ts"],
-      "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/lib/mobileKeyboardProxy.ts"]
+      "components": [
+        "web/src/components/MobileLiveTerminal.tsx",
+        "web/src/components/MobileTerminalToolbar.tsx",
+        "web/src/lib/mobileKeyboardProxy.ts"
+      ]
     },
     {
       "id": "dashboard.summary-excludes-trash",

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -47,7 +47,13 @@ export function makeLiveFrame(opts: { rows?: number; history?: number; window?: 
 
 export async function mockTerminalApis(
   page: Page,
-  opts: { liveHistory?: number; delayLiveWindowShrinkMs?: number; tool?: string } = {},
+  opts: {
+    liveHistory?: number;
+    delayLiveWindowShrinkMs?: number;
+    tool?: string;
+    /** Extra sessions beyond pinch-test, for tests that switch between them. */
+    extraSessions?: Array<{ id: string; title: string }>;
+  } = {},
 ): Promise<MockHandle> {
   const liveSockets: Array<{ send: (data: string) => void }> = [];
   const handle: MockHandle = {
@@ -98,6 +104,24 @@ export async function mockTerminalApis(
             profile: "default",
             workspace_repos: [],
           },
+          ...(opts.extraSessions ?? []).map((session) => ({
+            id: session.id,
+            title: session.title,
+            project_path: `/tmp/${session.id}`,
+            group_path: "/tmp",
+            tool: opts.tool ?? "claude",
+            status: "Running",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+          })),
         ],
         workspace_ordering: [],
       },

--- a/web/tests/live-terminal-ime-rewrite.spec.ts
+++ b/web/tests/live-terminal-ime-rewrite.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+
+// iOS WebKit fires no composition events for the Korean keyboard (WebKit bug
+// 274700). Every keystroke rewrites the trailing syllable through the plain
+// editing path instead: `deleteContentBackward` for the previous state, then
+// `insertText` with the new one ("ㅎ" -> "하" -> "한"). WebKit dispatches no
+// delete event at all when the textarea has nothing before the caret, so the
+// hidden input has to retain typed text for those deletes to be observable.
+//
+// Chromium fires `beforeinput` neither for execCommand nor for CDP-driven
+// deletes, so the keystrokes are synthesized the way backspace-autorepeat.spec
+// does, with one addition: the browser's default action (mutating the
+// textarea) is mirrored whenever the handler leaves the event uncancelled.
+
+// Text bytes only: JSON control frames (resize / window / cadence) share the WS.
+function textBytes(handle: MockHandle, start: number) {
+  return handle.liveMessages
+    .slice(start)
+    .map((msg) => msg.toString("utf8"))
+    .filter((s) => !s.startsWith("{"))
+    .join("");
+}
+
+const INPUT = 'textarea[aria-label="Live terminal input"]';
+
+// Emit one soft-keyboard edit on the live view's hidden input and apply the
+// default action if the page did not preventDefault it.
+async function softKey(page: Page, inputType: "insertText" | "deleteContentBackward", data: string | null = null) {
+  await page.evaluate(
+    ({ selector, inputType, data }) => {
+      const ta = document.querySelector<HTMLTextAreaElement>(selector);
+      if (!ta) throw new Error("live terminal input not found");
+      ta.focus();
+      const ev = new InputEvent("beforeinput", { inputType, data, bubbles: true, cancelable: true });
+      if (!ta.dispatchEvent(ev)) return;
+      const end = ta.value.length;
+      if (inputType === "insertText") ta.setRangeText(data ?? "", end, end, "end");
+      else ta.setRangeText("", Math.max(0, end - 1), end, "end");
+    },
+    { selector: INPUT, inputType, data },
+  );
+}
+
+const { defaultBrowserType: _iphoneBrowser, ...iPhone13 } = devices["iPhone 13"];
+
+test.describe("Live terminal IME syllable rewrite", () => {
+  test.use(iPhone13);
+
+  async function openSession(page: Page, handle: MockHandle) {
+    await page.goto("/");
+    await openMobileSidebar(page);
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
+    await expect.poll(() => handle.liveMessages.length, { timeout: 5_000 }).toBeGreaterThan(0);
+  }
+
+  test("delete + reinsert of the trailing syllable reaches the PTY as DEL + text", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+
+    const start = handle.liveMessages.length;
+    // What the iOS Korean keyboard emits for the keystrokes ㅎ, ㅏ, ㄴ.
+    await softKey(page, "insertText", "ㅎ");
+    await softKey(page, "deleteContentBackward");
+    await softKey(page, "insertText", "하");
+    await softKey(page, "deleteContentBackward");
+    await softKey(page, "insertText", "한");
+
+    // The typed text stays in the hidden input as IME context...
+    await expect(page.locator(INPUT)).toHaveValue("한");
+    // ...and the PTY sees each rewrite as delete + reinsert, ending on 한.
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("ㅎ\x7f하\x7f한");
+  });
+
+  test("Enter submits and drops the retained IME context", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+
+    const start = handle.liveMessages.length;
+    await softKey(page, "insertText", "한");
+    await page
+      .locator(INPUT)
+      .dispatchEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, cancelable: true });
+
+    await expect(page.locator(INPUT)).toHaveValue("");
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("한\r");
+  });
+});

--- a/web/tests/live-terminal-ime-rewrite.spec.ts
+++ b/web/tests/live-terminal-ime-rewrite.spec.ts
@@ -88,4 +88,43 @@ test.describe("Live terminal IME syllable rewrite", () => {
     await expect(page.locator(INPUT)).toHaveValue("");
     await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("한\r");
   });
+
+  test("switching sessions drops the retained syllable instead of replaying it", async ({ page }) => {
+    const handle = await mockTerminalApis(page, { extraSessions: [{ id: "other", title: "other" }] });
+    await openSession(page, handle);
+
+    // A syllable mid-rewrite is retained in the shadow for the deletes to
+    // stay observable.
+    await softKey(page, "insertText", "ㅎ");
+    await expect(page.locator(INPUT)).toHaveValue("ㅎ");
+
+    // Selecting another session must drop that shadow with the receiver:
+    // replaying a delete against the new PTY would delete its prompt text
+    // before the replacement syllable arrives.
+    await openMobileSidebar(page);
+    await clickSidebarSession(page, "other");
+    await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
+    await expect(page.locator(INPUT)).toHaveValue("");
+  });
+
+  test("out-of-band toolbar input drops the retained syllable before the next rewrite", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+
+    const start = handle.liveMessages.length;
+    await softKey(page, "insertText", "한");
+    await expect(page.locator(INPUT)).toHaveValue("한");
+
+    // Tab bypasses the shadow textarea: once it reaches the PTY the retained
+    // syllable no longer mirrors the line, so the next Korean keystroke must
+    // not rewrite the stale value as DEL + 하 over the cleared prompt.
+    await page.locator('button[aria-label="Tab"]').click();
+    await expect(page.locator(INPUT)).toHaveValue("");
+
+    // The rewrite re-arms from an empty shadow, mirroring the keyboard.
+    await softKey(page, "deleteContentBackward");
+    await softKey(page, "insertText", "하");
+    await expect(page.locator(INPUT)).toHaveValue("하");
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("한\t\x7f하");
+  });
 });

--- a/web/tests/mobile-keyboard.spec.ts
+++ b/web/tests/mobile-keyboard.spec.ts
@@ -355,7 +355,10 @@ test.describe("Mobile proxy input keydown handling", () => {
       const delivered = proxy.dispatchEvent(event);
       return { data: event.data, delivered, inputType: event.inputType };
     });
-    expect(input).toEqual({ data: "reselected", delivered: false, inputType: "insertText" });
+    // `delivered` is dispatchEvent's return: true means the default was NOT
+    // prevented, so the text also lands in the proxy textarea as IME context
+    // (forwardTerminalBeforeInput).
+    expect(input).toEqual({ data: "reselected", delivered: true, inputType: "insertText" });
     await expect
       .poll(() => terminal.liveMessages.map((message) => message.toString()).join("\n"))
       .toContain("reselected");


### PR DESCRIPTION
Closes #3692 (findings from `orientpine:fix/web-ime-syllable-rewrite`, whose head is not pushable from here; this branch supersedes it and is rebased on current main).

## What

- `transitionKeyboardProxy` clears `keyboardProxyRef.current.value` alongside `clearMobileKeyboardProxyInput()` so a mid-rewrite syllable retained by the old session cannot delete text in the new one (src/App.tsx).
- Toolbar keys (Tab, Escape, Ctrl, arrows) reach the PTY without a `beforeinput` on the shadow textarea, so every out-of-band send calls the new `invalidateRetainedImeContext()` and drops the retained syllable before the next rewrite (src/lib/mobileKeyboardProxy.ts, src/components/MobileTerminalToolbar.tsx).
- Regressions in `tests/live-terminal-ime-rewrite.spec.ts`: the session switch drops the shadow; the Tab bypass drops it and the rewrite re-arms from an empty line. `mockTerminalApis` gains `extraSessions` for the switch test.

## Why

The review findings on #3692 left two paths where the retained intermediate syllable outlived the PTY line it mirrored (session switch, out-of-band toolbar input), so the next Korean keystroke replayed `DEL + replacement` into a prompt that no longer held it.

## Tests

- `live-terminal-ime-rewrite` spec 4 passed (incl. the 2 new regressions)
- `MobileTerminalToolbar.test.tsx` 5 passed, `mobileKeyboardProxy.test.ts` 9 passed
- `tsc -b`, `eslint`, oxfmt clean; coverage-matrix entry updated

## Notes

The `browserName: _iphoneBrowser` suggestion was not applied: the mocked configs pin a single chromium project and a describe-level browser override would skip the whole file; the `defaultBrowserType` drop is the documented convention in the sibling device specs (e.g. `tests/backspace-autorepeat.spec.ts:49-52`).