### PR TITLE
docs(tui): describe live-send's socket transport as the default

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -2,11 +2,26 @@
 //!
 //! When a user presses `Tab` on a runnable session, the home view installs
 //! a `LiveSendState` and routes every subsequent key event through this
-//! module's translator. Each translation produces a `tmux send-keys` call
-//! against the target pane: plain characters go literally, every other
-//! key (arrows, Esc, Tab, modifier combos) goes by tmux key name with
-//! `C-` / `M-` prefixes. The user exits with one of the configured
-//! exit chords (default: `Ctrl+q`).
+//! module's translator. Each translation produces a `TmuxAction`, delivered
+//! by whichever transport the pane has armed.
+//!
+//! While a VT channel carries input (`[tmux] vt_live`, tmux 3.8 or newer,
+//! unix) the action is encoded to raw terminal bytes and written into the
+//! pane socket, bypassing tmux's own key translation, so the encoder honors
+//! the pane's DECCKM state itself. That is the default. Presence of a live
+//! input channel is a single-writer signal: every keystroke then goes over
+//! the socket and none through `send-keys`, since the two writers would
+//! interleave on one pty input stream.
+//!
+//! Otherwise each action forks `tmux send-keys`: plain characters go
+//! literally, every other key (arrows, Esc, Tab, modifier combos) by tmux
+//! key name with `C-` / `M-` prefixes. This is the path for tmux older than
+//! 3.8 (through 3.7a, writing to a dead pane's input takes the whole tmux
+//! server down), a pane whose forwarder has not connected or has died, and
+//! `vt_live` turned off.
+//!
+//! The user exits with one of the configured exit chords (default:
+//! `Ctrl+q`).
 //!
 //! Exit chord configuration: the user picks a comma-separated list
 //! of chord specs (`C-q`, `M-x`, `F12`, …) via settings. Default is
@@ -21,15 +36,16 @@
 //! - No echo, no inline editing, no review step. The preview pane is the
 //!   only feedback channel; users who need multi-line composition or want
 //!   to proofread voice/dictation should use the compose dialog on `M`.
-//! - Each coalesced keystroke run becomes one `tmux send-keys`
-//!   subprocess. A long-lived `tmux -C` control-mode connection was
+//! - On the `send-keys` fallback, each coalesced keystroke run becomes
+//!   one subprocess. A long-lived `tmux -C` control-mode connection was
 //!   tried (#1485) to avoid that fork cost on mobile, but the
 //!   connection turned out to be unreliable on macOS tmux 3.x: it
 //!   EOF'd within milliseconds of spawn, leaving us paying the spawn
 //!   cost while never benefiting from the connection. Forking per
 //!   batch is the simpler, more portable model; the per-batch fork
 //!   cost is bounded by user typing speed (held keys / pastes
-//!   coalesce into one fork) and is invisible on a laptop.
+//!   coalesce into one fork) and is invisible on a laptop. The socket
+//!   path forks nothing per keystroke.
 //!
 //! Reserved (non-forwarded) chords:
 //! - The configured exit chord list — exits live mode (see above).


### PR DESCRIPTION
## Description

`live_send.rs`'s module doc describes the pre-VT design. It says each translation "produces a `tmux send-keys` call", and a trade-off bullet costs every coalesced keystroke run at one subprocess. Both have been the fallback since the VT channel landed.

While a channel is armed for input (`[tmux] vt_live`, tmux 3.8 or newer, unix) the action is encoded to raw terminal bytes and written into the pane socket, bypassing tmux's key translation (`live_send.rs:2236`, `encode_action_bytes`). The single-writer invariant means no keystroke takes the `send-keys` path at all while that channel is live. `send-keys` covers tmux older than 3.8, a forwarder that has not connected or has died, and `vt_live` off.

Doc comment only, no code change. Prompted by #3340, which proposes reusing this transport for remote tmux rows: the stale text sends a reader looking for a key-name protocol that is no longer the one in use.

## PR Type

- [x] Documentation

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Found while validating #3340's live-ws claims against `main`. The staleness was what led the reviewing agent to the wrong conclusion first time through, which is the argument for fixing it. `cargo fmt`, `cargo clippy` and `cargo doc` clean.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzjnMgi5yGTRGiwEVz3ye5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `live_send.rs` documentation to describe the VT socket transport as the default for `vt_live` on tmux 3.8+ Unix systems.
- Documented `tmux send-keys` as the fallback for older tmux versions, unavailable forwarders, or disabled `vt_live`.
- Clarified raw terminal byte handling and noted that the socket path avoids per-keystroke process creation.

This documentation-only change improves accuracy and reduces confusion about live mode’s current transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->