### PR TITLE
fix(web): keep IME edits on the active terminal surface

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -873,27 +873,22 @@ function AppContent({
     }
   };
 
-  // The keyboard proxy survives terminal mounts so iOS can retain the focus
-  // authorized by a sidebar tap. Drop its receiver only at a real session
-  // boundary: clearing it while reselecting the active session leaves that
-  // still-mounted terminal without anything to re-register it.
+  // Preserve the gesture-authorized proxy, but never carry its edits across
+  // sessions or mobile surfaces. Reselecting the same target keeps its receiver.
   const keyboardProxySessionIdRef = useRef(activeSessionId);
-  const transitionKeyboardProxy = useCallback((nextSessionId: string | null) => {
-    if (keyboardProxySessionIdRef.current === nextSessionId) return;
+  const keyboardProxyViewRef = useRef<RightPanelView>(singlePane ? rightPanelView : "agent");
+  const transitionKeyboardProxy = useCallback((nextSessionId: string | null, nextView: RightPanelView) => {
+    if (keyboardProxySessionIdRef.current === nextSessionId && keyboardProxyViewRef.current === nextView) return;
     keyboardProxySessionIdRef.current = nextSessionId;
-    // The retained syllable mirrors the old session's PTY edit, so carrying
-    // it over would let the next deleteContentBackward delete the new
-    // session's text before the replacement arrives.
+    keyboardProxyViewRef.current = nextView;
     if (keyboardProxyRef.current) keyboardProxyRef.current.value = "";
     clearMobileKeyboardProxyInput();
   }, []);
 
-  // Sidebar selection clears before the proxy can accept another edit. This
-  // also covers browser history and every other route change before the next
-  // input event, without clearing an unchanged session.
+  // Cover history and programmatic switches before the next input event.
   useLayoutEffect(() => {
-    transitionKeyboardProxy(activeSessionId);
-  }, [activeSessionId, transitionKeyboardProxy]);
+    transitionKeyboardProxy(activeSessionId, singlePane ? rightPanelView : "agent");
+  }, [activeSessionId, singlePane, rightPanelView, transitionKeyboardProxy]);
 
   useEffect(() => {
     const proxy = keyboardProxy;
@@ -918,7 +913,7 @@ function AppContent({
       const ws = workspaces.find((w) => w.sessions.some((s) => s.id === sessionId));
       if (ws) {
         const picked = ws.sessions.find((s) => s.id === sessionId);
-        transitionKeyboardProxy(sessionId);
+        transitionKeyboardProxy(sessionId, sessionId === activeSessionId && singlePane ? rightPanelView : "agent");
         navigate(`/session/${encodeURIComponent(sessionId)}`);
         // iOS does not permit a session's asynchronously mounted terminal
         // input to inherit this sidebar tap's keyboard authorization. The
@@ -943,7 +938,17 @@ function AppContent({
         if (window.innerWidth < 768) setSidebarOpen(false);
       }
     },
-    [navigate, workspaces, focusAgentInput, isCoarse, transitionKeyboardProxy, webSettings.autoOpenKeyboard],
+    [
+      navigate,
+      workspaces,
+      focusAgentInput,
+      isCoarse,
+      transitionKeyboardProxy,
+      webSettings.autoOpenKeyboard,
+      activeSessionId,
+      singlePane,
+      rightPanelView,
+    ],
   );
 
   const handleSelectWorkspace = (workspaceId: string, sessionId: string | null) => {
@@ -951,7 +956,7 @@ function AppContent({
     if (ws) {
       const picked = ws.sessions.find((s) => s.id === sessionId);
       if (picked) {
-        transitionKeyboardProxy(picked.id);
+        transitionKeyboardProxy(picked.id, picked.id === activeSessionId && singlePane ? rightPanelView : "agent");
         navigate(`/session/${encodeURIComponent(picked.id)}`);
         // See handleSelectSession: keep focus on the persistent keyboard input
         // until the selected surface can receive it.
@@ -967,7 +972,7 @@ function AppContent({
           focusAgentInput(picked);
         }
       } else {
-        transitionKeyboardProxy(null);
+        transitionKeyboardProxy(null, "agent");
         navigate("/");
       }
     }
@@ -1364,10 +1369,14 @@ function AppContent({
     }
   }, [isMdUp, rightDockCollapsed, setDockCollapsed, availableRightGroups.length, openTab]);
 
-  const handlePickView = useCallback((view: RightPanelView) => {
-    setRightPanelView(view);
-    setPickerOpen(false);
-  }, []);
+  const handlePickView = useCallback(
+    (view: RightPanelView) => {
+      transitionKeyboardProxy(activeSessionId, view);
+      setRightPanelView(view);
+      setPickerOpen(false);
+    },
+    [activeSessionId, transitionKeyboardProxy],
+  );
 
   const handleSelectFile = useCallback((path: string, repoName?: string, line?: number) => {
     setSelectedFile({ path, repoName, line });
@@ -1783,7 +1792,7 @@ function AppContent({
         <MobileMainPane
           view={rightPanelView}
           pluginPanes={pluginPanes}
-          onBackToAgent={() => setRightPanelView("agent")}
+          onBackToAgent={() => handlePickView("agent")}
           pairedMounted={pairedMounted}
           activeSession={activeSession ?? null}
           activeSessionId={activeSessionId}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1720,12 +1720,10 @@ export function MobileLiveTerminal({
     [sendData, ctrlActiveRef, clearCtrl],
   );
 
-  // Mirrors `active` for async continuations: a paste's upload completion
-  // must observe whether this session still owns the foreground AT THAT
-  // TIME, not at paste time (the handler's closure captures the paste-time
-  // value). See #3885 review.
   const activeRef = useRef(active);
-  activeRef.current = active;
+  useLayoutEffect(() => {
+    activeRef.current = active;
+  }, [active]);
 
   // Native (not React-synthetic) beforeinput: React's onBeforeInput is
   // backed by keypress in Chromium and carries no inputType, so the
@@ -1865,23 +1863,17 @@ export function MobileLiveTerminal({
         );
         const parts = [text.trim(), ...paths.map(escapePastePath)].filter((s) => s.length > 0);
         if (parts.length === 0) return;
-        // Leading and trailing spaces keep the path from gluing onto queued
-        // text or the user's next keystroke. No newline: never auto-submit.
-        // Re-invalidated here too: the upload's await leaves room for the
-        // user to type a syllable this insert would then displace. The
-        // live terminal's own textarea must be named: with no target the
-        // helper clears only the proxy, and the local shadow would keep
-        // the syllable the pasted path displaces. The shared proxy is only
-        // cleared while this session still owns the foreground NOW (ref,
-        // not the paste-time closure): a late upload from a backgrounded
-        // session must not wipe the syllable the foreground session's
-        // proxy retained. See #3885.
-        if (activeRef.current) invalidateRetainedImeContext(inputRef.current);
-        else if (inputRef.current) inputRef.current.value = "";
+        const target = inputRef.current;
+        if (!target) return;
+        // An unmounted session cannot send; a background session may finish
+        // its own paste but must not invalidate the foreground proxy.
+        if (activeRef.current) invalidateRetainedImeContext(target);
+        else target.value = "";
+        // Pad the path without submitting the command.
         sendData(bracketedPaste(` ${parts.join(" ")} `));
       })();
     },
-    [active, inputRef, sendData, uploadPastedImage],
+    [inputRef, sendData, uploadPastedImage],
   );
 
   const handleCompositionStart = useCallback(() => {

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1909,16 +1909,14 @@ export function MobileLiveTerminal({
       // Only a composition that took over the typed word may have its prefix
       // dropped; anything else is new text and goes to the pane whole.
       const rest = retroactive && data.startsWith(run) ? data.slice(run.length) : data;
-      // The typed word is still the one under the caret, so a second
-      // composition over it (a suggestion tap, then the space commit) has to
-      // be stripped against everything the pane has of that word. A
-      // composition that stood on its own leaves no typed word behind: its
-      // result must not become a run for the next composition to strip.
       if (!rest) typedWordRef.current = run;
-      else if (sendKeys(rest) && retroactive) typedWordRef.current = plainRunAfter(run, rest);
-      // Leave the committed text in the textarea: an IME that re-edits a
-      // committed syllable (delete + reinsert) needs it there for the delete
-      // to surface as a beforeinput. See forwardTerminalBeforeInput.
+      else if (!sendKeys(rest)) {
+        invalidateRetainedImeContext(e.target instanceof HTMLTextAreaElement ? e.target : null);
+      } else if (retroactive) {
+        // A later suggestion must strip the whole word already sent.
+        typedWordRef.current = plainRunAfter(run, rest);
+      }
+      // Only accepted text may remain as context for an IME delete + reinsert.
     },
     [sendKeys, typedWordRef],
   );

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1720,6 +1720,13 @@ export function MobileLiveTerminal({
     [sendData, ctrlActiveRef, clearCtrl],
   );
 
+  // Mirrors `active` for async continuations: a paste's upload completion
+  // must observe whether this session still owns the foreground AT THAT
+  // TIME, not at paste time (the handler's closure captures the paste-time
+  // value). See #3885 review.
+  const activeRef = useRef(active);
+  activeRef.current = active;
+
   // Native (not React-synthetic) beforeinput: React's onBeforeInput is
   // backed by keypress in Chromium and carries no inputType, so the
   // soft-keyboard input types below would never match through it.
@@ -1864,12 +1871,17 @@ export function MobileLiveTerminal({
         // user to type a syllable this insert would then displace. The
         // live terminal's own textarea must be named: with no target the
         // helper clears only the proxy, and the local shadow would keep
-        // the syllable the pasted path displaces. See #3885.
-        invalidateRetainedImeContext(inputRef.current);
+        // the syllable the pasted path displaces. The shared proxy is only
+        // cleared while this session still owns the foreground NOW (ref,
+        // not the paste-time closure): a late upload from a backgrounded
+        // session must not wipe the syllable the foreground session's
+        // proxy retained. See #3885.
+        if (activeRef.current) invalidateRetainedImeContext(inputRef.current);
+        else if (inputRef.current) inputRef.current.value = "";
         sendData(bracketedPaste(` ${parts.join(" ")} `));
       })();
     },
-    [inputRef, sendData, uploadPastedImage],
+    [active, inputRef, sendData, uploadPastedImage],
   );
 
   const handleCompositionStart = useCallback(() => {

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1861,12 +1861,15 @@ export function MobileLiveTerminal({
         // Leading and trailing spaces keep the path from gluing onto queued
         // text or the user's next keystroke. No newline: never auto-submit.
         // Re-invalidated here too: the upload's await leaves room for the
-        // user to type a syllable this insert would then displace.
-        invalidateRetainedImeContext();
+        // user to type a syllable this insert would then displace. The
+        // live terminal's own textarea must be named: with no target the
+        // helper clears only the proxy, and the local shadow would keep
+        // the syllable the pasted path displaces. See #3885.
+        invalidateRetainedImeContext(inputRef.current);
         sendData(bracketedPaste(` ${parts.join(" ")} `));
       })();
     },
-    [sendData, uploadPastedImage],
+    [inputRef, sendData, uploadPastedImage],
   );
 
   const handleCompositionStart = useCallback(() => {

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -52,11 +52,8 @@ function layerClass(active: boolean): string {
   return active ? base : `${base} invisible pointer-events-none`;
 }
 
-/** The single full-viewport pane shown below the `md` breakpoint (#1452).
- *  The picker promotes one of agent / diff / paired into it. The agent
- *  terminal and the paired shell (once first opened) stay mounted but
- *  hidden via `visibility` so their PTY, scrollback, and focus survive
- *  view switches; `display:none` would collapse xterm geometry to zero. */
+/** Keep terminal geometry and scrollback across switches; only the visible
+ *  surface owns keyboard input. */
 export function MobileMainPane({
   view,
   pluginPanes,
@@ -127,17 +124,13 @@ export function MobileMainPane({
               />
             </Suspense>
           ) : (
-            // Reserve the bottom home-indicator inset on this wrapper (the App
-            // root no longer does; see index.css .safe-area-inset) so the last
-            // terminal row clears it. Kept off the pane root itself, which owns
-            // the keyboard-open lift and must stay inset-free when closed (#1432).
-            // Collapses to 0 with the keyboard open (iOS reports the inset as 0)
-            // and on desktop.
+            // Clear the home indicator without changing the keyboard-open lift.
             <div
               className="flex-1 flex flex-col min-h-0 overflow-hidden"
               style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
             >
               <TerminalSessionStack
+                active={view === "agent"}
                 activeSessionId={activeSessionId!}
                 sessions={sessions.filter((session) => session.view !== "structured")}
                 persistent={webSettings.persistentTerminals}
@@ -148,19 +141,14 @@ export function MobileMainPane({
         </div>
 
         {pairedMounted && (
-          // Reserve the bottom home-indicator inset here too (the App root no
-          // longer does; see index.css .safe-area-inset), matching the agent
-          // terminal wrapper above. The paired shell is the same LiveTerminalView
-          // component, so it needs identical clearance; without it the last row
-          // and toolbar sat under the home indicator. Collapses to 0 with the
-          // keyboard open (iOS reports the inset as 0) and on desktop.
+          // Match the agent terminal’s home-indicator clearance.
           <div
             className={layerClass(view === "paired")}
             inert={view !== "paired"}
             data-testid="mobile-paired-layer"
             style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
           >
-            <PairedShellPane session={activeSession} sessionId={activeSessionId} />
+            <PairedShellPane session={activeSession} sessionId={activeSessionId} active={view === "paired"} />
           </div>
         )}
 

--- a/web/src/components/PairedTerminal.tsx
+++ b/web/src/components/PairedTerminal.tsx
@@ -4,17 +4,16 @@ import type { SessionResponse } from "../lib/types";
 
 type ShellMode = "host" | "container";
 
-/** Host/container shell switch plus the paired terminal. Used both in the
- *  desktop right-panel split and as the promoted single full-viewport mobile
- *  pane. Renders the capture-snapshot live view on every device (same
- *  architecture as the agent pane); the xterm.js PTY relay was removed. */
+/** Host/container shell shared by desktop docks and the mobile paired view. */
 export function PairedShellPane({
   session,
   sessionId,
+  active = true,
   terminalIndex = 0,
 }: {
   session: SessionResponse | null;
   sessionId: string | null;
+  active?: boolean;
   /** Which paired-terminal instance this tab renders (#2437). 0 is the
    *  primary shell shared with the native TUI. */
   terminalIndex?: number;
@@ -53,6 +52,7 @@ export function PairedShellPane({
         <LiveTerminalView
           key={`${sessionId}-${effectiveMode}-${terminalIndex}`}
           session={session}
+          active={active}
           surface={effectiveMode === "container" ? "paired-container" : "paired-host"}
           terminalIndex={terminalIndex}
         />

--- a/web/src/components/TerminalSessionStack.tsx
+++ b/web/src/components/TerminalSessionStack.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_PERSISTENT_TERMINALS, normalizePersistentTerminalLimit } from "
 import { TerminalView } from "./TerminalView";
 
 interface Props {
+  active?: boolean;
   activeSessionId: string;
   sessions: SessionResponse[];
   persistent: boolean;
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export function TerminalSessionStack({
+  active = true,
   activeSessionId,
   sessions,
   persistent,
@@ -55,18 +57,18 @@ export function TerminalSessionStack({
       {visibleIds.map((sessionId) => {
         const session = sessionsById.get(sessionId);
         if (!session) return null;
-        const active = sessionId === activeSessionId;
+        const selected = sessionId === activeSessionId;
         return (
           <div
             key={sessionId}
-            aria-hidden={!active}
+            aria-hidden={!selected}
             className={
-              active
+              selected
                 ? "absolute inset-0 flex flex-col min-h-0"
                 : "absolute inset-0 flex flex-col min-h-0 invisible pointer-events-none"
             }
           >
-            <TerminalView session={session} active={active} />
+            <TerminalView session={session} active={active && selected} />
           </div>
         );
       })}

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -11,9 +11,14 @@
 
 import { createRef } from "react";
 import { describe, expect, it, vi, beforeAll } from "vitest";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { MobileLiveTerminal } from "../MobileLiveTerminal";
 import type { LiveFrame } from "../../hooks/useLiveTerminal";
+import {
+  clearMobileKeyboardProxyInput,
+  deliverMobileKeyboardProxyInput,
+  forwardTerminalBeforeInput,
+} from "../../lib/mobileKeyboardProxy";
 
 vi.mock("../../hooks/useWebSettings", () => ({
   useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
@@ -43,10 +48,11 @@ const frame: LiveFrame = {
   mouseSgr: false,
 };
 
-function renderTerm(uploadPastedImage = vi.fn().mockResolvedValue(null)) {
+function renderTerm(uploadPastedImage = vi.fn().mockResolvedValue(null), ctrlActive = false) {
   const inputRef = createRef<HTMLTextAreaElement>();
-  const sendData = vi.fn();
-  render(
+  const ctrlActiveRef = { current: ctrlActive };
+  const sendData = vi.fn<(data: string) => boolean>(() => true);
+  const view = render(
     <MobileLiveTerminal
       frame={frame}
       connected
@@ -62,15 +68,17 @@ function renderTerm(uploadPastedImage = vi.fn().mockResolvedValue(null)) {
       uploadPastedImage={uploadPastedImage}
       forwardWheel={vi.fn()}
       forwardButton={vi.fn()}
-      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
-      clearCtrl={vi.fn()}
+      ctrlActiveRef={ctrlActiveRef}
+      clearCtrl={() => {
+        ctrlActiveRef.current = false;
+      }}
       inputRef={inputRef}
       onInputFocusChange={vi.fn()}
       bottomAlign
       keyboardOpen={false}
     />,
   );
-  return { input: inputRef.current!, sendData, uploadPastedImage };
+  return { input: inputRef.current!, sendData, uploadPastedImage, unmount: view.unmount };
 }
 
 // A clipboard item wrapping a File, as clipboardData.items exposes it.
@@ -102,6 +110,65 @@ function stubKeyboardLayout(entries: [string, string][]) {
 }
 
 describe("MobileLiveTerminal paste", () => {
+  it("retains accepted replay after a Ctrl chord for the next Korean rewrite", () => {
+    clearMobileKeyboardProxyInput();
+    const proxy = document.createElement("textarea");
+    proxy.dataset.keyboardProxy = "";
+    proxy.value = "cㅎ";
+    document.body.append(proxy);
+    try {
+      deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "c", isComposing: false });
+      deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "ㅎ", isComposing: false });
+      const { sendData } = renderTerm(undefined, true);
+      expect(sendData.mock.calls.map(([data]) => data).join("")).toBe("\x03ㅎ");
+      expect(proxy.value).toBe("ㅎ");
+      proxy.addEventListener("beforeinput", (event) =>
+        forwardTerminalBeforeInput(event as InputEvent, deliverMobileKeyboardProxyInput),
+      );
+      expect(
+        proxy.dispatchEvent(
+          new InputEvent("beforeinput", { inputType: "deleteContentBackward", bubbles: true, cancelable: true }),
+        ),
+      ).toBe(true);
+      proxy.value = "";
+      expect(
+        proxy.dispatchEvent(
+          new InputEvent("beforeinput", { inputType: "insertText", data: "하", bubbles: true, cancelable: true }),
+        ),
+      ).toBe(true);
+      proxy.value = "하";
+      expect(sendData.mock.calls.map(([data]) => data).join("")).toBe("\x03ㅎ\x7f하");
+    } finally {
+      proxy.remove();
+      clearMobileKeyboardProxyInput();
+    }
+  });
+
+  it("does not invalidate another session's proxy after the uploading terminal unmounts", async () => {
+    let finish!: (path: string) => void;
+    const pending = new Promise<string>((resolve) => {
+      finish = resolve;
+    });
+    const { input, sendData, unmount } = renderTerm(vi.fn(() => pending));
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => "", items: [imageItem(new File(["x"], "shot.png", { type: "image/png" }))] },
+    });
+    unmount();
+    const proxy = document.createElement("textarea");
+    proxy.dataset.keyboardProxy = "";
+    proxy.value = "ㅎ";
+    document.body.append(proxy);
+    try {
+      await act(async () => {
+        finish("/tmp/paste.png");
+        await pending;
+      });
+      expect(proxy.value).toBe("ㅎ");
+      expect(sendData).not.toHaveBeenCalled();
+    } finally {
+      proxy.remove();
+    }
+  });
   it("does not swallow Ctrl+V into a literal ^V, and the paste event sends a bracketed paste", () => {
     const { input, sendData } = renderTerm();
 

--- a/web/src/lib/mobileKeyboardProxy.test.ts
+++ b/web/src/lib/mobileKeyboardProxy.test.ts
@@ -140,7 +140,7 @@ describe("mobile keyboard proxy", () => {
 
   // A drained queue with an accepting receiver leaves the proxy alone.
   it("keeps the proxy content when drained edits are accepted", () => {
-    document.body.innerHTML = '<textarea data-keyboard-proxy></textarea>';
+    document.body.innerHTML = "<textarea data-keyboard-proxy></textarea>";
     const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]")!;
     proxy.value = "ㅎ";
     deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "가", isComposing: false });

--- a/web/src/lib/mobileKeyboardProxy.test.ts
+++ b/web/src/lib/mobileKeyboardProxy.test.ts
@@ -78,11 +78,12 @@ describe("forwardTerminalBeforeInput", () => {
     expect(ev.defaultPrevented).toBe(true);
   });
 
-  it("cancels a delete the pane refused, so the textarea keeps its text", () => {
+  it("cancels a refused delete and drops the retained text", () => {
     const ta = document.createElement("textarea");
     ta.value = "\uadf8";
     const { ev } = beforeInput(ta, { inputType: "deleteContentBackward" }, false);
     expect(ev.defaultPrevented).toBe(true);
+    expect(ta.value).toBe("");
   });
 
   it("ignores other input types", () => {
@@ -152,17 +153,6 @@ describe("mobile keyboard proxy", () => {
     document.body.innerHTML = "";
   });
 
-  // Drain without a mounted proxy (unit callers, non-browser consumers):
-  // the refusal path must tolerate the missing element.
-  it("tolerates a missing proxy when a drained edit is refused", () => {
-    document.body.innerHTML = "";
-    deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "ㅎ", isComposing: false });
-    const receive = vi.fn(() => false);
-    const unregister = registerMobileKeyboardProxyReceiver(receive);
-    expect(receive).toHaveBeenCalled();
-    unregister();
-  });
-
   // Unregistering a receiver that is not the current one must not detach
   // the live receiver.
   it("keeps the current receiver when an older cleanup runs", () => {
@@ -182,13 +172,12 @@ describe("mobile keyboard proxy", () => {
 // must also tolerate a non-textarea target (the handler is wired per-input,
 // but nothing in the helper's contract guarantees it).
 describe("forwardTerminalBeforeInput refused-edit target guard", () => {
-  it("does not throw when the target is not a textarea", () => {
+  it("prevents refused edits on non-textarea targets", () => {
     const div = document.createElement("div");
-    div.dispatchEvent = () => true; // not used directly; helper is called explicitly
     const deliver = vi.fn(() => false);
     const ev = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: "c" });
     Object.defineProperty(ev, "target", { value: div });
-    expect(() => forwardTerminalBeforeInput(ev, deliver)).not.toThrow();
+    forwardTerminalBeforeInput(ev, deliver);
     expect(ev.defaultPrevented).toBe(true);
   });
 

--- a/web/src/lib/mobileKeyboardProxy.test.ts
+++ b/web/src/lib/mobileKeyboardProxy.test.ts
@@ -49,6 +49,17 @@ describe("forwardTerminalBeforeInput", () => {
     expect(ta.value).toBe("");
   });
 
+  // The line-break branch runs for other targets too (the helper is
+  // target-agnostic); it must not throw on a non-textarea.
+  it("tolerates a non-textarea target on line breaks", () => {
+    const div = document.createElement("div");
+    const deliver = vi.fn(() => true);
+    const ev = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertLineBreak" });
+    Object.defineProperty(ev, "target", { value: div });
+    expect(() => forwardTerminalBeforeInput(ev, deliver)).not.toThrow();
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
   it("swallows pastes so they never enter the textarea", () => {
     const ta = document.createElement("textarea");
     const { ev, deliver } = beforeInput(ta, { inputType: "insertFromPaste", data: "a\nb" });
@@ -125,6 +136,71 @@ describe("mobile keyboard proxy", () => {
     expect(proxy.value).toBe("");
     unregister();
     document.body.innerHTML = "";
+  });
+
+  // A drained queue with an accepting receiver leaves the proxy alone.
+  it("keeps the proxy content when drained edits are accepted", () => {
+    document.body.innerHTML = '<textarea data-keyboard-proxy></textarea>';
+    const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]")!;
+    proxy.value = "ㅎ";
+    deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "가", isComposing: false });
+    const receive = vi.fn(() => true);
+    const unregister = registerMobileKeyboardProxyReceiver(receive);
+    expect(receive).toHaveBeenCalled();
+    expect(proxy.value).toBe("ㅎ");
+    unregister();
+    document.body.innerHTML = "";
+  });
+
+  // Drain without a mounted proxy (unit callers, non-browser consumers):
+  // the refusal path must tolerate the missing element.
+  it("tolerates a missing proxy when a drained edit is refused", () => {
+    document.body.innerHTML = "";
+    deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "ㅎ", isComposing: false });
+    const receive = vi.fn(() => false);
+    const unregister = registerMobileKeyboardProxyReceiver(receive);
+    expect(receive).toHaveBeenCalled();
+    unregister();
+  });
+
+  // Unregistering a receiver that is not the current one must not detach
+  // the live receiver.
+  it("keeps the current receiver when an older cleanup runs", () => {
+    const first = vi.fn(() => true);
+    const stop1 = registerMobileKeyboardProxyReceiver(first);
+    const second = vi.fn(() => true);
+    const stop2 = registerMobileKeyboardProxyReceiver(second);
+    stop1();
+    deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "x", isComposing: false });
+    expect(second).toHaveBeenCalledWith({ inputType: "insertText", data: "x", isComposing: false });
+    expect(first).not.toHaveBeenCalledWith({ inputType: "insertText", data: "x", isComposing: false });
+    stop2();
+  });
+});
+
+// #3885: a refused edit clears the target when it is a textarea. The guard
+// must also tolerate a non-textarea target (the handler is wired per-input,
+// but nothing in the helper's contract guarantees it).
+describe("forwardTerminalBeforeInput refused-edit target guard", () => {
+  it("does not throw when the target is not a textarea", () => {
+    const div = document.createElement("div");
+    div.dispatchEvent = () => true; // not used directly; helper is called explicitly
+    const deliver = vi.fn(() => false);
+    const ev = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: "c" });
+    Object.defineProperty(ev, "target", { value: div });
+    expect(() => forwardTerminalBeforeInput(ev, deliver)).not.toThrow();
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("clears the target textarea when the pane refuses the edit", () => {
+    const ta = document.createElement("textarea");
+    ta.value = "한";
+    const deliver = vi.fn(() => false);
+    const ev = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: "c" });
+    Object.defineProperty(ev, "target", { value: ta });
+    forwardTerminalBeforeInput(ev, deliver);
+    expect(ta.value).toBe("");
+    expect(ev.defaultPrevented).toBe(true);
   });
 });
 

--- a/web/src/lib/mobileKeyboardProxy.test.ts
+++ b/web/src/lib/mobileKeyboardProxy.test.ts
@@ -97,6 +97,25 @@ describe("mobile keyboard proxy", () => {
     registerMobileKeyboardProxyReceiver(receive);
     expect(receive).not.toHaveBeenCalled();
   });
+
+  // #3885 case 3: a queued edit the receiver refuses must not survive in the
+  // proxy textarea. The drain replays the queue verbatim; when the pane
+  // refuses an edit, the shadow that holds it no longer mirrors the line.
+  it("clears the proxy when a drained queued edit is refused", () => {
+    document.body.innerHTML = "<textarea data-keyboard-proxy></textarea>";
+    const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]")!;
+    proxy.value = "ㅎ";
+    expect(proxy.value).toBe("ㅎ");
+    deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "가", isComposing: false });
+
+    const receive = vi.fn(() => false);
+    const unregister = registerMobileKeyboardProxyReceiver(receive);
+    expect(receive).toHaveBeenCalledWith({ inputType: "insertText", data: "가", isComposing: false });
+    // The queued edit the pane refused must not leave the proxy holding "ㅎ".
+    expect(proxy.value).toBe("");
+    unregister();
+    document.body.innerHTML = "";
+  });
 });
 
 describe("invalidateRetainedImeContext", () => {
@@ -117,6 +136,23 @@ describe("invalidateRetainedImeContext", () => {
     invalidateRetainedImeContext(local);
 
     expect(local.value).toBe("");
+    expect(proxy.value).toBe("");
+  });
+
+  // #3885 case 2 shape: the no-argument call must not be relied on for the
+  // live terminal's own textarea. (The spec-level regression covers the
+  // upload completion; this pins the helper contract the fix rests on.)
+  it("clears only the proxy with no element passed", () => {
+    const proxy = document.createElement("textarea");
+    proxy.setAttribute("data-keyboard-proxy", "");
+    proxy.value = "ㅎ";
+    document.body.append(proxy);
+    const local = document.createElement("textarea");
+    local.value = "ㅎ";
+
+    invalidateRetainedImeContext();
+
+    expect(local.value).toBe("ㅎ");
     expect(proxy.value).toBe("");
   });
 

--- a/web/src/lib/mobileKeyboardProxy.test.ts
+++ b/web/src/lib/mobileKeyboardProxy.test.ts
@@ -90,6 +90,16 @@ describe("mobile keyboard proxy", () => {
     expect(receive).toHaveBeenCalledWith({ inputType: "insertText", data: "first", isComposing: false });
   });
 
+  // The overflow guard: a bound queue rejects further edits instead of
+  // growing without limit while no terminal is mounted.
+  it("rejects input past the queue bound", () => {
+    for (let i = 0; i < 128; i++) {
+      const ok = deliverMobileKeyboardProxyInput({ inputType: "insertText", data: `x${i}`, isComposing: false });
+      expect(ok).toBe(true);
+    }
+    expect(deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "over", isComposing: false })).toBe(false);
+  });
+
   it("drops queued input at a session boundary", () => {
     deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "old", isComposing: false });
     clearMobileKeyboardProxyInput();

--- a/web/src/lib/mobileKeyboardProxy.ts
+++ b/web/src/lib/mobileKeyboardProxy.ts
@@ -26,7 +26,15 @@ export function registerMobileKeyboardProxyReceiver(next: Receiver) {
   receiver = next;
   const queued = pending;
   pending = [];
-  for (const input of queued) next(input);
+  for (const input of queued) {
+    if (!next(input)) {
+      // A refused edit means the pane that just mounted rejected it; the
+      // shadow still holds the queued text, which the line does not show.
+      const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]");
+      if (proxy) proxy.value = "";
+      break;
+    }
+  }
   return () => {
     if (receiver === next) receiver = null;
   };
@@ -77,7 +85,16 @@ export function forwardTerminalBeforeInput(ev: InputEvent, deliver: Receiver) {
   switch (ev.inputType) {
     case "insertText":
     case "deleteContentBackward":
-      if (!deliver({ inputType: ev.inputType, data: ev.data, isComposing: ev.isComposing })) ev.preventDefault();
+      if (!deliver({ inputType: ev.inputType, data: ev.data, isComposing: ev.isComposing })) {
+        // The pane refused the edit (a Ctrl chord turned it into a control
+        // code; a read-only viewer dropped it), yet the shadow still holds
+        // the syllable it was mirroring. The chord consumed that shadow's
+        // job, so whatever it holds now no longer mirrors the line; keep
+        // it and the next rewrite opens with a delete against text the
+        // user did not type. See #3885.
+        if (ev.target instanceof HTMLTextAreaElement) ev.target.value = "";
+        ev.preventDefault();
+      }
       break;
     case "insertLineBreak":
     case "insertParagraph":

--- a/web/src/lib/mobileKeyboardProxy.ts
+++ b/web/src/lib/mobileKeyboardProxy.ts
@@ -26,14 +26,21 @@ export function registerMobileKeyboardProxyReceiver(next: Receiver) {
   receiver = next;
   const queued = pending;
   pending = [];
+  let refused = false;
   for (const input of queued) {
     if (!next(input)) {
-      // A refused edit means the pane that just mounted rejected it; the
-      // shadow still holds the queued text, which the line does not show.
-      const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]");
-      if (proxy) proxy.value = "";
-      break;
+      refused = true;
+      continue;
     }
+  }
+  if (refused) {
+    // A refused edit must not survive in the shadow: the pane does not hold
+    // it, so the next rewrite would open with a delete against text the user
+    // did not type. Later queued edits stay deliverable — `false` can mean
+    // one edit was transformed (a Ctrl chord sent its control code) rather
+    // than that the receiver is wedged.
+    const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]");
+    if (proxy) proxy.value = "";
   }
   return () => {
     if (receiver === next) receiver = null;

--- a/web/src/lib/mobileKeyboardProxy.ts
+++ b/web/src/lib/mobileKeyboardProxy.ts
@@ -26,21 +26,26 @@ export function registerMobileKeyboardProxyReceiver(next: Receiver) {
   receiver = next;
   const queued = pending;
   pending = [];
-  let refused = false;
+  let retained: string | null = null;
   for (const input of queued) {
-    if (!next(input)) {
-      refused = true;
-      continue;
+    const accepted = next(input);
+    if (
+      !accepted ||
+      input.inputType === "insertLineBreak" ||
+      input.inputType === "insertParagraph" ||
+      input.inputType === "insertFromPaste"
+    ) {
+      retained = "";
+    } else if (retained !== null) {
+      if (input.inputType === "insertText") retained += input.data ?? "";
+      else if (input.inputType === "deleteContentBackward") retained = Array.from(retained).slice(0, -1).join("");
     }
   }
-  if (refused) {
-    // A refused edit must not survive in the shadow: the pane does not hold
-    // it, so the next rewrite would open with a delete against text the user
-    // did not type. Later queued edits stay deliverable — `false` can mean
-    // one edit was transformed (a Ctrl chord sent its control code) rather
-    // than that the receiver is wedged.
+  // Browser edits were already applied while buffered. Rebuild only the
+  // accepted suffix after an invalidation, without discarding later input.
+  if (retained !== null) {
     const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]");
-    if (proxy) proxy.value = "";
+    if (proxy) proxy.value = retained;
   }
   return () => {
     if (receiver === next) receiver = null;
@@ -93,12 +98,6 @@ export function forwardTerminalBeforeInput(ev: InputEvent, deliver: Receiver) {
     case "insertText":
     case "deleteContentBackward":
       if (!deliver({ inputType: ev.inputType, data: ev.data, isComposing: ev.isComposing })) {
-        // The pane refused the edit (a Ctrl chord turned it into a control
-        // code; a read-only viewer dropped it), yet the shadow still holds
-        // the syllable it was mirroring. The chord consumed that shadow's
-        // job, so whatever it holds now no longer mirrors the line; keep
-        // it and the next rewrite opens with a delete against text the
-        // user did not type. See #3885.
         if (ev.target instanceof HTMLTextAreaElement) ev.target.value = "";
         ev.preventDefault();
       }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -100,6 +100,9 @@
         "web/src/App.tsx",
         "web/src/components/MobileLiveTerminal.tsx",
         "web/src/components/MobileTerminalToolbar.tsx",
+        "web/src/components/MobileMainPane.tsx",
+        "web/src/components/PairedTerminal.tsx",
+        "web/src/components/TerminalSessionStack.tsx",
         "web/src/lib/mobileKeyboardProxy.ts"
       ]
     },

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -1,8 +1,6 @@
 import type { Page } from "@playwright/test";
 
-// Shared mocks so a running `aoe serve` + tmux aren't required. We stub the
-// REST API and route the PTY WebSocket so the xterm.js terminal mounts and the
-// gesture handlers in useTerminal.ts are exercised against the real frontend.
+// Shared REST and WebSocket mocks for terminal browser tests.
 
 export interface MockHandle {
   /** Raw bytes received from the page via WebSocket (PTY data + JSON messages). */
@@ -53,9 +51,9 @@ export async function mockTerminalApis(
     tool?: string;
     /** Extra sessions beyond pinch-test, for tests that switch between them. */
     extraSessions?: Array<{ id: string; title: string }>;
-    /** Hold every paste-image upload until the page dispatches
-     *  `release-paste-image`, so a test can type during the await. */
+    /** Hold image uploads until the page calls releasePasteImage. */
     pendingPaste?: boolean;
+    onLiveMessage?: (url: string, message: Buffer) => void;
   } = {},
 ): Promise<MockHandle> {
   const liveSockets: Array<{ send: (data: string) => void }> = [];
@@ -132,8 +130,7 @@ export async function mockTerminalApis(
   });
   await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
   if (opts.pendingPaste) {
-    // Hold the upload open until the page fires `release-paste-image`: the
-    // test types into the shadow during the await, then releases.
+    // Keep uploads pending while the test edits or switches surfaces.
     let release: (() => void) | null = null;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -185,11 +182,10 @@ export async function mockTerminalApis(
       }
     };
     ws.onMessage((msg) => {
-      if (Buffer.isBuffer(msg)) {
-        handle.liveMessages.push(msg);
-        return;
-      }
-      handle.liveMessages.push(Buffer.from(msg));
+      const message = Buffer.isBuffer(msg) ? msg : Buffer.from(msg);
+      handle.liveMessages.push(message);
+      opts.onLiveMessage?.(ws.url(), message);
+      if (Buffer.isBuffer(msg)) return;
       try {
         const control = JSON.parse(String(msg)) as { type?: string; rows?: number; lines?: number };
         if (control.type === "claim_if_vacant") {

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -53,6 +53,9 @@ export async function mockTerminalApis(
     tool?: string;
     /** Extra sessions beyond pinch-test, for tests that switch between them. */
     extraSessions?: Array<{ id: string; title: string }>;
+    /** Hold every paste-image upload until the page dispatches
+     *  `release-paste-image`, so a test can type during the await. */
+    pendingPaste?: boolean;
   } = {},
 ): Promise<MockHandle> {
   const liveSockets: Array<{ send: (data: string) => void }> = [];
@@ -128,6 +131,19 @@ export async function mockTerminalApis(
     });
   });
   await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
+  if (opts.pendingPaste) {
+    // Hold the upload open until the page fires `release-paste-image`: the
+    // test types into the shadow during the await, then releases.
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.exposeFunction("releasePasteImage", () => release?.());
+    await page.route("**/api/sessions/*/paste-image", async (r) => {
+      await gate;
+      await r.fulfill({ json: { path: "/tmp/paste/shot.png" } });
+    });
+  }
   // Matches the bare path plus the `?index=N` query (#2437) for POST ensure and
   // DELETE kill, and the container-terminal variant.
   await page.route("**/api/sessions/*/terminal*", (r) => r.fulfill({ status: 200, body: "" }));

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -256,7 +256,12 @@ export function readFontSize(page: Page, which: "mobile" | "desktop") {
 
 export async function seedSettings(
   page: Page,
-  settings: { mobileFontSize?: number; desktopFontSize?: number; autoOpenKeyboard?: boolean },
+  settings: {
+    mobileFontSize?: number;
+    desktopFontSize?: number;
+    autoOpenKeyboard?: boolean;
+    persistentTerminals?: boolean;
+  },
 ) {
   await page.evaluate((settings) => {
     localStorage.setItem(

--- a/web/tests/live-terminal-ime-rewrite.spec.ts
+++ b/web/tests/live-terminal-ime-rewrite.spec.ts
@@ -284,11 +284,13 @@ test.describe("Live terminal IME syllable rewrite", () => {
   });
 
   test("only the visible mobile surface owns proxy input after a round trip", async ({ page }) => {
-    const writes: Array<{ url: string; text: string }> = [];
+    const writes: Record<string, string> = {};
     const handle = await mockTerminalApis(page, {
       onLiveMessage: (url, message) => {
         const text = message.toString("utf8");
-        if (!text.startsWith("{")) writes.push({ url, text });
+        if (text.startsWith("{")) return;
+        const path = new URL(url).pathname;
+        writes[path] = (writes[path] ?? "") + text;
       },
     });
     await openSession(page, handle);
@@ -305,23 +307,23 @@ test.describe("Live terminal IME syllable rewrite", () => {
     await softKey(page, "insertText", "ㄴ", PROXY);
     await page.locator(PROXY).dispatchEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
     await expect
-      .poll(() => writes.map(({ url, text }) => ({ path: new URL(url).pathname, text })))
-      .toEqual([
-        { path: "/sessions/pinch-test/live-ws", text: "ㅎ" },
-        { path: "/sessions/pinch-test/terminal/live-ws", text: "ㅏ" },
-        { path: "/sessions/pinch-test/live-ws", text: "ㄴ" },
-        { path: "/sessions/pinch-test/live-ws", text: "\r" },
-      ]);
+      .poll(() => writes)
+      .toEqual({
+        "/sessions/pinch-test/live-ws": "ㅎㄴ\r",
+        "/sessions/pinch-test/terminal/live-ws": "ㅏ",
+      });
     await expect(page.locator('[data-term="paired"]')).toHaveCount(1);
   });
 
   test("a hidden paired terminal upload preserves the agent proxy", async ({ page }) => {
-    const writes: Array<{ url: string; text: string }> = [];
+    const writes: Record<string, string> = {};
     const handle = await mockTerminalApis(page, {
       pendingPaste: true,
       onLiveMessage: (url, message) => {
         const text = message.toString("utf8");
-        if (!text.startsWith("{")) writes.push({ url, text });
+        if (text.startsWith("{")) return;
+        const path = new URL(url).pathname;
+        writes[path] = (writes[path] ?? "") + text;
       },
     });
     await openSession(page, handle);
@@ -339,24 +341,12 @@ test.describe("Live terminal IME syllable rewrite", () => {
     await softKey(page, "insertText", "ㅎ", PROXY);
     await page.evaluate(() => (window as unknown as { releasePasteImage: () => void }).releasePasteImage());
     await expect
-      .poll(() =>
-        writes
-          .filter(({ url }) => new URL(url).pathname.endsWith("/terminal/live-ws"))
-          .map(({ text }) => text)
-          .join(""),
-      )
+      .poll(() => writes["/sessions/pinch-test/terminal/live-ws"])
       .toBe("ㄱ\x1b[200~ /tmp/paste/shot.png \x1b[201~");
     expect(await valueOf(page, pairedInput)).toBe("");
     expect(await valueOf(page, PROXY)).toBe("ㅎ");
     await softKey(page, "deleteContentBackward", null, PROXY);
     await softKey(page, "insertText", "하", PROXY);
-    await expect
-      .poll(() =>
-        writes
-          .filter(({ url }) => new URL(url).pathname === "/sessions/pinch-test/live-ws")
-          .map(({ text }) => text)
-          .join(""),
-      )
-      .toBe("ㅎ\x7f하");
+    await expect.poll(() => writes["/sessions/pinch-test/live-ws"]).toBe("ㅎ\x7f하");
   });
 });

--- a/web/tests/live-terminal-ime-rewrite.spec.ts
+++ b/web/tests/live-terminal-ime-rewrite.spec.ts
@@ -261,4 +261,102 @@ test.describe("Live terminal IME syllable rewrite", () => {
     await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toContain("/tmp/paste");
     expect(await valueOf(page, PROXY)).toBe("ㅎ");
   });
+
+  test("refused composition commits cannot seed the next rewrite", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+    for (const selector of [INPUT, PROXY]) {
+      const start = handle.liveMessages.length;
+      await page.locator('button[aria-label="Ctrl"]').click();
+      await page.locator(selector).evaluate((element) => {
+        const input = element as HTMLTextAreaElement;
+        input.focus();
+        input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+        input.value = "c";
+        input.dispatchEvent(new CompositionEvent("compositionupdate", { data: "c", bubbles: true }));
+        input.dispatchEvent(new CompositionEvent("compositionend", { data: "c", bubbles: true }));
+      });
+      expect(await valueOf(page, selector)).toBe("");
+      await softKey(page, "deleteContentBackward", null, selector);
+      await softKey(page, "insertText", "ㅎ", selector);
+      await expect.poll(() => textBytes(handle, start)).toBe("\x03ㅎ");
+    }
+  });
+
+  test("only the visible mobile surface owns proxy input after a round trip", async ({ page }) => {
+    const writes: Array<{ url: string; text: string }> = [];
+    const handle = await mockTerminalApis(page, {
+      onLiveMessage: (url, message) => {
+        const text = message.toString("utf8");
+        if (!text.startsWith("{")) writes.push({ url, text });
+      },
+    });
+    await openSession(page, handle);
+    await softKey(page, "insertText", "ㅎ", PROXY);
+    await page.getByRole("button", { name: "Toggle panels", exact: true }).click();
+    await page.getByTestId("mobile-right-panel-pick-paired").click();
+    await expect(page.locator('[data-term="paired"]')).toBeVisible();
+    expect(await valueOf(page, PROXY)).toBe("");
+    await softKey(page, "deleteContentBackward", null, PROXY);
+    await softKey(page, "insertText", "ㅏ", PROXY);
+    await page.getByTestId("mobile-back-to-agent").click();
+    expect(await valueOf(page, PROXY)).toBe("");
+    await softKey(page, "deleteContentBackward", null, PROXY);
+    await softKey(page, "insertText", "ㄴ", PROXY);
+    await page.locator(PROXY).dispatchEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    await expect
+      .poll(() => writes.map(({ url, text }) => ({ path: new URL(url).pathname, text })))
+      .toEqual([
+        { path: "/sessions/pinch-test/live-ws", text: "ㅎ" },
+        { path: "/sessions/pinch-test/terminal/live-ws", text: "ㅏ" },
+        { path: "/sessions/pinch-test/live-ws", text: "ㄴ" },
+        { path: "/sessions/pinch-test/live-ws", text: "\r" },
+      ]);
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(1);
+  });
+
+  test("a hidden paired terminal upload preserves the agent proxy", async ({ page }) => {
+    const writes: Array<{ url: string; text: string }> = [];
+    const handle = await mockTerminalApis(page, {
+      pendingPaste: true,
+      onLiveMessage: (url, message) => {
+        const text = message.toString("utf8");
+        if (!text.startsWith("{")) writes.push({ url, text });
+      },
+    });
+    await openSession(page, handle);
+    await page.getByRole("button", { name: "Toggle panels", exact: true }).click();
+    await page.getByTestId("mobile-right-panel-pick-paired").click();
+    await expect(page.locator('[data-term="paired"]')).toBeVisible();
+    const pairedInput = `[data-term="paired"] ${INPUT}`;
+    await page.locator(pairedInput).evaluate((element) => {
+      const clipboardData = new DataTransfer();
+      clipboardData.items.add(new File(["x"], "shot.png", { type: "image/png" }));
+      element.dispatchEvent(new ClipboardEvent("paste", { clipboardData, bubbles: true, cancelable: true }));
+    });
+    await softKey(page, "insertText", "ㄱ", pairedInput);
+    await page.getByTestId("mobile-back-to-agent").click();
+    await softKey(page, "insertText", "ㅎ", PROXY);
+    await page.evaluate(() => (window as unknown as { releasePasteImage: () => void }).releasePasteImage());
+    await expect
+      .poll(() =>
+        writes
+          .filter(({ url }) => new URL(url).pathname.endsWith("/terminal/live-ws"))
+          .map(({ text }) => text)
+          .join(""),
+      )
+      .toBe("ㄱ\x1b[200~ /tmp/paste/shot.png \x1b[201~");
+    expect(await valueOf(page, pairedInput)).toBe("");
+    expect(await valueOf(page, PROXY)).toBe("ㅎ");
+    await softKey(page, "deleteContentBackward", null, PROXY);
+    await softKey(page, "insertText", "하", PROXY);
+    await expect
+      .poll(() =>
+        writes
+          .filter(({ url }) => new URL(url).pathname === "/sessions/pinch-test/live-ws")
+          .map(({ text }) => text)
+          .join(""),
+      )
+      .toBe("ㅎ\x7f하");
+  });
 });

--- a/web/tests/live-terminal-ime-rewrite.spec.ts
+++ b/web/tests/live-terminal-ime-rewrite.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "./helpers/mockedTest";
 import { devices, type Page } from "@playwright/test";
 import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
 import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+import { seedSettings } from "./helpers/terminal-mocks";
 
 // iOS WebKit fires no composition events for the Korean keyboard (WebKit bug
 // 274700). Every keystroke rewrites the trailing syllable through the plain
@@ -212,5 +213,61 @@ test.describe("Live terminal IME syllable rewrite", () => {
     await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toContain("/tmp/paste");
     expect(await valueOf(page, INPUT)).toBe("");
     await expect.poll(() => valueOf(page, PROXY)).toBe("");
+  });
+
+  // #3885 review: the async upload's completion must not wipe the proxy's
+  // retained syllable of the FOREGROUND session. A late upload from a
+  // backgrounded session (still mounted in the stack) clears its own local
+  // textarea but leaves the shared proxy — which now belongs to the session
+  // the user switched to — untouched.
+  test("a late upload from a backgrounded session keeps the foreground proxy", async ({ page }) => {
+    const handle = await mockTerminalApis(page, {
+      pendingPaste: true,
+      extraSessions: [{ id: "other", title: "other" }],
+    });
+    // Keep both sessions mounted across the switch: the scenario is a late
+    // upload racing a foreground switch, not a session teardown.
+    await page.goto("/");
+    await seedSettings(page, { persistentTerminals: true });
+    await page.reload();
+    await openSession(page, handle);
+
+    // Session A: paste an image, hold the upload.
+    const start = handle.liveMessages.length;
+    await page.evaluate(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Live terminal input"]');
+      if (!ta) throw new Error("live terminal input not found");
+      ta.focus();
+      const dt = new DataTransfer();
+      dt.items.add(new File(["x"], "shot.png", { type: "image/png" }));
+      ta.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }));
+    });
+    // Switch to session B (A stays mounted, its upload still pending). The
+    // switch itself drops whatever A's proxy held.
+    await openMobileSidebar(page);
+    await clickSidebarSession(page, "other");
+    await page.locator(`[data-live-terminal]:visible`).waitFor({ state: "visible", timeout: 10_000 });
+
+    // Let the switch's layout-effect proxy clear land before typing (two
+    // animation frames), so the syllable below is unambiguously B's.
+    await page.evaluate(() =>
+      Promise.all([
+        new Promise((r) => requestAnimationFrame(() => r(null))),
+        new Promise((r) => requestAnimationFrame(() => r(null))),
+      ]),
+    );
+
+    // The foreground user (session B) retains a syllable in the shared proxy.
+    await softKey(page, "insertText", "ㅎ", PROXY);
+    expect(await valueOf(page, PROXY)).toBe("ㅎ");
+
+    await page.evaluate(() => {
+      const w = window as unknown as { releasePasteImage?: () => void };
+      w.releasePasteImage?.();
+    });
+    // A's continuation sends its path to A's PTY and clears only A's local
+    // textarea; B's retained proxy syllable survives.
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toContain("/tmp/paste");
+    expect(await valueOf(page, PROXY)).toBe("ㅎ");
   });
 });

--- a/web/tests/live-terminal-ime-rewrite.spec.ts
+++ b/web/tests/live-terminal-ime-rewrite.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from "./helpers/mockedTest";
 import { devices, type Page } from "@playwright/test";
-import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
+import { mockTerminalApis, seedSettings, type MockHandle } from "./helpers/terminal-mocks";
 import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
-import { seedSettings } from "./helpers/terminal-mocks";
 
 // iOS WebKit fires no composition events for the Korean keyboard (WebKit bug
 // 274700). Every keystroke rewrites the trailing syllable through the plain
@@ -43,6 +42,7 @@ async function softKey(
       const ta = document.querySelector<HTMLTextAreaElement>(selector);
       if (!ta) throw new Error("live terminal input not found");
       ta.focus();
+      if (inputType === "deleteContentBackward" && ta.value === "") return;
       const ev = new InputEvent("beforeinput", { inputType, data, bubbles: true, cancelable: true });
       if (!ta.dispatchEvent(ev)) return;
       const end = ta.value.length;
@@ -139,7 +139,7 @@ test.describe("Live terminal IME syllable rewrite", () => {
     await softKey(page, "deleteContentBackward");
     await softKey(page, "insertText", "하");
     expect(await valueOf(page, INPUT)).toBe("하");
-    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("한\t\x7f하");
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("한\t하");
   });
 
   // The proxy is the element under test, not INPUT: a session switch unmounts
@@ -247,15 +247,6 @@ test.describe("Live terminal IME syllable rewrite", () => {
     await openMobileSidebar(page);
     await clickSidebarSession(page, "other");
     await page.locator(`[data-live-terminal]:visible`).waitFor({ state: "visible", timeout: 10_000 });
-
-    // Let the switch's layout-effect proxy clear land before typing (two
-    // animation frames), so the syllable below is unambiguously B's.
-    await page.evaluate(() =>
-      Promise.all([
-        new Promise((r) => requestAnimationFrame(() => r(null))),
-        new Promise((r) => requestAnimationFrame(() => r(null))),
-      ]),
-    );
 
     // The foreground user (session B) retains a syllable in the shared proxy.
     await softKey(page, "insertText", "ㅎ", PROXY);

--- a/web/tests/live-terminal-ime-rewrite.spec.ts
+++ b/web/tests/live-terminal-ime-rewrite.spec.ts
@@ -160,4 +160,57 @@ test.describe("Live terminal IME syllable rewrite", () => {
     // rewrites it as DEL + replacement into the newly selected session.
     expect(await valueOf(page, PROXY)).toBe("");
   });
+
+  // #3885 case 1: the Ctrl latch's refusal must also clear a NON-empty
+  // shadow. The chord is transformed into a control code, so the retained
+  // syllable no longer mirrors anything the pane has; the next rewrite
+  // would open with a delete and eat a character the user did type.
+  test("a Ctrl chord over existing retained text drops it", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+
+    const start = handle.liveMessages.length;
+    await softKey(page, "insertText", "한");
+    await page.locator('button[aria-label="Ctrl"]').click();
+    await softKey(page, "insertText", "c");
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("한\x03");
+
+    // The chord consumed the shadow's job: no stale syllable may survive it.
+    expect(await valueOf(page, INPUT)).toBe("");
+    // The next rewrite re-arms from an empty line: no leading DEL.
+    await softKey(page, "insertText", "ㅎ");
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toBe("한\x03ㅎ");
+  });
+
+  // #3885 case 2: an async image upload's completion invalidates BOTH hidden
+  // inputs. The await leaves room for a syllable typed into the local
+  // textarea; inserting the paste path afterwards displaces it, so the
+  // shadow must not retain what the line will no longer show.
+  test("image upload completion drops a syllable typed during the upload", async ({ page }) => {
+    const handle = await mockTerminalApis(page, { pendingPaste: true });
+    await openSession(page, handle);
+
+    const start = handle.liveMessages.length;
+    // Paste an image while the upload is held, then type during the await.
+    await page.evaluate(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Live terminal input"]');
+      if (!ta) throw new Error("live terminal input not found");
+      ta.focus();
+      const dt = new DataTransfer();
+      dt.items.add(new File(["x"], "shot.png", { type: "image/png" }));
+      ta.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }));
+    });
+    await softKey(page, "insertText", "ㅎ");
+    await expect(page.locator(INPUT)).toHaveValue("ㅎ");
+
+    await page.evaluate(() => {
+      const w = window as unknown as { releasePasteImage?: () => void };
+      w.releasePasteImage?.();
+    });
+    // The pasted path is sent, and the syllable typed during the await is
+    // dropped from the shadow: the line shows the path, not the syllable.
+    await expect.poll(() => textBytes(handle, start), { timeout: 5_000 }).toContain("/tmp/paste");
+    expect(await valueOf(page, INPUT)).toBe("");
+    await expect.poll(() => valueOf(page, PROXY)).toBe("");
+  });
 });


### PR DESCRIPTION
## Description

Closes #3885. Keep retained IME text consistent with accepted terminal edits, including queued replay, refused composition commits, asynchronous image paste and mobile agent/paired surface switches.

- Preserve independently accepted queued edits and reconstruct their accepted shadow suffix after refusal. The real-component regression replaces the one displaced by the earlier force-push; 9b2c7b6a remains preserved.
- Skip upload completion after unmount. A mounted background terminal can finish its initiated paste without clearing the foreground proxy.
- Propagate the visible mobile surface's active state through TerminalSessionStack and PairedShellPane. Keep terminal views mounted, but register proxy listeners only on the visible surface. Clear buffered and retained proxy text on a real session/surface boundary, not when reselecting the same target.
- Clear the event textarea and shared proxy when compositionend cannot deliver its commit. Accepted text still supplies the next IME rewrite's context.

Main is merged without rewriting history. The maintainer's synchronous paste correction from #3895 and both branches' regression tests are retained. The hidden agent/paired ownership defect previously described as separate is now addressed here, not deferred.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass locally as detailed below
- [x] Documentation updated where necessary: component ownership comments and coverage-matrix mapping; no new controls or settings
- [x] UI verification: actual Chromium mobile surface inspected; no styling/layout change requiring a comparison screenshot

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Covered by live-terminal-ime-rewrite.spec.ts, mobile-right-panel-picker.spec.ts, mobile-keyboard.spec.ts and terminal-focus-shortcut.spec.ts; coverage-matrix validator passes.
- All three added regressions failed before correction: refused composition retained c; a surface switch retained the previous syllable; the hidden paired terminal received the agent's keystroke during its pending upload.
- 3824 unit tests in 362 files passed. The four browser specs passed 39 cases; 2 existing native-proxy cases are skipped by the suite. After refining assertions to compare complete byte streams per destination, all 11 IME cases passed again at 09c50a0c.
- Format, ESLint, TypeScript, production build, matrix validation and commit-hook Cargo formatter/Clippy passed.
- Actual browser smoke at 390×844: paired received ㅏ; returning to agent cleared the proxy, kept the paired view mounted, and routed ㄴ plus Enter only to the agent. Captured both visible surfaces and removed the temporary driver/server.

This uses the real frontend with mocked REST/WebSockets and synthetic native events/default edits. It does not establish native iOS keyboard behavior or exercise a live PTY. The browser model suppresses backward deletes on an empty shadow.

**TUI / CLI (e2e test)**
- [x] N/A: web-only behavior correction

CI at 09c50a0c is green: 34 successful checks, 1 skipped, GitHub merge state CLEAN. Local verification and native-device limitations are stated separately above.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Oh My Pi, GPT-6-astra.

**Any Additional AI Details:** AI-authored corrections and actual local verification. The previous replay delta received independent reviews; the additional surface/composition corrections have the reproduction and browser evidence above.

- [x] I am an AI Agent filling out this form (check box if true)
