### PR TITLE
fix(tui): cap and pad row tags with the renderer's cell metric

### DIFF
--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -19,7 +19,7 @@ pub use dir_picker::{DirPicker, DirPickerResult};
 pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
 pub use preview::{format_scroll_indicator, Preview};
-pub use text::truncate_to_width;
+pub use text::{prefix_within_width, truncate_to_width};
 pub(crate) use text_input::{focused_input_spans, input_scroll, visible_slice};
 pub use text_input::{
     longest_common_prefix, render_text_field, render_text_field_with_ghost,

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -19,7 +19,7 @@ pub use dir_picker::{DirPicker, DirPickerResult};
 pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
 pub use preview::{format_scroll_indicator, Preview};
-pub use text::{prefix_within_width, truncate_to_width};
+pub use text::{prefix_within_width, rendered_width, truncate_to_width};
 pub(crate) use text_input::{focused_input_spans, input_scroll, visible_slice};
 pub use text_input::{
     longest_common_prefix, render_text_field, render_text_field_with_ghost,

--- a/src/tui/components/text.rs
+++ b/src/tui/components/text.rs
@@ -100,7 +100,6 @@ pub(crate) fn line_columns(line: &ratatui::text::Line, width: u16) -> LineColumn
 /// "" when `max_width` is 0 (the text gets sacrificed entirely so
 /// whatever fixed content it competes with wins).
 pub fn truncate_to_width(text: &str, max_width: usize) -> String {
-    use unicode_segmentation::UnicodeSegmentation;
     use unicode_width::UnicodeWidthStr;
     if max_width == 0 {
         return String::new();
@@ -109,34 +108,42 @@ pub fn truncate_to_width(text: &str, max_width: usize) -> String {
         return text.to_string();
     }
     // Reserve one cell for the ellipsis.
-    let budget = max_width.saturating_sub(1);
-    let mut out = String::new();
-    // Step by grapheme cluster, and measure the accumulated prefix rather than
-    // summing per-piece widths. Both matter, for different reasons.
-    //
-    // Clusters, because a `char` is not a display unit: cutting mid-cluster
-    // leaves a dangling combining mark ("क्" out of "क्ष") or strips a VS16 so
-    // the base glyph flips from emoji to text presentation.
-    //
-    // Accumulated measurement, because `UnicodeWidthStr::width` resolves those
-    // clusters, so "\u{26a0}\u{fe0f}" is 2 cells while its chars sum to 1.
-    // Summing over-admits and returns a string wider than the budget, breaking
-    // the promise above (and underflowing any caller that subtracts the result
-    // from a remaining budget).
-    for g in text.graphemes(true) {
-        out.push_str(g);
-        if UnicodeWidthStr::width(out.as_str()) > budget {
-            out.truncate(out.len() - g.len());
-            break;
-        }
-    }
+    let mut out = prefix_within_width(text, max_width.saturating_sub(1)).to_string();
     out.push('\u{2026}');
     out
 }
 
+/// The longest prefix of `text` that fits in `max_width` display cells,
+/// with no ellipsis. Steps by grapheme cluster and measures the accumulated
+/// prefix rather than summing per-piece widths. Both matter, for different
+/// reasons.
+///
+/// Clusters, because a `char` is not a display unit: cutting mid-cluster
+/// leaves a dangling combining mark ("क्" out of "क्ष") or strips a VS16 so
+/// the base glyph flips from emoji to text presentation.
+///
+/// Accumulated measurement, because `UnicodeWidthStr::width` resolves those
+/// clusters, so "\u{26a0}\u{fe0f}" is 2 cells while its chars sum to 1 and
+/// "\u{1f91d}\u{1f3fd}" is 2 cells while its chars sum to 4. Summing
+/// over-admits the first (a string wider than the budget, which underflows
+/// any caller that subtracts the result from a remaining budget) and
+/// under-admits the second.
+pub fn prefix_within_width(text: &str, max_width: usize) -> &str {
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
+    let mut end = 0;
+    for (start, g) in text.grapheme_indices(true) {
+        if UnicodeWidthStr::width(&text[..start + g.len()]) > max_width {
+            break;
+        }
+        end = start + g.len();
+    }
+    &text[..end]
+}
+
 #[cfg(test)]
 mod tests {
-    use super::line_columns;
+    use super::{line_columns, prefix_within_width, truncate_to_width};
 
     /// A wide grapheme occupies two columns and its continuation cell is reset
     /// by the renderer. Reading that back out of a buffer yields a phantom
@@ -170,7 +177,24 @@ mod tests {
         assert_eq!(columns.slice(0, 5), "hello");
     }
 
-    use super::truncate_to_width;
+    #[test]
+    fn prefix_within_width_measures_clusters_as_a_string() {
+        // No ellipsis, and a prefix that fits comes back whole.
+        assert_eq!(prefix_within_width("abc", 4), "abc");
+        assert_eq!(prefix_within_width("abcdef", 4), "abcd");
+        assert_eq!(prefix_within_width("abc", 0), "");
+        // Per-scalar widths sum to 4 but the string is 5 cells: drop `a`.
+        assert_eq!(
+            prefix_within_width("\u{2665}\u{fe0f}界a", 4),
+            "\u{2665}\u{fe0f}界"
+        );
+        // Per-scalar widths sum to 5 but the skin-tone cluster is 2 cells:
+        // keep `m`.
+        assert_eq!(
+            prefix_within_width("\u{1f91d}\u{1f3fd}m", 4),
+            "\u{1f91d}\u{1f3fd}m"
+        );
+    }
 
     #[test]
     fn truncate_to_width_passthrough_when_fits() {

--- a/src/tui/components/text.rs
+++ b/src/tui/components/text.rs
@@ -129,11 +129,18 @@ pub fn truncate_to_width(text: &str, max_width: usize) -> String {
 /// any caller that subtracts the result from a remaining budget) and
 /// under-admits the second.
 pub fn prefix_within_width(text: &str, max_width: usize) -> &str {
+    use ratatui::buffer::CellWidth;
     use unicode_segmentation::UnicodeSegmentation;
-    use unicode_width::UnicodeWidthStr;
+    let mut cells = 0usize;
     let mut end = 0;
     for (start, g) in text.grapheme_indices(true) {
-        if UnicodeWidthStr::width(&text[..start + g.len()]) > max_width {
+        // The renderer's own per-grapheme metric (`CellWidth`, the same rule
+        // `Span::styled_graphemes` + `Buffer::set_stringn` apply), not
+        // `UnicodeWidthStr`: the latter resolves halfwidth katakana
+        // dakuten/handakuten to zero cells, while the renderer paints each of
+        // them into a cell, so a string-width budget would over-admit them.
+        cells += g.cell_width() as usize;
+        if cells > max_width {
             break;
         }
         end = start + g.len();

--- a/src/tui/components/text.rs
+++ b/src/tui/components/text.rs
@@ -100,11 +100,10 @@ pub(crate) fn line_columns(line: &ratatui::text::Line, width: u16) -> LineColumn
 /// "" when `max_width` is 0 (the text gets sacrificed entirely so
 /// whatever fixed content it competes with wins).
 pub fn truncate_to_width(text: &str, max_width: usize) -> String {
-    use unicode_width::UnicodeWidthStr;
     if max_width == 0 {
         return String::new();
     }
-    if UnicodeWidthStr::width(text) <= max_width {
+    if rendered_width(text) <= max_width {
         return text.to_string();
     }
     // Reserve one cell for the ellipsis.
@@ -113,32 +112,36 @@ pub fn truncate_to_width(text: &str, max_width: usize) -> String {
     out
 }
 
-/// The longest prefix of `text` that fits in `max_width` display cells,
-/// with no ellipsis. Steps by grapheme cluster and measures the accumulated
-/// prefix rather than summing per-piece widths. Both matter, for different
-/// reasons.
+/// Cells `text` occupies when the renderer paints it: the per-grapheme
+/// `CellWidth` metric that `Span::styled_graphemes` and `Buffer::set_stringn`
+/// apply, summed over clusters.
 ///
-/// Clusters, because a `char` is not a display unit: cutting mid-cluster
-/// leaves a dangling combining mark ("क्" out of "क्ष") or strips a VS16 so
-/// the base glyph flips from emoji to text presentation.
+/// Not `UnicodeWidthStr::width`, which resolves halfwidth katakana
+/// dakuten/handakuten (U+FF9E, U+FF9F) to zero cells where the renderer
+/// spends one on each, so a string-width budget admits twice the text that
+/// fits for that script.
+pub fn rendered_width(text: &str) -> usize {
+    use ratatui::buffer::CellWidth;
+    use unicode_segmentation::UnicodeSegmentation;
+    text.graphemes(true).map(|g| g.cell_width() as usize).sum()
+}
+
+/// The longest prefix of `text` that fits in `max_width` display cells, with
+/// no ellipsis.
 ///
-/// Accumulated measurement, because `UnicodeWidthStr::width` resolves those
-/// clusters, so "\u{26a0}\u{fe0f}" is 2 cells while its chars sum to 1 and
-/// "\u{1f91d}\u{1f3fd}" is 2 cells while its chars sum to 4. Summing
-/// over-admits the first (a string wider than the budget, which underflows
-/// any caller that subtracts the result from a remaining budget) and
-/// under-admits the second.
+/// Steps by grapheme cluster, because a `char` is not a display unit: cutting
+/// mid-cluster leaves a dangling combining mark ("क्" out of "क्ष") or strips a
+/// VS16 so the base glyph flips from emoji to text presentation. Cells come
+/// from [`rendered_width`], so a cluster whose scalars do not sum to what it
+/// paints ("\u{26a0}\u{fe0f}" is 2 cells where its chars sum to 1,
+/// "\u{1f91d}\u{1f3fd}" is 2 where they sum to 4) neither over- nor
+/// under-fills the budget.
 pub fn prefix_within_width(text: &str, max_width: usize) -> &str {
     use ratatui::buffer::CellWidth;
     use unicode_segmentation::UnicodeSegmentation;
     let mut cells = 0usize;
     let mut end = 0;
     for (start, g) in text.grapheme_indices(true) {
-        // The renderer's own per-grapheme metric (`CellWidth`, the same rule
-        // `Span::styled_graphemes` + `Buffer::set_stringn` apply), not
-        // `UnicodeWidthStr`: the latter resolves halfwidth katakana
-        // dakuten/handakuten to zero cells, while the renderer paints each of
-        // them into a cell, so a string-width budget would over-admit them.
         cells += g.cell_width() as usize;
         if cells > max_width {
             break;
@@ -150,7 +153,7 @@ pub fn prefix_within_width(text: &str, max_width: usize) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{line_columns, prefix_within_width, truncate_to_width};
+    use super::{line_columns, prefix_within_width, rendered_width, truncate_to_width};
 
     /// A wide grapheme occupies two columns and its continuation cell is reset
     /// by the renderer. Reading that back out of a buffer yields a phantom
@@ -201,6 +204,18 @@ mod tests {
             prefix_within_width("\u{1f91d}\u{1f3fd}m", 4),
             "\u{1f91d}\u{1f3fd}m"
         );
+    }
+
+    /// The passthrough guard has to use the renderer's metric too: halfwidth
+    /// katakana dakuten scores zero in `UnicodeWidthStr`, so a string-width
+    /// guard hands back twice the budget untouched.
+    #[test]
+    fn truncate_to_width_guard_uses_the_rendered_metric() {
+        let halfwidth = "\u{ff8a}\u{ff9f}".repeat(20);
+        assert_eq!(rendered_width(&halfwidth), 40);
+        let out = truncate_to_width(&halfwidth, 24);
+        assert!(rendered_width(&out) <= 24, "{out:?}");
+        assert!(out.ends_with('\u{2026}'));
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -709,11 +709,23 @@ pub(crate) fn profile_short_code(profile: &str) -> String {
     let code: String = match segments.as_slice() {
         [] => String::new(),
         [single] => single.chars().take(3).collect(),
-        many => many
-            .iter()
-            .filter_map(|s| s.chars().next())
-            .take(4)
-            .collect(),
+        [lead, rest @ ..] => {
+            // Keep a short lead segment whole (`gna-main` -> `gnam`,
+            // `bsc-main`/`bso-main` -> `bscm`/`bsom`) so sibling profiles
+            // that share an initial stay distinguishable at a glance; a
+            // longer lead still contributes its initial only
+            // (`forit-backup` -> `fb`).
+            let lead_part: String = if lead.chars().count() <= 3 {
+                (*lead).to_string()
+            } else {
+                lead.chars().take(1).collect()
+            };
+            lead_part
+                .chars()
+                .chain(rest.iter().filter_map(|s| s.chars().next()))
+                .take(4)
+                .collect()
+        }
     };
     code.to_lowercase()
 }
@@ -4913,7 +4925,19 @@ mod tests {
     fn profile_short_code_multi_segment_takes_initials() {
         assert_eq!(profile_short_code("forit-backup"), "fb");
         assert_eq!(profile_short_code("pivot-main"), "pm");
-        assert_eq!(profile_short_code("wma-work"), "ww");
+        assert_eq!(profile_short_code("connect_airlines-work"), "caw");
+    }
+
+    #[test]
+    fn profile_short_code_keeps_short_lead_segment_whole() {
+        assert_eq!(profile_short_code("gna-main"), "gnam");
+        assert_eq!(profile_short_code("bsc-main"), "bscm");
+        assert_eq!(profile_short_code("bso-main"), "bsom");
+        assert_eq!(profile_short_code("RAS-Main"), "rasm");
+        assert_eq!(profile_short_code("aoe-fiw"), "aoef");
+        assert_eq!(profile_short_code("wma-work"), "wmaw");
+        assert_eq!(profile_short_code("p9-main"), "p9m");
+        assert_eq!(profile_short_code("bp-main"), "bpm");
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -18,8 +18,8 @@ use crate::session::config::{GroupByMode, RowTagMode, SortOrder};
 use crate::session::{Item, Status};
 use crate::tui::components::preview::{self, CachedPreview};
 use crate::tui::components::{
-    format_scroll_indicator, set_prefixed_input_cursor_position, truncate_to_width, HelpOverlay,
-    Preview,
+    format_scroll_indicator, prefix_within_width, set_prefixed_input_cursor_position,
+    truncate_to_width, HelpOverlay, Preview,
 };
 use crate::tui::responsive;
 use crate::tui::styles::{has_min_contrast, Theme};
@@ -701,20 +701,22 @@ fn branch_tag_content(branch: &str, max_width: usize) -> Option<String> {
 /// Compact display code for a profile name, used by the per-row profile tag
 /// in all-profiles view where the full name is too wide.
 ///
-/// Hyphen/underscore-delimited names keep a short lead segment (three
-/// characters or fewer) whole and append the initials of the remaining
-/// segments, so sibling profiles that share an initial stay distinguishable
-/// at a glance (`gna-main` becomes `gnam`, `bsc-main`/`bso-main` become
-/// `bscm`/`bsom`, `wma-work` becomes `wmaw`); a longer lead contributes its
-/// initial only (`forit-backup` becomes `fb`). Single-segment names take
-/// their first three chars (`default` becomes `def`). The code is lowercased
-/// and THEN capped at four terminal cells, measured by display width: a case
-/// expansion (`İ` lowercases to two scalars) or a wide glyph (`界` is two
-/// cells) can therefore never push the fixed-width `[....]` tag past
+/// Hyphen/underscore-delimited names keep a short lead segment (at most
+/// three grapheme clusters) whole and append the first cluster of each
+/// remaining segment, so sibling profiles that share an initial stay
+/// distinguishable at a glance (`gna-main` becomes `gnam`, `bsc-main` and
+/// `bso-main` become `bscm` and `bsom`, `wma-work` becomes `wmaw`); a longer
+/// lead contributes its initial only (`forit-backup` becomes `fb`).
+/// Single-segment names take their first three clusters (`default` becomes
+/// `def`). The code is lowercased and then cut to four terminal cells on a
+/// cluster boundary, measured as a string the way [`RowTag::rendered`]
+/// measures it, so a case expansion (`İ`), a wide glyph (`界`) or an emoji
+/// sequence (`♥️`, `🤝🏽`) never pushes the fixed-width tag past
 /// [`RowTag::max_width`]. The mapping is per-name and deterministic, so two
 /// profiles that collapse to the same code render identically; the full name
 /// still shows in a filtered view's list title and in the New/Restart dialogs.
 pub(crate) fn profile_short_code(profile: &str) -> String {
+    use unicode_segmentation::UnicodeSegmentation;
     const MAX_CELLS: usize = 4;
     let segments: Vec<&str> = profile
         .split(['-', '_'])
@@ -722,42 +724,18 @@ pub(crate) fn profile_short_code(profile: &str) -> String {
         .collect();
     let code: String = match segments.as_slice() {
         [] => String::new(),
-        [single] => single.chars().take(3).collect(),
+        [single] => single.graphemes(true).take(3).collect(),
         [lead, rest @ ..] => {
-            // Keep a short lead segment whole (`gna-main` -> `gnam`,
-            // `bsc-main`/`bso-main` -> `bscm`/`bsom`) so sibling profiles
-            // that share an initial stay distinguishable at a glance; a
-            // longer lead still contributes its initial only
-            // (`forit-backup` -> `fb`).
-            let lead_part: String = if lead.chars().count() <= 3 {
+            let mut code: String = if lead.graphemes(true).count() <= 3 {
                 (*lead).to_string()
             } else {
-                lead.chars().take(1).collect()
+                lead.graphemes(true).take(1).collect()
             };
-            lead_part
-                .chars()
-                .chain(rest.iter().filter_map(|s| s.chars().next()))
-                .take(MAX_CELLS)
-                .collect()
+            code.extend(rest.iter().filter_map(|s| s.graphemes(true).next()));
+            code
         }
     };
-    truncate_to_display_width(&code.to_lowercase(), MAX_CELLS)
-}
-
-/// The longest prefix of `s` that fits in `max_cells` terminal cells
-/// (`unicode-width`), so a tag cap holds on screen and not just in scalars.
-fn truncate_to_display_width(s: &str, max_cells: usize) -> String {
-    let mut out = String::new();
-    let mut used = 0;
-    for c in s.chars() {
-        let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-        if used + w > max_cells {
-            break;
-        }
-        used += w;
-        out.push(c);
-    }
-    out
+    prefix_within_width(&code.to_lowercase(), MAX_CELLS).to_string()
 }
 
 /// Format a timestamp as a compact relative age (e.g. `3m`, `2h`, `4d`, `2mo`).
@@ -4981,9 +4959,9 @@ mod tests {
         assert_eq!(profile_short_code("a-b-c-d-e-f"), "abcd");
     }
 
-    /// The four-cell cap is enforced AFTER lowercasing and by display width:
+    /// The four-cell cap is enforced after lowercasing and by display width:
     /// `İ` lowercases to `i` + a combining dot (two scalars, one cell) and
-    /// `界` is one scalar but two cells — neither may widen the tag.
+    /// `界` is one scalar but two cells; neither may widen the tag.
     #[test]
     fn profile_short_code_caps_by_display_width_after_lowercasing() {
         use unicode_width::UnicodeWidthStr;
@@ -5000,6 +4978,45 @@ mod tests {
                 profile_short_code(name).width() <= 4,
                 "{name:?} -> {:?} exceeds four cells",
                 profile_short_code(name)
+            );
+        }
+    }
+
+    /// `UnicodeWidthChar` is not additive across an emoji sequence: `♥` plus
+    /// VS16 measures 1 + 0 per scalar but 2 as a string, and a skin tone
+    /// measures 2 alone but 0 once joined to its base. The cap has to measure
+    /// grapheme-aligned prefixes as a string, the way `RowTag::rendered()`
+    /// does, or the tag over- or under-fills.
+    #[test]
+    fn profile_short_code_measures_width_across_grapheme_clusters() {
+        use unicode_width::UnicodeWidthStr;
+        // Per-scalar sum admits `a` (1 + 0 + 2 + 1 = 4) but the string is 5 cells.
+        assert_eq!(
+            profile_short_code("\u{2665}\u{fe0f}界-a"),
+            "\u{2665}\u{fe0f}界"
+        );
+        // Per-scalar sum (2 + 2) rejects `m`, yet `🤝🏽m` is 3 cells.
+        assert_eq!(
+            profile_short_code("\u{1f91d}\u{1f3fd}-main"),
+            "\u{1f91d}\u{1f3fd}m"
+        );
+        // A segment's initial is its first cluster, so the VS16 that keeps
+        // the heart in emoji presentation travels with it.
+        assert_eq!(
+            profile_short_code("x-\u{2665}\u{fe0f}"),
+            "x\u{2665}\u{fe0f}"
+        );
+        for name in [
+            "\u{2665}\u{fe0f}\u{2665}\u{fe0f}\u{2665}\u{fe0f}",
+            "\u{1f91d}\u{1f3fd}-a-b-c-d",
+            "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}-main",
+            "क्ष-main",
+        ] {
+            let code = profile_short_code(name);
+            assert!(
+                code.width() <= 4,
+                "{name:?} -> {code:?} is {} cells",
+                code.width()
             );
         }
     }
@@ -5212,8 +5229,8 @@ mod tests {
 
     #[test]
     fn row_tag_content_fits_within_max_width() {
-        // RowTag.rendered() right-pads to max_width by display width —
-        // if content ever exceeds max_width the pad is zero and the bracket
+        // RowTag.rendered() right-pads to max_width by display width; if
+        // content ever exceeds max_width the pad is zero and the bracket
         // span jitters. profile_short_code's documented cap of 4 cells is
         // the tightest case to spot-check.
         use unicode_width::UnicodeWidthStr;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -578,15 +578,6 @@ fn push_shelf_error_lines(
     }
 }
 
-/// Compact display code for a profile name, used by the per-row profile tag
-/// in all-profiles view where the full name is too wide.
-///
-/// Hyphen/underscore-delimited names collapse to their segment initials
-/// (`forit-backup` becomes `fb`); single-segment names take their first three
-/// chars (`default` becomes `def`). Always lowercased, capped at four chars.
-/// The mapping is per-name and deterministic, so two profiles that collapse to
-/// the same code render identically; the full name still shows in a filtered
-/// view's list title and in the New/Restart dialogs.
 /// Per-row tag content plus the mode's max content width. The renderer
 /// right-pads `content` to `max_width` so the bracket span is fixed-width
 /// across rows (`[fb  ]` vs `[def ]`), keeping the activity column from
@@ -600,8 +591,14 @@ pub(crate) struct RowTag {
 const BRANCH_TAG_WIDTH: usize = 12;
 
 impl RowTag {
+    /// The bracketed tag, right-padded to `max_width` terminal cells. Padding
+    /// is measured by display width, not `char` count, so a wide glyph
+    /// (`界`, two cells) or a combining mark (zero cells) in the content still
+    /// yields a bracket span of exactly `max_width + 2` cells.
     pub fn rendered(&self) -> String {
-        format!("[{:<width$}]", self.content, width = self.max_width)
+        let used = unicode_width::UnicodeWidthStr::width(self.content.as_str());
+        let pad = self.max_width.saturating_sub(used);
+        format!("[{}{}]", self.content, " ".repeat(pad))
     }
 }
 
@@ -701,7 +698,24 @@ fn branch_tag_content(branch: &str, max_width: usize) -> Option<String> {
     }
 }
 
+/// Compact display code for a profile name, used by the per-row profile tag
+/// in all-profiles view where the full name is too wide.
+///
+/// Hyphen/underscore-delimited names keep a short lead segment (three
+/// characters or fewer) whole and append the initials of the remaining
+/// segments, so sibling profiles that share an initial stay distinguishable
+/// at a glance (`gna-main` becomes `gnam`, `bsc-main`/`bso-main` become
+/// `bscm`/`bsom`, `wma-work` becomes `wmaw`); a longer lead contributes its
+/// initial only (`forit-backup` becomes `fb`). Single-segment names take
+/// their first three chars (`default` becomes `def`). The code is lowercased
+/// and THEN capped at four terminal cells, measured by display width: a case
+/// expansion (`İ` lowercases to two scalars) or a wide glyph (`界` is two
+/// cells) can therefore never push the fixed-width `[....]` tag past
+/// [`RowTag::max_width`]. The mapping is per-name and deterministic, so two
+/// profiles that collapse to the same code render identically; the full name
+/// still shows in a filtered view's list title and in the New/Restart dialogs.
 pub(crate) fn profile_short_code(profile: &str) -> String {
+    const MAX_CELLS: usize = 4;
     let segments: Vec<&str> = profile
         .split(['-', '_'])
         .filter(|s| !s.is_empty())
@@ -723,11 +737,27 @@ pub(crate) fn profile_short_code(profile: &str) -> String {
             lead_part
                 .chars()
                 .chain(rest.iter().filter_map(|s| s.chars().next()))
-                .take(4)
+                .take(MAX_CELLS)
                 .collect()
         }
     };
-    code.to_lowercase()
+    truncate_to_display_width(&code.to_lowercase(), MAX_CELLS)
+}
+
+/// The longest prefix of `s` that fits in `max_cells` terminal cells
+/// (`unicode-width`), so a tag cap holds on screen and not just in scalars.
+fn truncate_to_display_width(s: &str, max_cells: usize) -> String {
+    let mut out = String::new();
+    let mut used = 0;
+    for c in s.chars() {
+        let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+        if used + w > max_cells {
+            break;
+        }
+        used += w;
+        out.push(c);
+    }
+    out
 }
 
 /// Format a timestamp as a compact relative age (e.g. `3m`, `2h`, `4d`, `2mo`).
@@ -4951,6 +4981,29 @@ mod tests {
         assert_eq!(profile_short_code("a-b-c-d-e-f"), "abcd");
     }
 
+    /// The four-cell cap is enforced AFTER lowercasing and by display width:
+    /// `İ` lowercases to `i` + a combining dot (two scalars, one cell) and
+    /// `界` is one scalar but two cells — neither may widen the tag.
+    #[test]
+    fn profile_short_code_caps_by_display_width_after_lowercasing() {
+        use unicode_width::UnicodeWidthStr;
+        let expanded = profile_short_code("İab-main");
+        assert_eq!(expanded, "i\u{307}abm");
+        assert_eq!(expanded.width(), 4);
+        assert_eq!(profile_short_code("界界界-main"), "界界");
+        assert_eq!(profile_short_code("界界界-main").width(), 4);
+        assert_eq!(profile_short_code("界-main"), "界m");
+        assert_eq!(profile_short_code("x界-main"), "x界m");
+        assert_eq!(profile_short_code("界界界界"), "界界");
+        for name in ["İİİİ-main", "界界界界-main", "İ界-x-y-z", "ÀÉÎ-main"] {
+            assert!(
+                profile_short_code(name).width() <= 4,
+                "{name:?} -> {:?} exceeds four cells",
+                profile_short_code(name)
+            );
+        }
+    }
+
     #[test]
     fn profile_short_code_lowercases_and_ignores_empty_segments() {
         assert_eq!(profile_short_code("Forit_Backup"), "fb");
@@ -5159,11 +5212,33 @@ mod tests {
 
     #[test]
     fn row_tag_content_fits_within_max_width() {
-        // RowTag.rendered() right-pads to max_width via `{:<width$}` —
-        // if content ever exceeds max_width the format width is ignored
-        // and the bracket span jitters. profile_short_code's documented
-        // cap of 4 is the tightest case to spot-check.
-        assert!(profile_short_code("forit-backup-extra").len() <= 4);
+        // RowTag.rendered() right-pads to max_width by display width —
+        // if content ever exceeds max_width the pad is zero and the bracket
+        // span jitters. profile_short_code's documented cap of 4 cells is
+        // the tightest case to spot-check.
+        use unicode_width::UnicodeWidthStr;
+        assert!(profile_short_code("forit-backup-extra").width() <= 4);
+        assert!(profile_short_code("界界界-main").width() <= 4);
+    }
+
+    /// Padding is display-width-aware: a two-cell glyph counts as two.
+    #[test]
+    fn row_tag_rendered_pads_by_display_width() {
+        let wide = RowTag {
+            content: "界界".to_string(),
+            max_width: 4,
+        };
+        assert_eq!(wide.rendered(), "[界界]");
+        let one_wide = RowTag {
+            content: "界m".to_string(),
+            max_width: 4,
+        };
+        assert_eq!(one_wide.rendered(), "[界m ]");
+        let combining = RowTag {
+            content: "i\u{307}abm".to_string(),
+            max_width: 4,
+        };
+        assert_eq!(combining.rendered(), "[i\u{307}abm]");
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -596,9 +596,21 @@ impl RowTag {
     /// (`界`, two cells) or a combining mark (zero cells) in the content still
     /// yields a bracket span of exactly `max_width + 2` cells.
     pub fn rendered(&self) -> String {
-        let used = unicode_width::UnicodeWidthStr::width(self.content.as_str());
+        // Cap the content to `max_width` of the renderer's cells first, then
+        // pad by the same metric: `UnicodeWidthStr` resolves halfwidth
+        // katakana dakuten/handakuten to zero cells while the renderer paints
+        // one cell each, so a `UnicodeWidthStr`-measured pad would overflow
+        // the tag's fixed-width contract. Grapheme-aligned measurement keeps
+        // combined sequences (emoji + VS16, skin-tone modifiers) whole.
+        use ratatui::buffer::CellWidth;
+        use unicode_segmentation::UnicodeSegmentation;
+        let content = crate::tui::components::prefix_within_width(&self.content, self.max_width);
+        let used: usize = content
+            .graphemes(true)
+            .map(|g| g.cell_width() as usize)
+            .sum();
         let pad = self.max_width.saturating_sub(used);
-        format!("[{}{}]", self.content, " ".repeat(pad))
+        format!("[{content}{}]", " ".repeat(pad))
     }
 }
 
@@ -715,6 +727,44 @@ fn branch_tag_content(branch: &str, max_width: usize) -> Option<String> {
 /// [`RowTag::max_width`]. The mapping is per-name and deterministic, so two
 /// profiles that collapse to the same code render identically; the full name
 /// still shows in a filtered view's list title and in the New/Restart dialogs.
+#[cfg(test)]
+mod row_tag_render_tests {
+    use super::RowTag;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::text::Line;
+
+    /// The bracketed tag must occupy exactly `max_width + 2` cells **as the
+    /// renderer paints it**: locked `ratatui-core` paints halfwidth katakana
+    /// dakuten/handakuten (U+FF9E/U+FF9F) one cell each, while
+    /// `UnicodeWidthStr` resolves them to zero, so a string-width metric
+    /// produces a nine-cell tag for `ｶﾞｻﾞﾊﾟ` where the renderer sees six
+    /// content cells. Asserting through a `Buffer` reads back what the
+    /// renderer actually paints.
+    #[test]
+    fn row_tag_rendered_fits_the_fixed_width_contract_in_a_buffer() {
+        let cases: [(&str, usize); 4] = [("ｶﾞｻﾞﾊﾟ", 4), ("main", 4), ("界界界", 4), ("♥️", 4)];
+        for (content, max_width) in cases {
+            let rendered = RowTag {
+                content: content.into(),
+                max_width,
+            }
+            .rendered();
+            let total = (max_width + 8) as u16;
+            let area = Rect::new(0, 0, total, 1);
+            let mut buffer = Buffer::empty(area);
+            // `set_line` returns the column after the last painted cell, so
+            // this reads back exactly what the renderer would paint.
+            let (x, _) = buffer.set_line(0, 0, &Line::raw(rendered.clone()), total);
+            assert_eq!(
+                x as usize,
+                max_width + 2,
+                "{content}: the rendered tag must paint exactly max_width + 2 cells"
+            );
+        }
+    }
+}
+
 pub(crate) fn profile_short_code(profile: &str) -> String {
     use unicode_segmentation::UnicodeSegmentation;
     const MAX_CELLS: usize = 4;
@@ -4507,6 +4557,51 @@ impl HomeView {
             .style(Style::default().bg(theme.selection));
         frame.render_widget(bar, area);
     }
+}
+
+#[cfg(test)]
+#[test]
+fn row_tag_rendered_caps_wide_content_to_max_width() {
+    let tag = RowTag {
+        content: "界".repeat(12),
+        max_width: BRANCH_TAG_WIDTH,
+    };
+    let rendered = tag.rendered();
+    let width = unicode_width::UnicodeWidthStr::width(rendered.as_str());
+    assert_eq!(
+        width,
+        BRANCH_TAG_WIDTH + 2,
+        "a wide branch name must cap at the tag contract, got {rendered:?}"
+    );
+}
+
+#[test]
+fn row_tag_rendered_keeps_grapheme_sequences_whole() {
+    // VS16 sequence plus a wide glyph: the VS16 adds no cells and the
+    // prefix measurement must not split the cluster or over-count it.
+    let tag = RowTag {
+        content: "\u{2665}\u{fe0f}界-a".to_string(),
+        max_width: BRANCH_TAG_WIDTH,
+    };
+    let rendered = tag.rendered();
+    assert!(
+        rendered.contains('\u{2665}'),
+        "the heart must survive grapheme-aligned truncation, got {rendered:?}"
+    );
+    let width = unicode_width::UnicodeWidthStr::width(rendered.as_str());
+    assert_eq!(width, BRANCH_TAG_WIDTH + 2, "got {rendered:?}");
+
+    // Skin-tone modifier: chars sum to 4 but the cluster is 2 cells, so
+    // a per-char budget would drop the trailing "m" that actually fits.
+    let tag = RowTag {
+        content: "\u{1f91d}\u{1f3fd}m".to_string(),
+        max_width: BRANCH_TAG_WIDTH,
+    };
+    let rendered = tag.rendered();
+    assert!(
+        rendered.contains('m'),
+        "the m fits in cells and must not be dropped, got {rendered:?}"
+    );
 }
 
 #[cfg(test)]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -18,8 +18,8 @@ use crate::session::config::{GroupByMode, RowTagMode, SortOrder};
 use crate::session::{Item, Status};
 use crate::tui::components::preview::{self, CachedPreview};
 use crate::tui::components::{
-    format_scroll_indicator, prefix_within_width, set_prefixed_input_cursor_position,
-    truncate_to_width, HelpOverlay, Preview,
+    format_scroll_indicator, prefix_within_width, rendered_width,
+    set_prefixed_input_cursor_position, truncate_to_width, HelpOverlay, Preview,
 };
 use crate::tui::responsive;
 use crate::tui::styles::{has_min_contrast, Theme};
@@ -596,20 +596,12 @@ impl RowTag {
     /// (`界`, two cells) or a combining mark (zero cells) in the content still
     /// yields a bracket span of exactly `max_width + 2` cells.
     pub fn rendered(&self) -> String {
-        // Cap the content to `max_width` of the renderer's cells first, then
-        // pad by the same metric: `UnicodeWidthStr` resolves halfwidth
-        // katakana dakuten/handakuten to zero cells while the renderer paints
-        // one cell each, so a `UnicodeWidthStr`-measured pad would overflow
-        // the tag's fixed-width contract. Grapheme-aligned measurement keeps
-        // combined sequences (emoji + VS16, skin-tone modifiers) whole.
-        use ratatui::buffer::CellWidth;
-        use unicode_segmentation::UnicodeSegmentation;
-        let content = crate::tui::components::prefix_within_width(&self.content, self.max_width);
-        let used: usize = content
-            .graphemes(true)
-            .map(|g| g.cell_width() as usize)
-            .sum();
-        let pad = self.max_width.saturating_sub(used);
+        // Cap first, then pad, both in the cells the renderer paints: a
+        // `UnicodeWidthStr` pad overflows the contract for scripts it scores
+        // below what ratatui spends on them. Grapheme-aligned, so combined
+        // sequences (emoji + VS16, skin-tone modifiers) stay whole.
+        let content = prefix_within_width(&self.content, self.max_width);
+        let pad = self.max_width.saturating_sub(rendered_width(content));
         format!("[{content}{}]", " ".repeat(pad))
     }
 }
@@ -727,44 +719,6 @@ fn branch_tag_content(branch: &str, max_width: usize) -> Option<String> {
 /// [`RowTag::max_width`]. The mapping is per-name and deterministic, so two
 /// profiles that collapse to the same code render identically; the full name
 /// still shows in a filtered view's list title and in the New/Restart dialogs.
-#[cfg(test)]
-mod row_tag_render_tests {
-    use super::RowTag;
-    use ratatui::buffer::Buffer;
-    use ratatui::layout::Rect;
-    use ratatui::text::Line;
-
-    /// The bracketed tag must occupy exactly `max_width + 2` cells **as the
-    /// renderer paints it**: locked `ratatui-core` paints halfwidth katakana
-    /// dakuten/handakuten (U+FF9E/U+FF9F) one cell each, while
-    /// `UnicodeWidthStr` resolves them to zero, so a string-width metric
-    /// produces a nine-cell tag for `ｶﾞｻﾞﾊﾟ` where the renderer sees six
-    /// content cells. Asserting through a `Buffer` reads back what the
-    /// renderer actually paints.
-    #[test]
-    fn row_tag_rendered_fits_the_fixed_width_contract_in_a_buffer() {
-        let cases: [(&str, usize); 4] = [("ｶﾞｻﾞﾊﾟ", 4), ("main", 4), ("界界界", 4), ("♥️", 4)];
-        for (content, max_width) in cases {
-            let rendered = RowTag {
-                content: content.into(),
-                max_width,
-            }
-            .rendered();
-            let total = (max_width + 8) as u16;
-            let area = Rect::new(0, 0, total, 1);
-            let mut buffer = Buffer::empty(area);
-            // `set_line` returns the column after the last painted cell, so
-            // this reads back exactly what the renderer would paint.
-            let (x, _) = buffer.set_line(0, 0, &Line::raw(rendered.clone()), total);
-            assert_eq!(
-                x as usize,
-                max_width + 2,
-                "{content}: the rendered tag must paint exactly max_width + 2 cells"
-            );
-        }
-    }
-}
-
 pub(crate) fn profile_short_code(profile: &str) -> String {
     use unicode_segmentation::UnicodeSegmentation;
     const MAX_CELLS: usize = 4;
@@ -4560,51 +4514,6 @@ impl HomeView {
 }
 
 #[cfg(test)]
-#[test]
-fn row_tag_rendered_caps_wide_content_to_max_width() {
-    let tag = RowTag {
-        content: "界".repeat(12),
-        max_width: BRANCH_TAG_WIDTH,
-    };
-    let rendered = tag.rendered();
-    let width = unicode_width::UnicodeWidthStr::width(rendered.as_str());
-    assert_eq!(
-        width,
-        BRANCH_TAG_WIDTH + 2,
-        "a wide branch name must cap at the tag contract, got {rendered:?}"
-    );
-}
-
-#[test]
-fn row_tag_rendered_keeps_grapheme_sequences_whole() {
-    // VS16 sequence plus a wide glyph: the VS16 adds no cells and the
-    // prefix measurement must not split the cluster or over-count it.
-    let tag = RowTag {
-        content: "\u{2665}\u{fe0f}界-a".to_string(),
-        max_width: BRANCH_TAG_WIDTH,
-    };
-    let rendered = tag.rendered();
-    assert!(
-        rendered.contains('\u{2665}'),
-        "the heart must survive grapheme-aligned truncation, got {rendered:?}"
-    );
-    let width = unicode_width::UnicodeWidthStr::width(rendered.as_str());
-    assert_eq!(width, BRANCH_TAG_WIDTH + 2, "got {rendered:?}");
-
-    // Skin-tone modifier: chars sum to 4 but the cluster is 2 cells, so
-    // a per-char budget would drop the trailing "m" that actually fits.
-    let tag = RowTag {
-        content: "\u{1f91d}\u{1f3fd}m".to_string(),
-        max_width: BRANCH_TAG_WIDTH,
-    };
-    let rendered = tag.rendered();
-    assert!(
-        rendered.contains('m'),
-        "the m fits in cells and must not be dropped, got {rendered:?}"
-    );
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -5331,6 +5240,81 @@ mod tests {
         use unicode_width::UnicodeWidthStr;
         assert!(profile_short_code("forit-backup-extra").width() <= 4);
         assert!(profile_short_code("界界界-main").width() <= 4);
+    }
+
+    /// The bracketed tag must occupy `max_width + 2` cells **as the renderer
+    /// paints them**: locked `ratatui-core` spends a cell on each halfwidth
+    /// katakana dakuten/handakuten (U+FF9E, U+FF9F) that `UnicodeWidthStr`
+    /// scores at zero, so a string-width metric draws a nine-cell tag for
+    /// `ｶﾞｻﾞﾊﾟ` where the renderer sees six content cells. Asserting through a
+    /// `Buffer` reads back what the renderer actually paints.
+    #[test]
+    fn row_tag_rendered_fits_the_fixed_width_contract_in_a_buffer() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        use ratatui::text::Line;
+        for (content, max_width) in [("ｶﾞｻﾞﾊﾟ", 4), ("main", 4), ("界界界", 4), ("♥️", 4)]
+        {
+            let rendered = RowTag {
+                content: content.into(),
+                max_width,
+            }
+            .rendered();
+            let total = (max_width + 8) as u16;
+            let mut buffer = Buffer::empty(Rect::new(0, 0, total, 1));
+            // `set_line` returns the column after the last painted cell.
+            let (x, _) = buffer.set_line(0, 0, &Line::raw(rendered.clone()), total);
+            assert_eq!(
+                x as usize,
+                max_width + 2,
+                "{content}: painted {rendered:?} past the fixed-width contract"
+            );
+        }
+    }
+
+    #[test]
+    fn row_tag_rendered_caps_wide_content_to_max_width() {
+        let tag = RowTag {
+            content: "界".repeat(12),
+            max_width: BRANCH_TAG_WIDTH,
+        };
+        let rendered = tag.rendered();
+        assert_eq!(
+            rendered_width(&rendered),
+            BRANCH_TAG_WIDTH + 2,
+            "a wide branch name must cap at the tag contract, got {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn row_tag_rendered_keeps_grapheme_sequences_whole() {
+        // VS16 sequence plus a wide glyph: the VS16 adds no cells and the
+        // prefix measurement must not split the cluster or over-count it.
+        let tag = RowTag {
+            content: "\u{2665}\u{fe0f}界-a".to_string(),
+            max_width: BRANCH_TAG_WIDTH,
+        };
+        let rendered = tag.rendered();
+        assert!(
+            rendered.contains('\u{2665}'),
+            "the heart must survive grapheme-aligned truncation, got {rendered:?}"
+        );
+        assert_eq!(
+            rendered_width(&rendered),
+            BRANCH_TAG_WIDTH + 2,
+            "got {rendered:?}"
+        );
+
+        // Skin-tone modifier: chars sum to 4 but the cluster is 2 cells, so
+        // a per-char budget would drop the trailing "m" that actually fits.
+        let tag = RowTag {
+            content: "\u{1f91d}\u{1f3fd}m".to_string(),
+            max_width: BRANCH_TAG_WIDTH,
+        };
+        assert!(
+            tag.rendered().contains('m'),
+            "the m fits in cells and must not be dropped"
+        );
     }
 
     /// Padding is display-width-aware: a two-cell glyph counts as two.


### PR DESCRIPTION
## Description

Closes the blocking P2 from #3680's review (built on that PR's head; merging this one supersedes #3680's remaining review delta).

`profile_short_code` and `RowTag::rendered` measured cap and padding with `UnicodeWidthStr`, but locked `ratatui-core 0.1.2` paints halfwidth katakana dakuten/handakuten (U+FF9E/U+FF9F) into one cell each where the string metric resolves them to zero. For profile `ｶﾞｻﾞﾊﾟ` the code kept three grapheme clusters and one padding space, and the renderer drew a nine-cell bracketed tag where the contract is six.

- Both the cap and the padding now use the renderer's per-grapheme `CellWidth` metric (`ratatui::buffer::CellWidth`), the same rule `Span::styled_graphemes` + `Buffer::set_stringn` apply.
- The fixed-width contract is asserted through a `Buffer` (`set_line`'s returned paint column), so the test measures what the renderer paints, not what `UnicodeWidthStr` claims. Cases: `ｶﾞｻﾞﾊﾟ`, `main`, `界界界`, `♥️`.
- Restores the `cfg(test)` guards and the two `RowTag` regression tests (`row_tag_rendered_caps_wide_content_to_max_width`, `row_tag_rendered_keeps_grapheme_sequences_whole`) left uncommitted by the previous session — this is why the last review-round comment referenced tests absent from the remote head.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (doc comments describe the renderer metric)
- [x] For UI changes: included screenshot or recording (no visual change in ASCII-only profiles; wide profiles align again)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: TUI row rendering, covered by Rust unit tests

**TUI / CLI (e2e test)**
- [x] N/A: covered by the buffer-backed unit tests

## AI Usage

- [x] AI was used

**AI Model/Tool used:** omp (OpenCode) with Omen Alpha

**Any Additional AI Details you'd like to share:** Fixes authored and verified in an AI session under Jérôme Benoit's review workflow.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed TUI profile short-code and row-tag width handling.
- Aligned truncation and padding with ratatui’s terminal cell-width behavior.
- Added shared `rendered_width` and `prefix_within_width` helpers.
- Restored regression tests for grapheme handling and fixed-width rendering.

These changes preserve grapheme clusters and improve rendering for katakana, wide characters, and emoji.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->