### PR TITLE
fix(web): render OSC 8 hyperlinks instead of leaking their escape bytes

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -5,6 +5,7 @@ import {
   LineParseCache,
   clusterSpanAt,
   findCursorCharIndex,
+  isHttpUrl,
   splitCellRuns,
   splitUrls,
   textWidth,
@@ -487,7 +488,10 @@ export const Row = memo(function Row({
     return (
       <div>
         {segs.map((seg, i) =>
-          splitUrls(seg.text).map((part, j) => {
+          // An OSC 8 hyperlink's displayed text need not be its URL (a PR
+          // title over a PR link), so a segment carrying one anchors as a
+          // whole instead of being re-scanned by the bare-URL regex.
+          (seg.url && isHttpUrl(seg.url) ? [{ text: seg.text, url: seg.url }] : splitUrls(seg.text)).map((part, j) => {
             const runs = splitCellRuns(part.text).map((run, k) => cellRunSpan(run, seg.style, `${i}-${j}-${k}`));
             // Whole-part anchors: a URL that runs into glued non-ASCII
             // keeps those glyphs in its href and inside the clickable

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -1059,3 +1059,33 @@ describe("clickable file path (#3088)", () => {
     expect(container.querySelector('[title="/tmp/main.rs"]')).not.toBeNull();
   });
 });
+
+describe("hyperlinks in tool output", () => {
+  // The card header is a toggle; output is collapsed until it is clicked.
+  const outputWith = (text: string) => {
+    const rendered = render(
+      <Wrap>
+        <ToolCard tool={fixtures.bash} result={makeCompletion({ toolCallId: "bash-1", text })} />
+      </Wrap>,
+    );
+    const header = rendered.container.querySelector("button");
+    if (header) fireEvent.click(header);
+    return rendered;
+  };
+
+  it("links output whose only escape sequence is a hyperlink", () => {
+    // No color code anywhere: this output used to miss the ANSI path
+    // entirely and render its escape bytes as text.
+    const { container } = outputWith("See \x1b]8;;https://example.com/pr/8\x1b\\the PR\x1b]8;;\x1b\\ now");
+    const link = container.querySelector('a[href="https://example.com/pr/8"]');
+    expect(link?.textContent).toBe("the PR");
+    expect(container.textContent).toContain("See the PR now");
+    expect(container.textContent).not.toContain("]8;;");
+  });
+
+  it("renders a target outside the scheme allowlist as plain text", () => {
+    const { container } = outputWith("run \x1b]8;;javascript:alert(1)\x1b\\this\x1b]8;;\x1b\\ now");
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("run this now");
+  });
+});

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -729,11 +729,28 @@ function AnsiBlock({ text }: { text: string }) {
   const segments = useMemo(() => parseAnsi(text), [text]);
   return (
     <pre className="overflow-x-auto px-3 py-2 text-xs font-mono text-text-primary whitespace-pre">
-      {segments.map((seg, i) => (
-        <span key={i} style={ansiSegmentStyle(seg.style)}>
-          {seg.text}
-        </span>
-      ))}
+      {segments.map((seg, i) => {
+        // Tool output is agent-controlled, so a hyperlink target answers to
+        // the same scheme policy as every other link on this card; a rejected
+        // target keeps its visible text and loses only the anchor.
+        const href = seg.url ? safeUri(seg.url, SAFE_LINK_SCHEMES) : null;
+        return href ? (
+          <a
+            key={i}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={ansiSegmentStyle(seg.style)}
+            className="underline"
+          >
+            {seg.text}
+          </a>
+        ) : (
+          <span key={i} style={ansiSegmentStyle(seg.style)}>
+            {seg.text}
+          </span>
+        );
+      })}
     </pre>
   );
 }

--- a/web/src/lib/ansi.test.ts
+++ b/web/src/lib/ansi.test.ts
@@ -93,3 +93,70 @@ describe("parseAnsi", () => {
     expect(segs[1].style).toEqual({});
   });
 });
+
+describe("OSC 8 hyperlinks and other OSC sequences", () => {
+  const link = (url: string, text: string, terminator = `${ESC}\\`) =>
+    `${ESC}]8;;${url}${terminator}${text}${ESC}]8;;${terminator}`;
+
+  it("tags the visible text with the link target, not a regex guess", () => {
+    const segs = parseAnsi(`Created PR ${link("https://github.com/x/y/pull/8", "here")}, done`);
+    expect(segs.map((s) => [s.text, s.url])).toEqual([
+      ["Created PR ", undefined],
+      ["here", "https://github.com/x/y/pull/8"],
+      [", done", undefined],
+    ]);
+  });
+
+  it("keeps SGR styling inside a link's visible text and still tags it", () => {
+    const styled = link("https://x.com", `${ESC}[31mred link${ESC}[0m`);
+    const segs = parseAnsi(styled);
+    expect(segs).toEqual([{ text: "red link", style: { fg: "#cd3131" }, url: "https://x.com" }]);
+  });
+
+  it("supports a BEL terminator instead of ST", () => {
+    const segs = parseAnsi(link("https://x.com", "click", "\x07"));
+    expect(segs).toEqual([{ text: "click", style: {}, url: "https://x.com" }]);
+  });
+
+  it("carries an id= parameter before the URL", () => {
+    const withId = `${ESC}]8;id=k16z3m;https://x.com/pull/8${ESC}\\click${ESC}]8;;${ESC}\\`;
+    const segs = parseAnsi(withId);
+    expect(segs).toEqual([{ text: "click", style: {}, url: "https://x.com/pull/8" }]);
+  });
+
+  it("runs an unterminated link to the end of the text instead of dropping it", () => {
+    const segs = parseAnsi(`${ESC}]8;;https://x.com${ESC}\\trailing text`);
+    expect(segs).toEqual([{ text: "trailing text", style: {}, url: "https://x.com" }]);
+  });
+
+  it("anchors the link to its own text when color opens before the link", () => {
+    // The shape `tmux capture-pane -e` emits: the SGR change lands BEFORE
+    // the OSC 8 opener, so counting escape bytes as visible text shifted
+    // the link right by the length of the color sequence.
+    const line = `Styled: ${ESC}[31m${ESC}]8;;https://example.com/red${ESC}\\red link${ESC}[39m${ESC}]8;;${ESC}\\`;
+    expect(parseAnsi(line)).toEqual([
+      { text: "Styled: ", style: {} },
+      { text: "red link", style: { fg: "#cd3131" }, url: "https://example.com/red" },
+    ]);
+  });
+
+  it("keeps the link off text that follows the closing sequence", () => {
+    const line = `${ESC}[32m${ESC}]8;;https://example.com${ESC}\\link${ESC}]8;;${ESC}\\ tail`;
+    expect(parseAnsi(line)).toEqual([
+      { text: "link", style: { fg: "#0dbc79" }, url: "https://example.com" },
+      { text: " tail", style: { fg: "#0dbc79" } },
+    ]);
+  });
+
+  it("detects output whose only escape sequence is a hyperlink", () => {
+    // Output with a link but no color must still reach this parser; the
+    // caller renders it as plain text otherwise and the bytes leak.
+    expect(hasAnsi(link("https://x.com", "click"))).toBe(true);
+    expect(hasAnsi(`${ESC}]0;title${ESC}\\`)).toBe(true);
+  });
+
+  it("drops non-hyperlink OSC sequences instead of leaking their escape bytes", () => {
+    const segs = parseAnsi(`${ESC}]0;window title${ESC}\\before${ESC}]52;c;aGk=\x07after`);
+    expect(segs.map((s) => s.text)).toEqual(["beforeafter"]);
+  });
+});

--- a/web/src/lib/ansi.ts
+++ b/web/src/lib/ansi.ts
@@ -1,28 +1,34 @@
 /* eslint-disable no-control-regex -- this file's whole job is to match ESC sequences */
-// ANSI SGR parser for Bash tool output.
+// ANSI SGR parser for Bash tool output and the live terminal view.
 //
 // claude-agent-acp forwards `\x1b[...m` color escapes from commands
 // like `git status --color=always` and `gls --color=always`. Shiki's
 // bash grammar treats them as raw text, so the user sees literal
-// `[01;34m` noise unless we render them ourselves.
+// `[01;34m` noise unless we render them ourselves. Agents also emit
+// `\x1b]8;;URL\x1b\TEXT\x1b]8;;\x1b\` OSC 8 hyperlinks (e.g. `gh pr
+// create` output); there is no xterm here to interpret those, so
+// without this parser they show up as literal escape bytes (#3519).
 //
-// We:
-//   1. Collapse `\r` (carriage-return repaints) so progress bars don't
-//      flatten into one concatenated line.
-//   2. Strip non-SGR CSI sequences (cursor movement, line erase, etc.)
-//      that would otherwise leak through as garbage characters.
-//   3. Walk the remaining SGR sequences (`\x1b[<n;n;…>m`) and emit
-//      typed segments the React layer can style.
+// One pass walks every escape sequence in order, carrying the SGR style
+// and the open hyperlink target as a single state. Text between sequences
+// becomes a segment stamped with that state, so there are no string
+// coordinates for two passes to disagree about.
+//
+// Carriage-return repaints are collapsed first, because that is a
+// line-oriented rewrite that needs no coordinate agreement.
 
 // Any CSI sequence: ESC [ params final-byte (any letter).
 const ANY_CSI = /\[[\d;?]*[a-zA-Z]/g;
-// SGR specifically: same shape, terminated by `m`.
-const SGR = /\[([\d;]*)m/g;
-// CSI sequences other than SGR — anything ending in a letter that
-// isn't `m`. We match the full sequence so ANY_CSI followed by a
-// negative-set replace would risk eating SGR; instead use a
-// non-`m`-terminator pattern.
-const NON_SGR_CSI = /\[[\d;?]*[a-ln-zA-LN-Z]/g;
+
+// Every escape sequence this parser understands, in one alternation so a
+// single walk sees them in the order they appear:
+//   1-2: CSI params + final byte. `m` is SGR; every other final byte is
+//        cursor movement, line erase and the like, dropped.
+//   3-4: OSC code + payload, terminated by BEL or ST (`ESC \`). Code 8
+//        carries `params;URI` and opens or closes a hyperlink; every other
+//        code (title sets, OSC 52 clipboard) is dropped whole, payload
+//        included, because none of it is meant to render.
+const TOKEN = /\[([\d;?]*)([a-zA-Z])|\]([0-9]+)(?:;([^\x07]*))?(?:\\|\x07)/g;
 
 export interface AnsiStyle {
   fg?: string;
@@ -37,14 +43,26 @@ export interface AnsiStyle {
 export interface AnsiSegment {
   text: string;
   style: AnsiStyle;
+  /** Hyperlink target when this span fell inside an OSC 8 sequence. */
+  url?: string;
 }
 
-// Match a real CSI sequence (`ESC [ params final-byte`), not just the
-// `ESC [` prefix. A markdown blob that quotes the literal characters
-// "\x1b[" — e.g. agent docs about color output — would otherwise trip
-// the ANSI fast path, find no SGR, and render as a plain `<pre>`
-// instead of going through Shiki for highlighting.
-const HAS_ANSI = /\x1b\[[\d;?]*[a-zA-Z]/;
+/** Everything an escape sequence can leave in effect past the end of a
+ *  line: tmux emits a reset only when the style changes, and a hyperlink
+ *  legitimately spans lines, so a per-line parse must thread both. */
+export interface AnsiState {
+  style: AnsiStyle;
+  /** Target of a hyperlink still open at this point, if any. */
+  url?: string;
+}
+
+// Match a real escape sequence, not just an `ESC [` or `ESC ]` prefix. A
+// markdown blob that quotes the literal characters "[" — e.g. agent
+// docs about color output — would otherwise trip the ANSI fast path, find
+// nothing to style, and render as a plain `<pre>` instead of going through
+// Shiki for highlighting. Output whose only sequence is a hyperlink counts:
+// it has no color code, and skipping it here leaks the escape bytes.
+const HAS_ANSI = /\[[\d;?]*[a-zA-Z]|\][0-9]+(?:;[^\x07]*)?(?:\\|\x07)/;
 
 export function hasAnsi(text: string): boolean {
   return HAS_ANSI.test(text);
@@ -223,35 +241,57 @@ function applySgr(style: AnsiStyle, params: number[]): AnsiStyle {
   return next;
 }
 
-/** Parse a string with ANSI SGR codes into styled segments, starting from
- *  `initial` SGR state and reporting the state left in effect at the end.
- *  This is the resumable core behind [`parseAnsi`]: tmux emits a reset only
- *  when the style changes, so SGR state legitimately spans lines, and a
- *  per-line parse cache must thread the carried style through explicitly.
- *  Non-SGR CSI sequences and `\r` repaints are stripped/collapsed first. */
-export function parseAnsiFrom(text: string, initial: AnsiStyle): { segs: AnsiSegment[]; exit: AnsiStyle } {
-  const cleaned = collapseCarriageReturns(text).replace(NON_SGR_CSI, "");
+/** Parse `text` into styled segments, starting from the escape state
+ *  `initial` leaves in effect and reporting the state left at the end.
+ *  This is the resumable core behind [`parseAnsi`]: a color or an open
+ *  hyperlink legitimately spans lines, so a per-line parse cache must
+ *  thread both through explicitly. */
+export function parseAnsiFrom(text: string, initial: AnsiState): { segs: AnsiSegment[]; exit: AnsiState } {
+  const clean = collapseCarriageReturns(text);
   const segs: AnsiSegment[] = [];
   let last = 0;
-  let cur: AnsiStyle = { ...initial };
-  for (const m of cleaned.matchAll(SGR)) {
-    const idx = m.index ?? 0;
-    if (idx > last) {
-      segs.push({ text: cleaned.slice(last, idx), style: { ...cur } });
+  let style: AnsiStyle = { ...initial.style };
+  let url = initial.url;
+  // A dropped sequence (cursor movement, a title set) leaves the state
+  // untouched, so the text on either side of it is one span rather than two.
+  let restyled = true;
+  const emit = (chunk: string) => {
+    if (chunk.length === 0) return;
+    const prev = segs[segs.length - 1];
+    if (!restyled && prev) {
+      prev.text += chunk;
+      return;
     }
-    const raw = m[1] ?? "";
-    const params = raw === "" ? [] : raw.split(";").map((s) => Number(s));
-    cur = applySgr(cur, params);
+    segs.push({ text: chunk, style: { ...style }, url });
+    restyled = false;
+  };
+  for (const m of clean.matchAll(TOKEN)) {
+    const idx = m.index ?? 0;
+    emit(clean.slice(last, idx));
     last = idx + m[0].length;
+    if (m[2] !== undefined) {
+      // CSI: SGR restyles, every other final byte is dropped.
+      if (m[2] !== "m") continue;
+      const raw = m[1] ?? "";
+      style = applySgr(style, raw === "" ? [] : raw.split(";").map((n) => Number(n)));
+      restyled = true;
+      continue;
+    }
+    if (m[3] !== "8") continue;
+    const payload = m[4] ?? "";
+    const sep = payload.indexOf(";");
+    // OSC 8 carries `params;URI`. An empty URI closes the link; a second
+    // open before a close (malformed input) retargets rather than nests.
+    // An open with no close runs to the end of the parsed text, so a frame
+    // cut mid-link still shows its visible text.
+    url = (sep >= 0 ? payload.slice(sep + 1) : "") || undefined;
+    restyled = true;
   }
-  if (last < cleaned.length) {
-    segs.push({ text: cleaned.slice(last), style: { ...cur } });
-  }
-  return { segs: segs.filter((s) => s.text.length > 0), exit: cur };
+  emit(clean.slice(last));
+  return { segs, exit: { style, url } };
 }
 
-/** Parse a string with ANSI SGR codes into styled segments. Non-SGR
- *  CSI sequences and `\r` repaints are stripped/collapsed first. */
+/** Parse a string with ANSI escape sequences into styled segments. */
 export function parseAnsi(text: string): AnsiSegment[] {
-  return parseAnsiFrom(text, {}).segs;
+  return parseAnsiFrom(text, { style: {} }).segs;
 }

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -5,6 +5,7 @@ import {
   ansiToLines,
   clusterSpanAt,
   findCursorCharIndex,
+  isHttpUrl,
   lineText,
   splitCellRuns,
   splitUrls,
@@ -40,12 +41,71 @@ describe("ansiToLines", () => {
   });
 });
 
+describe("isHttpUrl", () => {
+  it("accepts only http(s) targets a browser should follow", () => {
+    const cases: [string, boolean][] = [
+      ["https://example.com/pull/8", true],
+      ["http://localhost:3000", true],
+      ["HTTPS://EXAMPLE.COM", true],
+      ["javascript:alert(1)", false],
+      ["vscode://file/etc/passwd", false],
+      ["ssh://host", false],
+      ["file:///etc/passwd", false],
+      ["mailto:a@b.c", false],
+      ["https://example.com/\u001b]8;;x", false],
+      ["https://", false],
+    ];
+    for (const [url, want] of cases) {
+      expect([url, isHttpUrl(url)]).toEqual([url, want]);
+    }
+  });
+});
+
+describe("hyperlinks across lines", () => {
+  const spanning = "\x1b]8;;https://example.com\x1b\\first\nsecond\x1b]8;;\x1b\\\nplain\n";
+  const expected = [
+    [{ text: "first", style: {}, url: "https://example.com" }],
+    [{ text: "second", style: {}, url: "https://example.com" }],
+    [{ text: "plain", style: {} }],
+  ];
+
+  it("carries a link target onto each line its text spans", () => {
+    expect(ansiToLines(spanning)).toEqual(expected);
+  });
+
+  // The live terminal renders through the cache, not ansiToLines, and the
+  // cache parses each line on its own: without the open link in its carried
+  // state the second line would render as plain text.
+  it("carries the target through the per-line cache the terminal uses", () => {
+    expect(new LineParseCache().lines(spanning)).toEqual(expected);
+  });
+
+  it("keys the cache on the open link, not just the style", () => {
+    // Three rows of byte-identical raw text, differing only in the link the
+    // rows between them left open. A cache keyed on style alone returns the
+    // first row's parse for all three.
+    const content = ["same", "\x1b]8;;https://example.com\x1b\\", "same", "\x1b]8;;\x1b\\", "same", ""].join("\n");
+    const rows = new LineParseCache().lines(content);
+    expect(rows[0]).toEqual([{ text: "same", style: {} }]);
+    expect(rows[2]).toEqual([{ text: "same", style: {}, url: "https://example.com" }]);
+    expect(rows[4]).toEqual([{ text: "same", style: {} }]);
+  });
+});
+
 describe("wrapLine", () => {
   const seg = (text: string, fg?: string) => ({ text, style: fg ? { fg } : {} });
 
   it("is the identity for lines within the column limit", () => {
     const line = [seg("hello world")];
     expect(wrapLine(line, 80)).toEqual([line]);
+  });
+
+  it("keeps a hyperlink target on every wrapped row", () => {
+    const link = { text: "aaaabbbb", style: {}, url: "https://example.com/long" };
+    expect(wrapLine([link], 4)).toEqual([
+      [{ text: "aaaa", style: {}, url: "https://example.com/long" }],
+      [{ text: "bbbb", style: {}, url: "https://example.com/long" }],
+    ]);
   });
 
   it("hard-wraps at the column boundary preserving styles", () => {

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -1,4 +1,4 @@
-import { parseAnsi, parseAnsiFrom, type AnsiSegment, type AnsiStyle } from "./ansi";
+import { parseAnsi, parseAnsiFrom, type AnsiSegment, type AnsiState } from "./ansi";
 
 // Frame helpers for the mobile live terminal: turn one `capture-pane -e`
 // snapshot into per-line styled segments the component can render as DOM
@@ -14,7 +14,7 @@ export function ansiToLines(content: string): AnsiSegment[][] {
     parts.forEach((part, i) => {
       if (i > 0) lines.push([]);
       if (part.length > 0) {
-        lines[lines.length - 1]!.push({ text: part, style: seg.style });
+        lines[lines.length - 1]!.push({ text: part, style: seg.style, url: seg.url });
       }
     });
   }
@@ -29,15 +29,16 @@ export function ansiToLines(content: string): AnsiSegment[][] {
 
 interface CachedLine {
   segs: AnsiSegment[];
-  /** SGR state left in effect after this line, threaded into the next. */
-  exit: AnsiStyle;
+  /** Escape state left in effect after this line, threaded into the next. */
+  exit: AnsiState;
 }
 
-/** Key for the SGR state a line is entered with. Two identical raw lines
- *  parsed under different carried styles are different render results, so
- *  the entry state is part of the cache key. */
-function styleKey(s: AnsiStyle): string {
-  return `${s.fg ?? ""}|${s.bg ?? ""}|${+!!s.bold}${+!!s.dim}${+!!s.italic}${+!!s.underline}${+!!s.inverse}`;
+/** Key for the escape state a line is entered with. Two identical raw lines
+ *  parsed under different carried styles, or one inside an open hyperlink
+ *  and one outside it, are different render results, so the entry state is
+ *  part of the cache key. */
+function styleKey({ style: s, url }: AnsiState): string {
+  return `${s.fg ?? ""}|${s.bg ?? ""}|${+!!s.bold}${+!!s.dim}${+!!s.italic}${+!!s.underline}${+!!s.inverse}|${url ?? ""}`;
 }
 
 /**
@@ -67,7 +68,7 @@ export class LineParseCache {
     this.live = new Map();
     const raw = typeof content === "string" ? content.split("\n") : content;
     const lines: AnsiSegment[][] = [];
-    let entry: AnsiStyle = {};
+    let entry: AnsiState = { style: {} };
     for (const r of raw) {
       // NUL separator: it appears in neither a style key (CSS color
       // strings) nor capture-pane text, so the key cannot be ambiguous.
@@ -103,6 +104,24 @@ export function lineText(line: AnsiSegment[]): string {
 // The match may run into glued non-ASCII glyphs; Row anchors whole parts,
 // so the href follows whatever this regex claims.
 const URL_RE = /https?:\/\/\S+/g;
+
+/** Whether a hyperlink target from pane output may become an href. Pane
+ *  output is agent-controlled, so a target only reaches the DOM when it is
+ *  the same http(s) the bare-URL matcher already accepts; the TUI's own OSC 8
+ *  scanner holds the same line. A rejected target renders as plain text. */
+export function isHttpUrl(url: string): boolean {
+  // A control byte in a target is never legitimate and would let pane output
+  // inject escapes into whatever re-emits it.
+  // eslint-disable-next-line no-control-regex
+  if (!/^https?:\/\//i.test(url) || /[\u0000-\u001f\u007f]/.test(url)) return false;
+  try {
+    // `https://` alone passes the prefix test but names no host, so it would
+    // render as an anchor that cannot navigate anywhere.
+    return new URL(url).hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
 // Trailing punctuation that is usually sentence/wrapping syntax, not the URL
 // (e.g. `see https://x.com/a).`). Stripped from the match; re-emitted as text.
 const URL_TRAILING = /[.,;:!?)\]}'">]+$/;
@@ -397,7 +416,7 @@ export function wrapLine(line: AnsiSegment[], cols: number): AnsiSegment[][] {
     let chunk = "";
     const flushChunk = () => {
       if (chunk.length > 0) {
-        current.push({ text: chunk, style: seg.style });
+        current.push({ text: chunk, style: seg.style, url: seg.url });
         chunk = "";
       }
     };


### PR DESCRIPTION
## Description

Fixes #3519.

Root cause looks like the xterm/PTY renderer removal in #2115. That change deliberately dropped a full terminal emulator (and its native OSC 8 support) in favor of a shared capture-based renderer. The replacement parser recognized SGR color codes, but not OSC sequences. So when something like `gh pr create` emitted hyperlinks to the created PR, the user got the literal bytes, resulting in a mangled, unclickable URL instead of a link.

This PR extracts the OSC 8 target onto the affected text segment, and drops every other OSC sequence so its payload no longer leaks into the rendered output.

Both screenshots below come from running the demo script in the testing section against a local debug build; it prints one line per case the parser has to handle.

### Before (missing OSC 8 support)

<img width="1144" height="372" alt="image" src="https://github.com/user-attachments/assets/39e29719-8a2d-4f4f-a248-6189862dbc3d" />


### After (with OSC 8 support)

<img width="1144" height="289" alt="image" src="https://github.com/user-attachments/assets/ee8a55eb-c247-473b-a215-90927e55061b" />

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed for this change)
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Covered by Vitest unit tests because this is pure parsing logic (escape-sequence extraction), not a browser behavior (focus, keyboard, drag/drop, touch).

**TUI / CLI (e2e test)**

- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code

**Any Additional AI Details you'd like to share:** Claude diagnosed the root cause, wrote the fix and tests, and prepared this PR; I reviewed the diff, iterated on its output, and ran it against my own live sessions in a local debug build. I'm the one deciding to move out of draft

- [ ] I am an AI Agent filling out this form (check box if true)

## How I tested

- Added unit tests for OSC 8 extraction: plain link, styled link text, BEL terminator, an `id=` parameter before the URL, an unterminated trailing link, and non-hyperlink OSC sequences (title set, OSC 52 clipboard) getting dropped rather than leaked.
- All tests, format checks, etc pass
- Built a debug binary from this branch and ran it against my own real aoe sessions; confirmed a printed OSC 8 hyperlink now renders as a clickable link in the terminal view instead of literal escape bytes (see before/after screenshots)

I used the following shell script in the terminal to inspect the different OSC 8 hyperlink cases (see the above screenshots)

```bash
#!/usr/bin/env bash
# Ignored scratch script: prints OSC 8 hyperlinks and other OSC noise.
esc=$'\033'; bel=$'\007'
printf 'Created PR %s]8;;https://github.com/anthropics/agent-of-empires/pull/3519%s\\PR #3519%s]8;;%s\\ in repo\n' "$esc" "$esc" "$esc" "$esc"
printf 'BEL form: %s]8;;https://example.com/bel%sclick me%s]8;;%s\n' "$esc" "$bel" "$esc" "$bel"
printf 'With id:  %s]8;id=abc123;https://example.com/withid%s\\labelled link%s]8;;%s\\\n' "$esc" "$esc" "$esc" "$esc"
printf 'Styled:   %s]8;;https://example.com/red%s\\%s[31mred link%s[0m%s]8;;%s\\\n' "$esc" "$esc" "$esc" "$esc" "$esc" "$esc"
printf 'Title set + clipboard: %s]0;window title%s\\before%s]52;c;aGk=%safter\n' "$esc" "$esc" "$esc" "$bel"
# Opens a link and never closes it: the visible text runs to end of line.
# The closer lands after the newline so the shell prompt that follows is not
# swept into the link the way a real terminal would sweep it.
printf 'Unterminated: %s]8;;https://example.com/open%s\\runs to end of line\n%s]8;;%s\\' "$esc" "$esc" "$esc" "$esc"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added OSC 8 hyperlink support for ST and BEL terminators.
- Removed unrelated OSC sequences from web and tool output.
- Preserved links across styles, rows, wrapped lines, and cached parsing.
- Made labelled HTTP(S) links clickable in terminal and tool-output views.
- Kept plain URL detection for unlinked text.
- Added parser and rendering tests.

## Benefits

- Hides escape codes from users.
- Keeps row widths and cursor positions accurate.
- Makes labelled links open their intended targets.
- Blocks unsafe hyperlink schemes from becoming clickable links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->