### PR TITLE
fix(acp): exclude unsupported session features from stale recovery

### DIFF
--- a/src/acp/acp_client/connection.rs
+++ b/src/acp/acp_client/connection.rs
@@ -298,9 +298,7 @@ pub(super) async fn run_connection_task<W, R>(
     // hit twice. Stale entries are filtered by reset-in-the-future at read
     // time instead. #3028, #3152.
     let last_rate_limit_rejections = Arc::new(std::sync::Mutex::new(HashMap::<String, i64>::new()));
-    // Set when a rejected first prompt on a stored session already emitted
-    // `SessionContextReset`: the connection then ends on a soft stop that the
-    // respawn recovers from, not on a startup error (#3560).
+    // A stored-session rejection emits one reset, then a recoverable soft stop.
     let context_reset_emitted = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let context_reset_emitted_for_block = context_reset_emitted.clone();
     // In-flight tool calls for the between-prompt (agent-initiated) path,
@@ -928,13 +926,7 @@ pub(super) async fn run_connection_task<W, R>(
             // for a clear command must forward the same gated list.
             let mcp_servers_for_reset = mcp_servers.clone();
 
-            // Mutable: a driven conversation reset (#2979) swaps in the
-            // fresh id from its `session/new` so every later
-            // `session/prompt` / cancel / mode switch addresses the new
-            // conversation.
-            // Whether the session id in use came from storage (a mid-turn
-            // resume, or a `session/load` of the stored id): only then is a
-            // first-prompt rejection the agent having dropped that session.
+            // Resets replace this ID and clear its stored-session provenance.
             let mut session_from_storage = matches!(mode, ConnectMode::Resume { .. });
             let mut acp_session_id: SessionId = match mode {
                 ConnectMode::Resume {

--- a/src/acp/acp_client/control.rs
+++ b/src/acp/acp_client/control.rs
@@ -1134,6 +1134,116 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn attached_session_only_resets_for_missing_session_errors() {
+        use crate::acp::acp_client::AcpClient;
+        use crate::acp::control_protocol::PromptOutcome;
+        use crate::acp::state::AcpSessionId;
+
+        for (message, should_reset) in [
+            ("Unsupported ACP session", true),
+            ("Unsupported session mode", false),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let socket = tmp.path().join("resume.sock");
+            let control = crate::process::worker::control_socket_sibling(&socket);
+            let listener = tokio::net::UnixListener::bind(control).unwrap();
+            let runner = async {
+                let (mut peer, _) = listener.accept().await.unwrap();
+                control_protocol::write_frame(
+                    &mut peer,
+                    &ControlBody::Hello {
+                        control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
+                        session_id: "resume".into(),
+                    },
+                )
+                .await
+                .unwrap();
+                while let Some(frame) = control_protocol::read_frame(&mut peer).await.unwrap() {
+                    let reply = match frame {
+                        ControlBody::Attach { .. } => continue,
+                        ControlBody::Initialize { .. } => ControlBody::Initialized {
+                            result: serde_json::json!({
+                                "protocolVersion": 1, "agentCapabilities": {}
+                            }),
+                        },
+                        ControlBody::ResumeSession => ControlBody::SessionReady {
+                            acp_session_id: "sid-stored".into(),
+                            result: serde_json::json!({}),
+                        },
+                        ControlBody::Prompt { request } => {
+                            assert_eq!(request["sessionId"], "sid-stored");
+                            control_protocol::write_frame(
+                                &mut peer,
+                                &ControlBody::PromptStarted { prompt_req_id: 1 },
+                            )
+                            .await
+                            .unwrap();
+                            ControlBody::PromptCompleted {
+                                prompt_req_id: 1,
+                                outcome: PromptOutcome::Error {
+                                    code: -32603,
+                                    message: message.into(),
+                                    data: None,
+                                },
+                            }
+                        }
+                        frame => panic!("unexpected resumed-session request: {frame:?}"),
+                    };
+                    control_protocol::write_frame(&mut peer, &reply)
+                        .await
+                        .unwrap();
+                }
+            };
+            let daemon = async {
+                let mut client = AcpClient::attach(
+                    socket,
+                    tmp.path().into(),
+                    vec![],
+                    "sid-stored".into(),
+                    false,
+                    AcpSessionId("resume".into()),
+                    None,
+                    "codex".into(),
+                    None,
+                )
+                .await
+                .unwrap();
+                client.send_prompt("continue", &[]).await.unwrap();
+                let mut recovery = Vec::new();
+                while let Some(event) = client.next_event().await {
+                    match event {
+                        Event::SessionContextReset { .. } => recovery.push("reset"),
+                        Event::Stopped { reason } => {
+                            assert_eq!(reason, "stored_session_rejected");
+                            recovery.push("stopped");
+                        }
+                        Event::AgentStartupError { message: error } => {
+                            assert!(error.contains(message), "{error}");
+                            recovery.push("error");
+                        }
+                        _ => {}
+                    }
+                }
+                assert_eq!(
+                    recovery,
+                    if should_reset {
+                        vec!["reset", "stopped"]
+                    } else {
+                        vec!["error"]
+                    },
+                    "{message}",
+                );
+                let _ = client.shutdown().await;
+            };
+            tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                tokio::join!(runner, daemon);
+            })
+            .await
+            .expect("attach recovery must finish and close its control socket");
+        }
+    }
+
     /// A waiterless completion for an adopted turn publishes its terminal
     /// event and disarms the resume-idle watchdog.
     #[tokio::test]

--- a/src/acp/acp_client/rate_limit.rs
+++ b/src/acp/acp_client/rate_limit.rs
@@ -41,21 +41,12 @@ pub(crate) fn classify_rate_limit_from_message(
     })
 }
 
-/// Recognize the agent's rejection of a stored/resumed ACP session id it no
-/// longer holds (e.g. OMP replying `Unsupported ACP session`). A resumed
-/// worker reuses the persisted `acp_session_id` without re-issuing
-/// `session/load`, so if the agent dropped that session across the
-/// interruption the first `session/prompt` fails with this class of error
-/// rather than a rate limit or a transport drop. The caller recovers via the
-/// established `SessionContextReset` path: the supervisor clears the stored
-/// id so the respawn opens a fresh `session/new`, while the SQLite transcript
-/// is preserved for replay. Deliberately narrow, a message fingerprint, so an
-/// unrelated prompt failure still ends the turn as an ordinary error instead
-/// of being silently swallowed into a context reset.
+/// Recognize missing stored session IDs, not unsupported session features.
+/// A storage-origin session may be lost before any prompt. The caller resets
+/// its identity while preserving the transcript for replay.
 pub(crate) fn is_unsupported_session_error(err: &agent_client_protocol::Error) -> bool {
     const PHRASES: &[&str] = &[
         "unsupported acp session",
-        "unsupported session",
         "unknown session",
         "session not found",
         "no such session",
@@ -343,6 +334,8 @@ mod tests {
             ("unknown tool", false),
             ("Unsupported content block in session/prompt", false),
             ("Method not found: session/prompt", false),
+            ("Unsupported session mode", false),
+            ("Unsupported session capability: fork", false),
         ];
         for (msg, expected) in cases {
             assert_eq!(classify(msg), expected, "{msg:?}");


### PR DESCRIPTION
## Description

Complete the remaining classifier finding from #3561 / #3882: the ambiguous fingerprint "unsupported session" still matched the originally reported "unsupported session mode" and "unsupported session capability: fork". Remove that generic fingerprint while retaining the existing explicit missing-session fingerprints, including OMP's "Unsupported ACP session". An unrelated prompt failure must not discard the stored conversation context.

Also address the outstanding coverage request: a real AcpClient::attach connects over a temporary Unix control socket, resumes the stored ID without session/load or session/new, and observes reset-before-soft-stop for a missing session versus an ordinary error for an unsupported mode. Shorten stale first-prompt-only comments; recovery already applies to any prompt using a stored ID.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no public contract change)
- [x] For UI changes: included screenshot or recording (not applicable)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: Rust ACP error classification and control transport

**TUI / CLI (e2e test)**
- [x] Skipped a test, because the unit integration scenario invokes the real attach API and transport against an isolated scripted runner without launching an unrelated UI.

The classifier regression failed before the fix on "Unsupported session mode". After the fix, all 236 acp::acp_client tests pass, including both original negative examples and the new socket-backed attach scenario. cargo fmt -- --check and cargo clippy -- -D warnings pass. The socket fixture exercises the actual client against a scripted runner protocol peer, not an external live adapter. Existing session/load coverage remains separate.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** GPT-6-astra via Oh My Pi.

**Any Additional AI Details:** Original review findings rechecked on current main; implemented and exercised the missing transport-boundary coverage.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Refined stale-session detection to recognize explicit missing-session errors only.
- Preserved support for OMP’s `Unsupported ACP session` message.
- Added socket-backed tests for attach, session resumption, and reset behavior.
- Prevented unrelated unsupported-mode errors from clearing stored conversation context.
- Updated comments to clarify session reset and recovery behavior.

All 236 ACP client tests pass, with formatting and Clippy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->