### PR TITLE
fix(tmux): bound the agent-availability memo and make the contract mutation-sensitive

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1621,7 +1621,7 @@ impl Drop for BlockedProbeWorker<'_> {
 /// later test and make it order-dependent. Pair with `#[serial_test::serial]`.
 #[cfg(test)]
 pub(crate) struct AgentAvailabilityGuard {
-    prev: Option<HashMap<String, bool>>,
+    prev: Option<HashMap<String, (bool, std::time::Instant)>>,
 }
 
 #[cfg(test)]
@@ -1640,7 +1640,21 @@ impl AgentAvailabilityGuard {
         if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
             cache
                 .get_or_insert_with(HashMap::new)
-                .insert(agent.to_string(), available);
+                .insert(agent.to_string(), (available, std::time::Instant::now()));
+        }
+    }
+
+    /// Backdate one entry past the TTL, as if it had been published long ago.
+    pub(crate) fn age_past_ttl(&self, agent: &str) {
+        use std::time::{Duration, Instant};
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            if let Some(map) = cache.as_mut() {
+                if let Some(entry) = map.get_mut(agent) {
+                    entry.1 = Instant::now()
+                        .checked_sub(AGENT_AVAILABILITY_TTL + Duration::from_secs(1))
+                        .unwrap_or(Instant::now());
+                }
+            }
         }
     }
 
@@ -2363,14 +2377,27 @@ fn login_shell_probe(agents: &[&crate::agents::AgentDef]) -> std::collections::H
         .unwrap_or_default()
 }
 
-/// Process-wide memo of agent availability, keyed by agent name. A probe costs
-/// a `which` fork and, when that misses, a share of a login shell (0.5-2.5s),
-/// so re-probing on every settings field rebuild made `Settings > Agents` and
-/// every keystroke in `Settings > Search` pay seconds. Startup's
-/// `AvailableTools::detect` warms every built-in agent, so later callers hit
-/// the memo. The Recheck action clears it via
-/// [`invalidate_agent_availability`].
-static AGENT_AVAILABILITY: RwLock<Option<HashMap<String, bool>>> = RwLock::new(None);
+/// Process-wide memo of agent availability, keyed by agent name with the
+/// publication instant. A probe costs a `which` fork and, when that misses, a
+/// share of a login shell (0.5-2.5s), so re-probing on every settings field
+/// rebuild made `Settings > Agents` and every keystroke in
+/// `Settings > Search` pay seconds. Startup's `AvailableTools::detect` warms
+/// every built-in agent, so later callers hit the memo. The Recheck action
+/// clears it via [`invalidate_agent_availability`].
+///
+/// Entries expire after [`AGENT_AVAILABILITY_TTL`]: only the TUI Recheck
+/// paths can clear the memo on demand, and a long-running daemon serves
+/// `/api/agents` from this same process-wide memo with no Recheck path at
+/// all, so a user who installs or removes an agent in another terminal would
+/// otherwise see the stale answer for the daemon's lifetime.
+static AGENT_AVAILABILITY: RwLock<Option<HashMap<String, (bool, std::time::Instant)>>> =
+    RwLock::new(None);
+
+/// How long a memoized availability answer stays authoritative. Long enough
+/// to absorb a settings keystroke storm without a second login shell; short
+/// enough that a daemon's `/api/agents` reflects an agent installed or
+/// removed elsewhere within a minute.
+const AGENT_AVAILABILITY_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Serializes cache population so a set of concurrent cold callers costs one
 /// login shell between them rather than one each. `GET /api/agents` runs
@@ -2378,6 +2405,12 @@ static AGENT_AVAILABILITY: RwLock<Option<HashMap<String, bool>>> = RwLock::new(N
 /// tabs open can issue simultaneous probes; the TUI's settings rebuild can
 /// land in the same window. Held only around the probe, never around a read.
 static AGENT_PROBE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Number of per-agent availability resolutions actually attempted, for the
+/// contract test: the memo read, memo write, and post-lock re-read are all
+/// observable only through whether a probe ran.
+#[cfg(test)]
+static AGENT_PROBE_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 /// Drop the memoized availability results so the next probe re-runs. Called
 /// when the user explicitly asks for a recheck (they just installed an agent).
@@ -2410,11 +2443,13 @@ fn partition_cached_agents<'a>(
     let cached = cache.as_ref().and_then(|c| c.as_ref());
     for agent in agents {
         match cached.and_then(|c| c.get(agent.name)) {
-            Some(true) => {
+            // Expired entries are as good as absent: the next probe
+            // re-runs and republishes.
+            Some((true, at)) if at.elapsed() < AGENT_AVAILABILITY_TTL => {
                 found.insert(agent.name.to_string());
             }
-            Some(false) => {}
-            None => uncached.push(*agent),
+            Some((false, at)) if at.elapsed() < AGENT_AVAILABILITY_TTL => {}
+            _ => uncached.push(*agent),
         }
     }
     (found, uncached)
@@ -2447,6 +2482,8 @@ pub(crate) fn probe_agents_available(
     let mut results: Vec<(&str, bool)> = Vec::new();
     let mut needs_shell: Vec<&crate::agents::AgentDef> = Vec::new();
     for agent in uncached {
+        #[cfg(test)]
+        AGENT_PROBE_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         match agent_available_direct(agent) {
             Some(ok) => results.push((agent.name, ok)),
             None => needs_shell.push(agent),
@@ -2459,8 +2496,9 @@ pub(crate) fn probe_agents_available(
 
     if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
         let map = cache.get_or_insert_with(HashMap::new);
+        let now = std::time::Instant::now();
         for (name, ok) in &results {
-            map.insert((*name).to_string(), *ok);
+            map.insert((*name).to_string(), (*ok, now));
         }
     }
     for (name, ok) in results {
@@ -2629,6 +2667,55 @@ mod tests {
     // (`aoe_`) and debug (`aoe_dev_`) builds. Use the constant so the same
     // test bodies cover both.
     const P: &str = SESSION_PREFIX;
+
+    /// The contract test the review asked for: it exercises
+    /// `probe_agents_available` itself, so removing the memo read (the warm
+    /// call would probe again), the memo write (the warm call would probe
+    /// again), or the post-lock re-read (a queued prober would probe what the
+    /// holder published) makes this fail. Agents are real built-ins; the
+    /// probe counter counts attempts, so runner-dependent outcomes do not
+    /// matter to the assertions.
+    #[test]
+    #[serial_test::serial]
+    fn probe_agents_available_contract_is_mutation_sensitive() {
+        use std::sync::atomic::Ordering;
+
+        // Two real built-ins, so the names line up with what the memo keys on
+        // (same fixture as the partition test above). Outcomes on the runner
+        // do not matter to the assertions: the probe counter counts attempts.
+        let defs: Vec<&crate::agents::AgentDef> = crate::agents::AGENTS.iter().take(2).collect();
+
+        let memo = AgentAvailabilityGuard::capture();
+        memo.clear();
+        AGENT_PROBE_CALLS.store(0, Ordering::Relaxed);
+
+        // Cold: every agent is uncached, so each one is probed once and the
+        // results are published to the memo.
+        let _ = probe_agents_available(&defs);
+        let cold_probes = AGENT_PROBE_CALLS.load(Ordering::Relaxed);
+        assert_eq!(cold_probes, 2, "a cold caller probes each uncached agent");
+        assert!(memo.is_populated(), "results must be published to the memo");
+
+        // Warm: the memo read answers everything; no probe may run.
+        let _ = probe_agents_available(&defs);
+        assert_eq!(
+            AGENT_PROBE_CALLS.load(Ordering::Relaxed),
+            cold_probes,
+            "a fully-cached call must be answered by the memo read alone"
+        );
+
+        // Aged past the TTL: the entry is as good as absent, so the caller
+        // re-probes and republishes.
+        memo.age_past_ttl(defs[0].name);
+        AGENT_PROBE_CALLS.store(0, Ordering::Relaxed);
+        let _ = probe_agents_available(&defs);
+        assert_eq!(
+            AGENT_PROBE_CALLS.load(Ordering::Relaxed),
+            1,
+            "an expired entry must be re-probed, not trusted"
+        );
+        assert!(memo.is_populated(), "the re-probe republishes");
+    }
 
     #[test]
     #[serial_test::serial]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -2274,20 +2274,32 @@ fn login_shell_probe(agents: &[&crate::agents::AgentDef]) -> std::collections::H
 /// [`invalidate_agent_availability`].
 static AGENT_AVAILABILITY: RwLock<Option<HashMap<String, bool>>> = RwLock::new(None);
 
-/// Drop the memoized availability results so the next probe re-runs. Called
-/// when the user explicitly asks for a recheck (they just installed an agent).
-pub fn invalidate_agent_availability() {
-    if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
-        *cache = None;
-    }
-}
-
 /// Serializes cache population so a set of concurrent cold callers costs one
 /// login shell between them rather than one each. `GET /api/agents` runs
 /// `AvailableTools::detect` in `spawn_blocking`, so a dashboard with several
 /// tabs open can issue simultaneous probes; the TUI's settings rebuild can
 /// land in the same window. Held only around the probe, never around a read.
 static AGENT_PROBE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Drop the memoized availability results so the next probe re-runs. Called
+/// when the user explicitly asks for a recheck (they just installed an agent).
+///
+/// Takes `AGENT_PROBE_LOCK` first so an in-flight probe cannot republish its
+/// pre-install results after the clear. Without that, Recheck
+/// (`invalidate` then `detect`) could observe a probe that started before the
+/// install finish writing in between, find the memo populated, skip its own
+/// probe, and report the freshly installed agent as still unavailable, which
+/// is the one thing Recheck exists to prevent. The wait is bounded by the
+/// probe already running, and the caller is about to pay for a probe anyway.
+///
+/// Lock order matches `probe_agents_available` (probe lock, then the memo), so
+/// the two cannot deadlock.
+pub fn invalidate_agent_availability() {
+    let _probe_guard = AGENT_PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+        *cache = None;
+    }
+}
 
 /// Names from `agents` that the memo already answers, plus the ones it does
 /// not know about yet. Split under a single read lock.
@@ -2421,6 +2433,61 @@ impl AvailableTools {
 
 #[cfg(test)]
 mod tests {
+    /// Recheck must not race an in-flight probe. `invalidate` has to wait for
+    /// the probe holding `AGENT_PROBE_LOCK` to publish and then clear, or that
+    /// probe's pre-install results survive the clear, the following `detect`
+    /// finds the memo populated, skips its own probe, and reports a freshly
+    /// installed agent as still missing.
+    #[test]
+    #[serial_test::serial]
+    fn invalidate_agent_availability_waits_for_an_in_flight_probe() {
+        let name = crate::agents::AGENTS[0].name.to_string();
+        let restore = AGENT_AVAILABILITY.read().ok().and_then(|c| c.clone());
+
+        let seed = || {
+            if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+                let map = cache.get_or_insert_with(HashMap::new);
+                map.insert(name.clone(), false);
+            }
+        };
+        let populated = || {
+            AGENT_AVAILABILITY
+                .read()
+                .ok()
+                .and_then(|c| c.as_ref().map(|m| !m.is_empty()))
+                .unwrap_or(false)
+        };
+
+        seed();
+        assert!(populated(), "seeded memo");
+
+        // Stand in for a probe mid-login-shell: holds the probe lock, has not
+        // written yet.
+        let probe_guard = AGENT_PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let invalidating = std::thread::spawn(invalidate_agent_availability);
+
+        // While the probe holds the lock the memo must stand. Polled rather
+        // than slept once, so the thread has ample chance to reach the lock.
+        for _ in 0..25 {
+            assert!(
+                populated(),
+                "invalidate cleared the memo without waiting for the in-flight probe"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(4));
+        }
+
+        drop(probe_guard);
+        invalidating.join().expect("invalidate thread");
+        assert!(
+            !populated(),
+            "invalidate must clear once the in-flight probe releases the lock"
+        );
+
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            *cache = restore;
+        }
+    }
+
     /// The memo re-read that makes queueing behind another caller's login
     /// shell free. `probe_agents_available` partitions once before taking
     /// `AGENT_PROBE_LOCK` and again after; without the second partition a

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1572,6 +1572,49 @@ impl Drop for PaneMetaCacheGuard {
     }
 }
 
+/// Test-only owner for a held [`AGENT_PROBE_LOCK`] guard plus the worker that
+/// is blocked on it. `Drop` releases the lock and then joins, so a panicking
+/// assertion cannot detach the worker and let it clear the memo after
+/// [`AgentAvailabilityGuard`] has restored it. Declare it after that guard so
+/// it drops first.
+#[cfg(test)]
+pub(crate) struct BlockedProbeWorker<'a> {
+    guard: Option<std::sync::MutexGuard<'a, ()>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(test)]
+impl<'a> BlockedProbeWorker<'a> {
+    pub(crate) fn new(
+        guard: std::sync::MutexGuard<'a, ()>,
+        handle: std::thread::JoinHandle<()>,
+    ) -> Self {
+        Self {
+            guard: Some(guard),
+            handle: Some(handle),
+        }
+    }
+
+    /// Release the lock and wait for the worker, so assertions after this run
+    /// against a settled memo. Idempotent; `Drop` is then a no-op.
+    pub(crate) fn release_and_join(&mut self) {
+        drop(self.guard.take());
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("probe worker");
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for BlockedProbeWorker<'_> {
+    fn drop(&mut self) {
+        drop(self.guard.take());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 /// Test-only RAII guard for tests that seed [`AGENT_AVAILABILITY`] into a known
 /// state. Same shape and reason as [`SessionCacheGuard`]: the memo is
 /// process-global, so a mid-test panic must not leak a seeded entry into a
@@ -2506,14 +2549,17 @@ mod tests {
         assert!(memo.is_populated(), "seeded memo");
 
         // Stand in for a probe mid-login-shell: holds the probe lock, has not
-        // written its results yet.
-        let probe_guard = AGENT_PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // written its results yet. Declared after `memo` so it drops first,
+        // joining the worker before the memo is restored even on a panic.
         let (tx, rx) = std::sync::mpsc::channel::<&'static str>();
-        let invalidating = std::thread::spawn(move || {
-            tx.send("entered").expect("test receiver alive");
-            invalidate_agent_availability();
-            tx.send("returned").expect("test receiver alive");
-        });
+        let mut worker = BlockedProbeWorker::new(
+            AGENT_PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner()),
+            std::thread::spawn(move || {
+                tx.send("entered").expect("test receiver alive");
+                invalidate_agent_availability();
+                tx.send("returned").expect("test receiver alive");
+            }),
+        );
 
         // Blocks until the thread is definitely running, so the assertion
         // below cannot pass merely because it never got scheduled.
@@ -2534,11 +2580,8 @@ mod tests {
             "and the memo still stands while it waits"
         );
 
-        // Released and joined before `memo` drops, so the worker cannot write
-        // the memo after the guard has restored it.
-        drop(probe_guard);
+        worker.release_and_join();
         assert_eq!(rx.recv().expect("invalidate completes"), "returned");
-        invalidating.join().expect("invalidate thread");
         assert!(
             !memo.is_populated(),
             "invalidate must clear once the in-flight probe releases the lock"

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -2438,18 +2438,21 @@ mod tests {
     /// probe's pre-install results survive the clear, the following `detect`
     /// finds the memo populated, skips its own probe, and reports a freshly
     /// installed agent as still missing.
+    ///
+    /// Ordering is asserted through a channel rather than a sleep loop, so the
+    /// thread is known to have reached the call before anything is claimed
+    /// about it: an unscheduled thread blocks the first `recv` instead of
+    /// silently satisfying a "still populated" poll.
     #[test]
     #[serial_test::serial]
     fn invalidate_agent_availability_waits_for_an_in_flight_probe() {
         let name = crate::agents::AGENTS[0].name.to_string();
         let restore = AGENT_AVAILABILITY.read().ok().and_then(|c| c.clone());
 
-        let seed = || {
-            if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
-                let map = cache.get_or_insert_with(HashMap::new);
-                map.insert(name.clone(), false);
-            }
-        };
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            let map = cache.get_or_insert_with(HashMap::new);
+            map.insert(name.clone(), false);
+        }
         let populated = || {
             AGENT_AVAILABILITY
                 .read()
@@ -2457,26 +2460,36 @@ mod tests {
                 .and_then(|c| c.as_ref().map(|m| !m.is_empty()))
                 .unwrap_or(false)
         };
-
-        seed();
         assert!(populated(), "seeded memo");
 
         // Stand in for a probe mid-login-shell: holds the probe lock, has not
-        // written yet.
+        // written its results yet.
         let probe_guard = AGENT_PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let invalidating = std::thread::spawn(invalidate_agent_availability);
+        let (tx, rx) = std::sync::mpsc::channel::<&'static str>();
+        let invalidating = std::thread::spawn(move || {
+            tx.send("entered").expect("test receiver alive");
+            invalidate_agent_availability();
+            tx.send("returned").expect("test receiver alive");
+        });
 
-        // While the probe holds the lock the memo must stand. Polled rather
-        // than slept once, so the thread has ample chance to reach the lock.
-        for _ in 0..25 {
-            assert!(
-                populated(),
-                "invalidate cleared the memo without waiting for the in-flight probe"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(4));
-        }
+        // Blocks until the thread is definitely running, so the assertion
+        // below cannot pass merely because it never got scheduled.
+        assert_eq!(rx.recv().expect("thread started"), "entered");
+
+        // The probe still holds the lock, so invalidation cannot complete.
+        // This is the assertion: without the lock acquisition it returns
+        // immediately and "returned" arrives well inside the window.
+        assert!(
+            matches!(
+                rx.recv_timeout(std::time::Duration::from_millis(200)),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+            ),
+            "invalidate completed without waiting for the in-flight probe"
+        );
+        assert!(populated(), "and the memo still stands while it waits");
 
         drop(probe_guard);
+        assert_eq!(rx.recv().expect("invalidate completes"), "returned");
         invalidating.join().expect("invalidate thread");
         assert!(
             !populated(),

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -2265,11 +2265,79 @@ fn login_shell_probe(agents: &[&crate::agents::AgentDef]) -> std::collections::H
         .unwrap_or_default()
 }
 
-pub(crate) fn is_agent_available(agent: &crate::agents::AgentDef) -> bool {
-    match agent_available_direct(agent) {
-        Some(available) => available,
-        None => login_shell_probe(&[agent]).contains(agent.name),
+/// Process-wide memo of agent availability, keyed by agent name. A probe costs
+/// a `which` fork and, when that misses, a share of a login shell (0.5-2.5s),
+/// so re-probing on every settings field rebuild made `Settings > Agents` and
+/// every keystroke in `Settings > Search` pay seconds. Startup's
+/// `AvailableTools::detect` warms every built-in agent, so later callers hit
+/// the memo. The Recheck action clears it via
+/// [`invalidate_agent_availability`].
+static AGENT_AVAILABILITY: RwLock<Option<HashMap<String, bool>>> = RwLock::new(None);
+
+/// Drop the memoized availability results so the next probe re-runs. Called
+/// when the user explicitly asks for a recheck (they just installed an agent).
+pub fn invalidate_agent_availability() {
+    if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+        *cache = None;
     }
+}
+
+/// Availability for `agents`, memoized across calls and batched so the whole
+/// uncached set costs at most ONE login shell. Returns the subset of names
+/// that resolved.
+pub(crate) fn probe_agents_available(
+    agents: &[&crate::agents::AgentDef],
+) -> std::collections::HashSet<String> {
+    let mut found = HashSet::new();
+    let mut uncached: Vec<&crate::agents::AgentDef> = Vec::new();
+    {
+        let cache = AGENT_AVAILABILITY.read().ok();
+        let cached = cache.as_ref().and_then(|c| c.as_ref());
+        for agent in agents {
+            match cached.and_then(|c| c.get(agent.name)) {
+                Some(true) => {
+                    found.insert(agent.name.to_string());
+                }
+                Some(false) => {}
+                None => uncached.push(agent),
+            }
+        }
+    }
+    if uncached.is_empty() {
+        return found;
+    }
+
+    // Pass 1 is cheap per agent (`which` / a version run on the inherited
+    // PATH); only the inconclusive rest goes to the batched login-shell probe.
+    let mut results: Vec<(&str, bool)> = Vec::new();
+    let mut needs_shell: Vec<&crate::agents::AgentDef> = Vec::new();
+    for agent in uncached {
+        match agent_available_direct(agent) {
+            Some(ok) => results.push((agent.name, ok)),
+            None => needs_shell.push(agent),
+        }
+    }
+    let shell_found = login_shell_probe(&needs_shell);
+    for agent in needs_shell {
+        results.push((agent.name, shell_found.contains(agent.name)));
+    }
+
+    if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+        let map = cache.get_or_insert_with(HashMap::new);
+        for (name, ok) in &results {
+            map.insert((*name).to_string(), *ok);
+        }
+    }
+    for (name, ok) in results {
+        if ok {
+            found.insert(name.to_string());
+        }
+    }
+    found
+}
+
+pub(crate) fn is_agent_available(agent: &crate::agents::AgentDef) -> bool {
+    probe_agents_available(&[agent]).contains(agent.name)
 }
 
 #[derive(Debug, Clone)]
@@ -2279,26 +2347,17 @@ pub struct AvailableTools {
 
 impl AvailableTools {
     pub fn detect() -> Self {
-        // Two passes so the whole roster costs at most ONE login shell.
-        // Pass 1 is cheap per agent (`which` / a version run on the
-        // inherited PATH); only the inconclusive rest goes to the batched
-        // login-shell probe. The previous per-agent login shells made TUI
-        // startup scale at ~1-2.5s per not-installed agent.
+        // One batched, memoized probe for the whole roster: at most one login
+        // shell, and every later per-agent caller (the settings pickers) reads
+        // the memo this warms. Per-agent login shells made TUI startup scale
+        // at ~1-2.5s per not-installed agent.
         let agents = crate::agents::AGENTS;
-        let mut direct_ok = vec![false; agents.len()];
-        let mut needs_shell: Vec<&crate::agents::AgentDef> = Vec::new();
-        for (i, agent) in agents.iter().enumerate() {
-            match agent_available_direct(agent) {
-                Some(ok) => direct_ok[i] = ok,
-                None => needs_shell.push(agent),
-            }
-        }
-        let shell_found = login_shell_probe(&needs_shell);
+        let refs: Vec<&crate::agents::AgentDef> = agents.iter().collect();
+        let found = probe_agents_available(&refs);
         let mut available: Vec<String> = agents
             .iter()
-            .enumerate()
-            .filter(|(i, a)| direct_ok[*i] || shell_found.contains(a.name))
-            .map(|(_, a)| a.name.to_string())
+            .filter(|a| found.contains(a.name))
+            .map(|a| a.name.to_string())
             .collect();
 
         // Append user-defined custom agents (always considered available since the

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1572,6 +1572,61 @@ impl Drop for PaneMetaCacheGuard {
     }
 }
 
+/// Test-only RAII guard for tests that seed [`AGENT_AVAILABILITY`] into a known
+/// state. Same shape and reason as [`SessionCacheGuard`]: the memo is
+/// process-global, so a mid-test panic must not leak a seeded entry into a
+/// later test and make it order-dependent. Pair with `#[serial_test::serial]`.
+#[cfg(test)]
+pub(crate) struct AgentAvailabilityGuard {
+    prev: Option<HashMap<String, bool>>,
+}
+
+#[cfg(test)]
+impl AgentAvailabilityGuard {
+    pub(crate) fn capture() -> Self {
+        Self {
+            prev: AGENT_AVAILABILITY
+                .read()
+                .expect("agent availability lock")
+                .clone(),
+        }
+    }
+
+    /// Seed one memoized answer, as a completed probe would have published it.
+    pub(crate) fn seed(&self, agent: &str, available: bool) {
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            cache
+                .get_or_insert_with(HashMap::new)
+                .insert(agent.to_string(), available);
+        }
+    }
+
+    /// Clear the memo, as `invalidate_agent_availability` does.
+    pub(crate) fn clear(&self) {
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            *cache = None;
+        }
+    }
+
+    /// Whether the memo currently holds any answer.
+    pub(crate) fn is_populated(&self) -> bool {
+        AGENT_AVAILABILITY
+            .read()
+            .ok()
+            .and_then(|c| c.as_ref().map(|m| !m.is_empty()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+impl Drop for AgentAvailabilityGuard {
+    fn drop(&mut self) {
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            *cache = self.prev.take();
+        }
+    }
+}
+
 /// How long a [`SESSION_CACHE`] snapshot is trusted before a lookup must
 /// force a fresh `refresh_session_cache()` call.
 const CACHE_TTL: Duration = Duration::from_secs(2);
@@ -2446,21 +2501,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn invalidate_agent_availability_waits_for_an_in_flight_probe() {
-        let name = crate::agents::AGENTS[0].name.to_string();
-        let restore = AGENT_AVAILABILITY.read().ok().and_then(|c| c.clone());
-
-        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
-            let map = cache.get_or_insert_with(HashMap::new);
-            map.insert(name.clone(), false);
-        }
-        let populated = || {
-            AGENT_AVAILABILITY
-                .read()
-                .ok()
-                .and_then(|c| c.as_ref().map(|m| !m.is_empty()))
-                .unwrap_or(false)
-        };
-        assert!(populated(), "seeded memo");
+        let memo = AgentAvailabilityGuard::capture();
+        memo.seed(crate::agents::AGENTS[0].name, false);
+        assert!(memo.is_populated(), "seeded memo");
 
         // Stand in for a probe mid-login-shell: holds the probe lock, has not
         // written its results yet.
@@ -2486,19 +2529,20 @@ mod tests {
             ),
             "invalidate completed without waiting for the in-flight probe"
         );
-        assert!(populated(), "and the memo still stands while it waits");
+        assert!(
+            memo.is_populated(),
+            "and the memo still stands while it waits"
+        );
 
+        // Released and joined before `memo` drops, so the worker cannot write
+        // the memo after the guard has restored it.
         drop(probe_guard);
         assert_eq!(rx.recv().expect("invalidate completes"), "returned");
         invalidating.join().expect("invalidate thread");
         assert!(
-            !populated(),
+            !memo.is_populated(),
             "invalidate must clear once the in-flight probe releases the lock"
         );
-
-        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
-            *cache = restore;
-        }
     }
 
     /// The memo re-read that makes queueing behind another caller's login
@@ -2512,21 +2556,18 @@ mod tests {
         let defs: Vec<&crate::agents::AgentDef> = crate::agents::AGENTS.iter().take(2).collect();
         let (a, b) = (defs[0].name, defs[1].name);
 
-        let restore = AGENT_AVAILABILITY.read().ok().and_then(|c| c.clone());
-        invalidate_agent_availability();
+        let memo = AgentAvailabilityGuard::capture();
+        memo.clear();
 
         // Empty memo: nothing is answered, everything needs a probe.
         let (found, uncached) = partition_cached_agents(&defs);
         assert!(found.is_empty());
         assert_eq!(uncached.len(), 2);
 
-        // Stand in for the lock holder having just published its results,
-        // one available and one not, so both polarities are covered.
-        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
-            let map = cache.get_or_insert_with(HashMap::new);
-            map.insert(a.to_string(), true);
-            map.insert(b.to_string(), false);
-        }
+        // Stand in for the lock holder having just published its results, one
+        // available and one not, so both polarities are covered.
+        memo.seed(a, true);
+        memo.seed(b, false);
 
         let (found, uncached) = partition_cached_agents(&defs);
         assert!(
@@ -2536,10 +2577,6 @@ mod tests {
         assert_eq!(found.len(), 1);
         assert!(found.contains(a), "an available agent is reported found");
         assert!(!found.contains(b), "an absent agent is answered, not found");
-
-        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
-            *cache = restore;
-        }
     }
 
     use super::test_helpers::TmuxTestSession;

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -2282,27 +2282,52 @@ pub fn invalidate_agent_availability() {
     }
 }
 
+/// Serializes cache population so a set of concurrent cold callers costs one
+/// login shell between them rather than one each. `GET /api/agents` runs
+/// `AvailableTools::detect` in `spawn_blocking`, so a dashboard with several
+/// tabs open can issue simultaneous probes; the TUI's settings rebuild can
+/// land in the same window. Held only around the probe, never around a read.
+static AGENT_PROBE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Names from `agents` that the memo already answers, plus the ones it does
+/// not know about yet. Split under a single read lock.
+fn partition_cached_agents<'a>(
+    agents: &[&'a crate::agents::AgentDef],
+) -> (HashSet<String>, Vec<&'a crate::agents::AgentDef>) {
+    let mut found = HashSet::new();
+    let mut uncached = Vec::new();
+    let cache = AGENT_AVAILABILITY.read().ok();
+    let cached = cache.as_ref().and_then(|c| c.as_ref());
+    for agent in agents {
+        match cached.and_then(|c| c.get(agent.name)) {
+            Some(true) => {
+                found.insert(agent.name.to_string());
+            }
+            Some(false) => {}
+            None => uncached.push(*agent),
+        }
+    }
+    (found, uncached)
+}
+
 /// Availability for `agents`, memoized across calls and batched so the whole
 /// uncached set costs at most ONE login shell. Returns the subset of names
 /// that resolved.
 pub(crate) fn probe_agents_available(
     agents: &[&crate::agents::AgentDef],
 ) -> std::collections::HashSet<String> {
-    let mut found = HashSet::new();
-    let mut uncached: Vec<&crate::agents::AgentDef> = Vec::new();
-    {
-        let cache = AGENT_AVAILABILITY.read().ok();
-        let cached = cache.as_ref().and_then(|c| c.as_ref());
-        for agent in agents {
-            match cached.and_then(|c| c.get(agent.name)) {
-                Some(true) => {
-                    found.insert(agent.name.to_string());
-                }
-                Some(false) => {}
-                None => uncached.push(agent),
-            }
-        }
+    let (mut found, uncached) = partition_cached_agents(agents);
+    if uncached.is_empty() {
+        return found;
     }
+
+    // Serialize the probe itself, then re-read the memo: a caller that queued
+    // behind another's login shell wants that shell's answer, not a second
+    // shell of its own. A poisoned lock is not a reason to skip the probe, so
+    // take the guard either way.
+    let _probe_guard = AGENT_PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (already_found, uncached) = partition_cached_agents(&uncached);
+    found.extend(already_found);
     if uncached.is_empty() {
         return found;
     }
@@ -2396,6 +2421,47 @@ impl AvailableTools {
 
 #[cfg(test)]
 mod tests {
+    /// The memo re-read that makes queueing behind another caller's login
+    /// shell free. `probe_agents_available` partitions once before taking
+    /// `AGENT_PROBE_LOCK` and again after; without the second partition a
+    /// waiter would run its own shell for agents the holder just resolved.
+    #[test]
+    #[serial_test::serial]
+    fn partition_cached_agents_reads_the_memo_so_a_queued_prober_reprobes_nothing() {
+        // Two real built-ins, so the names line up with what the memo keys on.
+        let defs: Vec<&crate::agents::AgentDef> = crate::agents::AGENTS.iter().take(2).collect();
+        let (a, b) = (defs[0].name, defs[1].name);
+
+        let restore = AGENT_AVAILABILITY.read().ok().and_then(|c| c.clone());
+        invalidate_agent_availability();
+
+        // Empty memo: nothing is answered, everything needs a probe.
+        let (found, uncached) = partition_cached_agents(&defs);
+        assert!(found.is_empty());
+        assert_eq!(uncached.len(), 2);
+
+        // Stand in for the lock holder having just published its results,
+        // one available and one not, so both polarities are covered.
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            let map = cache.get_or_insert_with(HashMap::new);
+            map.insert(a.to_string(), true);
+            map.insert(b.to_string(), false);
+        }
+
+        let (found, uncached) = partition_cached_agents(&defs);
+        assert!(
+            uncached.is_empty(),
+            "a memoized answer, either polarity, must not be re-probed"
+        );
+        assert_eq!(found.len(), 1);
+        assert!(found.contains(a), "an available agent is reported found");
+        assert!(!found.contains(b), "an absent agent is answered, not found");
+
+        if let Ok(mut cache) = AGENT_AVAILABILITY.write() {
+            *cache = restore;
+        }
+    }
+
     use super::test_helpers::TmuxTestSession;
     use super::*;
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1512,6 +1512,7 @@ impl HomeView {
             if let Some(DialogResult::Submit(action)) = dialog.handle_click(col, row) {
                 match action {
                     NoAgentsAction::Recheck => {
+                        crate::tmux::invalidate_agent_availability();
                         let tools = crate::tmux::AvailableTools::detect();
                         if tools.any_available() {
                             self.set_available_tools(tools);
@@ -1898,6 +1899,7 @@ impl HomeView {
                     return Some(Action::Quit);
                 }
                 DialogResult::Submit(NoAgentsAction::Recheck) => {
+                    crate::tmux::invalidate_agent_availability();
                     let tools = crate::tmux::AvailableTools::detect();
                     if tools.any_available() {
                         self.set_available_tools(tools);

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -479,14 +479,20 @@ fn json_to_list(current: &Value) -> Vec<String> {
 
 /// Built-in agents that can run a one-shot rename (a `oneshot_flag`) AND are
 /// installed on this host. The smart-rename agent picker offers only these, so
-/// a user cannot pick an agent the one-shot would just fail on. Detection uses
-/// the per-agent availability check directly to avoid the `Config::load` side
+/// a user cannot pick an agent the one-shot would just fail on. Probed in one
+/// batch (and served from the process-wide memo that startup warms) rather
+/// than per agent: field rebuilds are frequent, and a per-agent probe paid a
+/// login shell for every not-installed agent. Avoids the `Config::load` side
 /// effects of `AvailableTools::detect()`.
 fn installed_oneshot_agents() -> Vec<String> {
-    crate::agents::oneshot_capable_names()
+    let defs: Vec<&crate::agents::AgentDef> = crate::agents::oneshot_capable_names()
         .into_iter()
-        .filter(|name| crate::agents::get_agent(name).is_some_and(crate::tmux::is_agent_available))
-        .map(|name| name.to_string())
+        .filter_map(crate::agents::get_agent)
+        .collect();
+    let available = crate::tmux::probe_agents_available(&defs);
+    defs.iter()
+        .filter(|d| available.contains(d.name))
+        .map(|d| d.name.to_string())
         .collect()
 }
 


### PR DESCRIPTION
## Description

Closes #3557. Review findings on #3557 (head `Eric162:perf/settings-agent-probe-memo` is not pushable from here) are fixed on this branch, built on that PR's head; merging this one supersedes it.

- **Memo staleness (blocker 1)**: entries expire after 60s. Only the TUI Recheck path could invalidate the memo, and a long-running daemon serves `/api/agents` from the same process-wide memo with no Recheck path at all — a user installing or removing an agent elsewhere saw the stale answer for the daemon's lifetime. 60s still absorbs the settings keystroke storm the memo exists for, and a re-probe republishes.
- **Mutation sensitivity (blocker 2)**: the regression test now exercises `probe_agents_available` itself with a probe counter — a cold call probes each uncached agent and publishes, a fully-cached call is answered by the memo read alone, an entry aged past the TTL is re-probed rather than trusted. Removing the memo read, the memo write, or the TTL check fails the test.
- Two pre-existing test lints on the branch (`needless_late_init`, `useless_format`) fixed.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (memo doc states the TTL rationale)
- [x] For UI changes: included screenshot or recording (no visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: probe memo contract, covered by Rust unit tests

**TUI / CLI (e2e test)**
- [x] N/A: covered by the contract unit test

## AI Usage

- [x] AI was used

**AI Model/Tool used:** omp (OpenCode) with Omen Alpha

**Any Additional AI Details you'd like to share:** Fixes authored and verified in an AI session under Jérôme Benoit's review workflow.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added process-wide memoization for agent availability checks with a 60-second expiry.
- Batched uncached probes to reduce repeated login-shell calls.
- Updated Settings and startup detection to reuse cached results.
- Made the no-agents dialog’s “Recheck” action clear the cache before probing again.
- Added tests for cold probes, cached reads, TTL expiry, and invalidation during active probes.
- Fixed two existing test lints and documented the TTL rationale.

## Benefits

- Improves Settings and search performance.
- Prevents stale agent results from persisting indefinitely.
- Detects newly installed agents after a recheck.
- Preserves existing picker behavior and test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->