### PR TITLE
fix(tui): align remote-home columns by the metric that places spans

### DIFF
--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -19,7 +19,7 @@ pub use dir_picker::{DirPicker, DirPickerResult};
 pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
 pub use preview::{format_scroll_indicator, Preview};
-pub use text::{prefix_within_width, rendered_width, truncate_to_width};
+pub use text::{fixed_width, prefix_within_width, rendered_width, truncate_to_width};
 pub(crate) use text_input::{focused_input_spans, input_scroll, visible_slice};
 pub use text_input::{
     longest_common_prefix, render_text_field, render_text_field_with_ghost,

--- a/src/tui/components/text.rs
+++ b/src/tui/components/text.rs
@@ -161,9 +161,32 @@ pub fn prefix_within_width(text: &str, max_width: usize) -> &str {
     &text[..end]
 }
 
+/// `text` fitted to a `max_width` column of a multi-span [`ratatui::text::Line`].
+///
+/// Cut and padded by different metrics, because ratatui lays a `Line` out with
+/// two that disagree: `Span::render` advances a cell per `CellWidth`, while
+/// `render_spans` starts the next span at `Span::width`, which is
+/// `UnicodeWidthStr`. They part only on halfwidth katakana
+/// dakuten/handakuten (U+FF9E, U+FF9F), where `CellWidth` charges the cell the
+/// terminal spends and `UnicodeWidthStr` scores zero.
+///
+/// So the cut uses [`truncate_to_width`], keeping painted glyphs inside the
+/// column, and the pad uses `UnicodeWidthStr`, landing the next span on the
+/// column boundary. Padding to `CellWidth` instead would start the next column
+/// one cell short per mark; a `{:<max_width$}` pad counts chars and leaves it
+/// short by one per wide glyph.
+pub fn fixed_width(text: &str, max_width: usize) -> String {
+    use unicode_width::UnicodeWidthStr;
+    let text = truncate_to_width(text, max_width);
+    let pad = max_width.saturating_sub(UnicodeWidthStr::width(text.as_str()));
+    format!("{text}{}", " ".repeat(pad))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{line_columns, prefix_within_width, rendered_width, truncate_to_width};
+    use super::{
+        fixed_width, line_columns, prefix_within_width, rendered_width, truncate_to_width,
+    };
 
     /// A wide grapheme occupies two columns and its continuation cell is reset
     /// by the renderer. Reading that back out of a buffer yields a phantom
@@ -250,6 +273,38 @@ mod tests {
         assert_eq!(x, 2, "{buffer:?}");
         assert_eq!(buffer[(0, 0)].symbol(), "a");
         assert_eq!(buffer[(1, 0)].symbol(), "b");
+    }
+
+    /// Both halves of the column contract: the next span starts exactly
+    /// `max_width` on, and the painted glyphs stay inside that. A `{:<width$}`
+    /// pad breaks the first for wide glyphs; a `CellWidth` pad breaks it for
+    /// halfwidth katakana.
+    #[test]
+    fn fixed_width_fits_a_line_column() {
+        use unicode_width::UnicodeWidthStr;
+        let wide = "\u{754c}".repeat(40);
+        for (text, width) in [
+            ("agent", 8),
+            ("\u{65e5}\u{672c}\u{8a9e}", 8),
+            ("\u{ff8a}\u{ff9e}\u{ff8a}\u{ff9e}\u{ff8a}\u{ff9e}", 8),
+            ("a much longer title than fits", 8),
+            (wide.as_str(), 24),
+            ("a\tb", 4),
+            ("", 3),
+        ] {
+            let out = fixed_width(text, width);
+            assert_eq!(
+                UnicodeWidthStr::width(out.as_str()),
+                width,
+                "{text:?} at {width}: next span must start on the boundary"
+            );
+            assert!(
+                rendered_width(out.trim_end()) <= width,
+                "{text:?} at {width}: painted glyphs must stay inside the column"
+            );
+        }
+        assert_eq!(fixed_width("ab", 5), "ab   ");
+        assert_eq!(fixed_width("abcdef", 0), "");
     }
 
     #[test]

--- a/src/tui/remote_home/render.rs
+++ b/src/tui/remote_home/render.rs
@@ -13,7 +13,7 @@ use crate::daemon::{
     ContextResumeAvailability, ContextResumeIndeterminateReason, ContextResumeUnavailableReason,
 };
 use crate::plugin::ui_state::Tone;
-use crate::tui::components::truncate_to_width;
+use crate::tui::components::{fixed_width, truncate_to_width};
 use crate::tui::plugin_ui;
 use crate::tui::styles::{has_min_contrast, Theme};
 
@@ -203,12 +203,18 @@ Press r to refresh, q to quit.",
             };
             let mut spans = vec![
                 Span::styled(
-                    format!(" {:<24}  ", truncate(&s.title, 24)),
+                    format!(" {}  ", fixed_width(&s.title, 24)),
                     readable(title_style),
                 ),
-                Span::styled(format!("{:<10}  ", s.status), readable(status_style)),
                 Span::styled(
-                    format!("{:<11}  ", context_resume_summary(s.context_resume)),
+                    format!("{}  ", fixed_width(&s.status, 10)),
+                    readable(status_style),
+                ),
+                Span::styled(
+                    format!(
+                        "{}  ",
+                        fixed_width(context_resume_summary(s.context_resume), 11)
+                    ),
                     readable(status_style),
                 ),
             ];
@@ -275,16 +281,6 @@ fn render_footer(frame: &mut Frame, area: Rect, theme: &Theme, state: &RemoteHom
     let block = Block::default().borders(Borders::TOP);
     let para = Paragraph::new(Line::from(spans)).block(block);
     frame.render_widget(para, area);
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let take = max.saturating_sub(1);
-        let truncated: String = s.chars().take(take).collect();
-        format!("{truncated}…")
-    }
 }
 
 #[cfg(test)]
@@ -457,6 +453,51 @@ mod tests {
         }
         // The cap holds, so the path still renders and stays aligned.
         let painted = rows(&state);
+        assert_eq!(
+            column_of(&painted, "/tmp/s1"),
+            column_of(&painted, "/tmp/s2")
+        );
+    }
+
+    /// The title, status and context columns are fixed-width, so a pad that
+    /// counted chars left them short for wide scripts and pushed the path
+    /// right on that row alone.
+    #[test]
+    fn wide_column_text_keeps_the_path_aligned() {
+        let cases: [(&str, &str); 3] = [
+            // 8 chars, 16 cells: a char pad reserved 8 cells too few.
+            (
+                "\u{691c}\u{67fb}\u{5931}\u{6557}\u{691c}\u{67fb}\u{5931}\u{6557}",
+                "idle",
+            ),
+            // Halfwidth katakana: `CellWidth` charges a cell for the dakuten
+            // that `UnicodeWidthStr` scores as zero.
+            ("\u{ff8a}\u{ff9e}\u{ff8a}\u{ff9e}\u{ff8a}\u{ff9e}", "idle"),
+            // A wide status is the same bug one column to the right.
+            ("plain", "\u{5b9f}\u{884c}\u{4e2d}"),
+        ];
+        for (title, status) in cases {
+            let mut state = state_with(&["s1", "s2"], json!([]));
+            state.sessions[0].title = title.to_string();
+            state.sessions[0].status = status.to_string();
+            let painted = rows(&state);
+            assert_eq!(
+                column_of(&painted, "/tmp/s1"),
+                column_of(&painted, "/tmp/s2"),
+                "title {title:?} status {status:?}: {painted:?}"
+            );
+            assert_eq!(column_of(&painted, "/tmp/s1"), 54, "{painted:?}");
+        }
+    }
+
+    /// A title past its column is cut to the budget, not to a char count, so
+    /// the column still ends where every other row's does.
+    #[test]
+    fn an_overlong_wide_title_is_cut_to_its_column() {
+        let mut state = state_with(&["s1", "s2"], json!([]));
+        state.sessions[0].title = "\u{754c}".repeat(40);
+        let painted = rows(&state);
+        assert_eq!(column_of(&painted, "/tmp/s1"), 54, "{painted:?}");
         assert_eq!(
             column_of(&painted, "/tmp/s1"),
             column_of(&painted, "/tmp/s2")


### PR DESCRIPTION
## Description

Follow-up to #3883, found while reviewing it. The remote-home session picker pads its title, status and context columns with `{:<N$}` and cuts titles with a local char-based `truncate`. Chars are not cells: an 8-char CJK title paints 16, so the column runs long and pushes the project path right on that row alone. Measured against a `TestBackend`, the path lands at column 62 instead of 54, and at 77 for a 40-char wide title.

Padding by `rendered_width` does not fix it. ratatui lays a `Line` out with two metrics that disagree: `Span::render` advances a cell per `CellWidth`, while `render_spans` starts the next span at `Span::width`, which is `UnicodeWidthStr`. They part only on halfwidth katakana dakuten/handakuten (U+FF9E, U+FF9F), where a `CellWidth` pad starts the next column one cell short per mark.

`fixed_width` therefore cuts with `truncate_to_width`, keeping painted glyphs inside the column, and pads with `UnicodeWidthStr`, landing the next span on the boundary.

The plugin row-column measurement at `remote_home/render.rs:66` is deliberately unchanged. `UnicodeWidthStr` is what decides where the path span starts, so it is correct there.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --lib --tests` and `cargo test --lib` (6930 passed) are clean. No screenshot: the change is a column offset, and the new `TestBackend` assertions state it more precisely than a capture would.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the three unit tests render the real picker through a `TestBackend` and assert painted column offsets, which is the whole behavior. A full-binary test would cost minutes for the same assertion. Each was confirmed to fail against the previous code.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any Additional AI Details you'd like to share:**

Found during a review of #3883. The agent first proposed padding by `rendered_width` and reverted it after the halfwidth-katakana test failed, then read `ratatui-core` 0.1.2's `Span::render` and `render_spans` to establish which metric governs span placement. Two adjacent changes it had proposed, to the plugin-column measurement and to `diagnostics::format_agent_title`, were dropped once that showed the existing code was already correct.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PodUXso6Y16zpy8Py1FmK3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed remote-home session picker column alignment for wide and halfwidth characters.
- Added `fixed_width` to truncate and pad text by rendered terminal width.
- Replaced character-count formatting in session rows with width-aware formatting.
- Added tests for CJK, halfwidth Katakana, truncation, padding, and column offsets.

This keeps project paths aligned and prevents titles or statuses from shifting later columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->