### PR TITLE
fix(server): scope the list_sessions resolver counter to AppState

### DIFF
--- a/src/server/api/sessions/list.rs
+++ b/src/server/api/sessions/list.rs
@@ -118,7 +118,12 @@ pub async fn list_sessions(
     // Share resolved config between the ACP-capability and smart-rename
     // overlays, halving disk reads when a profile/project pair repeats in the
     // 3s sidebar poll. See #2603.
-    let mut session_cfg_cache = SessionCfgCache::default();
+    // Monotonic, so the delta below is this request's own count and no reset
+    // can race a concurrent request on the same state.
+    let misses_before = state
+        .list_sessions_resolver_misses
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let mut session_cfg_cache = SessionCfgCache::new(&state.list_sessions_resolver_misses);
 
     // Overlay custom-agent ACP capability (built-ins were resolved in the
     // constructor). Distinct `(profile, project_path)` pairs each resolve
@@ -254,10 +259,10 @@ pub async fn list_sessions(
     }
 
     // Both overlays have run, so the count is final for this request.
-    let resolver_misses = session_cfg_cache.misses();
-    state
+    let resolver_misses = state
         .list_sessions_resolver_misses
-        .store(resolver_misses, std::sync::atomic::Ordering::Relaxed);
+        .load(std::sync::atomic::Ordering::Relaxed)
+        .saturating_sub(misses_before);
     tracing::debug!(
         target: "http.api.sessions",
         rows = sessions.len(),

--- a/src/server/api/sessions/list.rs
+++ b/src/server/api/sessions/list.rs
@@ -118,7 +118,7 @@ pub async fn list_sessions(
     // Share resolved config between the ACP-capability and smart-rename
     // overlays, halving disk reads when a profile/project pair repeats in the
     // 3s sidebar poll. See #2603.
-    let mut session_cfg_cache: HashMap<(String, String), SessionConfig> = HashMap::new();
+    let mut session_cfg_cache = SessionCfgCache::default();
 
     // Overlay custom-agent ACP capability (built-ins were resolved in the
     // constructor). Distinct `(profile, project_path)` pairs each resolve
@@ -127,11 +127,7 @@ pub async fn list_sessions(
         if resp.acp_capable {
             continue;
         }
-        let cfg = resolve_session_cfg(
-            &mut session_cfg_cache,
-            &inst.source_profile,
-            &inst.project_path,
-        );
+        let cfg = session_cfg_cache.resolve(&inst.source_profile, &inst.project_path);
         resp.acp_capable = custom_agent_acp_capable(cfg, &inst.tool);
     }
 
@@ -238,11 +234,7 @@ pub async fn list_sessions(
             if attempted.contains(&inst.id) {
                 continue;
             }
-            let session_cfg = resolve_session_cfg(
-                &mut session_cfg_cache,
-                &inst.source_profile,
-                &inst.project_path,
-            );
+            let session_cfg = session_cfg_cache.resolve(&inst.source_profile, &inst.project_path);
             let cfg = resolve_smart_rename_config(session_cfg);
             let eligible = check_eligible_resolved(
                 inst.is_structured(),
@@ -260,6 +252,18 @@ pub async fn list_sessions(
             }
         }
     }
+
+    // Both overlays have run, so the count is final for this request.
+    let resolver_misses = session_cfg_cache.misses();
+    state
+        .list_sessions_resolver_misses
+        .store(resolver_misses, std::sync::atomic::Ordering::Relaxed);
+    tracing::debug!(
+        target: "http.api.sessions",
+        rows = sessions.len(),
+        resolver_misses,
+        "list_sessions resolved session config once per unique profile/project pair"
+    );
 
     // The park probe touches config files and SQLite; run it with the
     // session registry unlocked so writers are not held behind it.

--- a/src/server/api/sessions/model.rs
+++ b/src/server/api/sessions/model.rs
@@ -310,34 +310,35 @@ pub(super) fn custom_agent_acp_capable(
         || crate::acp::inherited_acp_base(tool, &session.agent_detect_as).is_some()
 }
 
-/// Resolve the [`SessionConfig`] for `(profile, project_path)` through the
-/// caller-owned per-request cache, resolving from disk on first miss only.
-/// See the `session_cfg_cache` declaration in `list_sessions` for the
-/// sharing rationale. See #2603.
-pub(super) fn resolve_session_cfg<'a>(
-    cache: &'a mut HashMap<(String, String), SessionConfig>,
-    profile: &str,
-    project_path: &str,
-) -> &'a SessionConfig {
-    cache
-        .entry((profile.to_string(), project_path.to_string()))
-        .or_insert_with(|| {
-            #[cfg(test)]
-            LIST_SESSIONS_RESOLVER_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            crate::session::config::repo_config::resolve_config_with_repo_or_warn(
-                profile,
-                std::path::Path::new(project_path),
-            )
-            .session
-        })
+/// Per-request cache for `(profile, project_path)` config resolution, shared
+/// across the `list_sessions` overlays so a repo-local override is read from
+/// disk once per unique pair rather than once per row. See #2603.
+#[derive(Default)]
+pub(super) struct SessionCfgCache {
+    entries: HashMap<(String, String), SessionConfig>,
+    misses: usize,
 }
 
-/// Test seam for the shared per-request cache invariant (#2603): bumped
-/// exactly once per unique `(profile, project_path)` that resolves through
-/// [`resolve_session_cfg`]. Mirrors the module-static test seam pattern used
-/// by [`crate::session::FAIL_NEXT_LIST_PROFILES`]. Readers must hold
-/// `#[serial_test::serial]`: a concurrent `list_sessions` call between reset
-/// and load would leak bumps into the assertion.
-#[cfg(test)]
-pub(crate) static LIST_SESSIONS_RESOLVER_MISSES: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+impl SessionCfgCache {
+    /// Resolve `(profile, project_path)`, reading from disk on first miss only.
+    pub(super) fn resolve(&mut self, profile: &str, project_path: &str) -> &SessionConfig {
+        let misses = &mut self.misses;
+        self.entries
+            .entry((profile.to_string(), project_path.to_string()))
+            .or_insert_with(|| {
+                *misses += 1;
+                crate::session::config::repo_config::resolve_config_with_repo_or_warn(
+                    profile,
+                    std::path::Path::new(project_path),
+                )
+                .session
+            })
+    }
+
+    /// Disk resolutions performed, i.e. unique pairs seen. `list_sessions`
+    /// publishes this on [`crate::server::AppState`] so the sharing invariant
+    /// is observable per request instead of through a process-global counter.
+    pub(super) fn misses(&self) -> usize {
+        self.misses
+    }
+}

--- a/src/server/api/sessions/model.rs
+++ b/src/server/api/sessions/model.rs
@@ -313,32 +313,36 @@ pub(super) fn custom_agent_acp_capable(
 /// Per-request cache for `(profile, project_path)` config resolution, shared
 /// across the `list_sessions` overlays so a repo-local override is read from
 /// disk once per unique pair rather than once per row. See #2603.
-#[derive(Default)]
-pub(super) struct SessionCfgCache {
+pub(super) struct SessionCfgCache<'a> {
     entries: HashMap<(String, String), SessionConfig>,
-    misses: usize,
+    /// Where this cache reports its disk reads. The counter belongs to the
+    /// request, not to the cache, so every cache the request opens adds to
+    /// one total: splitting the shared cache per overlay then shows up as
+    /// extra resolutions instead of hiding behind a second private tally.
+    /// There is no counter-less constructor for the same reason.
+    misses: &'a std::sync::atomic::AtomicUsize,
 }
 
-impl SessionCfgCache {
+impl<'a> SessionCfgCache<'a> {
+    pub(super) fn new(misses: &'a std::sync::atomic::AtomicUsize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            misses,
+        }
+    }
+
     /// Resolve `(profile, project_path)`, reading from disk on first miss only.
     pub(super) fn resolve(&mut self, profile: &str, project_path: &str) -> &SessionConfig {
-        let misses = &mut self.misses;
+        let misses = self.misses;
         self.entries
             .entry((profile.to_string(), project_path.to_string()))
             .or_insert_with(|| {
-                *misses += 1;
+                misses.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 crate::session::config::repo_config::resolve_config_with_repo_or_warn(
                     profile,
                     std::path::Path::new(project_path),
                 )
                 .session
             })
-    }
-
-    /// Disk resolutions performed, i.e. unique pairs seen. `list_sessions`
-    /// publishes this on [`crate::server::AppState`] so the sharing invariant
-    /// is observable per request instead of through a process-global counter.
-    pub(super) fn misses(&self) -> usize {
-        self.misses
     }
 }

--- a/src/server/api/sessions/tests.rs
+++ b/src/server/api/sessions/tests.rs
@@ -639,19 +639,19 @@ async fn list_sessions_shares_config_resolution_across_overlays() {
     let a2 = mk("default", "/tmp/repo-a-2603");
     let b = mk("default", "/tmp/repo-b-2603");
 
+    // The counter lives on this state, so no concurrent test can bump it.
     let state = crate::server::test_support::build_test_app_state(vec![a, a2, b]);
 
-    LIST_SESSIONS_RESOLVER_MISSES.store(0, Ordering::Relaxed);
     let _envelope = list_sessions(
         axum::extract::State(state.clone()),
         axum::extract::Query(ListSessionsQuery { state: None }),
     )
     .await;
-    let misses = LIST_SESSIONS_RESOLVER_MISSES.load(Ordering::Relaxed);
+    let misses = state.list_sessions_resolver_misses.load(Ordering::Relaxed);
 
     assert_eq!(
         misses, 2,
-        "shared cache must resolve exactly once per unique (profile, project_path) across both overlays; got {misses}",
+        "shared cache must resolve once per unique (profile, project_path) across both overlays; got {misses}",
     );
 }
 

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -709,6 +709,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         allowed_origins,
         instance_locks,
         idempotency_locks,
+        list_sessions_resolver_misses: std::sync::atomic::AtomicUsize::new(0),
         smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
         smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
         smart_rename_semaphore: tokio::sync::Semaphore::new(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -142,6 +142,13 @@ pub struct AppState {
     /// the daemon has ever seen. See #3156.
     pub idempotency_locks:
         Arc<RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// Disk config resolutions performed by the most recent `list_sessions`
+    /// request, one per unique `(profile, project_path)`. Published per
+    /// request so the shared-cache invariant (#2603) is visible in the
+    /// request log and can be asserted against a single `AppState`, rather
+    /// than through a process-global counter every concurrent test would
+    /// have to serialize against.
+    pub list_sessions_resolver_misses: std::sync::atomic::AtomicUsize,
     /// Session ids with an in-flight smart-rename one-shot, so a burst of rapid
     /// first prompts cannot spawn concurrent title generators for the same
     /// session. Synchronous mutex: critical sections are tiny and never span an

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -142,12 +142,12 @@ pub struct AppState {
     /// the daemon has ever seen. See #3156.
     pub idempotency_locks:
         Arc<RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
-    /// Disk config resolutions performed by the most recent `list_sessions`
-    /// request, one per unique `(profile, project_path)`. Published per
-    /// request so the shared-cache invariant (#2603) is visible in the
-    /// request log and can be asserted against a single `AppState`, rather
-    /// than through a process-global counter every concurrent test would
-    /// have to serialize against.
+    /// Disk config resolutions performed by `list_sessions`, one per unique
+    /// `(profile, project_path)` per request, accumulated monotonically.
+    /// Every cache a request opens reports here, so the shared-cache
+    /// invariant (#2603) still fails loudly if an overlay is given its own
+    /// cache. Scoped to one `AppState` rather than the process so a
+    /// concurrent test cannot leak counts into an assertion.
     pub list_sessions_resolver_misses: std::sync::atomic::AtomicUsize,
     /// Session ids with an in-flight smart-rename one-shot, so a burst of rapid
     /// first prompts cannot spawn concurrent title generators for the same

--- a/src/server/test_support.rs
+++ b/src/server/test_support.rs
@@ -97,6 +97,7 @@ fn build_test_app_state_impl(
         allowed_origins,
         instance_locks,
         idempotency_locks,
+        list_sessions_resolver_misses: std::sync::atomic::AtomicUsize::new(0),
         smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
         smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
         smart_rename_semaphore: tokio::sync::Semaphore::new(


### PR DESCRIPTION
## Description

`list_sessions_shares_config_resolution_across_overlays` asserted against a process-global `LIST_SESSIONS_RESOLVER_MISSES` that every `list_sessions` call in the process bumped. Any concurrent caller landing between the counter's reset and its load leaked misses into the assertion. The static's own doc comment named the hazard and pushed the burden onto readers via `#[serial]`, which cannot cover unmarked tests. It failed `Cargo Test (linux, bare-core)` during #3882 with 3 misses instead of 2, and passed on re-run.

The counter now lives in the per-request cache, promoted to a `SessionCfgCache` owning its entries and its miss count, and `list_sessions` publishes that count on `AppState` once both overlays have run. Each test builds its own `AppState`, so the assertion cannot observe another request's resolutions. The count also reaches a `debug!` line, so the sharing invariant (#2603) is visible in the request log instead of only under `cfg(test)`.

The integration-level assertion is kept deliberately: a unit test on the cache alone would still pass if an overlay were given its own cache, which is the regression #2603 guards against.

Verified by hammering `list_sessions` on a second `AppState` from a concurrent task, 200 iterations: the old global read 98 where 2 was expected; the per-state counter read 2 every time. That scratch test is not committed.

I did not identify which concurrent test triggered the CI failure. Both `list_sessions` callers in the suite are `#[serial]`, and the router tests that reach `/api/sessions` are denied before the handler with empty state. The fix removes the class rather than the one trigger.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The existing test is the coverage; this change makes it deterministic. No behavior change to the endpoint.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Diagnosed and written in a Claude Code session with @njbrake, including the concurrency experiment that pinned the mechanism.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAR986qooEi4ev6gg1c7aw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replaced process-global miss tracking with request-scoped tracking in `SessionCfgCache`.
- Shared the miss counter across both session-config overlays.
- Added per-request miss reporting and debug logging through `AppState`.
- Updated tests and state initialization for the new counter.

## Benefits

- Prevents concurrent requests from affecting cache-invariant tests.
- Preserves detection of split caches across overlays.
- Keeps endpoint behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->