### PR TITLE
fix(web): clear the local IME shadow when a paste bypasses the textarea

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1749,8 +1749,9 @@ export function MobileLiveTerminal({
           return true;
         case "insertFromPaste": {
           // The paste lands on the line without passing through the
-          // textarea, so the retained syllable stops mirroring it.
-          invalidateRetainedImeContext();
+          // textarea, so the retained syllable stops mirroring it. Name the
+          // local input: with no target the helper clears only the proxy.
+          invalidateRetainedImeContext(inputRef.current);
           if (input.data) sendData(bracketedPaste(input.data));
           return true;
         }
@@ -1758,7 +1759,7 @@ export function MobileLiveTerminal({
           return true;
       }
     },
-    [sendKeys, sendData, typedWordRef],
+    [sendKeys, sendData, typedWordRef, inputRef],
   );
   const handleBeforeInput = useCallback(
     (ev: InputEvent) => forwardTerminalBeforeInput(ev, handleMobileKeyboardProxyInput),

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -102,6 +102,39 @@ function stubKeyboardLayout(entries: [string, string][]) {
 }
 
 describe("MobileLiveTerminal paste", () => {
+  // The paste is swallowed by forwardTerminalBeforeInput and never enters the
+  // textarea, so a syllable typed before it stays retained while the line now
+  // shows the pasted text. The next Korean rewrite would then open with a
+  // delete against text the user did not type. The async image-upload path had
+  // the same gap (#3885); this is its synchronous sibling.
+  it("drops a retained syllable when a paste bypasses the textarea", () => {
+    const proxy = document.createElement("textarea");
+    proxy.setAttribute("data-keyboard-proxy", "");
+    proxy.value = "\ud55c";
+    document.body.append(proxy);
+    try {
+      const { input, sendData } = renderTerm();
+      input.value = "\ud55c";
+
+      fireEvent(
+        input,
+        new InputEvent("beforeinput", {
+          bubbles: true,
+          cancelable: true,
+          inputType: "insertFromPaste",
+          data: "ls -al",
+        }),
+      );
+
+      expect(sendData).toHaveBeenCalledWith(expect.stringContaining("ls -al"));
+      // Either hidden input can hold focus, so both shadows must drop it.
+      expect(input.value).toBe("");
+      expect(proxy.value).toBe("");
+    } finally {
+      proxy.remove();
+    }
+  });
+
   it("does not swallow Ctrl+V into a literal ^V, and the paste event sends a bracketed paste", () => {
     const { input, sendData } = renderTerm();
 


### PR DESCRIPTION
## Description

`forwardTerminalBeforeInput` swallows `insertFromPaste` so the paste never enters the textarea, but the receiver at `MobileLiveTerminal.tsx:1753` invalidated with no target, and `invalidateRetainedImeContext` clears only App's proxy in that case. A syllable typed before the paste stayed in the live terminal's own textarea while the line showed the pasted text, so the next Korean rewrite opened with a delete against text the user did not type.

Found while reviewing #3893. That PR applies the identical correction to the async image-upload path at line 1865; this is its synchronous sibling, reached whenever a paste arrives through the terminal's textarea rather than an upload. Deliberately separate: it is a fourth case, outside the three #3885 enumerates, and independent of #3893's other changes.

Reproduced before fixing: with the old call, a textarea holding `한` still held it after the paste while the proxy cleared.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`npm run format:check`, `npm run lint`, `npx tsc -b` and `npm run test:unit` (3798 passed, 362 files) are clean, as is `node tests/validate-coverage-matrix.mjs`. No screenshot: nothing visual changes. The behavior is the value of a hidden textarea, which the new assertion states more precisely than a capture could.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Covered: `MobileLiveTerminal.paste.test.tsx` renders the real component and drives a native `beforeinput`, asserting both hidden inputs drop the retained syllable. The test was confirmed to fail against the previous call (`expected '한' to be ''`). `coverage-matrix.json` already maps this spec to `MobileLiveTerminal.tsx` under `terminal.clipboard-chords`, so no matrix change is needed and the validator passes.

**TUI / CLI (e2e test)**
- [x] N/A: web-only change

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any Additional AI Details you'd like to share:**

Found during a review of #3893, by grepping the other call sites of the helper that PR was fixing rather than from the issue text. The agent reproduced the stale shadow before writing the fix, then confirmed the test fails without it.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PodUXso6Y16zpy8Py1FmK3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed paste handling for web IME input.
- Clears both the terminal textarea and keyboard-proxy textarea after paste.
- Added Playwright coverage for native `beforeinput` paste events.
- Prevents previously typed IME syllables from remaining after paste.

## Technical details

`MobileLiveTerminal` now passes the local textarea to `invalidateRetainedImeContext` and updates the callback dependencies.

## Benefit

Paste operations now leave both hidden inputs synchronized and clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->