### PR TITLE
fix(tmux): refuse ambiguous live agent poller seeds

### DIFF
--- a/src/session/instance/polling.rs
+++ b/src/session/instance/polling.rs
@@ -102,27 +102,9 @@ fn try_acquire_managed_capture_lease(
     Ok(ManagedCaptureLease(lease))
 }
 
-/// The tmux session name to seed a session-id poller with, or `None` when
-/// this instance has no agent pane for one to follow.
-///
-/// `live_agent` is the live agent session for the id, which a fresh scan
-/// classifies by the kind each session was stamped with at creation. It is
-/// decisive: a row whose agent pane is gone has nothing a session-id poller
-/// can follow, however many paired terminals outlived it. Seeded with one of
-/// those, a poller re-resolves to that same live name every tick, probes
-/// `Alive`, and so never terminates, holding a budget slot for an agent that
-/// is gone while reading session-id state off the wrong pane (#3880).
-///
-/// `derived` is the title-derived agent name, asked only when the scan found
-/// nothing live for the id: a poller started alongside its own tmux session
-/// still needs a target, and `MISSING_TARGET_GRACE` covers the race. It keeps
-/// the name-shape filter because there is no live session to read a kind
-/// marker from, so a title sanitizing under an auxiliary prefix fails closed
-/// there (see `tmux::session_kind`).
-///
-/// A scan that found panes for the id but no agent among them is not that
-/// case: the derived name would then be a session that is not running, and a
-/// poller on it burns a budget slot until `MISSING_TARGET_GRACE` expires.
+/// Use a unique live agent; paired-only or ambiguous live panes forbid fallback.
+/// An empty or unavailable scan may use the derived name during MISSING_TARGET_GRACE.
+/// Its name-shape check remains necessary because no live kind marker is available.
 fn poller_seed_name(
     live: AgentSeed,
     derived: impl FnOnce() -> Option<String>,
@@ -130,7 +112,7 @@ fn poller_seed_name(
 ) -> Option<String> {
     match live {
         AgentSeed::Agent(name) => Some(name),
-        AgentSeed::OtherKindOnly => None,
+        AgentSeed::NoUniqueAgent => None,
         AgentSeed::NothingLive => {
             derived().filter(|name| crate::tmux::agent_session_belongs_to(name, session_id))
         }
@@ -1095,7 +1077,7 @@ mod tests {
             ),
             (
                 "only a terminal outlived the agent",
-                super::AgentSeed::OtherKindOnly,
+                super::AgentSeed::NoUniqueAgent,
                 Some(&agent),
                 None,
             ),

--- a/src/session/instance/tmux_session.rs
+++ b/src/session/instance/tmux_session.rs
@@ -11,20 +11,13 @@ pub(super) fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option
     )
 }
 
-/// What one live scan says about `instance_id`'s panes, for seeding a
-/// session-id poller.
-///
-/// [`tmux_env_session_name_for_instance_id`] answers "does this row have any
-/// live pane", which a terminal outliving its agent satisfies. A poller needs
-/// the agent pane specifically: seeded with a terminal it would probe that
-/// pane as alive forever (#3880). It also needs to tell "no agent yet" from
-/// "no agent any more", since only the first is a reason to fall back to the
-/// title-derived name.
+/// Live-scan result for seeding a session-id poller.
+/// Only an empty or unavailable scan permits a title-derived fallback.
 pub(crate) enum AgentSeed {
-    /// The live agent session for the id.
+    /// The unique live agent session for the id.
     Agent(String),
-    /// Panes are live for the id, none of them the agent.
-    OtherKindOnly,
+    /// Live panes exist, but no unique eligible agent can be selected.
+    NoUniqueAgent,
     /// Nothing live for the id, or the tmux server could not be reached.
     NothingLive,
 }
@@ -47,7 +40,7 @@ pub(super) fn live_agent_seed_for_instance_id(instance_id: &str) -> AgentSeed {
     )
     .is_some()
     {
-        return AgentSeed::OtherKindOnly;
+        return AgentSeed::NoUniqueAgent;
     }
     AgentSeed::NothingLive
 }
@@ -95,9 +88,7 @@ impl Instance {
         tmux_env_session_name_for_instance_id(&self.id)
     }
 
-    /// [`Self::has_live_agent_pane_in`] as a fresh probe, answering with the
-    /// agent session's name and, failing that, whether anything else for this
-    /// row is still live.
+    /// Fresh agent-seed classification, including live panes with no unique eligible agent.
     pub(crate) fn live_agent_seed(&self) -> AgentSeed {
         live_agent_seed_for_instance_id(&self.id)
     }

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1013,33 +1013,21 @@ impl LiveSessionSnapshot {
     }
 }
 
-/// The live AGENT session name for `session_id`, ignoring a paired terminal or
-/// container pane. The session-id poller needs this rather than
-/// [`live_any_kind_name_for_id_in`]: seeded with a terminal name, it probes
-/// that pane as alive and holds a budget slot for an agent that is gone.
-///
-/// Fails closed on one case, deliberately. A title sanitizing under
-/// [`AGENT_EXCLUDED_PREFIXES`] gives an agent name `NameShape::agent` refuses,
-/// so that session gets no poller repair. Accepting the instance's own derived
-/// name instead would reopen the leak: `aoe_term_Foo_<id>` is both the agent
-/// name for title `term_Foo` and the paired-terminal name for title `Foo`, so a
-/// smart rename across that boundary makes the surviving terminal
-/// indistinguishable from the agent by name alone, and nothing durable on the
-/// pane records which kind it is.
+/// The unique live agent pane for a poller seed. Marked panes use their durable
+/// kind; legacy unmarked panes retain name-shape filtering. Multiple live
+/// matches are ambiguous and cannot safely seed a poller.
 pub(crate) fn live_agent_name_for_id_in(
     snapshot: &LiveSessionSnapshot,
     session_id: &str,
 ) -> Option<String> {
-    let sessions = snapshot.sessions()?;
-    let suffix = id_suffix(session_id);
-    let agent = NameShape::agent(&suffix);
-    sessions
-        .iter()
-        .find(|(name, kind)| {
-            agent.matches_marked(name, kind.map(SessionKind::as_marker))
-                && !snapshot.pane_dead(name)
-        })
-        .map(|(name, _)| name.clone())
+    live_agent_name_for_id(
+        snapshot
+            .sessions()?
+            .iter()
+            .map(|(name, kind)| (name.as_str(), kind.map(SessionKind::as_marker))),
+        session_id,
+        |name| snapshot.pane_dead(name),
+    )
 }
 
 /// [`live_agent_name_for_id_in`] against a scan the caller has just taken,
@@ -1051,9 +1039,11 @@ pub(crate) fn live_agent_name_for_id<'a>(
 ) -> Option<String> {
     let suffix = id_suffix(session_id);
     let agent = NameShape::agent(&suffix);
-    live.into_iter()
-        .find(|(name, marker)| agent.matches_marked(name, *marker) && !pane_dead(name))
-        .map(|(name, _)| name.to_string())
+    let mut matches = live
+        .into_iter()
+        .filter(|(name, marker)| agent.matches_marked(name, *marker) && !pane_dead(name));
+    let (name, _) = matches.next()?;
+    matches.next().is_none().then(|| name.to_owned())
 }
 
 /// [`live_any_kind_name_for_id`] against an already-taken snapshot, so a batch
@@ -3809,6 +3799,31 @@ mod tests {
             "a later scope is still subtracted when an earlier one holds a separator"
         );
         assert!(!parsed.contains_key("a"), "a scope value is not a session");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn live_agent_lookup_rejects_multiple_live_matches() {
+        let first = format!("{P}first_{ID8}");
+        let second = format!("{TERMINAL_PREFIX}second_{ID8}");
+        let names = vec![
+            (first.clone(), Some(SessionKind::Agent)),
+            (second.clone(), Some(SessionKind::Agent)),
+        ];
+        let snapshot =
+            LiveSessionSnapshot::from_marked_parts(Some(names.clone()), Some(HashMap::new()));
+        assert_eq!(live_agent_name_for_id_in(&snapshot, ID), None);
+        assert_eq!(
+            live_agent_name_for_id(
+                names
+                    .iter()
+                    .map(|(name, kind)| (name.as_str(), kind.map(SessionKind::as_marker))),
+                ID,
+                |name| name == second,
+            ),
+            Some(first),
+            "a dead duplicate must not disqualify the only live agent",
+        );
     }
 
     /// The kind marker is what name shape cannot say, in both directions: an


### PR DESCRIPTION
## Description

Follow up the ambiguity finding on #3558 / #3872 (discussion_r3978734237). The selected live name now supplies the actual poller seed, so the earlier is_some-only dismissal no longer describes the caller. Both lookup entrypoints now share one unique-match resolver: two live agent matches for the same id8 return None, while a dead duplicate does not disqualify the only live agent. Allocate the returned name only after uniqueness is established.

Preserve the durable SessionKind markers from #3894 and legacy unmarked name filtering; remove the stale comment claiming no durable kind exists. No exact-derived-name exception or fallback to an auxiliary pane is introduced.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation updated where necessary
- [x] UI screenshot or recording: not applicable

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: Rust-only correction

**TUI / CLI (e2e test)**
- [x] Skipped full-binary coverage because the focused regression directly exercises the affected behavior without unrelated UI setup.

The regression failed before the fix: a two-agent snapshot returned aoe_dev_first_abc12345 instead of None. After the fix, all 7 live_agent_ tests pass, including marker-over-name semantics, the single-live/dead-duplicate boundary, poller seed selection and repair refusal. cargo fmt and cargo clippy -- -D warnings pass. The separate agent_seed filter matched zero tests and is not counted as coverage.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** GPT-6-astra via Oh My Pi.

**Any Additional AI Details:** Original review finding rechecked on current main; implemented and verified the correction.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Centralized tmux live-agent lookup through a shared unique-match resolver.
- Rejects ambiguous results when multiple live agents share the same `id8`.
- Ignores dead duplicates when one live agent remains.
- Uses the verified live-agent name as the poller seed.
- Renamed `AgentSeed::OtherKindOnly` to `AgentSeed::NoUniqueAgent` to clarify ambiguous or unavailable matches.
- Preserves existing session markers and legacy name filtering.
- Added regression coverage for duplicate live and dead agents.

This prevents incorrect poller selection in tmux while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->