### PR TITLE
fix(tmux): record each session's kind on the session itself

### DIFF
--- a/docs/guides/tmux-status-bar.md
+++ b/docs/guides/tmux-status-bar.md
@@ -131,10 +131,15 @@ cannot: a title such as `term notes` gives an agent session a name shaped like
 a paired terminal's. A session started by an earlier aoe carries no value until
 it is restarted.
 
-Read it, but do not set it. aoe sets it per session, and ignores any value it
-could have read from a global `set -g @aoe_kind` of yours, since a global one
-applies to every session on the server and would tell aoe that panes are
-something they are not.
+Read it, but do not set it. A value of yours at server (`set -s`), window
+(`set -w`) or global-window (`set -gw`) scope does not sit behind the one aoe
+writes, it replaces it for every session on the server, and a global-session
+one (`set -g`) is read by every session that has no value of its own. aoe
+discards any value the server-wide scopes could have produced rather than
+believe a pane is something it is not, so setting one costs you the marker
+entirely: those sessions fall back to being classified by name, which is the
+ambiguity `@aoe_kind` exists to remove. Window and pane scope vary per pane
+and cannot be discarded this way at all.
 
 ```tmux
 # Only decorate the agent pane

--- a/docs/guides/tmux-status-bar.md
+++ b/docs/guides/tmux-status-bar.md
@@ -128,8 +128,13 @@ set -g status-right "#{@aoe_title} #{@aoe_branch} #{@aoe_sandbox} | %H:%M"
 `cterm` (container terminal), or `tool`. It is written when the session is
 created and survives renames, so it stays accurate where the session name
 cannot: a title such as `term notes` gives an agent session a name shaped like
-a paired terminal's. A session started by an earlier aoe carries no
-value until it is restarted.
+a paired terminal's. A session started by an earlier aoe carries no value until
+it is restarted.
+
+Read it, but do not set it. aoe sets it per session, and ignores any value it
+could have read from a global `set -g @aoe_kind` of yours, since a global one
+applies to every session on the server and would tell aoe that panes are
+something they are not.
 
 ```tmux
 # Only decorate the agent pane

--- a/docs/guides/tmux-status-bar.md
+++ b/docs/guides/tmux-status-bar.md
@@ -118,10 +118,22 @@ set -g status-right "#{?#{==:#(aoe tmux status),},,%#(aoe tmux status) | }%H:%M"
 
 ## tmux User Options
 
-aoe sets `@aoe_title`, `@aoe_branch` (worktree sessions), and `@aoe_sandbox` (sandboxed sessions) on each session, which you can reference in your own config:
+aoe sets `@aoe_title`, `@aoe_branch` (worktree sessions), `@aoe_sandbox` (sandboxed sessions), and `@aoe_kind` on each session, which you can reference in your own config:
 
 ```tmux
 set -g status-right "#{@aoe_title} #{@aoe_branch} #{@aoe_sandbox} | %H:%M"
+```
+
+`@aoe_kind` is what kind of session it is: `agent`, `term` (paired terminal),
+`cterm` (container terminal), or `tool`. It is written when the session is
+created and survives renames, so it stays accurate where the session name
+cannot: a title such as `term notes` gives an agent session a name shaped like
+a paired terminal's. A session started by an earlier aoe carries no
+value until it is restarted.
+
+```tmux
+# Only decorate the agent pane
+set -g status-right "#{?#{==:#{@aoe_kind},agent},#{@aoe_title},} | %H:%M"
 ```
 
 ## Troubleshooting

--- a/src/server/api/sessions/tests.rs
+++ b/src/server/api/sessions/tests.rs
@@ -3695,6 +3695,10 @@ fn resolve_hook_plan_inherits_trust_across_worktrees() {
     );
 }
 #[tokio::test]
+// Serial with the rest of the `list_sessions` callers: this one bumps
+// `LIST_SESSIONS_RESOLVER_MISSES`, which
+// `list_sessions_shares_config_resolution_across_overlays` resets and reads.
+#[serial_test::serial]
 async fn list_sessions_projects_pending_approvals_only_for_running_workers() {
     use crate::acp::permissions::build_approval;
     use crate::acp::state::ToolCall;

--- a/src/server/api/sessions/tests.rs
+++ b/src/server/api/sessions/tests.rs
@@ -3695,10 +3695,6 @@ fn resolve_hook_plan_inherits_trust_across_worktrees() {
     );
 }
 #[tokio::test]
-// Serial with the rest of the `list_sessions` callers: this one bumps
-// `LIST_SESSIONS_RESOLVER_MISSES`, which
-// `list_sessions_shares_config_resolution_across_overlays` resets and reads.
-#[serial_test::serial]
 async fn list_sessions_projects_pending_approvals_only_for_running_workers() {
     use crate::acp::permissions::build_approval;
     use crate::acp::state::ToolCall;

--- a/src/session/capture/mod.rs
+++ b/src/session/capture/mod.rs
@@ -380,8 +380,6 @@ fn build_exclusion_set(
     };
 
     let aoe_sessions: Vec<&str> = names
-        .iter()
-        .map(String::as_str)
         .filter(|name| {
             name.starts_with(crate::tmux::SESSION_PREFIX)
                 && !name.starts_with(crate::tmux::TOOL_PREFIX)

--- a/src/session/instance/mod.rs
+++ b/src/session/instance/mod.rs
@@ -76,7 +76,7 @@ pub use start::{LaunchSidOutcome, StartOutcome};
 pub(crate) use status::PassiveStatusPatch;
 pub use status::{Status, TMUX_SERVER_UNREACHABLE_ERROR, TMUX_SESSION_GONE_ERROR};
 pub(crate) use tmux_session::{
-    duplicate_session_error, find_duplicate_session, is_duplicate_session,
+    duplicate_session_error, find_duplicate_session, is_duplicate_session, AgentSeed,
 };
 /// Why a session can never resume, decided from the registry alone and
 /// before any runtime probe. `Agent` covers both an unresolved tool and one

--- a/src/session/instance/polling.rs
+++ b/src/session/instance/polling.rs
@@ -119,14 +119,22 @@ fn try_acquire_managed_capture_lease(
 /// the name-shape filter because there is no live session to read a kind
 /// marker from, so a title sanitizing under an auxiliary prefix fails closed
 /// there (see `tmux::session_kind`).
+///
+/// A scan that found panes for the id but no agent among them is not that
+/// case: the derived name would then be a session that is not running, and a
+/// poller on it burns a budget slot until `MISSING_TARGET_GRACE` expires.
 fn poller_seed_name(
-    live_agent: Option<String>,
+    live: AgentSeed,
     derived: impl FnOnce() -> Option<String>,
     session_id: &str,
 ) -> Option<String> {
-    live_agent.or_else(|| {
-        derived().filter(|name| crate::tmux::agent_session_belongs_to(name, session_id))
-    })
+    match live {
+        AgentSeed::Agent(name) => Some(name),
+        AgentSeed::OtherKindOnly => None,
+        AgentSeed::NothingLive => {
+            derived().filter(|name| crate::tmux::agent_session_belongs_to(name, session_id))
+        }
+    }
 }
 
 impl Instance {
@@ -340,7 +348,7 @@ impl Instance {
         // reported as over budget, and the next repair tick stops looking once
         // its own snapshot agrees the agent pane is gone.
         let Some(tmux_session_name) = poller_seed_name(
-            self.live_agent_tmux_name(),
+            self.live_agent_seed(),
             || self.tmux_session().ok().map(|s| s.name().to_string()),
             &self.id,
         ) else {
@@ -1048,11 +1056,12 @@ mod tests {
         );
     }
 
-    /// The live arm is decisive and the derived arm is the fallback. The
-    /// live arm's own filtering is the kind-aware scan in
-    /// `tmux::live_agent_name_for_id`, pinned there; here the seed must take
-    /// whatever agent name that scan returns, including one whose sanitized
-    /// title reads as a paired terminal's.
+    /// The live arm is decisive and the derived arm is the fallback only when
+    /// the scan found nothing live at all. The live arm's own filtering is the
+    /// kind-aware scan in `tmux::live_agent_name_for_id`, pinned there; here
+    /// the seed must take whatever agent name that scan returns, including one
+    /// whose sanitized title reads as a paired terminal's, and must not fall
+    /// back to a derived name for a row whose agent pane is gone.
     #[test]
     fn poller_seed_name_prefers_the_live_agent_and_falls_back_to_the_derived_name() {
         const ID: &str = "9f2c41d6-0000-4000-8000-000000000001";
@@ -1063,27 +1072,48 @@ mod tests {
         // the session says what kind it is.
         let aux_shaped = crate::tmux::Session::generate_name(ID, "term rewriting");
 
-        // (case, live agent name, derived name, expected seed)
-        type Case<'a> = (&'a str, Option<&'a str>, Option<&'a str>, Option<&'a str>);
-        let cases: &[Case] = &[
-            ("agent pane live", Some(&agent), Some(&agent), Some(&agent)),
+        // (case, what the live scan says, derived name, expected seed)
+        type Case<'a> = (&'a str, super::AgentSeed, Option<&'a str>, Option<&'a str>);
+        let cases: Vec<Case> = vec![
+            (
+                "agent pane live",
+                super::AgentSeed::Agent(agent.clone()),
+                Some(&agent),
+                Some(&agent),
+            ),
             (
                 "live agent under its pre-rename name",
-                Some(&agent),
+                super::AgentSeed::Agent(agent.clone()),
                 Some(&renamed),
                 Some(&agent),
             ),
             (
                 "live agent whose title reads as a terminal",
-                Some(&aux_shaped),
+                super::AgentSeed::Agent(aux_shaped.clone()),
                 Some(&aux_shaped),
                 Some(&aux_shaped),
             ),
-            ("nothing live yet", None, Some(&agent), Some(&agent)),
-            ("nothing live and no derived name", None, None, None),
+            (
+                "only a terminal outlived the agent",
+                super::AgentSeed::OtherKindOnly,
+                Some(&agent),
+                None,
+            ),
+            (
+                "nothing live yet",
+                super::AgentSeed::NothingLive,
+                Some(&agent),
+                Some(&agent),
+            ),
+            (
+                "nothing live and no derived name",
+                super::AgentSeed::NothingLive,
+                None,
+                None,
+            ),
             (
                 "nothing live and an aux-shaped derived name",
-                None,
+                super::AgentSeed::NothingLive,
                 Some(&aux_shaped),
                 None,
             ),
@@ -1091,13 +1121,8 @@ mod tests {
 
         for (case, live, derived, expected) in cases {
             assert_eq!(
-                super::poller_seed_name(
-                    live.map(str::to_string),
-                    || derived.map(str::to_string),
-                    ID,
-                )
-                .as_deref(),
-                *expected,
+                super::poller_seed_name(live, || derived.map(str::to_string), ID).as_deref(),
+                expected,
                 "{case}"
             );
         }
@@ -1127,7 +1152,11 @@ mod tests {
         // A `tmux` answering every query with that one session, marked as the
         // agent, which is what the real `list-sessions -F` scan reads back.
         let shim = temp.path().join("tmux");
-        std::fs::write(&shim, format!("#!/bin/sh\necho '{live_name}|agent'\n")).unwrap();
+        std::fs::write(
+            &shim,
+            format!("#!/bin/sh\necho '{live_name}|1789065184|agent'\n"),
+        )
+        .unwrap();
         std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
         let path = format!(
             "{}:{}",

--- a/src/session/instance/polling.rs
+++ b/src/session/instance/polling.rs
@@ -105,31 +105,28 @@ fn try_acquire_managed_capture_lease(
 /// The tmux session name to seed a session-id poller with, or `None` when
 /// this instance has no agent pane for one to follow.
 ///
-/// `live_any_kind` is the live name of any kind carrying the id (agent, else a
-/// paired terminal, else a container terminal); `derived` is the title-derived
-/// name, asked only when nothing is live yet so a poller started alongside its
-/// tmux session still gets a target. Both are filtered to the agent shape: a
-/// poller seeded with a terminal name re-resolves to that same live name every
-/// tick, probes `Alive`, and so never terminates, holding a budget slot for an
-/// agent that is gone while reading session-id state off the wrong pane.
+/// `live_agent` is the live agent session for the id, which a fresh scan
+/// classifies by the kind each session was stamped with at creation. It is
+/// decisive: a row whose agent pane is gone has nothing a session-id poller
+/// can follow, however many paired terminals outlived it. Seeded with one of
+/// those, a poller re-resolves to that same live name every tick, probes
+/// `Alive`, and so never terminates, holding a budget slot for an agent that
+/// is gone while reading session-id state off the wrong pane (#3880).
 ///
-/// A live terminal is a decisive answer rather than a reason to fall back: it
-/// is only reached when the agent pane is absent or dead, and the derived name
-/// would then name a session that is not running.
-///
-/// Fails closed for a title sanitizing under the agent shape's excluded
-/// prefixes: its own agent name reads as a paired terminal's, so such a
-/// session runs no session-id poller at all. See
-/// `tmux::live_agent_name_for_id_in` for why that ambiguity has no cheaper
-/// answer.
+/// `derived` is the title-derived agent name, asked only when the scan found
+/// nothing live for the id: a poller started alongside its own tmux session
+/// still needs a target, and `MISSING_TARGET_GRACE` covers the race. It keeps
+/// the name-shape filter because there is no live session to read a kind
+/// marker from, so a title sanitizing under an auxiliary prefix fails closed
+/// there (see `tmux::session_kind`).
 fn poller_seed_name(
-    live_any_kind: Option<String>,
+    live_agent: Option<String>,
     derived: impl FnOnce() -> Option<String>,
     session_id: &str,
 ) -> Option<String> {
-    live_any_kind
-        .or_else(derived)
-        .filter(|name| crate::tmux::agent_session_belongs_to(name, session_id))
+    live_agent.or_else(|| {
+        derived().filter(|name| crate::tmux::agent_session_belongs_to(name, session_id))
+    })
 }
 
 impl Instance {
@@ -343,7 +340,7 @@ impl Instance {
         // reported as over budget, and the next repair tick stops looking once
         // its own snapshot agrees the agent pane is gone.
         let Some(tmux_session_name) = poller_seed_name(
-            self.tmux_env_session_name(),
+            self.live_agent_tmux_name(),
             || self.tmux_session().ok().map(|s| s.name().to_string()),
             &self.id,
         ) else {
@@ -1051,40 +1048,42 @@ mod tests {
         );
     }
 
-    /// The seed must name the AGENT pane whichever arm answers. A paired or
-    /// container terminal outliving its agent still answers the live lookup,
-    /// and a poller seeded with that name re-resolves to it forever.
+    /// The live arm is decisive and the derived arm is the fallback. The
+    /// live arm's own filtering is the kind-aware scan in
+    /// `tmux::live_agent_name_for_id`, pinned there; here the seed must take
+    /// whatever agent name that scan returns, including one whose sanitized
+    /// title reads as a paired terminal's.
     #[test]
-    fn poller_seed_name_accepts_only_an_agent_name() {
+    fn poller_seed_name_prefers_the_live_agent_and_falls_back_to_the_derived_name() {
         const ID: &str = "9f2c41d6-0000-4000-8000-000000000001";
         let agent = crate::tmux::Session::generate_name(ID, "Vikings");
-        let terminal = crate::tmux::TerminalSession::generate_name(ID, "Vikings");
-        let container = crate::tmux::ContainerTerminalSession::generate_name(ID, "Vikings");
-        // A title sanitizing under TERMINAL_PREFIX makes even the agent's own
-        // name unrecognizable as one.
+        let renamed = crate::tmux::Session::generate_name(ID, "Vikings the sequel");
+        // A title sanitizing under TERMINAL_PREFIX: the agent name the name
+        // shape alone refuses, which the live scan now answers with because
+        // the session says what kind it is.
         let aux_shaped = crate::tmux::Session::generate_name(ID, "term rewriting");
 
-        // (case, live name of any kind, derived name, expected seed)
+        // (case, live agent name, derived name, expected seed)
         type Case<'a> = (&'a str, Option<&'a str>, Option<&'a str>, Option<&'a str>);
         let cases: &[Case] = &[
             ("agent pane live", Some(&agent), Some(&agent), Some(&agent)),
             (
-                "only a paired terminal live",
-                Some(&terminal),
+                "live agent under its pre-rename name",
                 Some(&agent),
-                None,
+                Some(&renamed),
+                Some(&agent),
             ),
             (
-                "only a container terminal live",
-                Some(&container),
-                Some(&agent),
-                None,
+                "live agent whose title reads as a terminal",
+                Some(&aux_shaped),
+                Some(&aux_shaped),
+                Some(&aux_shaped),
             ),
             ("nothing live yet", None, Some(&agent), Some(&agent)),
             ("nothing live and no derived name", None, None, None),
             (
-                "aux-shaped title",
-                Some(&aux_shaped),
+                "nothing live and an aux-shaped derived name",
+                None,
                 Some(&aux_shaped),
                 None,
             ),
@@ -1102,6 +1101,44 @@ mod tests {
                 "{case}"
             );
         }
+    }
+
+    /// #3888 end to end: a row titled `term rewriting` whose agent session is
+    /// live and marked gets a poller, on that session. Before the kind
+    /// marker its own agent name was indistinguishable from a paired
+    /// terminal's, so every start declined and the row captured no
+    /// conversation id.
+    #[test]
+    #[serial_test::serial]
+    #[cfg(unix)]
+    fn an_aux_shaped_title_polls_its_marked_agent_pane() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _budget = crate::session::poller::test_support::IsolatedBudget::with_ceiling(1);
+        let temp = tempfile::tempdir().unwrap();
+        let mut inst = Instance::new("term rewriting", "/tmp/aux-shaped-title");
+        inst.tool = "claude".to_string();
+        let live_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        assert!(
+            !crate::tmux::agent_session_belongs_to(&live_name, &inst.id),
+            "fixture: this title's agent name is one the name shape refuses"
+        );
+
+        // A `tmux` answering every query with that one session, marked as the
+        // agent, which is what the real `list-sessions -F` scan reads back.
+        let shim = temp.path().join("tmux");
+        std::fs::write(&shim, format!("#!/bin/sh\necho '{live_name}|agent'\n")).unwrap();
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = format!(
+            "{}:{}",
+            temp.path().display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let _guard = crate::session::test_support::EnvGuard::set(&[("PATH", path)]);
+
+        assert_eq!(inst.maybe_start_poller(), PollerStart::Started);
+        assert!(inst.session_id_poller_is_running());
+        inst.stop_poller();
     }
 
     /// The race #3880 describes: repair sees a live agent pane in its

--- a/src/session/instance/tmux_session.rs
+++ b/src/session/instance/tmux_session.rs
@@ -2,16 +2,41 @@
 
 use super::*;
 
-pub(super) fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
+/// One authoritative `list-sessions`, each line `<name>|<kind marker>`.
+fn live_sessions_probe() -> Option<String> {
     let output = crate::tmux::tmux_query_command()
-        .args(["list-sessions", "-F", "#{session_name}"])
+        .args(["list-sessions", "-F", "#{session_name}|#{@aoe_kind}"])
         .output()
         .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    crate::tmux::live_any_kind_name_for_id(stdout.lines(), instance_id)
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+pub(super) fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
+    let stdout = live_sessions_probe()?;
+    crate::tmux::live_any_kind_name_for_id(
+        stdout.lines().map(crate::tmux::split_kind_marker),
+        instance_id,
+        crate::tmux::utils::is_pane_dead,
+    )
+}
+
+/// The live AGENT session for `instance_id`, ignoring its paired terminals,
+/// container terminals and tool sub-sessions.
+///
+/// [`tmux_env_session_name_for_instance_id`] answers "does this row have any
+/// live pane", which a terminal outliving its agent satisfies. A session-id
+/// poller needs the agent pane specifically: seeded with a terminal it would
+/// probe that pane as alive forever (#3880).
+pub(super) fn live_agent_name_for_instance_id(instance_id: &str) -> Option<String> {
+    let stdout = live_sessions_probe()?;
+    crate::tmux::live_agent_name_for_id(
+        stdout.lines().map(crate::tmux::split_kind_marker),
+        instance_id,
+        crate::tmux::utils::is_pane_dead,
+    )
 }
 
 /// Find another session that owns the exact title and normalized path.
@@ -55,6 +80,12 @@ impl Instance {
 
     pub(crate) fn tmux_env_session_name(&self) -> Option<String> {
         tmux_env_session_name_for_instance_id(&self.id)
+    }
+
+    /// [`Self::has_live_agent_pane_in`] as a fresh probe, answering with the
+    /// agent session's name.
+    pub(crate) fn live_agent_tmux_name(&self) -> Option<String> {
+        live_agent_name_for_instance_id(&self.id)
     }
 
     /// [`Self::tmux_env_session_name`] answered from a snapshot the caller

--- a/src/session/instance/tmux_session.rs
+++ b/src/session/instance/tmux_session.rs
@@ -2,41 +2,54 @@
 
 use super::*;
 
-/// One authoritative `list-sessions`, each line `<name>|<kind marker>`.
-fn live_sessions_probe() -> Option<String> {
-    let output = crate::tmux::tmux_query_command()
-        .args(["list-sessions", "-F", "#{session_name}|#{@aoe_kind}"])
-        .output()
-        .ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
 pub(super) fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
-    let stdout = live_sessions_probe()?;
+    let live = crate::tmux::probe_live_sessions()?;
     crate::tmux::live_any_kind_name_for_id(
-        stdout.lines().map(crate::tmux::split_kind_marker),
+        crate::tmux::marked_names(&live),
         instance_id,
         crate::tmux::utils::is_pane_dead,
     )
 }
 
-/// The live AGENT session for `instance_id`, ignoring its paired terminals,
-/// container terminals and tool sub-sessions.
+/// What one live scan says about `instance_id`'s panes, for seeding a
+/// session-id poller.
 ///
 /// [`tmux_env_session_name_for_instance_id`] answers "does this row have any
-/// live pane", which a terminal outliving its agent satisfies. A session-id
-/// poller needs the agent pane specifically: seeded with a terminal it would
-/// probe that pane as alive forever (#3880).
-pub(super) fn live_agent_name_for_instance_id(instance_id: &str) -> Option<String> {
-    let stdout = live_sessions_probe()?;
-    crate::tmux::live_agent_name_for_id(
-        stdout.lines().map(crate::tmux::split_kind_marker),
+/// live pane", which a terminal outliving its agent satisfies. A poller needs
+/// the agent pane specifically: seeded with a terminal it would probe that
+/// pane as alive forever (#3880). It also needs to tell "no agent yet" from
+/// "no agent any more", since only the first is a reason to fall back to the
+/// title-derived name.
+pub(crate) enum AgentSeed {
+    /// The live agent session for the id.
+    Agent(String),
+    /// Panes are live for the id, none of them the agent.
+    OtherKindOnly,
+    /// Nothing live for the id, or the tmux server could not be reached.
+    NothingLive,
+}
+
+pub(super) fn live_agent_seed_for_instance_id(instance_id: &str) -> AgentSeed {
+    let Some(live) = crate::tmux::probe_live_sessions() else {
+        return AgentSeed::NothingLive;
+    };
+    if let Some(name) = crate::tmux::live_agent_name_for_id(
+        crate::tmux::marked_names(&live),
+        instance_id,
+        crate::tmux::utils::is_pane_dead,
+    ) {
+        return AgentSeed::Agent(name);
+    }
+    if crate::tmux::live_any_kind_name_for_id(
+        crate::tmux::marked_names(&live),
         instance_id,
         crate::tmux::utils::is_pane_dead,
     )
+    .is_some()
+    {
+        return AgentSeed::OtherKindOnly;
+    }
+    AgentSeed::NothingLive
 }
 
 /// Find another session that owns the exact title and normalized path.
@@ -83,9 +96,10 @@ impl Instance {
     }
 
     /// [`Self::has_live_agent_pane_in`] as a fresh probe, answering with the
-    /// agent session's name.
-    pub(crate) fn live_agent_tmux_name(&self) -> Option<String> {
-        live_agent_name_for_instance_id(&self.id)
+    /// agent session's name and, failing that, whether anything else for this
+    /// row is still live.
+    pub(crate) fn live_agent_seed(&self) -> AgentSeed {
+        live_agent_seed_for_instance_id(&self.id)
     }
 
     /// [`Self::tmux_env_session_name`] answered from a snapshot the caller
@@ -224,10 +238,16 @@ mod tests {
 
         // A `tmux` that answers with one live session name, standing in for the
         // probe that succeeds after the snapshot's own `list-sessions` failed.
-        // The pane-liveness check reads the same output and parses it as "not
-        // dead", which is what the real probe does for any answer but `1`.
+        // The session scan's own format, so the shim exercises the parser the
+        // probe really uses. The pane-liveness check reads the same output and
+        // parses it as "not dead", which is what the real probe does for any
+        // answer but `1`.
         let shim = temp.path().join("tmux");
-        std::fs::write(&shim, format!("#!/bin/sh\necho '{live_name}'\n")).unwrap();
+        std::fs::write(
+            &shim,
+            format!("#!/bin/sh\necho '{live_name}|1789065184|agent'\n"),
+        )
+        .unwrap();
         std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
         let path = format!(
             "{}:{}",

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod detect;
 pub(crate) mod env;
 pub(crate) mod osc8;
 mod session;
+mod session_kind;
 pub mod status_bar;
 pub(crate) mod status_detection;
 pub(crate) mod status_rules;
@@ -26,6 +27,8 @@ pub use status_detection::{
 pub use terminal_session::{kill_all_terminals_for_id, ContainerTerminalSession, TerminalSession};
 pub use tool_session::{kill_all_tool_sessions_for_id, ToolSession};
 pub use utils::{attach_return_hint, tmux_prefix_display};
+
+pub(crate) use session_kind::{append_session_kind_args, SessionKind};
 
 /// OSC 8 hyperlinks the live VT channel for `session` has seen, oldest first.
 /// Always empty off unix, where there is no channel and the capture fallback
@@ -324,8 +327,30 @@ static SESSION_CACHE: RwLock<SessionCache> = RwLock::new(SessionCache {
     outcome: SessionCacheRefresh::Unknown,
 });
 
+/// One live tmux session, as the shared `list-sessions` scan sees it.
+#[derive(Debug, Clone)]
+pub(crate) struct LiveSession {
+    /// tmux's `#{session_activity}` epoch seconds.
+    activity: i64,
+    /// The kind this session was stamped with at creation, absent for a
+    /// session created before [`session_kind::KIND_OPTION`] existed.
+    kind: Option<SessionKind>,
+}
+
+#[cfg(test)]
+impl LiveSession {
+    /// A session as an older build (or a tmux that never answered the option)
+    /// leaves it: present, with nothing recorded about its kind.
+    fn unmarked() -> Self {
+        Self {
+            activity: 0,
+            kind: None,
+        }
+    }
+}
+
 struct SessionCache {
-    data: Option<HashMap<String, i64>>,
+    data: Option<HashMap<String, LiveSession>>,
     time: Option<Instant>,
     refresh_id: u64,
     outcome: SessionCacheRefresh,
@@ -489,7 +514,7 @@ fn next_refresh_id(counter: &std::sync::atomic::AtomicU64) -> u64 {
 
 fn publish_session_cache(
     refresh_id: u64,
-    data: Option<HashMap<String, i64>>,
+    data: Option<HashMap<String, LiveSession>>,
     outcome: SessionCacheRefresh,
     respect_forced_guard: bool,
 ) -> SessionCacheRefresh {
@@ -514,23 +539,50 @@ fn publish_session_cache(
     cache.outcome = outcome;
     outcome
 }
+/// Parse the `#{session_name}|#{session_activity}|#{@aoe_kind}` scan.
+///
+/// The kind field is last and expands to the empty string for a session with
+/// no marker, so a line that is short or empty there is an unmarked session,
+/// not a parse failure. Session names are sanitized to `[A-Za-z0-9_-]`, so
+/// they never contain [`FIELD_SEP`] themselves.
+fn parse_session_scan(stdout: &str) -> HashMap<String, LiveSession> {
+    let mut map = HashMap::new();
+    for line in stdout.lines() {
+        let Some((name, rest)) = line.split_once(FIELD_SEP) else {
+            continue;
+        };
+        let (activity, marker) = match rest.split_once(FIELD_SEP) {
+            Some((activity, marker)) => (activity, Some(marker)),
+            None => (rest, None),
+        };
+        map.insert(
+            name.to_string(),
+            LiveSession {
+                activity: activity.parse().unwrap_or(0),
+                kind: marker.and_then(SessionKind::from_marker),
+            },
+        );
+    }
+    map
+}
+
 pub fn refresh_session_cache() -> SessionCacheRefresh {
     let refresh_id = next_refresh_id(&SESSION_REFRESH_ID);
     let start = Instant::now();
     let mut command = tmux_query_command();
-    command.args(["list-sessions", "-F", "#{session_name}|#{session_activity}"]);
+    command.args([
+        "list-sessions",
+        "-F",
+        "#{session_name}|#{session_activity}|#{@aoe_kind}",
+    ]);
     let output = run_tmux_command_with_timeout(&mut command);
     let (new_data, outcome) = match output {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
-            let mut map = HashMap::new();
-            for line in stdout.lines() {
-                if let Some((name, activity)) = line.split_once(FIELD_SEP) {
-                    let activity: i64 = activity.parse().unwrap_or(0);
-                    map.insert(name.to_string(), activity);
-                }
-            }
-            (Some(map), SessionCacheRefresh::Populated)
+            (
+                Some(parse_session_scan(&stdout)),
+                SessionCacheRefresh::Populated,
+            )
         }
         Ok(out) if tmux_no_server_running(&out.stderr) => {
             tracing::trace!(target: "tmux.cache", "no tmux server running; cache cleared");
@@ -690,10 +742,6 @@ fn id_suffix(session_id: &str) -> String {
     format!("_{}", crate::cli::truncate_id(session_id, 8))
 }
 
-/// Auxiliary kinds whose prefixes nest under `SESSION_PREFIX`, so the agent
-/// shape has to exclude them explicitly.
-const AGENT_EXCLUDED_PREFIXES: &[&str] = &[TERMINAL_PREFIX, CONTAINER_TERMINAL_PREFIX, TOOL_PREFIX];
-
 /// How one kind of aoe tmux session's name is shaped for one session id, so a
 /// live session can still be found after the title embedded in the name has
 /// gone stale. Every name of a given kind is
@@ -706,9 +754,12 @@ const AGENT_EXCLUDED_PREFIXES: &[&str] = &[TERMINAL_PREFIX, CONTAINER_TERMINAL_P
 pub(crate) struct NameShape<'a> {
     pub prefix: &'a str,
     pub suffix: &'a str,
-    /// Prefixes nesting under `prefix` that must never be adopted. Empty for
-    /// every kind but the agent, whose `aoe_` prefixes all the others.
-    pub excluded_prefixes: &'a [&'a str],
+    /// The kind a name of this shape belongs to. A live session is matched
+    /// against this rather than against the prefix alone: the auxiliary
+    /// prefixes nest under `SESSION_PREFIX`, and a sanitized title can carry
+    /// a name into another kind's shape, so only [`SessionKind`] separates
+    /// them (see [`session_kind`]).
+    pub kind: SessionKind,
 }
 
 impl NameShape<'_> {
@@ -718,38 +769,42 @@ impl NameShape<'_> {
         NameShape {
             prefix: SESSION_PREFIX,
             suffix,
-            excluded_prefixes: AGENT_EXCLUDED_PREFIXES,
+            kind: SessionKind::Agent,
         }
     }
 
-    /// The paired-terminal shape for a session id. `TERMINAL_PREFIX` does not
-    /// nest under any other kind's prefix, so nothing is excluded.
+    /// The paired-terminal shape for a session id.
     pub(crate) fn terminal<'a>(suffix: &'a str) -> NameShape<'a> {
         NameShape {
             prefix: TERMINAL_PREFIX,
             suffix,
-            excluded_prefixes: &[],
+            kind: SessionKind::Terminal,
         }
     }
 
-    /// The container-terminal shape for a session id. `CONTAINER_TERMINAL_PREFIX`
-    /// does not nest under any other kind's prefix, so nothing is excluded.
+    /// The container-terminal shape for a session id.
     pub(crate) fn container<'a>(suffix: &'a str) -> NameShape<'a> {
         NameShape {
             prefix: CONTAINER_TERMINAL_PREFIX,
             suffix,
-            excluded_prefixes: &[],
+            kind: SessionKind::ContainerTerminal,
         }
     }
 
-    /// True when `name` has this shape. A name whose sanitized title pushes it
-    /// under an excluded prefix fails here, so it never resolves and callers
-    /// keep their title-derived name: mistaking a paired terminal for the agent
-    /// pane would be worse than not resolving at all.
-    fn matches(&self, name: &str) -> bool {
+    /// True when the live session `name`, stamped with kind marker `marker`,
+    /// is this shape's session for this id. `marker` is `None` for a session
+    /// created before [`session_kind::KIND_OPTION`] existed, which classifies
+    /// by name shape and so cannot tell an agent titled `term Foo` from the
+    /// paired terminal of a row titled `Foo`.
+    fn matches_marked(&self, name: &str, marker: Option<&str>) -> bool {
         name.starts_with(self.prefix)
             && name.ends_with(self.suffix)
-            && !self.excluded_prefixes.iter().any(|p| name.starts_with(p))
+            && SessionKind::of(name, marker) == Some(self.kind)
+    }
+
+    /// [`Self::matches_marked`] for a caller holding only the name.
+    fn matches(&self, name: &str) -> bool {
+        self.matches_marked(name, None)
     }
 }
 
@@ -788,9 +843,13 @@ pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
 /// [`Self::names`] returns `None`, so a one-shot caller that cannot retry can
 /// tell Unknown from Absent and probe per row instead (see
 /// `Instance::tmux_env_session_name_in_or_probe`).
+/// A live session's name paired with the kind marker the scan read for it,
+/// absent for a session created before the marker existed.
+pub(crate) type MarkedSessionName = (String, Option<SessionKind>);
+
 #[derive(Default)]
 pub(crate) struct LiveSessionSnapshot {
-    names: OnceLock<Option<Vec<String>>>,
+    sessions: OnceLock<Option<Vec<MarkedSessionName>>>,
     panes: OnceLock<Option<HashMap<String, PaneMetadata>>>,
 }
 
@@ -808,8 +867,21 @@ impl LiveSessionSnapshot {
         names: Option<Vec<String>>,
         panes: Option<HashMap<String, PaneMetadata>>,
     ) -> Self {
+        Self::from_marked_parts(
+            names.map(|names| names.into_iter().map(|name| (name, None)).collect()),
+            panes,
+        )
+    }
+
+    /// [`Self::from_parts`] for a test that needs the sessions stamped with
+    /// the kind marker a live scan would have read.
+    #[cfg(test)]
+    pub(crate) fn from_marked_parts(
+        names: Option<Vec<MarkedSessionName>>,
+        panes: Option<HashMap<String, PaneMetadata>>,
+    ) -> Self {
         let snapshot = Self::new();
-        let _ = snapshot.names.set(names);
+        let _ = snapshot.sessions.set(names);
         let _ = snapshot.panes.set(panes);
         snapshot
     }
@@ -817,20 +889,29 @@ impl LiveSessionSnapshot {
     /// Live session names, or None when the tmux server could not be reached.
     /// The fresh observation also warms the display cache, so TUI startup can
     /// reuse this pass instead of issuing another list-sessions command.
-    pub(crate) fn names(&self) -> Option<&[String]> {
-        self.names
+    /// Live session names paired with the kind each was stamped with, or
+    /// `None` when the tmux server could not be reached.
+    pub(crate) fn sessions(&self) -> Option<&[MarkedSessionName]> {
+        self.sessions
             .get_or_init(|| {
                 if refresh_session_cache() != SessionCacheRefresh::Populated {
                     return None;
                 }
                 SESSION_CACHE.read().ok().and_then(|cache| {
-                    cache
-                        .data
-                        .as_ref()
-                        .map(|sessions| sessions.keys().cloned().collect())
+                    cache.data.as_ref().map(|sessions| {
+                        sessions
+                            .iter()
+                            .map(|(name, session)| (name.clone(), session.kind))
+                            .collect()
+                    })
                 })
             })
             .as_deref()
+    }
+
+    /// [`Self::sessions`] for a caller that only needs the names.
+    pub(crate) fn names(&self) -> Option<impl Iterator<Item = &str>> {
+        Some(self.sessions()?.iter().map(|(name, _)| name.as_str()))
     }
 
     /// Whether `name`'s first pane is dead, mirroring `utils::is_pane_dead`
@@ -866,14 +947,30 @@ pub(crate) fn live_agent_name_for_id_in(
     snapshot: &LiveSessionSnapshot,
     session_id: &str,
 ) -> Option<String> {
-    let names = snapshot.names()?;
+    let sessions = snapshot.sessions()?;
     let suffix = id_suffix(session_id);
     let agent = NameShape::agent(&suffix);
-    names
+    sessions
         .iter()
-        .map(String::as_str)
-        .find(|name| agent.matches(name) && !snapshot.pane_dead(name))
-        .map(str::to_string)
+        .find(|(name, kind)| {
+            agent.matches_marked(name, kind.map(SessionKind::as_marker))
+                && !snapshot.pane_dead(name)
+        })
+        .map(|(name, _)| name.clone())
+}
+
+/// [`live_agent_name_for_id_in`] against a scan the caller has just taken,
+/// as `(name, kind marker)` pairs.
+pub(crate) fn live_agent_name_for_id<'a>(
+    live: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+    session_id: &str,
+    pane_dead: impl Fn(&str) -> bool,
+) -> Option<String> {
+    let suffix = id_suffix(session_id);
+    let agent = NameShape::agent(&suffix);
+    live.into_iter()
+        .find(|(name, marker)| agent.matches_marked(name, *marker) && !pane_dead(name))
+        .map(|(name, _)| name.to_string())
 }
 
 /// [`live_any_kind_name_for_id`] against an already-taken snapshot, so a batch
@@ -882,28 +979,14 @@ pub(crate) fn live_any_kind_name_for_id_in(
     snapshot: &LiveSessionSnapshot,
     session_id: &str,
 ) -> Option<String> {
-    let names = snapshot.names()?;
-    let suffix = id_suffix(session_id);
-    let agent = NameShape::agent(&suffix);
-    let terminal = NameShape::terminal(&suffix);
-    let container = NameShape::container(&suffix);
-    let (mut agent_hit, mut terminal_hit, mut container_hit) = (None, None, None);
-    for name in names {
-        let name = name.as_str();
-        let bucket = if agent.matches(name) {
-            &mut agent_hit
-        } else if terminal.matches(name) {
-            &mut terminal_hit
-        } else if container.matches(name) {
-            &mut container_hit
-        } else {
-            continue;
-        };
-        if bucket.is_none() && !snapshot.pane_dead(name) {
-            *bucket = Some(name.to_string());
-        }
-    }
-    agent_hit.or(terminal_hit).or(container_hit)
+    let sessions = snapshot.sessions()?;
+    live_any_kind_name_for_id(
+        sessions
+            .iter()
+            .map(|(name, kind)| (name.as_str(), kind.map(SessionKind::as_marker))),
+        session_id,
+        |name| snapshot.pane_dead(name),
+    )
 }
 
 /// The live tmux session name carrying `session_id`'s `_<id8>` tail, preferring
@@ -914,29 +997,48 @@ pub(crate) fn live_any_kind_name_for_id_in(
 /// where any live pane for the id is evidence the session exists. Matching runs
 /// through [`NameShape`] so the name shapes stay the single source of truth.
 pub(crate) fn live_any_kind_name_for_id<'a>(
-    live_names: impl IntoIterator<Item = &'a str>,
+    live: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
     session_id: &str,
+    pane_dead: impl Fn(&str) -> bool,
 ) -> Option<String> {
     let suffix = id_suffix(session_id);
     let agent = NameShape::agent(&suffix);
     let terminal = NameShape::terminal(&suffix);
     let container = NameShape::container(&suffix);
     let (mut agent_hit, mut terminal_hit, mut container_hit) = (None, None, None);
-    for name in live_names {
-        let bucket = if agent.matches(name) {
+    for (name, marker) in live {
+        let bucket = if agent.matches_marked(name, marker) {
             &mut agent_hit
-        } else if terminal.matches(name) {
+        } else if terminal.matches_marked(name, marker) {
             &mut terminal_hit
-        } else if container.matches(name) {
+        } else if container.matches_marked(name, marker) {
             &mut container_hit
         } else {
             continue;
         };
-        if bucket.is_none() && !utils::is_pane_dead(name) {
+        if bucket.is_none() && !pane_dead(name) {
             *bucket = Some(name.to_string());
         }
     }
     agent_hit.or(terminal_hit).or(container_hit)
+}
+
+/// Name-only pairs for a caller with no kind markers to offer.
+#[cfg(test)]
+fn unmarked<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+) -> impl Iterator<Item = (&'a str, Option<&'a str>)> {
+    names.into_iter().map(|name| (name, None))
+}
+
+/// Split one `#{session_name}|#{@aoe_kind}` scan line. A line with no
+/// separator is a name with no marker, which is what a `tmux` that predates
+/// the option (or a test shim printing names alone) emits.
+pub(crate) fn split_kind_marker(line: &str) -> (&str, Option<&str>) {
+    match line.split_once(FIELD_SEP) {
+        Some((name, marker)) => (name, Some(marker)),
+        None => (line, None),
+    }
 }
 
 /// The tmux session name to act on for one of a session's panes, resolved
@@ -950,23 +1052,28 @@ pub(crate) fn live_any_kind_name_for_id<'a>(
 /// and keeps `create` from spawning a second pane beside it. Two candidates are
 /// ambiguous, so `derived` wins there as well.
 pub(crate) fn resolve_session_name<'a>(
-    live_names: impl IntoIterator<Item = &'a str>,
+    live: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
     derived: &str,
     shape: &NameShape,
 ) -> String {
     let mut adopted: Option<&str> = None;
     let mut ambiguous = false;
     let mut derived_is_live = false;
-    for name in live_names {
-        // Test `derived` on its own rather than through the shape: a title that
-        // sanitizes under an excluded prefix makes the derived name fail
-        // `matches`, and a live derived name must still win over an older
-        // session rather than be filtered out of its own match.
+    for (name, marker) in live {
+        // Test `derived` on its own rather than through the shape: an
+        // unmarked session whose sanitized title lands under another kind's
+        // prefix fails the shape, and a live derived name must still win over
+        // an older session rather than be filtered out of its own match. A
+        // session that SAYS it is another kind is the exception: a title moved
+        // across an auxiliary prefix leaves a paired terminal holding what is
+        // now the agent's derived name, and adopting it points the operation
+        // at the wrong pane.
         if name == derived {
-            derived_is_live = true;
+            derived_is_live = SessionKind::from_marker(marker.unwrap_or_default())
+                .is_none_or(|kind| kind == shape.kind);
             continue;
         }
-        if !shape.matches(name) {
+        if !shape.matches_marked(name, marker) {
             continue;
         }
         if adopted.replace(name).is_some() {
@@ -979,14 +1086,31 @@ pub(crate) fn resolve_session_name<'a>(
     }
 }
 
-/// `resolve_session_name` for the agent pane, against `live_names`.
+/// `resolve_session_name` for the agent pane, against names alone. A caller
+/// holding kind markers should use [`resolve_agent_session_name_marked`]: with
+/// no marker every name falls back to its shape, which cannot separate an
+/// agent titled `term Foo` from a paired terminal.
 pub fn resolve_agent_session_name<'a>(
     live_names: impl IntoIterator<Item = &'a str>,
     session_id: &str,
     derived: &str,
 ) -> String {
+    resolve_agent_session_name_marked(
+        live_names.into_iter().map(|name| (name, None)),
+        session_id,
+        derived,
+    )
+}
+
+/// [`resolve_agent_session_name`] for a caller that also has each session's
+/// kind marker.
+pub(crate) fn resolve_agent_session_name_marked<'a>(
+    live: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+    session_id: &str,
+    derived: &str,
+) -> String {
     let suffix = id_suffix(session_id);
-    resolve_session_name(live_names, derived, &NameShape::agent(&suffix))
+    resolve_session_name(live, derived, &NameShape::agent(&suffix))
 }
 
 /// [`resolve_agent_session_name`] against a [`batch_pane_metadata`] snapshot
@@ -1049,17 +1173,29 @@ pub fn live_agent_session_name(session_id: &str, derived: &str) -> String {
 }
 
 fn resolve_session_name_from_snapshot(
-    names: Option<&HashMap<String, i64>>,
+    sessions: Option<&HashMap<String, LiveSession>>,
     derived: &str,
     shape: &NameShape,
 ) -> String {
-    let Some(names) = names else {
+    let Some(sessions) = sessions else {
         return derived.to_string();
     };
-    if names.contains_key(derived) {
+    // Fast path only when the live derived name is also this kind: a session
+    // marked as another kind has to go through the scan, which looks for the
+    // one this shape is actually asking for.
+    if sessions
+        .get(derived)
+        .is_some_and(|session| session.kind.is_none_or(|kind| kind == shape.kind))
+    {
         return derived.to_string();
     }
-    resolve_session_name(names.keys().map(String::as_str), derived, shape)
+    resolve_session_name(
+        sessions
+            .iter()
+            .map(|(name, session)| (name.as_str(), session.kind.map(SessionKind::as_marker))),
+        derived,
+        shape,
+    )
 }
 
 /// Resolve from the current authoritative cache snapshot without spawning.
@@ -1402,7 +1538,7 @@ pub(crate) fn observed_window_size_from_cache(session_name: &str) -> Option<((u1
 pub fn test_inject_session_into_cache(name: &str) {
     if let Ok(mut cache) = SESSION_CACHE.write() {
         let map = cache.data.get_or_insert_with(HashMap::new);
-        map.insert(name.to_string(), 0);
+        map.insert(name.to_string(), LiveSession::unmarked());
         cache.time = Some(Instant::now());
     }
 }
@@ -1500,7 +1636,7 @@ pub(crate) mod fork_probe {
 /// cache is process-global.
 #[cfg(test)]
 pub(crate) struct SessionCacheGuard {
-    prev_data: Option<HashMap<String, i64>>,
+    prev_data: Option<HashMap<String, LiveSession>>,
     prev_time: Option<Instant>,
     prev_refresh_id: u64,
     prev_outcome: SessionCacheRefresh,
@@ -1547,7 +1683,12 @@ impl SessionCacheGuard {
     /// Force a fresh "server reachable" snapshot containing exactly `names`.
     pub(crate) fn force_present(&self, names: &[&str]) {
         if let Ok(mut cache) = SESSION_CACHE.write() {
-            cache.data = Some(names.iter().map(|n| (n.to_string(), 0)).collect());
+            cache.data = Some(
+                names
+                    .iter()
+                    .map(|n| (n.to_string(), LiveSession::unmarked()))
+                    .collect(),
+            );
             cache.time = Some(Instant::now());
             cache.outcome = SessionCacheRefresh::Populated;
         }
@@ -1764,7 +1905,11 @@ pub fn session_exists_from_cache(name: &str) -> Option<bool> {
 /// `aoe ps`, not a liveness decision.
 pub fn session_activity(name: &str) -> Option<i64> {
     let cache = SESSION_CACHE.read().ok()?;
-    cache.data.as_ref()?.get(name).copied()
+    cache
+        .data
+        .as_ref()?
+        .get(name)
+        .map(|session| session.activity)
 }
 
 /// Tri-state result of probing whether an aoe tmux session exists, per
@@ -2973,7 +3118,10 @@ mod tests {
         assert_eq!(
             publish_session_cache(
                 session_newer,
-                Some(HashMap::from([("new-session".to_string(), 0)])),
+                Some(HashMap::from([(
+                    "new-session".to_string(),
+                    LiveSession::unmarked(),
+                )])),
                 SessionCacheRefresh::Populated,
                 false,
             ),
@@ -3416,17 +3564,23 @@ mod tests {
 
         let all = [agent.as_str(), terminal.as_str(), container.as_str()];
         assert_eq!(
-            live_any_kind_name_for_id(all, ID).as_deref(),
+            live_any_kind_name_for_id(unmarked(all), ID, utils::is_pane_dead).as_deref(),
             Some(agent.as_str()),
             "the agent pane wins when present"
         );
         assert_eq!(
-            live_any_kind_name_for_id([terminal.as_str(), container.as_str()], ID).as_deref(),
+            live_any_kind_name_for_id(
+                unmarked([terminal.as_str(), container.as_str()]),
+                ID,
+                utils::is_pane_dead
+            )
+            .as_deref(),
             Some(terminal.as_str()),
             "the paired terminal is preferred over the container terminal"
         );
         assert_eq!(
-            live_any_kind_name_for_id([container.as_str()], ID).as_deref(),
+            live_any_kind_name_for_id(unmarked([container.as_str()]), ID, utils::is_pane_dead)
+                .as_deref(),
             Some(container.as_str()),
         );
     }
@@ -3462,7 +3616,12 @@ mod tests {
         // And the any-kind lookup still answers it, since peer exclusion and
         // the TUI reload legitimately want any live pane for the id.
         assert_eq!(
-            live_any_kind_name_for_id([terminal.as_str(), container.as_str()], ID).as_deref(),
+            live_any_kind_name_for_id(
+                unmarked([terminal.as_str(), container.as_str()]),
+                ID,
+                utils::is_pane_dead
+            )
+            .as_deref(),
             Some(terminal.as_str()),
         );
 
@@ -3476,6 +3635,128 @@ mod tests {
         assert_eq!(live_agent_name_for_id_in(&snapshot, ID), None);
     }
 
+    /// The scan is where a marker becomes usable at all: a wrong split
+    /// silently unmarks every session and puts the whole fleet back on the
+    /// ambiguous name-shape guess.
+    #[test]
+    fn session_scan_reads_the_kind_field_and_tolerates_its_absence() {
+        let parsed = parse_session_scan(
+            "aoe_Vikings_abcd1234|1789065184|agent\n\
+             aoe_term_Vikings_abcd1234|1789065184|term\n\
+             unmarked_session|1789065184|\n\
+             short_line|1789065184\n\
+             aoe_Weird_abcd1234|1789065184|from-a-newer-build\n\
+             garbage-with-no-separator",
+        );
+
+        assert_eq!(
+            parsed.get("aoe_Vikings_abcd1234").unwrap().kind,
+            Some(SessionKind::Agent)
+        );
+        assert_eq!(
+            parsed.get("aoe_term_Vikings_abcd1234").unwrap().kind,
+            Some(SessionKind::Terminal)
+        );
+        assert_eq!(
+            parsed.get("unmarked_session").unwrap().activity,
+            1789065184,
+            "an empty kind field still carries the session and its activity"
+        );
+        assert_eq!(parsed.get("unmarked_session").unwrap().kind, None);
+        assert_eq!(parsed.get("short_line").unwrap().kind, None);
+        assert_eq!(
+            parsed.get("aoe_Weird_abcd1234").unwrap().kind,
+            None,
+            "a marker this build does not know is not evidence of a kind"
+        );
+        assert!(!parsed.contains_key("garbage-with-no-separator"));
+    }
+
+    /// The kind marker is what name shape cannot say, in both directions: an
+    /// agent whose title sanitizes into a terminal's shape is still the agent
+    /// pane (#3888), and a paired terminal is never one however its name
+    /// reads (#3880).
+    #[test]
+    #[serial_test::serial]
+    fn live_agent_lookup_follows_the_marker_over_the_name_shape() {
+        // `aoe_term_rewriting_<id8>`: the agent name for title `term
+        // rewriting`, and the paired-terminal name for title `rewriting`.
+        let ambiguous = format!("{TERMINAL_PREFIX}rewriting_{ID8}");
+
+        let as_agent = LiveSessionSnapshot::from_marked_parts(
+            Some(vec![(ambiguous.clone(), Some(SessionKind::Agent))]),
+            Some(HashMap::new()),
+        );
+        assert_eq!(
+            live_agent_name_for_id_in(&as_agent, ID).as_deref(),
+            Some(ambiguous.as_str()),
+            "a marked agent is the row's agent pane whatever its title sanitized to"
+        );
+
+        let as_terminal = LiveSessionSnapshot::from_marked_parts(
+            Some(vec![(ambiguous.clone(), Some(SessionKind::Terminal))]),
+            Some(HashMap::new()),
+        );
+        assert_eq!(
+            live_agent_name_for_id_in(&as_terminal, ID),
+            None,
+            "a marked terminal never passes as the agent pane"
+        );
+
+        let unmarked_snapshot =
+            LiveSessionSnapshot::from_parts(Some(vec![ambiguous.clone()]), Some(HashMap::new()));
+        assert_eq!(
+            live_agent_name_for_id_in(&unmarked_snapshot, ID),
+            None,
+            "a session created before the marker keeps the old, ambiguous guess"
+        );
+
+        // The any-kind lookup buckets by the same classifier, so the marked
+        // agent is preferred over a terminal rather than mistaken for one.
+        let terminal = format!("{TERMINAL_PREFIX}other_{ID8}");
+        assert_eq!(
+            live_any_kind_name_for_id(
+                [
+                    (terminal.as_str(), Some("term")),
+                    (ambiguous.as_str(), Some("agent")),
+                ],
+                ID,
+                |_| false
+            )
+            .as_deref(),
+            Some(ambiguous.as_str()),
+        );
+    }
+
+    /// The collision a smart rename creates: a row titled `Foo` gets the
+    /// paired terminal `aoe_term_Foo_<id8>`, is retitled to `term Foo`, and
+    /// that terminal now holds the agent's derived name. Adopting it would
+    /// point every lifecycle operation, and the session-id poller, at the
+    /// wrong pane.
+    #[test]
+    fn a_session_marked_another_kind_is_not_the_live_derived_name() {
+        let derived = format!("{TERMINAL_PREFIX}Foo_{ID8}");
+        let agent = format!("{P}Foo_{ID8}");
+
+        assert_eq!(
+            resolve_agent_session_name_marked(
+                [
+                    (derived.as_str(), Some("term")),
+                    (agent.as_str(), Some("agent")),
+                ],
+                ID,
+                &derived
+            ),
+            agent,
+            "the marked agent wins over a terminal wearing the derived name"
+        );
+        assert_eq!(
+            resolve_agent_session_name([derived.as_str(), agent.as_str()], ID, &derived),
+            derived,
+            "unmarked keeps the pre-marker answer: a live derived name wins"
+        );
+    }
+
     #[test]
     #[serial_test::serial]
     fn live_any_kind_name_for_id_excludes_tool_subsessions_and_other_ids() {
@@ -3486,7 +3767,11 @@ mod tests {
             "vim".to_string(),
         ];
         assert_eq!(
-            live_any_kind_name_for_id(names.iter().map(String::as_str), ID),
+            live_any_kind_name_for_id(
+                unmarked(names.iter().map(String::as_str)),
+                ID,
+                utils::is_pane_dead
+            ),
             None,
             "a tool sub-session and other ids are never this session's pane"
         );

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -539,15 +539,72 @@ fn publish_session_cache(
     cache.outcome = outcome;
     outcome
 }
-/// Parse the `#{session_name}|#{session_activity}|#{@aoe_kind}` scan.
+/// One authoritative scan, parsed: the same command and parser the shared
+/// cache uses, for a caller that needs a fresh answer rather than the cache's.
+/// `None` when the tmux server could not be reached, which is not evidence
+/// that anything is absent.
+pub(crate) fn probe_live_sessions() -> Option<HashMap<String, LiveSession>> {
+    let output = run_tmux_command_with_timeout(&mut session_scan_command()).ok()?;
+    output
+        .status
+        .success()
+        .then(|| parse_session_scan(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Every live session as `(name, kind marker)` pairs, the shape the id
+/// lookups take.
+pub(crate) fn marked_names(
+    sessions: &HashMap<String, LiveSession>,
+) -> impl Iterator<Item = (&str, Option<&str>)> {
+    sessions
+        .iter()
+        .map(|(name, session)| (name.as_str(), session.kind.map(SessionKind::as_marker)))
+}
+
+/// The one scan every kind-aware lookup reads: the global `@aoe_kind` (see
+/// [`parse_session_scan`]) followed by one line per live session.
+fn session_scan_command() -> Command {
+    let mut command = tmux_query_command();
+    command.args([
+        "show-options",
+        "-gqv",
+        session_kind::KIND_OPTION,
+        ";",
+        "list-sessions",
+        "-F",
+        SESSION_SCAN_FORMAT,
+    ]);
+    command
+}
+
+const SESSION_SCAN_FORMAT: &str = "#{session_name}|#{session_activity}|#{@aoe_kind}";
+
+/// Parse the [`session_scan_command`] output.
 ///
-/// The kind field is last and expands to the empty string for a session with
-/// no marker, so a line that is short or empty there is an unmarked session,
-/// not a parse failure. Session names are sanitized to `[A-Za-z0-9_-]`, so
-/// they never contain [`FIELD_SEP`] themselves.
+/// A session line is `<name>|<activity>|<kind marker>`, the marker empty for a
+/// session with no mark, so a line that is short or empty there is an unmarked
+/// session and not a parse failure.
+///
+/// The first line is the GLOBAL `@aoe_kind`, printed only when the user set
+/// one, and recognized by carrying no [`FIELD_SEP`] where a session line
+/// always has two. It has to be subtracted: `#{@aoe_kind}` falls through to
+/// the global value for every session that does not set its own, so a user who
+/// sets one would otherwise mark their whole server as agents. A session whose
+/// value merely equals the global is treated as unmarked, which is the
+/// name-shape fallback rather than a wrong answer.
+///
+/// aoe-created names are sanitized to `[A-Za-z0-9_-]`, but the shared server
+/// also carries foreign sessions, whose names tmux does allow `|` in. Such a
+/// name splits into a nonsense key that no `_<id8>` lookup can match, which is
+/// the same outcome it had before the kind field existed.
 fn parse_session_scan(stdout: &str) -> HashMap<String, LiveSession> {
+    let mut lines = stdout.lines().peekable();
+    let global = lines
+        .next_if(|line| !line.contains(FIELD_SEP))
+        .filter(|line| !line.is_empty());
+
     let mut map = HashMap::new();
-    for line in stdout.lines() {
+    for line in lines {
         let Some((name, rest)) = line.split_once(FIELD_SEP) else {
             continue;
         };
@@ -559,7 +616,9 @@ fn parse_session_scan(stdout: &str) -> HashMap<String, LiveSession> {
             name.to_string(),
             LiveSession {
                 activity: activity.parse().unwrap_or(0),
-                kind: marker.and_then(SessionKind::from_marker),
+                kind: marker
+                    .filter(|marker| Some(*marker) != global)
+                    .and_then(SessionKind::from_marker),
             },
         );
     }
@@ -569,12 +628,7 @@ fn parse_session_scan(stdout: &str) -> HashMap<String, LiveSession> {
 pub fn refresh_session_cache() -> SessionCacheRefresh {
     let refresh_id = next_refresh_id(&SESSION_REFRESH_ID);
     let start = Instant::now();
-    let mut command = tmux_query_command();
-    command.args([
-        "list-sessions",
-        "-F",
-        "#{session_name}|#{session_activity}|#{@aoe_kind}",
-    ]);
+    let mut command = session_scan_command();
     let output = run_tmux_command_with_timeout(&mut command);
     let (new_data, outcome) = match output {
         Ok(out) if out.status.success() => {
@@ -1031,16 +1085,6 @@ fn unmarked<'a>(
     names.into_iter().map(|name| (name, None))
 }
 
-/// Split one `#{session_name}|#{@aoe_kind}` scan line. A line with no
-/// separator is a name with no marker, which is what a `tmux` that predates
-/// the option (or a test shim printing names alone) emits.
-pub(crate) fn split_kind_marker(line: &str) -> (&str, Option<&str>) {
-    match line.split_once(FIELD_SEP) {
-        Some((name, marker)) => (name, Some(marker)),
-        None => (line, None),
-    }
-}
-
 /// The tmux session name to act on for one of a session's panes, resolved
 /// against `live_names` (any iterator of live tmux session names).
 ///
@@ -1086,31 +1130,21 @@ pub(crate) fn resolve_session_name<'a>(
     }
 }
 
-/// `resolve_session_name` for the agent pane, against names alone. A caller
-/// holding kind markers should use [`resolve_agent_session_name_marked`]: with
-/// no marker every name falls back to its shape, which cannot separate an
-/// agent titled `term Foo` from a paired terminal.
+/// `resolve_session_name` for the agent pane, against names alone: with no
+/// kind marker every name falls back to its shape, which cannot separate an
+/// agent titled `term Foo` from a paired terminal. Callers reading the shared
+/// scan resolve through `live_session_name`, which does have the markers.
 pub fn resolve_agent_session_name<'a>(
     live_names: impl IntoIterator<Item = &'a str>,
     session_id: &str,
     derived: &str,
 ) -> String {
-    resolve_agent_session_name_marked(
-        live_names.into_iter().map(|name| (name, None)),
-        session_id,
-        derived,
-    )
-}
-
-/// [`resolve_agent_session_name`] for a caller that also has each session's
-/// kind marker.
-pub(crate) fn resolve_agent_session_name_marked<'a>(
-    live: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
-    session_id: &str,
-    derived: &str,
-) -> String {
     let suffix = id_suffix(session_id);
-    resolve_session_name(live, derived, &NameShape::agent(&suffix))
+    resolve_session_name(
+        live_names.into_iter().map(|name| (name, None)),
+        derived,
+        &NameShape::agent(&suffix),
+    )
 }
 
 /// [`resolve_agent_session_name`] against a [`batch_pane_metadata`] snapshot
@@ -3672,6 +3706,47 @@ mod tests {
         assert!(!parsed.contains_key("garbage-with-no-separator"));
     }
 
+    /// `#{@aoe_kind}` falls through to the global option, so a user who sets
+    /// one would otherwise have every unmarked session on their server claim
+    /// that kind, which is how a paired terminal would pass as an agent pane
+    /// again. The scan prints the global first so it can be subtracted.
+    #[test]
+    fn a_global_kind_option_marks_nothing() {
+        let agent = format!("{P}Vikings{ID8}");
+        let terminal = format!("{TERMINAL_PREFIX}Vikings{ID8}");
+        let scan = format!(
+            "agent\n\
+             {agent}|1789065184|agent\n\
+             {terminal}|1789065184|agent\n\
+             {terminal}_t1|1789065184|term"
+        );
+
+        let parsed = parse_session_scan(&scan);
+        assert_eq!(
+            parsed.get(&terminal).unwrap().kind,
+            None,
+            "a value the global could have produced is not a mark"
+        );
+        assert_eq!(
+            parsed.get(&agent).unwrap().kind,
+            None,
+            "including on a session that really is an agent: unmarked falls \
+             back to the name shape, which is right for it"
+        );
+        assert_eq!(
+            parsed.get(&format!("{terminal}_t1")).unwrap().kind,
+            Some(SessionKind::Terminal),
+            "a value the global cannot explain is still a mark"
+        );
+
+        // Without a global line every mark stands.
+        let parsed = parse_session_scan(&format!("{terminal}|1789065184|agent"));
+        assert_eq!(
+            parsed.get(&terminal).unwrap().kind,
+            Some(SessionKind::Agent)
+        );
+    }
+
     /// The kind marker is what name shape cannot say, in both directions: an
     /// agent whose title sanitizes into a terminal's shape is still the agent
     /// pane (#3888), and a paired terminal is never one however its name
@@ -3739,13 +3814,13 @@ mod tests {
         let agent = format!("{P}Foo_{ID8}");
 
         assert_eq!(
-            resolve_agent_session_name_marked(
+            resolve_session_name(
                 [
                     (derived.as_str(), Some("term")),
                     (agent.as_str(), Some("agent")),
                 ],
-                ID,
-                &derived
+                &derived,
+                &NameShape::agent(&id_suffix(ID))
             ),
             agent,
             "the marked agent wins over a terminal wearing the derived name"

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -561,23 +561,50 @@ pub(crate) fn marked_names(
         .map(|(name, session)| (name.as_str(), session.kind.map(SessionKind::as_marker)))
 }
 
-/// The one scan every kind-aware lookup reads: the global `@aoe_kind` (see
-/// [`parse_session_scan`]) followed by one line per live session.
+/// The one scan every kind-aware lookup reads: the inheritable `@aoe_kind`
+/// scopes (see [`parse_session_scan`]) followed by one line per live session.
 fn session_scan_command() -> Command {
     let mut command = tmux_query_command();
-    command.args([
-        "show-options",
-        "-gqv",
-        session_kind::KIND_OPTION,
-        ";",
-        "list-sessions",
-        "-F",
-        SESSION_SCAN_FORMAT,
-    ]);
+    for flags in INHERITABLE_KIND_SCOPES {
+        command.args(["show-options", flags, session_kind::KIND_OPTION, ";"]);
+    }
+    command.args(["list-sessions", "-F", SESSION_SCAN_FORMAT]);
     command
 }
 
+/// The server-wide option scopes a `list-sessions` `#{@aoe_kind}` reads, as
+/// `show-options` flag sets, each read back so [`parse_session_scan`] can
+/// subtract it.
+///
+/// Measured on tmux 3.6, highest first: `-s` > `-gw` > `-w` > a session's own
+/// value > `-g`. Only `-g` is a fall-through; the rest OVERRIDE the mark aoe
+/// wrote, so a user who sets one does not shadow aoe's answer selectively,
+/// they hide every mark on the server and put the whole fleet back on the
+/// name-shape guess. Subtracting them is therefore never able to discard a
+/// legitimate mark: when they are set, no legitimate mark is visible anyway.
+///
+/// `-w` and `-p` reach the format too but are per-window and per-pane, so a
+/// single subtracted value cannot cover them. Setting `@aoe_kind` yourself
+/// stays unsupported (`docs/guides/tmux-status-bar.md`).
+const INHERITABLE_KIND_SCOPES: [&str; 3] = ["-gqv", "-sqv", "-gwqv"];
+
 const SESSION_SCAN_FORMAT: &str = "#{session_name}|#{session_activity}|#{@aoe_kind}";
+
+/// Whether a scan line is a session rather than one of the leading
+/// [`INHERITABLE_KIND_SCOPES`] values.
+///
+/// A session line is `<name>|<activity>|<marker>`, so its second field is
+/// always `#{session_activity}`'s integer. Testing that rather than the mere
+/// presence of a [`FIELD_SEP`] keeps a scope value that happens to contain one
+/// from ending the scope block early, which would leave every later scope
+/// unsubtracted and hand a paired terminal the agent's kind.
+fn is_session_line(line: &str) -> bool {
+    let mut fields = line.split(FIELD_SEP);
+    fields.next();
+    fields
+        .next()
+        .is_some_and(|activity| activity.parse::<i64>().is_ok())
+}
 
 /// Parse the [`session_scan_command`] output.
 ///
@@ -585,13 +612,13 @@ const SESSION_SCAN_FORMAT: &str = "#{session_name}|#{session_activity}|#{@aoe_ki
 /// session with no mark, so a line that is short or empty there is an unmarked
 /// session and not a parse failure.
 ///
-/// The first line is the GLOBAL `@aoe_kind`, printed only when the user set
-/// one, and recognized by carrying no [`FIELD_SEP`] where a session line
-/// always has two. It has to be subtracted: `#{@aoe_kind}` falls through to
-/// the global value for every session that does not set its own, so a user who
-/// sets one would otherwise mark their whole server as agents. A session whose
-/// value merely equals the global is treated as unmarked, which is the
-/// name-shape fallback rather than a wrong answer.
+/// The leading lines are the [`INHERITABLE_KIND_SCOPES`] values, printed only
+/// for a scope the user set one in and told apart by [`is_session_line`].
+/// They have to be subtracted: a session that sets none of its own reads the
+/// broadest scope that is set, so a user who sets one would otherwise mark
+/// their whole server as agents and a paired terminal would pass as an agent
+/// pane. A session whose value merely equals one of them is treated as
+/// unmarked, which is the name-shape fallback rather than a wrong answer.
 ///
 /// aoe-created names are sanitized to `[A-Za-z0-9_-]`, but the shared server
 /// also carries foreign sessions, whose names tmux does allow `|` in. Such a
@@ -599,9 +626,12 @@ const SESSION_SCAN_FORMAT: &str = "#{session_name}|#{session_activity}|#{@aoe_ki
 /// the same outcome it had before the kind field existed.
 fn parse_session_scan(stdout: &str) -> HashMap<String, LiveSession> {
     let mut lines = stdout.lines().peekable();
-    let global = lines
-        .next_if(|line| !line.contains(FIELD_SEP))
-        .filter(|line| !line.is_empty());
+    let mut inherited: Vec<&str> = Vec::new();
+    while let Some(line) = lines.next_if(|line| !is_session_line(line)) {
+        if !line.is_empty() {
+            inherited.push(line);
+        }
+    }
 
     let mut map = HashMap::new();
     for line in lines {
@@ -617,7 +647,7 @@ fn parse_session_scan(stdout: &str) -> HashMap<String, LiveSession> {
             LiveSession {
                 activity: activity.parse().unwrap_or(0),
                 kind: marker
-                    .filter(|marker| Some(*marker) != global)
+                    .filter(|marker| !inherited.contains(marker))
                     .and_then(SessionKind::from_marker),
             },
         );
@@ -872,6 +902,10 @@ pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
     NameShape::agent(&id_suffix(session_id)).matches(tmux_name)
 }
 
+/// A live session's name paired with the kind marker the scan read for it,
+/// absent for a session created before the marker existed.
+pub(crate) type MarkedSessionName = (String, Option<SessionKind>);
+
 /// One tmux observation shared by a batch of per-instance liveness lookups.
 ///
 /// A pass that asks "is this instance's pane live?" once per stored session
@@ -894,13 +928,9 @@ pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
 /// that only needs session names never forks `list-panes`.
 ///
 /// An unreachable server is preserved rather than collapsed into "absent":
-/// [`Self::names`] returns `None`, so a one-shot caller that cannot retry can
-/// tell Unknown from Absent and probe per row instead (see
+/// [`LiveSessionSnapshot::sessions`] returns `None`, so a one-shot caller that
+/// cannot retry can tell Unknown from Absent and probe per row instead (see
 /// `Instance::tmux_env_session_name_in_or_probe`).
-/// A live session's name paired with the kind marker the scan read for it,
-/// absent for a session created before the marker existed.
-pub(crate) type MarkedSessionName = (String, Option<SessionKind>);
-
 #[derive(Default)]
 pub(crate) struct LiveSessionSnapshot {
     sessions: OnceLock<Option<Vec<MarkedSessionName>>>,
@@ -940,11 +970,10 @@ impl LiveSessionSnapshot {
         snapshot
     }
 
-    /// Live session names, or None when the tmux server could not be reached.
-    /// The fresh observation also warms the display cache, so TUI startup can
-    /// reuse this pass instead of issuing another list-sessions command.
     /// Live session names paired with the kind each was stamped with, or
-    /// `None` when the tmux server could not be reached.
+    /// `None` when the tmux server could not be reached. The fresh
+    /// observation also warms the display cache, so TUI startup can reuse
+    /// this pass instead of issuing another list-sessions command.
     pub(crate) fn sessions(&self) -> Option<&[MarkedSessionName]> {
         self.sessions
             .get_or_init(|| {
@@ -3706,12 +3735,13 @@ mod tests {
         assert!(!parsed.contains_key("garbage-with-no-separator"));
     }
 
-    /// `#{@aoe_kind}` falls through to the global option, so a user who sets
-    /// one would otherwise have every unmarked session on their server claim
-    /// that kind, which is how a paired terminal would pass as an agent pane
-    /// again. The scan prints the global first so it can be subtracted.
+    /// `#{@aoe_kind}` falls through to the server, global-window and
+    /// global-session options, so a user who sets one would otherwise have
+    /// every unmarked session on their server claim that kind, which is how a
+    /// paired terminal would pass as an agent pane again. The scan prints
+    /// those scopes first so they can be subtracted.
     #[test]
-    fn a_global_kind_option_marks_nothing() {
+    fn an_inherited_kind_option_marks_nothing() {
         let agent = format!("{P}Vikings{ID8}");
         let terminal = format!("{TERMINAL_PREFIX}Vikings{ID8}");
         let scan = format!(
@@ -3745,6 +3775,40 @@ mod tests {
             parsed.get(&terminal).unwrap().kind,
             Some(SessionKind::Agent)
         );
+
+        // `#{@aoe_kind}` inherits from the server and global-window scopes as
+        // well, so the scan reads back one line per scope and every value has
+        // to be subtracted, not just the first.
+        let parsed = parse_session_scan(&format!(
+            "term\n\
+             agent\n\
+             {agent}|1789065184|agent\n\
+             {terminal}|1789065184|term\n\
+             {terminal}_t1|1789065184|tool"
+        ));
+        assert_eq!(parsed.get(&agent).unwrap().kind, None);
+        assert_eq!(parsed.get(&terminal).unwrap().kind, None);
+        assert_eq!(
+            parsed.get(&format!("{terminal}_t1")).unwrap().kind,
+            Some(SessionKind::Tool),
+            "a value no scope could have produced is still a mark"
+        );
+
+        // A separator inside one scope's value must not end the scope block:
+        // the scopes are printed in a fixed order, so a `|` in the first one
+        // would otherwise leave the rest unsubtracted and hand this terminal
+        // the agent kind.
+        let parsed = parse_session_scan(&format!(
+            "a|b\n\
+             agent\n\
+             {terminal}|1789065184|agent"
+        ));
+        assert_eq!(
+            parsed.get(&terminal).unwrap().kind,
+            None,
+            "a later scope is still subtracted when an earlier one holds a separator"
+        );
+        assert!(!parsed.contains_key("a"), "a scope value is not a session");
     }
 
     /// The kind marker is what name shape cannot say, in both directions: an

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -531,6 +531,11 @@ impl Session {
         append_pane_base_index_args(&mut args, &self.name);
         append_window_size_args(&mut args, &self.name);
         append_tmux_setting_args(&mut args, &self.name, &config);
+        crate::tmux::append_session_kind_args(
+            &mut args,
+            &self.name,
+            crate::tmux::SessionKind::Agent,
+        );
 
         let output = crate::tmux::tmux_command().args(&args).output()?;
 
@@ -3155,6 +3160,45 @@ mod tests {
         let created_at_ms = Session::from_name(guard.name()).created_at_ms().unwrap();
         assert!(created_at_ms > 0);
         assert_eq!(created_at_ms % 1000, 999);
+    }
+
+    /// The marker has to survive the wiring, not just tmux: the option is
+    /// chained onto `new-session`, and a scan reads it back through the same
+    /// `-F` the session cache uses. A rename must not lose it, since that is
+    /// the case the marker exists for (smart rename is on by default).
+    #[test]
+    #[serial_test::serial]
+    fn create_marks_the_agent_session_and_a_rename_keeps_the_mark() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let guard = TmuxTestSession::new("aoe_test_kind_marker");
+        let session = Session::from_name(guard.name());
+        session
+            .create(&temp.path().to_string_lossy(), Some("sleep 30"), "default")
+            .expect("create the agent session");
+
+        let read_marker = |name: &str| -> String {
+            let out = crate::tmux::tmux_command()
+                .args(["display-message", "-p", "-t", name, "#{@aoe_kind}"])
+                .output()
+                .expect("tmux display-message");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        assert_eq!(read_marker(guard.name()), "agent");
+
+        let renamed = TmuxTestSession::new("aoe_test_kind_renamed");
+        crate::tmux::tmux_command()
+            .args(["rename-session", "-t", guard.name(), renamed.name()])
+            .output()
+            .expect("tmux rename-session");
+        assert_eq!(
+            read_marker(renamed.name()),
+            "agent",
+            "the mark travels with the session, unlike its name"
+        );
     }
 
     #[test]

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -3162,41 +3162,66 @@ mod tests {
         assert_eq!(created_at_ms % 1000, 999);
     }
 
-    /// The marker has to survive the wiring, not just tmux: the option is
-    /// chained onto `new-session`, and a scan reads it back through the same
-    /// `-F` the session cache uses. A rename must not lose it, since that is
-    /// the case the marker exists for (smart rename is on by default).
+    /// The marker has to survive the wiring, not just tmux. Every kind is
+    /// created through its own production path and read back through the very
+    /// scan command and parser the session cache uses, so a typo in the `-F`
+    /// string or a missing chain on one kind fails here. A rename must not
+    /// lose the mark, since that is the case it exists for (smart rename is on
+    /// by default).
     #[test]
     #[serial_test::serial]
-    fn create_marks_the_agent_session_and_a_rename_keeps_the_mark() {
+    fn every_kind_is_marked_at_creation_and_keeps_its_mark_across_a_rename() {
         if !tmux_available() {
             eprintln!("Skipping test: tmux not available");
             return;
         }
         let temp = tempfile::tempdir().expect("tempdir");
-        let guard = TmuxTestSession::new("aoe_test_kind_marker");
-        let session = Session::from_name(guard.name());
-        session
-            .create(&temp.path().to_string_lossy(), Some("sleep 30"), "default")
+        let dir = temp.path().to_string_lossy().to_string();
+        // A distinct id per run so these names cannot collide with a parallel
+        // test's, and a title that sanitizes cleanly.
+        let id = format!("kindmark{}", std::process::id());
+        let title = "Vikings";
+
+        let agent = Session::new(&id, title).expect("agent session");
+        let _agent_guard = TmuxTestSession::from_name(agent.name());
+        agent
+            .create(&dir, Some("sleep 30"), "default")
             .expect("create the agent session");
 
-        let read_marker = |name: &str| -> String {
-            let out = crate::tmux::tmux_command()
-                .args(["display-message", "-p", "-t", name, "#{@aoe_kind}"])
-                .output()
-                .expect("tmux display-message");
-            String::from_utf8_lossy(&out.stdout).trim().to_string()
-        };
-        assert_eq!(read_marker(guard.name()), "agent");
+        let terminal = crate::tmux::TerminalSession::new(&id, title).expect("terminal session");
+        let _terminal_guard = TmuxTestSession::from_name(terminal.name());
+        terminal
+            .create_with_size(&dir, Some("sleep 30"), None, "default")
+            .expect("create the paired terminal");
+
+        let tool = crate::tmux::ToolSession::new(&id, title, "lazygit");
+        let _tool_guard = TmuxTestSession::from_name(tool.session_name());
+        tool.create_with_size(&dir, "sleep 30", None, "default")
+            .expect("create the tool sub-session");
+
+        let scan = crate::tmux::probe_live_sessions().expect("the scan reaches tmux");
+        assert_eq!(
+            scan.get(agent.name()).and_then(|s| s.kind),
+            Some(crate::tmux::SessionKind::Agent),
+        );
+        assert_eq!(
+            scan.get(terminal.name()).and_then(|s| s.kind),
+            Some(crate::tmux::SessionKind::Terminal),
+        );
+        assert_eq!(
+            scan.get(tool.session_name()).and_then(|s| s.kind),
+            Some(crate::tmux::SessionKind::Tool),
+        );
 
         let renamed = TmuxTestSession::new("aoe_test_kind_renamed");
         crate::tmux::tmux_command()
-            .args(["rename-session", "-t", guard.name(), renamed.name()])
+            .args(["rename-session", "-t", agent.name(), renamed.name()])
             .output()
             .expect("tmux rename-session");
+        let scan = crate::tmux::probe_live_sessions().expect("the scan reaches tmux");
         assert_eq!(
-            read_marker(renamed.name()),
-            "agent",
+            scan.get(renamed.name()).and_then(|s| s.kind),
+            Some(crate::tmux::SessionKind::Agent),
             "the mark travels with the session, unlike its name"
         );
     }

--- a/src/tmux/session_kind.rs
+++ b/src/tmux/session_kind.rs
@@ -1,0 +1,185 @@
+//! What kind of aoe session a live tmux session is, recorded on the session
+//! itself rather than inferred from its name.
+//!
+//! Every kind's name is `<prefix><sanitized title><suffix>`, so a title that
+//! sanitizes under another kind's prefix produces a name of that kind's shape:
+//! `aoe_term_Foo_<id8>` is both the agent name for title `term Foo` and the
+//! paired-terminal name for title `Foo`. Name shape alone cannot separate
+//! them, which cost the ambiguous rows their session-id poller (#3888) and,
+//! the other way around, let a poller follow a paired terminal that outlived
+//! its agent (#3880).
+//!
+//! `@aoe_kind` is written once at creation and moves with the session through
+//! renames, so a scan that reads it never has to guess. It joins the existing
+//! `@aoe_*` user options (`@aoe_title`, `@aoe_branch`, `@aoe_sandbox`), which
+//! are aoe's own namespace and never override a user's tmux config.
+
+use super::{CONTAINER_TERMINAL_PREFIX, SESSION_PREFIX, TERMINAL_PREFIX, TOOL_PREFIX};
+
+/// The tmux user option carrying [`SessionKind`].
+pub(crate) const KIND_OPTION: &str = "@aoe_kind";
+
+/// The kind of aoe tmux session, as recorded by [`KIND_OPTION`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionKind {
+    /// The pane the agent runs in, and the only kind a session-id poller can
+    /// follow.
+    Agent,
+    Terminal,
+    ContainerTerminal,
+    Tool,
+}
+
+impl SessionKind {
+    /// The stored marker value. Stable: a session created by an earlier build
+    /// keeps whatever it was stamped with for its whole life.
+    pub(crate) const fn as_marker(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::Terminal => "term",
+            Self::ContainerTerminal => "cterm",
+            Self::Tool => "tool",
+        }
+    }
+
+    /// Parse a stored marker. `None` for an unset option (empty) or a
+    /// value this build does not know.
+    pub(crate) fn from_marker(marker: &str) -> Option<Self> {
+        match marker {
+            "agent" => Some(Self::Agent),
+            "term" => Some(Self::Terminal),
+            "cterm" => Some(Self::ContainerTerminal),
+            "tool" => Some(Self::Tool),
+            _ => None,
+        }
+    }
+
+    /// Classify by name shape, for a session with no marker: one created
+    /// before this option existed, or whose `set-option` did not land.
+    ///
+    /// This is the ambiguous answer the marker replaces, kept as the fallback
+    /// so an upgrade does not have to restart every running session. The
+    /// auxiliary prefixes nest under [`SESSION_PREFIX`], so they are tested
+    /// first and the agent arm is what is left.
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        if name.starts_with(TERMINAL_PREFIX) {
+            Some(Self::Terminal)
+        } else if name.starts_with(CONTAINER_TERMINAL_PREFIX) {
+            Some(Self::ContainerTerminal)
+        } else if name.starts_with(TOOL_PREFIX) {
+            Some(Self::Tool)
+        } else if name.starts_with(SESSION_PREFIX) {
+            Some(Self::Agent)
+        } else {
+            None
+        }
+    }
+
+    /// The kind of a live session: the marker it was created with, else its
+    /// name shape. An unparsable marker is treated as absent rather than as
+    /// evidence of anything.
+    pub(crate) fn of(name: &str, marker: Option<&str>) -> Option<Self> {
+        marker
+            .and_then(Self::from_marker)
+            .or_else(|| Self::from_name(name))
+    }
+}
+
+/// Append `; set-option -t <target> @aoe_kind <kind>` to an in-flight
+/// `new-session` argument list, so a session is marked in the same tmux
+/// invocation that creates it.
+///
+/// Chained rather than sent afterwards for the same reason
+/// `append_remain_on_exit_args` is: a second call is a second fork, and the
+/// gap between them is a window where a scan sees the session unmarked and
+/// falls back to guessing from its name.
+pub(crate) fn append_session_kind_args(args: &mut Vec<String>, target: &str, kind: SessionKind) {
+    args.extend([
+        ";".to_string(),
+        "set-option".to_string(),
+        "-t".to_string(),
+        target.to_string(),
+        KIND_OPTION.to_string(),
+        kind.as_marker().to_string(),
+    ]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ID8: &str = "_abcd1234";
+
+    /// The marker is what the name shape cannot say. A title sanitizing to
+    /// `term_...` gives an agent session a paired terminal's shape, and a
+    /// paired terminal of a plainly titled row gives the same string, so both
+    /// directions have to come from the marker.
+    #[test]
+    fn marker_outranks_the_name_shape_in_both_directions() {
+        let ambiguous = format!("{TERMINAL_PREFIX}Foo{ID8}");
+
+        assert_eq!(
+            SessionKind::of(&ambiguous, Some("agent")),
+            Some(SessionKind::Agent),
+            "an agent titled `term Foo` is an agent"
+        );
+        assert_eq!(
+            SessionKind::of(&ambiguous, Some("term")),
+            Some(SessionKind::Terminal),
+            "the paired terminal of a row titled `Foo` is a terminal"
+        );
+        assert_eq!(
+            SessionKind::of(&ambiguous, None),
+            Some(SessionKind::Terminal),
+            "unmarked keeps the pre-marker guess"
+        );
+    }
+
+    #[test]
+    fn unmarked_and_unparsable_fall_back_to_the_name_shape() {
+        let cases = [
+            (format!("{SESSION_PREFIX}Vikings{ID8}"), SessionKind::Agent),
+            (
+                format!("{TERMINAL_PREFIX}Vikings{ID8}"),
+                SessionKind::Terminal,
+            ),
+            (
+                format!("{CONTAINER_TERMINAL_PREFIX}Vikings{ID8}"),
+                SessionKind::ContainerTerminal,
+            ),
+            (
+                format!("{TOOL_PREFIX}claude_Vikings{ID8}"),
+                SessionKind::Tool,
+            ),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(SessionKind::of(&name, None), Some(expected), "{name}");
+            assert_eq!(
+                SessionKind::of(&name, Some("")),
+                Some(expected),
+                "an unset option reads as empty, not as a kind: {name}"
+            );
+            assert_eq!(
+                SessionKind::of(&name, Some("nonsense")),
+                Some(expected),
+                "an unparsable marker is not evidence: {name}"
+            );
+        }
+        assert_eq!(SessionKind::of("someone-elses-session", None), None);
+    }
+
+    #[test]
+    fn markers_round_trip() {
+        for kind in [
+            SessionKind::Agent,
+            SessionKind::Terminal,
+            SessionKind::ContainerTerminal,
+            SessionKind::Tool,
+        ] {
+            assert_eq!(
+                SessionKind::of("someone-elses-session", Some(kind.as_marker())),
+                Some(kind),
+            );
+        }
+    }
+}

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -31,6 +31,13 @@ impl TerminalKind {
         }
     }
 
+    fn session_kind(self) -> crate::tmux::SessionKind {
+        match self {
+            TerminalKind::Host => crate::tmux::SessionKind::Terminal,
+            TerminalKind::Container => crate::tmux::SessionKind::ContainerTerminal,
+        }
+    }
+
     fn label(self) -> &'static str {
         match self {
             TerminalKind::Host => "terminal session",
@@ -157,7 +164,7 @@ impl PairedTerminal {
         let shape = crate::tmux::NameShape {
             prefix: kind.prefix(),
             suffix: &suffix,
-            excluded_prefixes: &[],
+            kind: kind.session_kind(),
         };
         if display_only {
             crate::tmux::session_name_for_display(&derived, &shape)
@@ -250,6 +257,7 @@ impl PairedTerminal {
             append_default_shell_args(&mut args, &self.name, shell);
         }
         append_tmux_setting_args(&mut args, &self.name, &config);
+        crate::tmux::append_session_kind_args(&mut args, &self.name, self.kind.session_kind());
 
         let output = crate::tmux::tmux_command().args(&args).output()?;
 

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -57,7 +57,7 @@ impl ToolSession {
         let shape = crate::tmux::NameShape {
             prefix: &prefix,
             suffix: &suffix,
-            excluded_prefixes: &[],
+            kind: crate::tmux::SessionKind::Tool,
         };
         let name = if display_only {
             crate::tmux::session_name_for_display(&derived, &shape)
@@ -129,6 +129,11 @@ impl ToolSession {
         append_pane_base_index_args(&mut args, &self.name);
         append_window_size_args(&mut args, &self.name);
         append_tmux_setting_args(&mut args, &self.name, &config);
+        crate::tmux::append_session_kind_args(
+            &mut args,
+            &self.name,
+            crate::tmux::SessionKind::Tool,
+        );
 
         let output = crate::tmux::tmux_command().args(&args).output()?;
 


### PR DESCRIPTION
## Description

Fixes #3888.

A tmux session's kind was inferred from its name, which cannot always say: `aoe_term_Foo_<id8>` is both the agent name for title `term Foo` and the paired-terminal name for title `Foo`. #3872 and #3884 resolved that ambiguity by refusing the name, which cost those rows their session-id poller. No poller runs, the conversation id is not observed while the pane is live, and resume can fall back to a stale or absent id.

Sessions now carry `@aoe_kind` (`agent`, `term`, `cterm`, `tool`), chained onto the `new-session` that creates them and read back by the shared `list-sessions` scan. `SessionKind::of` is the one classifier: the marker when the session has one, the old name shape when it does not, so a session started by an earlier aoe keeps the behavior it has today rather than becoming unclassifiable.

That closes both directions. An agent titled `term rewriting` is found as its row's agent pane again, and a paired terminal holding what a rename has since made the agent's derived name is no longer adopted as the agent, which is the collision #3880 was about.

A marker is trusted only at session scope. `#{@aoe_kind}` falls through to the global option, so the scan reads the global in the same invocation and subtracts it: a value a user's own `set -g @aoe_kind` could have produced is treated as unmarked, which is the name-shape fallback rather than a wrong answer.

Bounds worth knowing. A session already running when you upgrade carries no marker until it is restarted, and keeps the name-shape answer. `resolve_agent_session_name_in`, which resolves from `list-panes` keys for the status poller and `aoe ps`, has no markers to read and is unchanged. `@aoe_kind` is documented alongside the other `@aoe_*` options users reference in their own status bars.

Carries one unrelated one-liner: `list_sessions_projects_pending_approvals_only_for_running_workers` is the only non-serial `list_sessions` caller, and its resolver-miss bumps leak into the counter a serial sibling resets and reads. It failed CI on this branch; the fix is its own commit.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the facts an e2e would add over the unit tests are already covered against real tmux and the real start path. `tmux::session::tests::every_kind_is_marked_at_creation_and_keeps_its_mark_across_a_rename` creates an agent, a paired terminal and a tool sub-session through their own production paths and reads all three back through the scan command and parser the session cache uses, including across a rename, so a typo in the `-F` string or a missing chain on one kind fails there; `polling::tests::an_aux_shaped_title_polls_its_marked_agent_pane` drives `maybe_start_poller` for a `term rewriting` row against a scan that answers with a marked agent. The rest is classification, which is pure. Reusing the Claude e2e fixture would mean duplicating its two-session correlation setup for one session.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any Additional AI Details you'd like to share:**

Diagnosis and fix drafted through back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiJcnooM1swcM35Q36XTuV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a durable `@aoe_kind` marker for agent, terminal, container terminal, and tool sessions.
- Updated session discovery to use the marker and retain name-based fallback for older sessions.
- Restored session-ID polling for agents with auxiliary-looking names.
- Prevented renamed paired terminals from being classified as agents.
- Updated session polling, tmux integration, documentation, and tests.
- Serialized a `list_sessions` caller to prevent resolver counter interference.

## Benefits

- Session classification remains correct after renames.
- Agent conversation IDs are reliably observed.
- Existing sessions remain compatible through fallback classification.
- User-defined global tmux options cannot incorrectly mark all sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->