### PR TITLE
fix(tests): remove three sources of cross-test interference

### DIFF
--- a/src/acp/fs_handler.rs
+++ b/src/acp/fs_handler.rs
@@ -293,8 +293,11 @@ mod tests {
     fn rejects_symlink_leaf_pointing_outside_root() {
         let temp = tempfile::tempdir().unwrap();
         let policy = FsPolicy::new(vec![temp.path().to_path_buf()]);
-        let outside = std::env::temp_dir().join("aoe-fs-handler-symlink-target");
-        let _ = std::fs::remove_file(&outside);
+        // Its own tempdir, not a fixed name under `$TMPDIR`: a second test
+        // binary running on this machine would otherwise share the path and
+        // could unlink the file between this write and the read below.
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside = outside_dir.path().join("symlink-target");
         std::fs::write(&outside, "secret").unwrap();
         let symlink_in_root = temp.path().join("escape");
         std::os::unix::fs::symlink(&outside, &symlink_in_root).unwrap();
@@ -307,7 +310,6 @@ mod tests {
 
         let target_after = std::fs::read_to_string(&outside).unwrap();
         assert_eq!(target_after, "secret", "outside file must remain untouched");
-        let _ = std::fs::remove_file(outside);
     }
 
     /// Dangling symlink (target does not exist) inside the allowed root.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -579,29 +579,17 @@ mod profile_listing_tests {
     use std::fs;
     use std::os::unix::fs::symlink;
 
-    fn make_temp_profiles_dir() -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "aoe-profile-listing-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0),
-        ));
-        fs::create_dir_all(&dir).expect("create tempdir");
-        dir
-    }
-
     #[test]
     fn list_profile_names_skips_symlinks_to_real_profiles() {
-        let dir = make_temp_profiles_dir();
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let dir = tmp.path();
         fs::create_dir(dir.join("default")).unwrap();
         fs::create_dir(dir.join("personal")).unwrap();
         // The cs/cxa pattern: aliases are symlinks pointing at `default`.
         symlink("default", dir.join("forit-work")).unwrap();
         symlink("default", dir.join("wma-work")).unwrap();
 
-        let names = list_profile_names_in(&dir).expect("list");
+        let names = list_profile_names_in(dir).expect("list");
         assert_eq!(
             names,
             vec!["default".to_string(), "personal".to_string()],
@@ -610,33 +598,31 @@ mod profile_listing_tests {
              with duplicates of the linked profile's data (the original \
              three-of-every-folder bug)."
         );
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn list_profile_names_includes_real_dirs_only() {
-        let dir = make_temp_profiles_dir();
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let dir = tmp.path();
         fs::create_dir(dir.join("default")).unwrap();
         fs::create_dir(dir.join("work")).unwrap();
         // A regular file in profiles/ should also be ignored.
         fs::write(dir.join("README"), "ignore me").unwrap();
 
-        let names = list_profile_names_in(&dir).expect("list");
+        let names = list_profile_names_in(dir).expect("list");
         assert_eq!(names, vec!["default".to_string(), "work".to_string()]);
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn list_profile_names_keeps_default_in_plain_order() {
         // Resolution input: "default" sorts like any other name here.
-        let dir = make_temp_profiles_dir();
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let dir = tmp.path();
         for name in ["default", "alpha", "beta", "zeta"] {
             fs::create_dir(dir.join(name)).unwrap();
         }
 
-        let names = list_profile_names_in(&dir).expect("list");
+        let names = list_profile_names_in(dir).expect("list");
         assert_eq!(
             names,
             vec![
@@ -646,8 +632,6 @@ mod profile_listing_tests {
                 "zeta".to_string(),
             ]
         );
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -912,7 +912,7 @@ mod tests {
         // Stand in for the orphaned `<agent> --resume <sid>` child: the sid
         // rides as `$0` of a compound-list `sh` so it stays alive with the id
         // in argv.
-        let mut child = std::process::Command::new("sh")
+        let mut child = std::process::Command::new("/bin/sh")
             .arg("-c")
             .arg("sleep 30; true")
             .arg(&sid)
@@ -1034,12 +1034,12 @@ mod tests {
         // under any other name, so the stand-in would die before the scan. The
         // sleep is short because it outlives the killed shell.
         std::fs::write(&agent, "#!/bin/sh\nsleep 10\n").unwrap();
-        // Hand the stub to `sh` instead of exec'ing it: a concurrent spawn in
-        // this binary can fork between the write's open and close and hold a
-        // writable copy, which fails execve with ETXTBSY (#3861). `sh` only
-        // opens it for reading. The kernel rewrites a shebang exec into this
-        // same argv, so the executable needle still matches the `claude`
-        // token and the stub needs no exec bit.
+        // The stub runs under `sh` so nothing execs it directly: a concurrent
+        // spawn in this binary can fork between the write's open and close and
+        // hold a writable copy, which fails execve with ETXTBSY (#3861). `sh`
+        // opens it for reading only. A shebang exec is rewritten by the kernel
+        // into this same argv, so the executable needle still matches the
+        // `claude` token and the stub needs no exec bit.
         let mut child = std::process::Command::new("/bin/sh")
             .arg(&agent)
             .env(crate::tmux::env::AOE_INSTANCE_ID_KEY, &inst.id)

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -1022,8 +1022,6 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn orphaned_hook_agent_requires_env_and_executable_not_captured_sid() {
-        use std::os::unix::fs::PermissionsExt;
-
         let mut inst = Instance::new("orphan-env-agent", "/tmp/test");
         inst.id = format!("orphanboth{:012}", std::process::id());
         // Model a first hook publication or a later native rotation: this id is
@@ -1036,8 +1034,14 @@ mod tests {
         // under any other name, so the stand-in would die before the scan. The
         // sleep is short because it outlives the killed shell.
         std::fs::write(&agent, "#!/bin/sh\nsleep 10\n").unwrap();
-        std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let mut child = std::process::Command::new(&agent)
+        // Hand the stub to `sh` instead of exec'ing it: a concurrent spawn in
+        // this binary can fork between the write's open and close and hold a
+        // writable copy, which fails execve with ETXTBSY (#3861). `sh` only
+        // opens it for reading. The kernel rewrites a shebang exec into this
+        // same argv, so the executable needle still matches the `claude`
+        // token and the stub needs no exec bit.
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg(&agent)
             .env(crate::tmux::env::AOE_INSTANCE_ID_KEY, &inst.id)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())


### PR DESCRIPTION
## Description

Three independent test-isolation fixes, one commit each so any can be dropped.

- **Orphan-agent stub, ETXTBSY (`Fixes #3861`).** Hand the stub to `/bin/sh` instead of exec'ing it. The issue ruled this shape out because it changes the executable name; it does not. The kernel rewrites a shebang exec into the same argv, so `/proc/<pid>/cmdline` reads `/bin/sh <stub>` either way, and `processes_matching` tests an executable needle against every argv token's basename rather than argv[0] alone. Under eight concurrent spawn threads a stress harness hit ETXTBSY on 112 of 2000 direct execs and 0 of 2000 through `sh`; with a helper holding the stub open for writing, the direct form fails every time and the `sh` form spawns every time. Mutating the executable needle to a name the stub does not carry still fails the test.
- **Profile listing.** `tempfile::tempdir` replaces a pid-plus-nanosecond path taken with `create_dir_all`. The key is not unique (3 of 200 sixteen-thread bursts share a nanosecond reading on Linux, macOS is coarser) and `create_dir_all` cannot report a collision, so two tests built profiles in one directory and the second's `create_dir` failed with `AlreadyExists`. That is the 09-09 failure on `main`.
- **fs-handler symlink target.** Its own tempdir replaces a fixed `$TMPDIR` name that a second concurrent `cargo test` on the same machine shares and can unlink between this test's write and its read.

Diagnosed, deliberately not fixed here:

- Around 155 bare `std::env::set_var("HOME", ...)` sites across 33 files rely on `#[serial]` alone and never restore, leaving `$HOME` pointing at a deleted `TempDir` for any later non-serial reader. #3760 records that `#[serial]` does not close this and that `test_support::isolate_home` is the discipline. Too broad to fold in here.
- `src/acp/acp_client/resolve_command.rs:295` and `:313` exec a written script by path, the #3861 shape, but the code under test picks the argv so the `sh` form does not apply: production spawns it at `resolve_command.rs:161`. Around 40 further write-then-chmod-then-exec fixtures share the hazard shape, among them `tests/e2e/harness.rs:336`, `src/acp/acp_client/spawn.rs:955`, `src/update/install.rs:885` and `tests/integration/terminal_smart_rename.rs:64`, since the writing process is also the forking one. No CI occurrence yet. Fixing them needs a retry on `ErrorKind::ExecutableFileBusy` at the spawn, or a helper process to write the fixture, neither of which belongs in this PR. `Fixes #3861` closes the ticket carrying that analysis, so this list is the surviving record.
- Wall-clock readiness waits (#3806) belong to PR #3807 and are untouched.
- `web/tests/live/acp-compaction-phase.spec.ts:62` failed three times on `main`, most recently on a commit already carrying #3844. No issue filed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --all-targets`, and `cargo test` are clean: 6885 lib and 289 integration tests pass, 0 failures. No docs change is warranted and there is no UI change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Test-only changes. Each fix keeps its test's assertions, and the recovery one was re-checked by mutation to confirm it can still fail.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Diagnosis, the stress and deterministic reproductions, and the patches were produced by Claude Opus 5 in discussion with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GEwxHbRR8Tg8fYn74Z6Yd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Isolated test temporary files and directories to prevent interference during concurrent test runs.
- Updated shell-stub tests to run through `/bin/sh`, which avoids Linux `ETXTBSY` failures.
- Added coverage to ignore regular files when listing profiles.
- Removed manual cleanup where temporary directories now manage cleanup automatically.

## Benefits

- Improves test reliability and repeatability.
- Prevents flaky failures caused by shared paths and concurrent processes.
- Does not change user-facing behavior.

## Validation

- Formatting, clippy, and tests pass.
- 6,885 library tests and 289 integration tests passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->