### PR TITLE
test(acp): guard effort provenance at the spawn boundary

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -4436,6 +4436,61 @@ mod tests {
         }
     }
 
+    /// `effort_explicit` crosses the spawn boundary as its own field rather
+    /// than being rederived from `effort`. The create path forwards a
+    /// daemon-resolved default while `Instance.acp_effort` is `None`, so a
+    /// nonempty effort is not a pin, and reading it as one makes a later pin
+    /// move refuse the new model's effort.
+    ///
+    /// Covers that boundary only. The resolution it feeds is covered by the
+    /// `respawn_` tests.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn spawn_does_not_rederive_effort_provenance_from_the_value() {
+        let _home = isolate_home();
+        let control = Arc::new(FakeProcessControl::default());
+        control.alive(4343);
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let sup = Arc::new(
+            Supervisor::new(VecSink::new())
+                .with_process_control(control)
+                .with_launcher(gated_launcher(entered.clone(), gate.clone(), 4343)),
+        );
+
+        // What the create path sends: an effort resolved from the pinned
+        // model's defaults, with no user selection behind it.
+        let mut req = spawn_request("s-prov");
+        req.effort = Some("low".into());
+        req.effort_explicit = false;
+
+        // The launcher parks on the gate, so spawn runs beside this task the
+        // way the create path's detached spawn does.
+        let spawner = {
+            let sup = Arc::clone(&sup);
+            tokio::spawn(async move { sup.spawn(req).await })
+        };
+        entered.notified().await;
+        gate.notify_one();
+        spawner.await.unwrap().expect("spawn");
+
+        let explicit = sup
+            .workers
+            .lock()
+            .await
+            .get("s-prov")
+            .map(|handle| match &handle.kind {
+                WorkerKind::Runner { spawn_config } => spawn_config.default_effort_explicit,
+                _ => panic!("runner handle expected"),
+            })
+            .expect("worker installed");
+        assert!(
+            !explicit,
+            "a resolved default effort must not read as a session pin; \
+             the watchdog would refuse the new model's inherited effort"
+        );
+    }
+
     /// An explicit request effort is a session pin (persisted in
     /// `Instance.acp_effort`): a model pin that later moves re-resolves the
     /// model but must not overwrite the effort the user asked for.


### PR DESCRIPTION
## Description

Restores the guard #3903 removed. `SpawnRequest.effort_explicit` must reach `SpawnConfig.default_effort_explicit` unchanged. Rederiving it from `effort` is the #3683 bug: the create path forwards a daemon-resolved default while `Instance.acp_effort` is `None`, so a nonempty effort read as a session pin makes a later pin move refuse the new model's effort.

Rederive the flag from the value and the lib suite passes without this test, and fails only with it.

The #3683 review asked for an accurate description of the test's scope, not its removal. The name and docstring now claim the supervisor boundary alone; resolution stays covered by the `respawn_` tests.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

Test-only: it restores coverage, not a second fix.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

`cargo test --lib` 6945 pass, `cargo clippy --lib --tests` and `cargo fmt --check` clean. Injecting `default_effort_explicit: effort.is_some()` fails this test and nothing else in the suite.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:** Raised during review of #3903; the coverage claim was measured by injecting the regression rather than inferred.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mx7gD3WEsjEP6e313WPyWK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restored a regression test in `src/acp/supervisor.rs`.
- Verified that `SpawnRequest.effort_explicit` reaches the supervisor spawn boundary unchanged.
- Prevented resolved default effort from being incorrectly treated as explicitly pinned effort.
- Added no production code changes.

## Benefits

This test protects against a recurrence of the `#3683` regression and preserves effort provenance during worker spawning. Library tests, Clippy, and formatting checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->