### PR TITLE
fix(tui): align diagnostic titles with paragraph rendering

### DIFF
--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -100,7 +100,7 @@ fn agent_metrics_cell(agent: &AgentMetric) -> String {
 
 fn format_agent_title(title: &str, width: usize) -> String {
     let title = truncate_to_width(title, width);
-    let padding = width.saturating_sub(title.width());
+    let padding = width.saturating_sub(super::text::rendered_width(&title));
     format!("{title}{}", " ".repeat(padding))
 }
 
@@ -501,10 +501,21 @@ mod tests {
     }
 
     #[test]
-    fn agent_table_title_padding_uses_display_width() {
-        for title in ["agent", "日本語", "aaaaaaaé"] {
-            let formatted = format_agent_title(title, 8);
-            assert_eq!(formatted.width(), 8, "title {title:?}");
+    fn agent_table_title_padding_keeps_metrics_aligned() {
+        use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
+
+        for title in ["agent", "日本語", "aaaaaaaé", "ｶﾞｷﾞｸﾞｹﾞ"] {
+            let agent = AgentMetric {
+                title: title.into(),
+                ..AgentMetric::default()
+            };
+            let mut spans = agent_name_spans(&agent, 8, &Theme::default());
+            spans.push(Span::raw("X"));
+            let area = Rect::new(0, 0, 24, 1);
+            let mut buffer = Buffer::empty(area);
+            Paragraph::new(Line::from(spans)).render(area, &mut buffer);
+            let metric_column = (0..24).find(|x| buffer[(*x, 0)].symbol() == "X");
+            assert_eq!(metric_column, Some(8), "title {title:?}");
         }
     }
 


### PR DESCRIPTION
## Description

Complete the diagnostic-title alignment finding from #3680 / #3876. The diagnostic table renders a Paragraph, whose grapheme stream advances by painted cell widths. Truncation already used that metric but title padding used UnicodeWidthStr, adding excess spaces after halfwidth kana marks. Use the shared rendered_width helper for padding too.

This is deliberately not a change to fixed_width: that helper documents the different behavior of direct multi-span Line rendering. An actual Paragraph experiment settled the distinction: ｶﾞｷﾞｸﾞｹﾞ pushed the next column to 12 instead of 8 before this fix. Replace the calculated-width assertion with an actual rendered-cell alignment regression.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation updated where necessary
- [x] UI evidence: actual terminal capture included below

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: Rust-only correction

**TUI / CLI (e2e test)**
- [x] Skipped full-binary coverage because the focused regression directly exercises the affected behavior without unrelated UI setup.

All 11 diagnostics tests pass; cargo fmt, cargo clippy -- -D warnings and cargo build --bin aoe pass. Launched the compiled TUI with isolated HOME/XDG directories and a private tmux socket, using a local sleep-based agent stub rather than an external model. Opened System Health through the command palette and captured the real terminal output below. Temporary sessions, socket and directory were removed.

```text
│                                  │  Agent                                  CPU       Mem  Procs  │
│                                  │  ｶﾞｷﾞｸﾞｹﾞ                              0.0%        6M      2  │
```

## AI Usage

- [x] AI was used

**AI Model/Tool used:** GPT-6-astra via Oh My Pi.

**Any Additional AI Details:** Original review finding rechecked on current main; implemented and verified the correction.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed diagnostic title alignment in the TUI for kana, wide, and combining characters.
- Added a regression test that checks rendered cell positions.
- Reused `rendered_width` to keep title padding consistent with existing rendering behavior.

This prevents excess spacing and keeps diagnostic columns aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->