### PR TITLE
fix(acp): ignore whitespace-only configured model pins

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -110,6 +110,7 @@ prevent_sleep_idle_grace_minutes = 15  # release once every session has been idl
 [acp.acp_defaults.opencode]
 model = "openai/gpt-5.5"
 # pin_model = true        # make `model` a pin: creation refuses any other model
+# Empty or whitespace-only model values are unset, including with pin_model.
 effort = "high"           # default thinking level
 mode = "plan"             # default mode, applied when the agent advertises one
 

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -508,13 +508,8 @@ pub struct SpawnRequest {
     pub provider_env: Vec<(String, String)>,
     pub model: Option<String>,
     pub effort: Option<String>,
-    /// Provenance of `effort`: true only when the user explicitly set it
-    /// (persisted in `Instance.acp_effort`), making it a session pin that
-    /// survives a later model-pin change. A nonempty `effort` alone proves
-    /// nothing — the creation path forwards the daemon-resolved default
-    /// while `Instance.acp_effort` stays `None` — so an inherited effort
-    /// must read false and re-resolve against the pinned model on respawn.
-    /// See #3683 review.
+    /// True for persisted user effort, not a resolved default. Only explicit
+    /// effort survives a model-pin change without being re-resolved.
     pub effort_explicit: bool,
     /// ACP session id from a previous run; when `Some` and the agent
     /// advertises `load_session = true`, the spawn calls
@@ -731,11 +726,7 @@ fn log_wrapper_substitution(session_id: &str, tool: &str, wrapper: &str, base: &
     );
 }
 
-/// Re-run the spawn model/effort resolution on a `SpawnConfig` cached at
-/// first launch, so a pin changed since then applies to the respawn. The
-/// cached values stand in for the original request. They are resolved
-/// values, so when the pin moves the model, the effort keyed on the new
-/// model replaces a cached effort keyed on the old one.
+/// Apply current model pins and effort defaults to a cached respawn request.
 fn refresh_spawn_model_effort(
     config: &mut SpawnConfig,
     defaults: Option<&crate::session::config::AcpAgentDefaults>,
@@ -745,10 +736,7 @@ fn refresh_spawn_model_effort(
         .iter()
         .find(|(key, _)| key == "AOE_AGENT_MODEL")
         .map(|(_, value)| value.clone());
-    // An explicit effort is a session pin: it survives the model-pin move.
-    // Inherited effort re-resolves for the model the respawn runs on, the
-    // keyed entry when one exists or the ordinary fallback (`effort_for_model`)
-    // when it does not; passing no request effort lets the resolver do that.
+    // Preserve explicit effort; resolve inherited effort for the new model.
     let (model, effort) = if config.default_effort_explicit {
         crate::session::config::resolve_spawn_model_effort(
             defaults,
@@ -4446,58 +4434,6 @@ mod tests {
                 "{name}"
             );
         }
-    }
-
-    /// The creation handoff must carry effort provenance, not derive it from
-    /// the value: the create path forwards the daemon-resolved default while
-    /// `Instance.acp_effort` is `None`, so a nonempty `effort` is NOT a pin.
-    /// Drives the real `Supervisor::spawn` with the request the create path
-    /// sends, then asserts the installed SpawnConfig reads inherited.
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn creation_handoff_keeps_resolved_default_effort_inherited() {
-        let _home = isolate_home();
-        let control = Arc::new(FakeProcessControl::default());
-        control.alive(4343);
-        let entered = Arc::new(tokio::sync::Notify::new());
-        let gate = Arc::new(tokio::sync::Notify::new());
-        let sup = Arc::new(
-            Supervisor::new(VecSink::new())
-                .with_process_control(control)
-                .with_launcher(gated_launcher(entered.clone(), gate.clone(), 4343)),
-        );
-
-        // What the create path sends: an effort that was resolved from the
-        // pinned model's defaults, with no user selection behind it.
-        let mut req = spawn_request("s-prov");
-        req.effort = Some("low".into());
-        req.effort_explicit = false;
-
-        // The launcher parks on the gate until released, so spawn runs
-        // beside this task like the create path's detached spawn does.
-        let spawner = {
-            let sup = Arc::clone(&sup);
-            tokio::spawn(async move { sup.spawn(req).await })
-        };
-        entered.notified().await;
-        gate.notify_one();
-        spawner.await.unwrap().expect("spawn");
-
-        let config = sup
-            .workers
-            .lock()
-            .await
-            .get("s-prov")
-            .map(|handle| match &handle.kind {
-                WorkerKind::Runner { spawn_config } => spawn_config.default_effort_explicit,
-                _ => panic!("runner handle expected"),
-            })
-            .expect("worker installed");
-        assert!(
-            !config,
-            "a resolved default effort must not read as a session pin; \
-             the watchdog would refuse the new model's inherited effort"
-        );
     }
 
     /// An explicit request effort is a session pin (persisted in

--- a/src/session/config/mod.rs
+++ b/src/session/config/mod.rs
@@ -1554,10 +1554,12 @@ impl AcpAgentDefaults {
             && self.effort_by_model.is_empty()
     }
 
-    /// Default model, with empty strings treated as unset (mirrors `mode`) so a
-    /// blank value never overrides the agent's own default at spawn.
+    /// Configured model, excluding empty or whitespace-only values.
     pub fn model(&self) -> Option<String> {
-        self.model.clone().filter(|value| !value.is_empty())
+        self.model
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
     }
 
     /// The pinned model: `model` when `pin_model` is on and the value is
@@ -4966,6 +4968,24 @@ mod tests {
         let (model, effort) = resolve_spawn_model_effort(None, None, None);
         assert_eq!(model, None);
         assert_eq!(effort, None);
+    }
+
+    #[test]
+    fn resolve_spawn_model_effort_ignores_blank_configured_pin() {
+        let defaults = AcpAgentDefaults {
+            model: Some(" \t\n".into()),
+            pin_model: true,
+            effort_by_model: HashMap::from([("requested".into(), "high".into())]),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_spawn_model_effort(Some(&defaults), Some("requested".into()), None),
+            (Some("requested".into()), Some("high".into()))
+        );
+        assert_eq!(
+            resolve_spawn_model_effort(Some(&defaults), None, None),
+            (None, None)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Follow-up to the remaining whitespace-pin review in #3683. A configured model containing only whitespace was returned as a pin and overrode valid requests. Filter blank values before cloning in the shared configured-model accessor, so neither the pin nor the fallback-default path can reintroduce the invalid value. Nonblank model IDs are unchanged.

Also address the review's provenance qualifications: shorten the effort comments and remove the test that only checked a copied internal flag while claiming a full creation handoff. Existing explicit/inherited respawn-resolution tests remain; this PR does not claim end-to-end creation-to-respawn coverage.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (not applicable)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: shared Rust configuration resolution; no frontend changes

**TUI / CLI (e2e test)**
- [x] Skipped a test, because the pure resolver regression directly proves requested-model precedence and absent-model behavior without launching an agent.

Regression failed before the fix: actual (Some(" \t\n"), None), expected (Some("requested"), Some("high")). After the fix: all 8 resolve_spawn_model_effort tests and 9 respawn_ tests pass. cargo fmt and cargo clippy --lib -- -D warnings pass; commit hook cargo clippy -- -D warnings also passes. No native UI or full creation-to-respawn run is claimed.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** GPT-6-astra via Oh My Pi.

**Any Additional AI Details:** Implemented from the original review finding, checked against current main, with a failing-before/passing-after regression.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Treats empty and whitespace-only ACP model values as unset.
- Prevents blank configured models from overriding requested models or triggering invalid fallback behavior.
- Adds documentation and coverage for the new behavior.
- Removes a misleading respawn handoff test and shortens related comments.

This keeps valid model selection unchanged and makes ACP configuration more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->