### PR TITLE
fix(tui): keep approval context visible with long labels

### DIFF
--- a/docs/structured-view/controls.md
+++ b/docs/structured-view/controls.md
@@ -36,6 +36,12 @@ The card clears as soon as your decision is accepted. If it already resolved on 
 
 Some agents put a **question** in the permission options rather than an allow/deny vocabulary: pi's `ask_user_question`, for instance, sends one `allow_once` option per answer. The daemon spots this (every option carries the same kind, so there is no allow/deny meaning to read and the labels are the whole content) and the card renders those labels instead, one button each; picking one sends back that option. **Dismiss** answers nothing: it cancels the request rather than denying it, so the agent is never handed an answer you did not pick. A destructive tool that asks this way keeps the hold-to-confirm on every answer that would run it. In the TUI the same card offers `a` to open the answer picker instead of allow-once. Lists that mix kinds stay on the Allow / Always / Deny buttons, including ones that repeat a kind, such as gemini's two "allow always" options for an MCP tool.
 
+### Approving from the native TUI home list
+
+Select a structured session and press `a` to respond to its first pending approval without entering the transcript. The dialog shows the session, tool, target and any destructive warning on separate lines. Long text ends with an ellipsis; open the structured view to inspect the full request before deciding if that context is insufficient.
+
+Use `a` for Allow, `A` for Allow Always, or `d` for Deny. Arrow keys or Tab select a button and Enter submits it. Escape closes the dialog without answering. Requests whose options are answers rather than allow/deny choices direct you to the structured view, where the labels are available; the home action never chooses an answer implicitly.
+
 ## Questions (AskUserQuestion)
 
 Some agents ask a structured question mid-turn rather than guessing. With `claude-agent-acp` this is the built-in `AskUserQuestion` tool; the daemon advertises the ACP form-elicitation capability so the agent surfaces it as a question card in the web dashboard. The same capability also lets an MCP server attached to the agent collect arbitrary structured input, which renders through the same card:

--- a/src/acp/approvals.rs
+++ b/src/acp/approvals.rs
@@ -165,32 +165,37 @@ pub fn is_destructive(tool_name: &str, args_preview: &str) -> bool {
     }
 }
 
-/// One-line "what is being approved" summary for an approval's
-/// `tool_call.args_preview`, keyed off the ACP `tool_call.kind`
-/// (`read`/`edit`/`write`/`delete`/`move` -> path, `execute` -> first
-/// command line). Mirrors the structured view's approval shelf
-/// (`structured_view/render.rs::approval_target`) minus the session
-/// path-root relativization the in-view shelf applies; the home permission
-/// dialog has no path roots, so it shows the raw path. Empty when the kind
-/// carries no obvious target or `args_preview` is not a JSON object.
-pub fn summarize_target(kind: &str, args_preview: &str) -> String {
-    const PATH_KEYS: &[&str] = &["path", "file_path", "filePath", "filename"];
-    const CMD_KEYS: &[&str] = &["command", "cmd", "args"];
-    let obj = match serde_json::from_str::<serde_json::Value>(args_preview) {
-        Ok(serde_json::Value::Object(map)) => map,
-        _ => return String::new(),
-    };
-    let pick = |keys: &[&str]| -> Option<String> {
-        keys.iter()
-            .find_map(|k| obj.get(*k).and_then(|v| v.as_str()))
-            .map(str::to_string)
-    };
+pub(crate) const PATH_KEYS: &[&str] = &["path", "file_path", "filePath", "filename"];
+pub(crate) const CMD_KEYS: &[&str] = &["command", "cmd", "args"];
+
+pub(crate) enum ToolTarget<'a> {
+    Path(&'a str),
+    Command(&'a str),
+}
+
+/// Primary target shared by approval and tool summaries. Formatting stays local.
+pub(crate) fn tool_target<'a>(
+    kind: &str,
+    args: &'a serde_json::Map<String, serde_json::Value>,
+) -> Option<ToolTarget<'a>> {
+    let pick = |keys: &[&str]| keys.iter().find_map(|key| args.get(*key)?.as_str());
     match kind {
-        "edit" | "write" | "read" | "delete" | "move" => pick(PATH_KEYS).unwrap_or_default(),
+        "edit" | "write" | "read" | "delete" | "move" => pick(PATH_KEYS).map(ToolTarget::Path),
         "execute" => pick(CMD_KEYS)
-            .and_then(|command| command.lines().next().map(str::to_string))
-            .unwrap_or_default(),
-        _ => String::new(),
+            .and_then(|command| command.lines().next())
+            .map(ToolTarget::Command),
+        _ => None,
+    }
+}
+
+/// Raw path or first command line for the home approval projection.
+pub fn summarize_target(kind: &str, args_preview: &str) -> String {
+    let Ok(serde_json::Value::Object(args)) = serde_json::from_str(args_preview) else {
+        return String::new();
+    };
+    match tool_target(kind, &args) {
+        Some(ToolTarget::Path(value) | ToolTarget::Command(value)) => value.to_owned(),
+        None => String::new(),
     }
 }
 

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2040,13 +2040,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             drop(client);
             return Err(self.retire_refused_install(&lease, identity, refusal).await);
         }
-        // Reconcile the durable log against reality before the drain starts.
-        // A fresh or respawned Runner has an empty `pending_responders`, so an
-        // `ApprovalRequested` with no matching `ApprovalResolved` is orphaned
-        // by the worker it replaced and would resurface as a dead 404 card.
-        // Sweeping after the drain would instead race a startup approval from
-        // the new worker, cancelling it while its live responder is still
-        // parked. See #1099.
+        // Retire the previous worker's requests before publishing this worker's events.
         self.cancel_orphaned_approvals(&session_id);
         self.cancel_orphaned_elicitations(&session_id);
         let drain_task = self.start_drain_task(session_id.clone(), lease.clone(), inbound);
@@ -8029,6 +8023,101 @@ cursor-acp-bridge = "agent acp"
             ),
             "an attach in flight must not count toward spawn capacity"
         );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn spawn_retires_old_approval_before_publishing_queued_request() {
+        use crate::acp::approvals::Approval;
+        use crate::acp::event_store::EventStore;
+        use crate::acp::state::ToolCall;
+
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::session::test_support::isolate_app_dir_at(home.path());
+        let store = Arc::new(EventStore::open(&home.path().join("acp.db"), 1000).unwrap());
+        let (tx, mut rx) = broadcast::channel(16);
+        let sink = Arc::new(ChannelSink {
+            tx,
+            event_store: store.clone(),
+            control_cache: Arc::new(crate::acp::control_cache::ControlStateCache::new()),
+        });
+        let approval = |nonce: &str| Approval {
+            nonce: Nonce(nonce.into()),
+            tool_call: ToolCall {
+                id: nonce.into(),
+                name: "Bash".into(),
+                kind: "execute".into(),
+                args_preview: r#"{"command":"pwd"}"#.into(),
+                started_at: chrono::Utc::now(),
+                parent_tool_call_id: None,
+                memory_recall: None,
+                diffs: Vec::new(),
+            },
+            destructive: false,
+            options: Vec::new(),
+            choice: false,
+            requested_at: chrono::Utc::now(),
+            resolved: None,
+        };
+        sink.publish(
+            "s-startup",
+            1,
+            &Event::ApprovalRequested {
+                approval: approval("old"),
+            },
+        );
+        let fresh = approval("live");
+        let senders: Arc<std::sync::Mutex<Vec<mpsc::Sender<Event>>>> = Default::default();
+        let launcher: Launcher = Arc::new(move |config, session_id| {
+            let fresh = fresh.clone();
+            let senders = senders.clone();
+            Box::pin(async move {
+                save_record(&session_id.0, 4345, config.generation);
+                let (client, tx) = AcpClient::fake_for_test(session_id);
+                tx.send(Event::ApprovalRequested { approval: fresh })
+                    .await
+                    .unwrap();
+                senders.lock().unwrap().push(tx);
+                Ok(client.with_runner_pid(4345))
+            })
+        });
+        let control = Arc::new(FakeProcessControl::default());
+        control.alive(4345);
+        let sup = Supervisor::new(sink)
+            .with_process_control(control)
+            .with_launcher(launcher);
+        sup.hydrate_seqs(store.all_session_seqs());
+        sup.spawn(spawn_request("s-startup")).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !store
+                .unresolved_approval_nonces("s-startup")
+                .contains(&Nonce("live".into()))
+            {
+                rx.recv().await.unwrap();
+            }
+        })
+        .await
+        .expect("queued approval must reach the durable log");
+        assert_eq!(
+            store.unresolved_approval_nonces("s-startup"),
+            vec![Nonce("live".into())]
+        );
+        let events: Vec<_> = store
+            .replay_from("s-startup", 0)
+            .into_iter()
+            .filter_map(|(_, event)| match event {
+                Event::ApprovalRequested { approval } => {
+                    Some(format!("requested:{}", approval.nonce.0))
+                }
+                Event::ApprovalResolved { nonce, decision } => {
+                    assert_eq!(decision, ApprovalDecision::Cancelled);
+                    Some(format!("cancelled:{}", nonce.0))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(events, ["requested:old", "cancelled:old", "requested:live"]);
+        sup.shutdown("s-startup").await.unwrap();
     }
 
     #[tokio::test]

--- a/src/tui/dialogs/permission_response.rs
+++ b/src/tui/dialogs/permission_response.rs
@@ -53,13 +53,9 @@ pub enum PermissionResponseChoice {
     Deny,
 }
 
-/// What a structured (ACP) approval is asking to do, shown in the dialog body
-/// so the user sees the tool and target without entering the structured view.
-/// `None` for the terminal keystroke path, whose prompt the user has already
-/// seen on the session pane.
 struct StructuredApprovalDetail {
-    /// One-line "tool: target" summary, or just the tool when no target.
-    summary: String,
+    tool_name: String,
+    target: String,
     destructive: bool,
 }
 
@@ -91,27 +87,19 @@ impl PermissionResponseDialog {
         Self::build(session_title, allow_always.is_some(), None)
     }
 
-    /// Construct the shared dialog for a structured (ACP) approval, which
-    /// always supports the protocol's AllowAlways decision. `tool_name` /
-    /// `target` / `destructive` come from the daemon's pending-approval
-    /// projection and are shown in the body so the user sees what they are
-    /// answering without opening the structured view.
+    /// Show the ACP tool, target and destructive flag before resolving its request.
     pub fn structured(
         session_title: &str,
         tool_name: &str,
         target: &str,
         destructive: bool,
     ) -> Self {
-        let summary = if target.is_empty() {
-            tool_name.to_string()
-        } else {
-            format!("{tool_name}: {target}")
-        };
         Self::build(
             session_title,
             true,
             Some(StructuredApprovalDetail {
-                summary,
+                tool_name: tool_name.to_owned(),
+                target: target.to_owned(),
                 destructive,
             }),
         )
@@ -186,40 +174,37 @@ impl PermissionResponseDialog {
             ])
             .split(inner);
 
-        let mut header_lines = vec![Line::from(Span::styled(
-            self.session_title.clone(),
+        use crate::tui::components::text::truncate_to_width;
+
+        let width = chunks[0].width as usize;
+        let mut header_lines = Vec::with_capacity(3);
+        header_lines.push(Line::from(Span::styled(
+            truncate_to_width(&self.session_title, width),
             Style::default().fg(theme.title).bold(),
-        ))];
+        )));
         match &self.detail {
-            // Structured (ACP) path: show what is being approved. Nothing is
-            // sent as keystrokes here, so the terminal guidance would be wrong.
             Some(detail) => {
-                let summary_color = if detail.destructive {
-                    theme.error
+                let warning = if detail.destructive {
+                    "destructive: "
                 } else {
-                    theme.text
+                    ""
                 };
-                let mut summary = detail.summary.clone();
-                if detail.destructive {
-                    summary.push_str("  · destructive");
-                }
+                header_lines.push(Line::from(vec![
+                    Span::styled(warning, Style::default().fg(theme.error).bold()),
+                    Span::styled(
+                        truncate_to_width(&detail.tool_name, width.saturating_sub(warning.len())),
+                        Style::default().fg(theme.text),
+                    ),
+                ]));
                 header_lines.push(Line::from(Span::styled(
-                    summary,
-                    Style::default().fg(summary_color),
-                )));
-                header_lines.push(Line::from(Span::styled(
-                    "Resolves the agent's pending permission request.",
-                    Style::default().fg(theme.dimmed),
-                )));
-            }
-            // Terminal path: the user has already seen the CLI prompt on the
-            // pane; AoE just replays the agent's keystrokes.
-            None => {
-                header_lines.push(Line::from(Span::styled(
-                    "AoE sends these as raw keystrokes; make sure the prompt is on screen.",
-                    Style::default().fg(theme.dimmed),
+                    truncate_to_width(&detail.target, width),
+                    Style::default().fg(theme.text),
                 )));
             }
+            None => header_lines.push(Line::from(Span::styled(
+                "AoE sends these as raw keystrokes; make sure the prompt is on screen.",
+                Style::default().fg(theme.dimmed),
+            ))),
         }
         let header = Paragraph::new(header_lines).wrap(Wrap { trim: false });
         frame.render_widget(header, chunks[0]);
@@ -402,37 +387,40 @@ mod tests {
     }
 
     #[test]
-    fn structured_dialog_shows_target_and_destructive_not_keystroke_hint() {
+    fn structured_dialog_keeps_approval_context_visible_with_long_labels() {
         use ratatui::backend::TestBackend;
         use ratatui::Terminal;
 
         let theme = crate::tui::styles::load_theme_with_mode("empire", false);
-        let mut dialog =
-            PermissionResponseDialog::structured("session-one", "Bash", "rm -rf build", true);
-        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
-        terminal
-            .draw(|f| dialog.render(f, f.area(), &theme))
-            .unwrap();
-        let out =
+        let long_title = "session-one ".repeat(30);
+        let long_tool = "Bash".repeat(30);
+        let long_target = format!("rm -rf build/{}", "deep/".repeat(40));
+        for (title, tool, target) in [
+            ("session-one", "Bash", "rm -rf build"),
+            (long_title.as_str(), "Bash", long_target.as_str()),
+            ("session-one", long_tool.as_str(), "rm -rf build"),
+        ] {
+            let mut dialog = PermissionResponseDialog::structured(title, tool, target, true);
+            let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
             terminal
-                .backend()
-                .buffer()
-                .content()
-                .iter()
-                .fold(String::new(), |mut acc, cell| {
+                .draw(|f| dialog.render(f, f.area(), &theme))
+                .unwrap();
+            let out = terminal.backend().buffer().content().iter().fold(
+                String::new(),
+                |mut acc, cell| {
                     acc.push_str(cell.symbol());
                     acc
-                });
-        // The body names the tool, the target, and the destructive flag, and
-        // drops the terminal-only "raw keystrokes" guidance that is wrong here.
-        assert!(out.contains("Bash: rm -rf build"), "target missing:\n{out}");
-        assert!(
-            out.contains("destructive"),
-            "destructive marker missing:\n{out}"
-        );
-        assert!(
-            !out.contains("raw keystrokes"),
-            "structured dialog must not show the keystroke guidance:\n{out}"
-        );
+                },
+            );
+            for context in [
+                "session-one",
+                "Bash",
+                "rm -rf build",
+                "destructive",
+                "[Allow]",
+            ] {
+                assert!(out.contains(context), "missing {context:?}:\n{out}");
+            }
+        }
     }
 }

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -25,6 +25,7 @@ use super::reducer::{
     AcpTranscript, NoteKind, PendingApproval, ToolCallRow, ToolCompletion, ToolOutcome,
 };
 use super::state::{FileIndex, StructuredViewState, ViewLayout};
+use crate::acp::approvals::{tool_target, ToolTarget, CMD_KEYS, PATH_KEYS};
 use crate::acp::session_paths::{relative_display_path, SessionPathRoots};
 use crate::acp::state::{SessionUsage, ToolOutputBlock};
 use crate::acp::transcript::{TranscriptRow, TranscriptRowKind};
@@ -376,16 +377,18 @@ fn approval_actions_line(theme: &Theme, active: bool, choice: bool) -> Line<'sta
 
 fn approval_target(row: &PendingApproval, path_roots: Option<&SessionPathRoots>) -> String {
     let args = parse_args_object(&row.args);
-    match row.kind.as_str() {
-        "edit" | "write" | "read" | "delete" | "move" => pick_str(args.as_ref(), PATH_KEYS)
-            .map(|path| relative_display_path(path, path_roots))
-            .unwrap_or_default(),
-        "execute" => pick_str(args.as_ref(), CMD_KEYS)
-            .and_then(|command| command.lines().next())
-            .unwrap_or_default()
-            .to_string(),
-        _ => String::new(),
-    }
+    display_tool_target(&row.kind, args.as_ref(), path_roots).unwrap_or_default()
+}
+
+fn display_tool_target(
+    kind: &str,
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+    path_roots: Option<&SessionPathRoots>,
+) -> Option<String> {
+    Some(match tool_target(kind, args?)? {
+        ToolTarget::Path(path) => relative_display_path(path, path_roots),
+        ToolTarget::Command(command) => command.to_owned(),
+    })
 }
 
 /// Most picker rows visible at once before the list windows around the
@@ -1537,14 +1540,9 @@ fn truncate_chars(s: &str, max_chars: usize) -> Option<String> {
     }
 }
 
-/// Arg-name variants the agents use for a tool's primary path, command,
-/// and edit before/after text. Mirrors the web structured view's `pickStr` key
-/// lists in `web/src/components/acp/ToolCards.tsx` so the TUI and the
-/// dashboard surface the same field across agent versions.
-const PATH_KEYS: &[&str] = &["path", "file_path", "filePath", "filename"];
+/// Edit payload variants shared with the web tool cards.
 const OLD_KEYS: &[&str] = &["old_string", "oldString", "old_str"];
 const NEW_KEYS: &[&str] = &["new_string", "newString", "new_str", "content"];
-const CMD_KEYS: &[&str] = &["command", "cmd", "args"];
 
 /// +/- lines beyond this budget collapse into a "+N more" footer so a
 /// large Edit can't flood the transcript on a narrow terminal.
@@ -1615,14 +1613,7 @@ fn compact_tool_line(
     let target = if let Some(diff) = tool.diffs.first() {
         Some(relative_display_path(&diff.path, path_roots))
     } else {
-        match tool.kind.as_str() {
-            "edit" | "write" | "read" | "delete" | "move" => pick_str(args.as_ref(), PATH_KEYS)
-                .map(|path| relative_display_path(path, path_roots)),
-            "execute" => pick_str(args.as_ref(), CMD_KEYS)
-                .and_then(|command| command.lines().next())
-                .map(ToString::to_string),
-            _ => None,
-        }
+        display_tool_target(&tool.kind, args.as_ref(), path_roots)
     };
     let mut spans = vec![
         Span::styled("✓ ", Style::default().fg(theme.running)),


### PR DESCRIPTION
## Description

Address the remaining findings from #3544 / #3867. A long session title could consume every header row while Allow remained visible; a long target could also bury the destructive warning. Reserve one bounded row each for session, warning/tool and target, preserving the warning independently of unbounded tool text. Ellipses indicate clipped context.

Share borrowed tool-target extraction and argument-key aliases between the daemon approval projection and TUI summaries. Keep path relativization in the renderer. Document the native home-list approval action and its explicit handling of answer lists.

Add a Supervisor::spawn regression with an old durable approval and a new approval already queued in the client: the old request is cancelled before the new request is published, and only the new one remains pending. This exercises the actual spawn/drain boundary with a fake client and real SQLite sink, not just the orphan helper. It does not force an adversarial post-drain scheduling interleaving.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation updated where necessary
- [x] UI evidence: actual terminal capture included below

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: Rust-only correction

**TUI / CLI (e2e test)**
- [x] Skipped full-binary coverage because the focused regression directly exercises the affected behavior without unrelated UI setup.

Before the layout fix, the long-title case rendered three title rows and Allow, but no tool/target/warning. Afterward: 11 permission-dialog tests, 5 approval tests and 57 structured-render tests pass. The new startup test passes; deleting the actual spawn sweep makes it fail with both old and live nonces pending, and restoring the sweep passes. cargo fmt, cargo clippy -- -D warnings and cargo build --bin aoe pass.

Manual full-binary check: isolated HOME/XDG, private tmux socket, localhost-only daemon and shared scripted ACP agent. A real pending request with a long title/target opened from home via a. The terminal capture is below. Pressing d recorded ApprovalResolved with decision Deny and the fake tool reported permission denied. The displayed rm command was never executed. Worker, daemon, tmux server and temporary files were removed.

```text
│                     ╭ Respond to Permission Prompt ────────────────────────╮                     │
│                     │                                                      │                     │
│                     │ approval-session-with-long-title-approval-session-w… │                     │
│                     │ destructive: Bash                                    │                     │
│                     │ rm -rf build/this-is-a-deliberately-long-target-for… │                     │
│                     │           [Allow]   [Allow Always]   [Deny]          │                     │
│                     │         a=allow  A=always  d=deny  Esc=cancel        │                     │
│                     │                                                      │                     │
│                     ╰──────────────────────────────────────────────────────╯                     │
```

## AI Usage

- [x] AI was used

**AI Model/Tool used:** GPT-6-astra via Oh My Pi.

**Any Additional AI Details:** Original review finding rechecked on current main; implemented and verified the correction.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved TUI approval dialogs so long session titles, tools, targets, and warnings remain visible through bounded rows and ellipsis.
- Shared tool-target extraction between daemon approval handling and structured-view rendering.
- Added documentation for approving requests from the native TUI home list.
- Added regression coverage for cancelling stale approvals before publishing new approvals.
- Preserved path relativization and simplified structured approval rendering.

## Benefits

The approval flow now provides clearer context, handles long text more safely, and keeps daemon and TUI summaries consistent. Focused validation and a manual terminal check support the changes.

## Potential follow-up

Additional tests could cover more tool argument formats and terminal widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->