### PR TITLE
fix(sandbox): stop a blanked credential from wedging every sandbox

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -367,6 +367,18 @@ at that session's next start when it is fresher. To seed the sandboxes from a
 new host login instead, stop them, delete `sandbox-v2/.credentials.json` and
 start one.
 
+Claude Code writes the file itself, and empties `accessToken` and
+`refreshToken` in place when the credential it holds fails to authenticate.
+That reaches every sandbox at once, through the mount they share. A file whose
+tokens are both empty holds no credential, whatever expiry is left beside
+them, so it is seeded like any other at the next start or TUI refresh and the
+container that emptied it costs the rest of them nothing more than a seed.
+
+Two containers that refresh at the same moment off one token stay a hazard the
+shared file cannot remove: one refresh wins, the other is refused, and the
+container that lost empties the file. The token the winner obtained goes with
+it, and the sandboxes are seeded from the host at the next start or refresh.
+
 A container created before this layout mounts only its store, so a stopped
 one is recreated at its next start, as it was for the store move, and a
 running one refuses to relaunch until it is stopped. Running `/logout` inside

--- a/src/session/config/container_config.rs
+++ b/src/session/config/container_config.rs
@@ -652,21 +652,33 @@ fn copy_dir_recursive_inner(
     Ok(())
 }
 
-/// Parse the `expiresAt` timestamp from a Claude Code credential JSON string.
-/// Returns `None` if the JSON is malformed or the field is missing/wrong type.
-fn parse_credential_expires_at(content: &str) -> Option<u64> {
-    let value: serde_json::Value = serde_json::from_str(content).ok()?;
-    value.get("claudeAiOauth")?.get("expiresAt")?.as_u64()
-}
-
 /// The furthest `expiresAt` a real token carries. The shared file is writable
 /// from inside every sandbox, so a planted timestamp beyond this would
 /// otherwise outrank every later login for good.
 const CREDENTIAL_EXPIRY_HORIZON: std::time::Duration =
     std::time::Duration::from_secs(400 * 24 * 60 * 60);
 
+/// The `expiresAt` of a credential a container could use, or `None` when the
+/// content is not one.
+///
+/// A blanked token block is not one. Claude Code empties `accessToken` and
+/// `refreshToken` in place when its credential fails to authenticate and
+/// keeps the rest of the block, so what it leaves still parses and can still
+/// carry an expiry (#3860). Read as a credential, that shell mounts dead into
+/// every later container and blocks the seed that would repair it.
 fn plausible_credential_expires_at(content: &str, now_ms: u64) -> Option<u64> {
-    parse_credential_expires_at(content).filter(|expires_at| {
+    let value: serde_json::Value = serde_json::from_str(content).ok()?;
+    let oauth = value.get("claudeAiOauth")?;
+    let filled = |field| {
+        oauth
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|token| !token.trim().is_empty())
+    };
+    if !filled("accessToken") && !filled("refreshToken") {
+        return None;
+    }
+    oauth.get("expiresAt")?.as_u64().filter(|expires_at| {
         *expires_at <= now_ms.saturating_add(CREDENTIAL_EXPIRY_HORIZON.as_millis() as u64)
     })
 }
@@ -4386,75 +4398,83 @@ mod tests {
 
     // --- credential freshness tests ---
 
-    #[test]
-    fn test_parse_credential_expires_at_valid() {
-        let json = r#"{"claudeAiOauth":{"expiresAt":1700000000}}"#;
-        assert_eq!(parse_credential_expires_at(json), Some(1700000000));
-    }
-
-    #[test]
-    fn test_parse_credential_expires_at_missing_key() {
-        // Missing claudeAiOauth entirely.
-        assert_eq!(parse_credential_expires_at(r#"{"other":"data"}"#), None);
-        // Missing expiresAt inside claudeAiOauth.
-        assert_eq!(
-            parse_credential_expires_at(r#"{"claudeAiOauth":{"token":"abc"}}"#),
-            None
-        );
-    }
-
-    #[test]
-    fn test_parse_credential_expires_at_invalid_json() {
-        assert_eq!(parse_credential_expires_at("not json at all"), None);
-        assert_eq!(parse_credential_expires_at(""), None);
-    }
-
-    #[test]
-    fn test_parse_credential_expires_at_wrong_type() {
-        // expiresAt is a string instead of a number.
-        let json = r#"{"claudeAiOauth":{"expiresAt":"1700000000"}}"#;
-        assert_eq!(parse_credential_expires_at(json), None);
-    }
-
-    #[test]
-    fn test_should_not_overwrite_with_stale_keychain() {
-        let sandbox = r#"{"claudeAiOauth":{"expiresAt":2000}}"#;
-        let keychain = r#"{"claudeAiOauth":{"expiresAt":1000}}"#;
-        assert!(!should_overwrite_credential(sandbox, keychain));
-    }
-
-    #[test]
-    fn test_should_overwrite_with_fresh_keychain() {
-        let sandbox = r#"{"claudeAiOauth":{"expiresAt":1000}}"#;
-        let keychain = r#"{"claudeAiOauth":{"expiresAt":2000}}"#;
-        assert!(should_overwrite_credential(sandbox, keychain));
-    }
-
-    #[test]
-    fn test_should_not_overwrite_equal_timestamps() {
-        let cred = r#"{"claudeAiOauth":{"expiresAt":1000}}"#;
-        assert!(!should_overwrite_credential(cred, cred));
-    }
-
-    #[test]
-    fn test_should_not_overwrite_when_keychain_unparseable() {
-        let sandbox = r#"{"claudeAiOauth":{"expiresAt":1000}}"#;
-        assert!(!should_overwrite_credential(sandbox, "not-json"));
-    }
-
-    #[test]
-    fn test_should_overwrite_when_both_unparseable() {
-        assert!(should_overwrite_credential("bad", "also-bad"));
-    }
-
-    #[test]
-    fn test_should_overwrite_when_only_keychain_parseable() {
-        let keychain = r#"{"claudeAiOauth":{"expiresAt":1000}}"#;
-        assert!(should_overwrite_credential("not-json", keychain));
-    }
-
+    /// Fields in the order `serde_json` writes them back, so a fold that
+    /// re-serializes a credential produces this string again.
     fn credential(expires_at: u64) -> String {
-        format!(r#"{{"claudeAiOauth":{{"expiresAt":{expires_at}}}}}"#)
+        format!(
+            r#"{{"claudeAiOauth":{{"accessToken":"access-{expires_at}","expiresAt":{expires_at},"refreshToken":"refresh-{expires_at}"}}}}"#
+        )
+    }
+
+    /// What Claude Code leaves behind when its credential fails to
+    /// authenticate: both tokens emptied in place, the rest of the block kept.
+    fn blanked_credential(expires_at: u64) -> String {
+        format!(
+            r#"{{"claudeAiOauth":{{"accessToken":"","expiresAt":{expires_at},"refreshToken":"","scopes":["user:inference"],"subscriptionType":"max"}}}}"#
+        )
+    }
+
+    #[test]
+    fn only_a_usable_credential_carries_an_expiry() {
+        let now = now_ms();
+        let horizon = CREDENTIAL_EXPIRY_HORIZON.as_millis() as u64;
+        let cases = [
+            (credential(1700000000), Some(1700000000)),
+            // Emptied tokens are not a credential, whatever expiry is left
+            // beside them (#3860).
+            (blanked_credential(1700000000), None),
+            (blanked_credential(0), None),
+            // Either token alone keeps a container going: an access token
+            // until it expires, a refresh token to get another.
+            (
+                r#"{"claudeAiOauth":{"accessToken":"a","expiresAt":10}}"#.into(),
+                Some(10),
+            ),
+            (
+                r#"{"claudeAiOauth":{"refreshToken":"r","expiresAt":10}}"#.into(),
+                Some(10),
+            ),
+            (r#"{"other":"data"}"#.into(), None),
+            (r#"{"claudeAiOauth":{"accessToken":"a"}}"#.into(), None),
+            (
+                r#"{"claudeAiOauth":{"accessToken":"a","expiresAt":"10"}}"#.into(),
+                None,
+            ),
+            ("not json at all".into(), None),
+            (String::new(), None),
+            // Planted from inside a sandbox to outrank every later login.
+            (credential(now + horizon + 1), None),
+        ];
+        for (content, expires_at) in cases {
+            assert_eq!(
+                plausible_credential_expires_at(&content, now),
+                expires_at,
+                "{content}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_freshest_credential_wins_an_overwrite() {
+        let cases = [
+            (credential(2000), credential(1000), false),
+            (credential(1000), credential(2000), true),
+            (credential(1000), credential(1000), false),
+            (credential(1000), "not-json".into(), false),
+            ("bad".into(), "also-bad".into(), true),
+            ("not-json".into(), credential(1000), true),
+            // A blanked file never outranks a credential however far its
+            // leftover expiry reaches, and a credential always replaces it.
+            (credential(1000), blanked_credential(9000), false),
+            (blanked_credential(9000), credential(1000), true),
+        ];
+        for (existing, incoming, overwrite) in cases {
+            assert_eq!(
+                should_overwrite_credential(&existing, &incoming),
+                overwrite,
+                "{existing} -> {incoming}"
+            );
+        }
     }
 
     #[test]
@@ -4629,6 +4649,50 @@ mod tests {
     }
 
     #[test]
+    fn an_emptied_shared_file_is_seeded_for_the_next_container() {
+        let home = TempDir::new().unwrap();
+        let host = home.path().join(".claude");
+        fs::create_dir_all(&host).unwrap();
+        let mount = claude_mount_without_keychain();
+        let root = host.join(SANDBOX_PRIVATE_SUBDIR);
+        let store = root.join("aaaaaaaaaaaaaaaa");
+        let shared = root.join(".credentials.json");
+        fs::create_dir_all(&store).unwrap();
+        let prepare = |fold| {
+            prepare_sandbox_dir_from(&mount, host.clone(), store.clone(), home.path(), fold)
+                .unwrap()
+        };
+
+        // A container whose credential fails to authenticate empties both
+        // tokens in place, through the mount every sandbox shares. The file
+        // it leaves keeps its expiry, and used to read as a credential no
+        // seed would replace: every container created afterwards came up on
+        // it and only deleting the file by hand got out (#3860). The next
+        // come-up seeds it now, and so does the poll, for the containers
+        // already running.
+        fs::write(host.join(".credentials.json"), credential(100)).unwrap();
+        for fold in [CredentialFold::SeedOnly, CredentialFold::Freshest] {
+            fs::write(&shared, blanked_credential(900)).unwrap();
+            prepare(fold);
+            let seeded = fs::read_to_string(&shared).unwrap();
+            assert!(holds_credential(&seeded), "{fold:?}");
+            assert_eq!(seeded, credential(100), "{fold:?}");
+        }
+
+        // The emptied file the container left is not a fresher credential
+        // than the one seeded over it, however far its leftover expiry
+        // reaches, so a second come-up does not put it back.
+        prepare(CredentialFold::Freshest);
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
+
+        // A copy a container emptied in a store is not a candidate either: it
+        // would otherwise outrank the login it is folded against.
+        fs::write(store.join(".credentials.json"), blanked_credential(900)).unwrap();
+        prepare(CredentialFold::Freshest);
+        assert_eq!(fs::read_to_string(&shared).unwrap(), credential(100));
+    }
+
+    #[test]
     #[serial_test::serial]
     fn claude_sandboxes_share_one_credential_mount() {
         let (_hg, _, _tmp_base) = BaseGuard::ready();
@@ -4739,6 +4803,9 @@ mod tests {
             ("", credential(1)),
             ("{}", credential(1)),
             (&credential(2), credential(3)),
+            // Blanked in place by a container that failed to authenticate:
+            // the copy is the only chain left, so it stays (#3860).
+            (&blanked_credential(9), credential(1)),
         ] {
             fs::write(&shared, unfolded).unwrap();
             fs::write(&copy, &copy_content).unwrap();


### PR DESCRIPTION
## Description

Fixes #3860.

Claude Code empties `accessToken` and `refreshToken` in place when the credential it is given fails to authenticate. Every Claude sandbox mounts one file, so that reaches all of them at once. The block it leaves keeps its expiry, and `plausible_credential_expires_at` read that as a credential: the fold refused to seed the file, every container created afterwards mounted a dead one, and deleting the file by hand was the only way out.

Both tokens empty is now no credential, whatever expiry is left beside them. An emptied file is seeded at the next start or TUI refresh like any other file holding none, and an emptied block never outranks a live credential: not as a store copy folded into the file, and not as the file a store copy is compared against before it is emptied.

**On the design.** Per-instance copies seeded at come-up are worse, not better. N containers seeded from one refresh token diverge at the first rotation and every container but the winner is logged out, which is the v027 behavior #3834 fixed; the sharing is what keeps a rotation visible to the rest. A lock or an atomic swap buys nothing, since Claude Code takes neither and writes through the mount.

Two containers refreshing off one token at the same moment stay a hazard the shared file cannot remove: the refused one empties the file and the token the winner obtained goes with it, leaving a seed from the host. Preserving that token across the emptying was tried on this branch and dropped, because a copy of what the file last held is a consumed token after any rotation and outranked the host login on expiry, putting the dead credential back on every come-up.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the blanking path is the fold, unit tested through the store preparation path. `an_emptied_shared_file_is_seeded_for_the_next_container` walks a container emptying the file and asserts what the next come-up and the poll leave there; `only_a_usable_credential_carries_an_expiry` and `the_freshest_credential_wins_an_overwrite` cover the emptied block against a live credential. Reaching it end to end needs a container whose credential fails to authenticate, which the harness has no way to produce.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Diagnosis, design and implementation by the model in discussion with @njbrake, who owns the decisions. A second model reviewed the branch against the scenario in #3860 and reproduced the regression noted above, which was dropped before review.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7pcPYaGSS9DWg5TK8Zo4e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Treats credentials with both token fields empty as unavailable.
- Reseeds shared credentials during the next sandbox start or TUI refresh.
- Preserves the last credential in a non-mounted backup file for expiry-based recovery.
- Adds tests and documentation for blanked, malformed, incomplete, and stale credentials.

## Benefits

Prevents one failed Claude authentication from affecting all sandboxes that share the credential file. It also enables automatic recovery without manual file deletion.

## Technical notes

- Blank credentials no longer outrank usable credentials.
- Simultaneous refreshes from the same token remain a known limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
