### PR TITLE
fix(tui): measure cell widths the way the renderer does

### DIFF
--- a/src/tui/components/text.rs
+++ b/src/tui/components/text.rs
@@ -120,10 +120,17 @@ pub fn truncate_to_width(text: &str, max_width: usize) -> String {
 /// dakuten/handakuten (U+FF9E, U+FF9F) to zero cells where the renderer
 /// spends one on each, so a string-width budget admits twice the text that
 /// fits for that script.
+///
+/// Clusters holding a control character are dropped first, as both renderer
+/// paths do: they paint nothing, and `CellWidth` debug-asserts when handed a
+/// lone ASCII control.
 pub fn rendered_width(text: &str) -> usize {
     use ratatui::buffer::CellWidth;
     use unicode_segmentation::UnicodeSegmentation;
-    text.graphemes(true).map(|g| g.cell_width() as usize).sum()
+    text.graphemes(true)
+        .filter(|g| !g.contains(char::is_control))
+        .map(|g| g.cell_width() as usize)
+        .sum()
 }
 
 /// The longest prefix of `text` that fits in `max_width` display cells, with
@@ -135,16 +142,19 @@ pub fn rendered_width(text: &str) -> usize {
 /// from [`rendered_width`], so a cluster whose scalars do not sum to what it
 /// paints ("\u{26a0}\u{fe0f}" is 2 cells where its chars sum to 1,
 /// "\u{1f91d}\u{1f3fd}" is 2 where they sum to 4) neither over- nor
-/// under-fills the budget.
+/// under-fills the budget. A cluster holding a control character costs
+/// nothing yet stays in the slice, so the result is still a borrowed prefix.
 pub fn prefix_within_width(text: &str, max_width: usize) -> &str {
     use ratatui::buffer::CellWidth;
     use unicode_segmentation::UnicodeSegmentation;
     let mut cells = 0usize;
     let mut end = 0;
     for (start, g) in text.grapheme_indices(true) {
-        cells += g.cell_width() as usize;
-        if cells > max_width {
-            break;
+        if !g.contains(char::is_control) {
+            cells += g.cell_width() as usize;
+            if cells > max_width {
+                break;
+            }
         }
         end = start + g.len();
     }
@@ -216,6 +226,30 @@ mod tests {
         let out = truncate_to_width(&halfwidth, 24);
         assert!(rendered_width(&out) <= 24, "{out:?}");
         assert!(out.ends_with('\u{2026}'));
+    }
+
+    /// Control characters paint nothing, so charging cells for them ellipsizes
+    /// text that fits, and `CellWidth` debug-asserts when a lone ASCII control
+    /// reaches it. Plugin row-column text can carry internal tabs.
+    #[test]
+    fn control_characters_cost_no_cells() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        use ratatui::text::Line;
+
+        assert_eq!(rendered_width("a\tb"), 2);
+        assert_eq!(rendered_width("a\r\nb"), 2);
+        assert_eq!(prefix_within_width("a\tb", 2), "a\tb");
+        assert_eq!(truncate_to_width("a\tb", 2), "a\tb");
+        // Still budgeted correctly once the visible text does overflow.
+        assert_eq!(truncate_to_width("a\tbcdef", 3), "a\tb\u{2026}");
+
+        // The two cells ratatui actually paints for the passthrough case.
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
+        let (x, _) = buffer.set_line(0, 0, &Line::raw(truncate_to_width("a\tb", 2)), 4);
+        assert_eq!(x, 2, "{buffer:?}");
+        assert_eq!(buffer[(0, 0)].symbol(), "a");
+        assert_eq!(buffer[(1, 0)].symbol(), "b");
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -674,10 +674,13 @@ fn branch_row_tag(inst: &crate::session::Instance) -> Option<RowTag> {
 
 fn workspace_branch_row_tag(branch: &str, repo_count: usize) -> Option<RowTag> {
     let suffix = format!("+{repo_count}");
-    let suffix_width = suffix.chars().count();
+    // Reserve the suffix in cells, not characters: `RowTag::rendered` caps the
+    // whole tag in cells, so a character-sized reservation lets a wide branch
+    // fill the budget and lose the repository count off the end.
+    let suffix_width = rendered_width(&suffix);
     if suffix_width >= BRANCH_TAG_WIDTH {
         return Some(RowTag {
-            content: suffix.chars().take(BRANCH_TAG_WIDTH).collect(),
+            content: prefix_within_width(&suffix, BRANCH_TAG_WIDTH).to_string(),
             max_width: BRANCH_TAG_WIDTH,
         });
     }
@@ -694,11 +697,11 @@ fn workspace_branch_row_tag(branch: &str, repo_count: usize) -> Option<RowTag> {
 
 fn branch_tag_content(branch: &str, max_width: usize) -> Option<String> {
     let last = branch.rsplit('/').next().unwrap_or("");
-    let trimmed: String = last.chars().take(max_width).collect();
+    let trimmed = prefix_within_width(last, max_width);
     if trimmed.is_empty() {
         None
     } else {
-        Some(trimmed)
+        Some(trimmed.to_string())
     }
 }
 
@@ -5303,6 +5306,18 @@ mod tests {
             BRANCH_TAG_WIDTH + 2,
             "a wide branch name must cap at the tag contract, got {rendered:?}"
         );
+    }
+
+    /// The repository count is what the workspace tag exists to carry, so the
+    /// branch must be cut in cells to leave room for it rather than filling
+    /// the cap and pushing it off the end.
+    #[test]
+    fn workspace_branch_row_tag_keeps_the_repository_count() {
+        let rendered = workspace_branch_row_tag(&"界".repeat(10), 2)
+            .expect("a wide branch still yields a tag")
+            .rendered();
+        assert_eq!(rendered, "[界界界界界+2]");
+        assert_eq!(rendered_width(&rendered), BRANCH_TAG_WIDTH + 2);
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -674,9 +674,6 @@ fn branch_row_tag(inst: &crate::session::Instance) -> Option<RowTag> {
 
 fn workspace_branch_row_tag(branch: &str, repo_count: usize) -> Option<RowTag> {
     let suffix = format!("+{repo_count}");
-    // Reserve the suffix in cells, not characters: `RowTag::rendered` caps the
-    // whole tag in cells, so a character-sized reservation lets a wide branch
-    // fill the budget and lose the repository count off the end.
     let suffix_width = rendered_width(&suffix);
     if suffix_width >= BRANCH_TAG_WIDTH {
         return Some(RowTag {
@@ -697,6 +694,9 @@ fn workspace_branch_row_tag(branch: &str, repo_count: usize) -> Option<RowTag> {
 
 fn branch_tag_content(branch: &str, max_width: usize) -> Option<String> {
     let last = branch.rsplit('/').next().unwrap_or("");
+    // Cut in cells, not characters: `RowTag::rendered` caps the whole tag in
+    // cells, so a character-sized cut lets a wide branch fill that cap and
+    // push the workspace repository count off the end.
     let trimmed = prefix_within_width(last, max_width);
     if trimmed.is_empty() {
         None


### PR DESCRIPTION
## Description

Fixes #3879: two regressions #3876 put on `main`. Neither is in v1.16.0.

**Control characters violated the renderer's width contract.** `rendered_width` and `prefix_within_width` measured every grapheme with `CellWidth`, where ratatui filters control-bearing clusters first. So `truncate_to_width("a\tb", 2)` panicked in debug (locked ratatui-core 0.1.2 debug-asserts on a single-byte ASCII control) and charged a cell the renderer never paints in release. Plugin row-column text can carry internal tabs and reaches this path through `src/tui/remote_home/render.rs:62`. Both helpers now apply the renderer's control predicate; `prefix_within_width` keeps control clusters inside the slice, so its result is still a borrowed prefix.

**Wide branch names hid the workspace repository count.** `workspace_branch_row_tag` reserved `+N` in characters while the whole-tag cap in `RowTag::rendered` works in cells, so ten `界` with two repositories kept six wide characters and dropped `+2`. The suffix is reserved, and the branch cut, in cells; that case now renders `[界界界界界+2]`.

The profile short-code behavior #3876 fixed is unchanged, halfwidth-katakana coverage included.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --all-targets` and `cargo test` are clean. No screenshot: the visible change is two cells of a row tag, and the new Buffer-backed assertions state it more precisely than a capture would.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: both cases are pure width arithmetic reachable from a unit test. `control_characters_cost_no_cells` asserts against a real `Buffer`, and `workspace_branch_row_tag_keeps_the_repository_count` asserts the rendered tag. A full-binary test would cost minutes to cover the same two cells.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any Additional AI Details you'd like to share:**

Issue #3879 supplied both regression cases. The agent confirmed the `CellWidth` debug assertion and the control filtering in the locked ratatui-core 0.1.2 source before changing either helper.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6VKY4XdAbrSc7QtoeYLkw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed TUI width handling for control characters.
- Updated workspace branch tags to reserve repository-count suffixes by display cells.
- Added regression tests for control characters and wide branch names.
- Retained halfwidth-katakana coverage.

## Benefits

- Prevents debug panics and incorrect text-width calculations.
- Keeps repository counts visible for wide branch names.
- Preserves accurate terminal rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->