### PR TITLE
Add Junie (JetBrains) as a supported agent

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Running several AI coding agents in parallel across tasks or branches means jugg
 
 ## Supported Agents
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, Qwen Code, Kimi Code, and Prime Agent. AoE auto-detects which are installed.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, Qwen Code, Kimi Code, Prime Agent, and Junie. AoE auto-detects which are installed.
 
 Agents carry a lifecycle state in AoE's registry. When an upstream vendor
 deprecates a CLI, AoE keeps supporting it but marks it everywhere it appears

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1472,6 +1472,33 @@ pub const AGENTS: &[AgentDef] = &[
         permission_response: None,
         lifecycle: AgentLifecycle::Active,
     },
+    AgentDef {
+        name: "junie",
+        oneshot_flag: None,
+        binary: "junie",
+        launch_subcommand: None,
+        aliases: &[],
+        detection: DetectionMethod::Which("junie"),
+        // Junie's "brave mode" auto-approves actions; `--brave` enables it so
+        // the agent runs unattended without stopping on each approval prompt.
+        yolo: Some(YoloMode::CliFlag("--brave")),
+        instruction_flag: None,
+        set_default_command: false,
+        detect_status: status_detection::detect_junie_status,
+        container_env: &[],
+        hook_config: None,
+        sidecar_hooks: None,
+        // Junie's interactive TUI exposes no documented native resume argv, so
+        // session resume/fork stay Unsupported (Levels 4/5 not wired here).
+        session_support: None,
+        fork_strategy: ForkStrategy::Unsupported,
+        host_only: false,
+        send_keys_enter_delay_ms: 0,
+        ready_marker: None,
+        install_hint: "curl -fsSL https://junie.jetbrains.com/install.sh | bash",
+        permission_response: None,
+        lifecycle: AgentLifecycle::Active,
+    },
 ];
 
 /// Look up an agent by canonical name.
@@ -2488,7 +2515,8 @@ mod tests {
                 "antigravity",
                 "kimi",
                 "omp",
-                "prime-agent"
+                "prime-agent",
+                "junie"
             ]
         );
     }
@@ -2546,6 +2574,7 @@ mod tests {
         assert_eq!(settings_index_from_name(Some("kimi")), 15);
         assert_eq!(settings_index_from_name(Some("omp")), 16);
         assert_eq!(settings_index_from_name(Some("prime-agent")), 17);
+        assert_eq!(settings_index_from_name(Some("junie")), 18);
 
         assert_eq!(name_from_settings_index(0), None);
         assert_eq!(name_from_settings_index(1), Some("claude"));
@@ -2562,6 +2591,7 @@ mod tests {
         assert_eq!(name_from_settings_index(15), Some("kimi"));
         assert_eq!(name_from_settings_index(16), Some("omp"));
         assert_eq!(name_from_settings_index(17), Some("prime-agent"));
+        assert_eq!(name_from_settings_index(18), Some("junie"));
         assert_eq!(name_from_settings_index(99), None);
     }
 

--- a/src/tmux/detect/manifests/junie.toml
+++ b/src/tmux/detect/manifests/junie.toml
@@ -1,0 +1,19 @@
+id = "junie"
+
+# Junie (JetBrains) shows a "Working…" status line while a turn runs, and its
+# tool-approval prompt offers an "Always allow" choice. An empty composer (a
+# bare "> " prompt) carries no marker, so it falls through to Idle.
+
+[[rules]]
+id = "working"
+state = "running"
+priority = 965
+region = "whole_recent"
+visible = true
+contains_any = ["working…", "working..."]
+
+[[rules]]
+extends = "approval_prompt"
+id = "approval_prompt"
+priority = 950
+contains_any = ["always allow"]

--- a/src/tmux/detect/mod.rs
+++ b/src/tmux/detect/mod.rs
@@ -37,6 +37,7 @@ const MANIFEST_SOURCES: &[(&str, &str)] = &[
     ("pi", include_str!("manifests/pi.toml")),
     ("codex", include_str!("manifests/codex.toml")),
     ("omp", include_str!("manifests/omp.toml")),
+    ("junie", include_str!("manifests/junie.toml")),
 ];
 
 /// What one capture says about a session.

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -190,6 +190,14 @@ pub fn detect_antigravity_status(raw_content: &str) -> Status {
     detect_via_manifest("antigravity", raw_content, "", None)
 }
 
+/// Junie (JetBrains) status detection via tmux pane parsing.
+/// Junie shows a "Working…" status line while a turn runs and an
+/// "Always allow" choice on its tool-approval prompt; an empty composer
+/// prompt reads as Idle. See `detect/manifests/junie.toml`.
+pub fn detect_junie_status(raw_content: &str) -> Status {
+    detect_via_manifest("junie", raw_content, "", None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Integrate Junie (JetBrains) as a supported agent

Hi, and thanks for maintaining Agent of Empires! 👋

This PR adds JetBrains' **Junie** CLI (`junie`, <https://junie.jetbrains.com>) to AoE's agent registry so it can be launched and monitored side by side with Claude Code, Codex, Gemini CLI, Pi, Factory Droid, and the others. CLI docs: <https://www.jetbrains.com/help/junie/>.

This is an official integration from JetBrains, offered as a **proposal** — please review and adjust to match your conventions.

## What it does

Following `docs/development/adding-agents.md`, this wires Junie in at **Level 2 (pane-parse status)**, mirroring the existing manifest-driven agents (`droid`/`qwen`/`opencode`):

- **`src/agents.rs`** — a new `AgentDef` for `"junie"`: `binary: "junie"`, `DetectionMethod::Which("junie")`, official install hint, and `YoloMode::CliFlag("--brave")` (Junie's "brave mode" auto-approves actions for unattended runs). It is **appended last** so every existing `settings_index_from_name`/`name_from_settings_index` value is unchanged; `test_agent_names` and `test_settings_index_roundtrip` are updated for the new trailing entry (`junie` = 18).
- **`src/tmux/detect/manifests/junie.toml`** (+ registration in `src/tmux/detect/mod.rs`) — status rules based on Junie's documented TUI: a `Working…` status line ⇒ `running`, an `Always allow` approval prompt ⇒ `waiting` (via the shared `approval_prompt` template), and an empty `>` composer ⇒ `idle` by default.
- **`src/tmux/status_detection.rs`** — `detect_junie_status`, a thin wrapper over `detect_via_manifest("junie", …)` like the other manifest agents.
- **`docs/index.md`** — lists Junie under **Supported Agents**.

### Deliberately not included

- **Session resume / fork (Level 4)** and **Docker-sandbox install (Level 5)** are left out: Junie's interactive TUI has no documented native resume argv I could verify, so `session_support: None` and `fork_strategy: Unsupported` fail closed rather than guess. No `AgentConfigMount`/Dockerfile entry is added, so Junie is not listed in the sandbox image table.
- **Hooks (Level 3):** none — status comes purely from pane parsing.

## Notes

- This is a **proposal** — feel free to request changes or adapt naming/paths to your conventions.
- The status regexes and the `--brave` YOLO flag follow Junie's **documented** TUI/CLI behaviour; they're a good starting point, and I'd be happy to refine the manifest against a live Junie session to match your detection conventions exactly.
- Junie CLI is under active development, so flags may shift between releases.
- Links: [junie.jetbrains.com](https://junie.jetbrains.com) · [docs](https://www.jetbrains.com/help/junie/) · [install](https://junie.jetbrains.com/install.sh)

## Testing

- Updated the registry tests in `src/agents.rs` (`test_agent_names`, `test_settings_index_roundtrip`) for the new entry; the new agent satisfies the existing per-agent invariants (`test_all_agents_have_yolo_support`, `test_only_kiro_uses_launch_subcommand`, `test_all_agents_have_install_hint`, fork/hook drift guards).
- Validated that `manifests/junie.toml` parses and that `contains_any` matching is case-insensitive (so `Working…` / `Always allow` match).
- **Heads-up:** my sandbox has no Rust toolchain and no network to fetch one, so I could not run `cargo fmt/clippy/test/build` locally. Please let CI run the full go/`cargo` suite; happy to fix up anything it flags.

Thanks for considering it! 🙌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds JetBrains Junie as a supported agent.
- Adds Junie detection, installation guidance, `--brave` mode, and status tracking.
- Updates the agent registry, documentation, and related tests.
- Preserves existing agent settings indices.
- Does not add session resume, fork, Docker sandbox, or hook support.

## Benefits

Users can launch and monitor Junie through Agent of Empires with consistent agent management.

## Further enhancement

Session resume, fork support, Docker sandbox integration, and hooks can be added later.

Local Rust checks were not run because the contributor’s sandbox lacked Rust and network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->