### PR TITLE
feat(cli): rename session branches without moving worktrees

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -497,6 +497,7 @@ Rename a session
 * `-t`, `--title <TITLE>` — New title for the session
 * `-g`, `--group <GROUP>` — New group for the session (empty string to ungroup)
 * `--rename-branch` — When the session is tied (session.tie_workdir_to_name) and an aoe-managed worktree, also rename the underlying git branch to match. Off by default; ignored for untied / non-worktree sessions
+* `--branch <BRANCH>` — Rename the Git branch without moving the worktree directory
 
 
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -2011,10 +2011,13 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
                         .and_then(|row| row.worktree_info.as_ref())
                         .map(|wt| wt.branch.as_str());
                     if persisted_branch == Some(info.branch.as_str()) {
-                        let git = crate::git::GitWorktree::new(std::path::PathBuf::from(
-                            &info.main_repo_path,
-                        ))?;
-                        if let Err(rollback) = git.rename_branch(branch, &info.branch) {
+                        if let Err(rollback) =
+                            crate::session::worktree_edit::rollback_worktree_branch(
+                                info,
+                                std::path::Path::new(&inst.project_path),
+                                branch,
+                            )
+                        {
                             bail!("Session metadata failed: {error}; branch rollback also failed: {rollback}. The directory is unchanged; inspect Git and session metadata before continuing.");
                         }
                     } else if persisted_branch != Some(branch.as_str()) {
@@ -2140,6 +2143,53 @@ mod rename_tests {
                 Ok(())
             })
             .unwrap();
+        let external = dir.path().join("external");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "--force",
+                external.to_str().unwrap(),
+                "agent-old",
+            ],
+        );
+        std::fs::write(external.join("external.txt"), "keep external").unwrap();
+        let before = serde_json::to_value(storage.load().unwrap()).unwrap();
+        let shared = rename_session(
+            "branch-only",
+            RenameArgs {
+                identifier: Some(id.clone()),
+                title: Some("Must not apply".into()),
+                group: None,
+                rename_branch: false,
+                branch: Some("blocked-shared".into()),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(shared.to_string().contains("another Git worktree"));
+        assert_eq!(
+            serde_json::to_value(storage.load().unwrap()).unwrap(),
+            before
+        );
+        for path in [&worktree, &external] {
+            assert_eq!(git(path, &["branch", "--show-current"]), "agent-old");
+            assert_eq!(git(path, &["rev-parse", "HEAD"]), head);
+        }
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("uncommitted.txt")).unwrap(),
+            "keep me"
+        );
+        assert_eq!(
+            std::fs::read_to_string(external.join("external.txt")).unwrap(),
+            "keep external"
+        );
+        assert!(git(&repo, &["branch", "--list", "blocked-shared"]).is_empty());
+        git(
+            &repo,
+            &["worktree", "remove", "--force", external.to_str().unwrap()],
+        );
         for branch in ["olof/bemlo-123-task", "olof/bemlo-123-task"] {
             rename_session(
                 "branch-only",
@@ -2262,6 +2312,44 @@ mod rename_tests {
         assert_eq!(
             git(&worktree, &["branch", "--show-current"]),
             "olof/bemlo-123-task"
+        );
+
+        let info = storage.load().unwrap()[0].worktree_info.clone().unwrap();
+        git(&worktree, &["branch", "-m", "rollback-source"]);
+        git(&worktree, &["checkout", "-b", "external-checkout"]);
+        let refs = git(&repo, &["show-ref", "--heads"]);
+        let error = crate::session::worktree_edit::rollback_worktree_branch(
+            &info,
+            &worktree,
+            "rollback-source",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("changed concurrently"));
+        assert_eq!(git(&repo, &["show-ref", "--heads"]), refs);
+        assert_eq!(
+            git(&worktree, &["branch", "--show-current"]),
+            "external-checkout"
+        );
+        assert_eq!(
+            storage.load().unwrap()[0]
+                .worktree_info
+                .as_ref()
+                .unwrap()
+                .branch,
+            info.branch
+        );
+        git(&worktree, &["checkout", "rollback-source"]);
+        crate::session::worktree_edit::rollback_worktree_branch(
+            &info,
+            &worktree,
+            "rollback-source",
+        )
+        .unwrap();
+        assert_eq!(git(&worktree, &["branch", "--show-current"]), info.branch);
+        assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), head);
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("uncommitted.txt")).unwrap(),
+            "keep me"
         );
     }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -2240,6 +2240,33 @@ mod rename_tests {
                 "refs/remotes/origin/olof/bemlo-123-task",
             ],
         );
+        for title in [Some("Updated title"), None, Some("olof/bemlo-123-task")] {
+            rename_session(
+                "branch-only",
+                RenameArgs {
+                    identifier: Some(id.clone()),
+                    title: title.map(str::to_owned),
+                    group: None,
+                    rename_branch: false,
+                    branch: Some("olof/bemlo-123-task".into()),
+                },
+            )
+            .await
+            .unwrap();
+            let current = storage.load().unwrap().pop().unwrap();
+            assert_eq!(current.title, title.unwrap_or("Updated title"));
+            assert_eq!(current.project_path, worktree.to_str().unwrap());
+            assert_eq!(current.worktree_info.unwrap().branch, "olof/bemlo-123-task");
+            assert_eq!(
+                git(&worktree, &["branch", "--show-current"]),
+                "olof/bemlo-123-task"
+            );
+            assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), head);
+            assert_eq!(
+                std::fs::read_to_string(worktree.join("uncommitted.txt")).unwrap(),
+                "keep me"
+            );
+        }
         let protected = rename_session(
             "branch-only",
             RenameArgs {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -208,6 +208,10 @@ pub struct RenameArgs {
     /// Off by default; ignored for untied / non-worktree sessions.
     #[arg(long)]
     rename_branch: bool,
+
+    /// Rename the Git branch without moving the worktree directory
+    #[arg(long, conflicts_with = "rename_branch")]
+    branch: Option<String>,
 }
 
 #[derive(Args)]
@@ -1729,8 +1733,8 @@ fn rename_success_message(
 }
 
 async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
-    if args.title.is_none() && args.group.is_none() {
-        bail!("At least one of --title or --group must be specified");
+    if args.title.is_none() && args.group.is_none() && args.branch.is_none() {
+        bail!("At least one of --title, --group or --branch must be specified");
     }
 
     let storage = Storage::open_unwatched(profile)?;
@@ -1761,7 +1765,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
 
     let id = inst.id.clone();
     let title_requested = args.title.is_some();
-    let session_lock_required = title_requested || args.rename_branch;
+    let session_lock_required = title_requested || args.rename_branch || args.branch.is_some();
 
     // The initial load only resolves the requested row. Serialize every
     // identity-changing rename from the fresh duplicate check through external
@@ -1818,7 +1822,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     // the two cannot drift. Decided per-session from the resolved setting.
     let config = crate::session::config::profile_config::resolve_config_or_warn(profile);
     let tied = inst.tie_workdir_applies(config.session.tie_workdir_to_name);
-    let tied_edit = tied && (args.title.is_some() || args.rename_branch);
+    let tied_edit = args.branch.is_none() && tied && (args.title.is_some() || args.rename_branch);
     let duplicate_path = if tied_edit {
         crate::session::worktree_edit::derived_worktree_path(
             std::path::Path::new(&inst.project_path),
@@ -1842,7 +1846,51 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
 
     let mut new_path: Option<String> = None;
     let mut new_branch: Option<String> = None;
-    if tied_edit {
+    if let Some(branch) = &args.branch {
+        let info = inst
+            .worktree_info
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Branch-only rename requires a managed worktree"))?;
+        if branch != &info.branch {
+            let path = std::path::Path::new(&inst.project_path).canonicalize()?;
+            let repo = std::path::Path::new(&info.main_repo_path).canonicalize()?;
+            let same_branch = |main_repo: &str, name: &str| {
+                name == info.branch
+                    && std::path::Path::new(main_repo).canonicalize().ok().as_ref() == Some(&repo)
+            };
+            for other_profile in crate::session::list_profiles()? {
+                let rows = Storage::open_unwatched(&other_profile)?.load()?;
+                if rows.iter().any(|other| {
+                    other.id != id
+                        && !other.is_trashed()
+                        && (std::path::Path::new(&other.project_path)
+                            .canonicalize()
+                            .ok()
+                            .as_ref()
+                            == Some(&path)
+                            || other
+                                .worktree_info
+                                .as_ref()
+                                .is_some_and(|wt| same_branch(&wt.main_repo_path, &wt.branch))
+                            || other.workspace_info.as_ref().is_some_and(|workspace| {
+                                workspace
+                                    .repos
+                                    .iter()
+                                    .any(|wt| same_branch(&wt.main_repo_path, &wt.branch))
+                            }))
+                }) {
+                    bail!("Another session shares this branch or worktree in profile {other_profile}; rename is not isolated");
+                }
+            }
+        }
+        if crate::session::worktree_edit::rename_worktree_branch(
+            info,
+            std::path::Path::new(&inst.project_path),
+            branch,
+        )? {
+            new_branch = Some(branch.clone());
+        }
+    } else if tied_edit {
         let current_path = inst.project_path.clone();
         let worktree_info = inst
             .worktree_info
@@ -1950,6 +1998,30 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     let (persisted_old_title, committed_title) = match persist {
         Ok(titles) => titles,
         Err(error) => {
+            if args.branch.is_some() {
+                if let Some(branch) = &new_branch {
+                    let info = inst
+                        .worktree_info
+                        .as_ref()
+                        .expect("branch rename checked worktree metadata");
+                    let stored = storage.load().map_err(|_| anyhow::anyhow!("Session metadata write failed ({error}) and its state cannot be read. Branch is {branch}; directory unchanged. Inspect before retrying."))?;
+                    let persisted_branch = stored
+                        .iter()
+                        .find(|row| row.id == id)
+                        .and_then(|row| row.worktree_info.as_ref())
+                        .map(|wt| wt.branch.as_str());
+                    if persisted_branch == Some(info.branch.as_str()) {
+                        let git = crate::git::GitWorktree::new(std::path::PathBuf::from(
+                            &info.main_repo_path,
+                        ))?;
+                        if let Err(rollback) = git.rename_branch(branch, &info.branch) {
+                            bail!("Session metadata failed: {error}; branch rollback also failed: {rollback}. The directory is unchanged; inspect Git and session metadata before continuing.");
+                        }
+                    } else if persisted_branch != Some(branch.as_str()) {
+                        bail!("Session metadata failed: {error}; its branch changed concurrently. Directory unchanged; inspect before continuing.");
+                    }
+                }
+            }
             // When the git move already landed, surface that the disk and
             // metadata are out of sync rather than a bare persist error.
             if let Some(path) = &new_path {
@@ -1978,6 +2050,11 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         }
     }
 
+    if args.branch.is_some() {
+        if let Some(branch) = &new_branch {
+            println!("✓ Branch renamed to: {branch} (worktree directory unchanged)");
+        }
+    }
     if let Some(path) = &new_path {
         println!("✓ Worktree moved to: {}", path);
         if let Some(branch) = &new_branch {
@@ -1997,6 +2074,196 @@ mod rename_tests {
     use super::{rename_session, rename_success_message, RenameArgs};
     use crate::session::{Instance, Status, Storage};
     use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn branch_rename_preserves_worktree_and_updates_metadata() {
+        let _guard = crate::session::test_support::isolate_app_dir();
+        let _tie_guard = crate::session::test_support::TieWorkdirToNameGuard::set(true);
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let worktree = dir.path().join("agent-fixed");
+        std::fs::create_dir(&repo).unwrap();
+        let git = |path: &std::path::Path, args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .current_dir(path)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        };
+        git(&repo, &["init", "-b", "main"]);
+        git(
+            &repo,
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "initial",
+            ],
+        );
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "agent-old",
+                worktree.to_str().unwrap(),
+            ],
+        );
+        let head = git(&worktree, &["rev-parse", "HEAD"]);
+        std::fs::write(worktree.join("uncommitted.txt"), "keep me").unwrap();
+        let storage = Storage::new_unwatched("branch-only").unwrap();
+        let mut target = Instance::new("Old Title", worktree.to_str().unwrap());
+        target.status = Status::Running;
+        target.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "agent-old".into(),
+            main_repo_path: repo.to_str().unwrap().into(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: Some("main".into()),
+        });
+        let id = target.id.clone();
+        storage
+            .update(|instances, _| {
+                instances.push(target);
+                Ok(())
+            })
+            .unwrap();
+        for branch in ["olof/bemlo-123-task", "olof/bemlo-123-task"] {
+            rename_session(
+                "branch-only",
+                RenameArgs {
+                    identifier: Some(id.clone()),
+                    title: Some(branch.into()),
+                    group: None,
+                    rename_branch: false,
+                    branch: Some(branch.into()),
+                },
+            )
+            .await
+            .unwrap();
+        }
+        let target = storage.load().unwrap().pop().unwrap();
+        assert_eq!(target.project_path, worktree.to_str().unwrap());
+        assert_eq!(target.title, "olof/bemlo-123-task");
+        assert_eq!(target.worktree_info.unwrap().branch, "olof/bemlo-123-task");
+        assert_eq!(
+            git(&worktree, &["branch", "--show-current"]),
+            "olof/bemlo-123-task"
+        );
+        assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), head);
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("uncommitted.txt")).unwrap(),
+            "keep me"
+        );
+        for branch in ["bad name", "-option", "bad..name", "refs/heads/"] {
+            assert!(rename_session(
+                "branch-only",
+                RenameArgs {
+                    identifier: Some(id.clone()),
+                    title: Some("Must not apply".into()),
+                    group: None,
+                    rename_branch: false,
+                    branch: Some(branch.into()),
+                },
+            )
+            .await
+            .is_err());
+        }
+        git(&repo, &["remote", "add", "origin", "."]);
+        git(
+            &repo,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/olof/bemlo-123-task",
+            ],
+        );
+        let protected = rename_session(
+            "branch-only",
+            RenameArgs {
+                identifier: Some(id.clone()),
+                title: None,
+                group: None,
+                rename_branch: false,
+                branch: Some("blocked-default".into()),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(protected.to_string().contains("default branch"));
+        git(
+            &repo,
+            &["symbolic-ref", "--delete", "refs/remotes/origin/HEAD"],
+        );
+        let peer_storage = Storage::new_unwatched("branch-peer").unwrap();
+        for with_worktree_info in [true, false] {
+            let mut peer = Instance::new("Peer", worktree.join(".").to_str().unwrap());
+            if with_worktree_info {
+                peer.worktree_info = storage.load().unwrap()[0].worktree_info.clone();
+                peer.worktree_info.as_mut().unwrap().managed_by_aoe = false;
+            }
+            peer_storage
+                .update(|rows, _| {
+                    *rows = vec![peer];
+                    Ok(())
+                })
+                .unwrap();
+            let shared = rename_session(
+                "branch-only",
+                RenameArgs {
+                    identifier: Some(id.clone()),
+                    title: Some("Must not apply".into()),
+                    group: None,
+                    rename_branch: false,
+                    branch: Some("would-change-peer".into()),
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(shared.to_string().contains("profile branch-peer"));
+            assert_eq!(
+                git(&worktree, &["branch", "--show-current"]),
+                "olof/bemlo-123-task"
+            );
+            assert_eq!(storage.load().unwrap()[0].title, "olof/bemlo-123-task");
+        }
+        peer_storage
+            .update(|rows, _| {
+                rows.clear();
+                Ok(())
+            })
+            .unwrap();
+        let error = rename_session(
+            "branch-only",
+            RenameArgs {
+                identifier: Some(id),
+                title: Some("collision".into()),
+                group: None,
+                rename_branch: false,
+                branch: Some("main".into()),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("already exists"));
+        assert_eq!(storage.load().unwrap()[0].title, "olof/bemlo-123-task");
+        assert_eq!(
+            git(&worktree, &["branch", "--show-current"]),
+            "olof/bemlo-123-task"
+        );
+    }
 
     // Three duplicate-identity behaviors kept in one test on purpose: they
     // share the costly setup that forces `#[serial]` (an isolated app dir plus
@@ -2025,6 +2292,7 @@ mod rename_tests {
                 title: Some("main branch".to_string()),
                 group: None,
                 rename_branch: false,
+                branch: None,
             },
         )
         .await
@@ -2040,6 +2308,7 @@ mod rename_tests {
                 title: None,
                 group: Some("work".to_string()),
                 rename_branch: false,
+                branch: None,
             },
         )
         .await
@@ -2080,6 +2349,7 @@ mod rename_tests {
                 title: Some("main branch".to_string()),
                 group: None,
                 rename_branch: false,
+                branch: None,
             },
         )
         .await
@@ -2124,6 +2394,7 @@ mod rename_tests {
                 title: Some("Main Branch".to_string()),
                 group: None,
                 rename_branch: false,
+                branch: None,
             },
         )
         .await

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -447,6 +447,60 @@ pub fn edit_worktree_workdir(
     })
 }
 
+/// Rename a managed branch without moving its directory or touching its files.
+/// The caller holds the session identity and lifecycle locks and persists the result.
+pub fn rename_worktree_branch(
+    info: &WorktreeInfo,
+    path: &Path,
+    branch: &str,
+) -> anyhow::Result<bool> {
+    anyhow::ensure!(
+        info.managed_by_aoe,
+        "Branch-only rename requires a managed worktree"
+    );
+    anyhow::ensure!(
+        !branch.is_empty() && branch.trim() == branch && !branch.starts_with('-'),
+        "Provide an exact Git branch name"
+    );
+    anyhow::ensure!(
+        git2::Reference::is_valid_name(&format!("refs/heads/{branch}")),
+        "Provide an exact valid Git branch name"
+    );
+    let git = GitWorktree::new(PathBuf::from(&info.main_repo_path))?;
+    let canonical = path.canonicalize()?;
+    anyhow::ensure!(
+        Path::new(&info.main_repo_path).canonicalize()? != canonical,
+        "The main checkout cannot be renamed as a task"
+    );
+    anyhow::ensure!(
+        git.list_worktrees()?
+            .iter()
+            .any(
+                |wt| wt.path.canonicalize().ok().as_ref() == Some(&canonical)
+                    && wt.branch.as_deref() == Some(&info.branch)
+            ),
+        "Worktree path or branch no longer matches session metadata"
+    );
+    anyhow::ensure!(
+        GitWorktree::get_current_branch(path)? == info.branch,
+        "Worktree branch changed; refresh session metadata before renaming"
+    );
+    let protected = git.protected_default_branch_names()?;
+    anyhow::ensure!(
+        !["main", "master"].contains(&info.branch.as_str()) && !protected.contains(&info.branch),
+        "The default branch cannot be renamed as a task"
+    );
+    if branch == info.branch {
+        return Ok(false);
+    }
+    anyhow::ensure!(
+        !git.branch_exists(branch)?,
+        "Target branch already exists: {branch}"
+    );
+    git.rename_branch(&info.branch, branch)?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -472,13 +472,12 @@ pub fn rename_worktree_branch(
         Path::new(&info.main_repo_path).canonicalize()? != canonical,
         "The main checkout cannot be renamed as a task"
     );
+    let worktrees = git.list_worktrees()?;
     anyhow::ensure!(
-        git.list_worktrees()?
-            .iter()
-            .any(
-                |wt| wt.path.canonicalize().ok().as_ref() == Some(&canonical)
-                    && wt.branch.as_deref() == Some(&info.branch)
-            ),
+        worktrees.iter().any(
+            |wt| wt.path.canonicalize().ok().as_ref() == Some(&canonical)
+                && wt.branch.as_deref() == Some(&info.branch)
+        ),
         "Worktree path or branch no longer matches session metadata"
     );
     anyhow::ensure!(
@@ -494,11 +493,33 @@ pub fn rename_worktree_branch(
         return Ok(false);
     }
     anyhow::ensure!(
+        !worktrees.iter().any(|wt| {
+            wt.branch.as_deref() == Some(&info.branch)
+                && wt.path.canonicalize().ok().as_ref() != Some(&canonical)
+        }),
+        "Source branch is shared by another Git worktree"
+    );
+    anyhow::ensure!(
         !git.branch_exists(branch)?,
         "Target branch already exists: {branch}"
     );
     git.rename_branch(&info.branch, branch)?;
     Ok(true)
+}
+
+/// Roll back a branch rename only while the worktree still uses the renamed branch.
+pub fn rollback_worktree_branch(
+    info: &WorktreeInfo,
+    path: &Path,
+    renamed_branch: &str,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        GitWorktree::get_current_branch(path)? == renamed_branch,
+        "Worktree branch changed concurrently; refusing branch rollback"
+    );
+    GitWorktree::new(PathBuf::from(&info.main_repo_path))?
+        .rename_branch(renamed_branch, &info.branch)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -484,14 +484,14 @@ pub fn rename_worktree_branch(
         GitWorktree::get_current_branch(path)? == info.branch,
         "Worktree branch changed; refresh session metadata before renaming"
     );
+    if branch == info.branch {
+        return Ok(false);
+    }
     let protected = git.protected_default_branch_names()?;
     anyhow::ensure!(
         !["main", "master"].contains(&info.branch.as_str()) && !protected.contains(&info.branch),
         "The default branch cannot be renamed as a task"
     );
-    if branch == info.branch {
-        return Ok(false);
-    }
     anyhow::ensure!(
         !worktrees.iter().any(|wt| {
             wt.branch.as_deref() == Some(&info.branch)


### PR DESCRIPTION
## Description

Add `aoe session rename ID --branch NAME [--title TITLE]` to adopt a task/ticket branch name while an agent keeps working in the same directory. For example, a session can start on `experiment`, later adopt `olof/project-123-fix`, and preserve its working directory, uncommitted files and conversation.

The new option updates Git and AoE's recorded branch/title under the existing session locks. It validates managed-worktree ownership and exact branch names, refuses branches attached to another Git worktree (including unregistered worktrees), worktrees/branches shared across profiles, default branches, stale metadata and existing targets. It reconciles persisted state and verifies the current worktree branch before rolling Git back after a metadata write error. Repeating a completed rename is a no-op. It works with tied worktree naming enabled; the existing `--rename-branch` directory-moving workflow is unchanged. Remote branches and pull requests are not modified.

This supersedes the earlier draft #3865, retaining its managed-worktree validation and adding the tied-directory/retry coverage and live verification. Related running-session behavior: #3428.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Validation on main `5d0f79e` plus this change:

- `cargo fmt --check`: passed.
- `cargo clippy`: exits successfully. Two warnings remain in unchanged upstream code (`src/acp/event_store.rs:1440`, `src/session/instance/accessors.rs:330`); neither is introduced by this patch.
- `cargo test`: 6,957 library tests, 289 integration tests and one CLI smoke test passed; seven tests and one doctest ignored. On NixOS, test executables ran through an isolated `buildFHSEnv` runner providing `/bin/cat`, `/usr/bin/printf` and `/bin/ps`, which existing tests expect. Cargo compilation stayed in the normal Nix development shell. No host filesystem or unrelated source changes were needed.
- CLI reference regenerated with `cargo run --package xtask -- gen-docs`.
- Additional isolated CLI checks passed for staged/unstaged edits, untracked binary data, Unicode/slashed branch names, branch-only title preservation, retries, invalid names, collisions, nonstandard remote default branches and a worktree shared across profiles. Injecting a metadata-write failure after Git renames the branch verifies rollback without changes to the title, index, working files or HEAD.

The protected-branch no-op regression verifies that requesting the current branch succeeds with or without a title update, including when it is now the remote default. Actual renames of that protected branch remain rejected. An isolated real-Git CLI probe also passed with staged, unstaged and untracked files unchanged.

Additional review regressions cover a forced second Git worktree with no AoE session: refusal preserves both branch names, HEADs, working files and complete session metadata. Rollback coverage verifies that an external checkout prevents reference mutation, while the ordinary rollback still succeeds. Both reported scenarios were reproduced against the previous CLI and checked against the rebuilt CLI using isolated repositories and injected metadata-write failures.

Earlier live structured Claude and Codex sessions adopted real test-ticket branches while preserving directories, HEAD and dirty files, and continued answering prompts without a daemon restart. The equivalent v1.15.3 downstream source patch has been synchronized and verified to apply exactly; these latest review guards have not been deployed to the live daemon.

A forced process kill between the Git rename and metadata persistence leaves a detectable mismatch; a retry refuses stale metadata and preserves files. This is not a crash-atomic transaction across Git and session storage. Ordinary reported metadata-write failures roll Git back.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the in-module regression invokes the rename handler with a real isolated Git repository and linked worktree. It verifies dirty-file/HEAD/directory preservation, persisted metadata, tied naming, retry and collision behavior. A live CLI/ACP smoke test supplements it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex (GPT-6).

**Any Additional AI Details you'd like to share:** Implemented and tested at Olof's request to support task naming after an agent has already started working. The PR is ready for maintainer review; upstream Actions still require maintainer approval.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `aoe session rename ID --branch NAME` to rename a session branch without moving its worktree.
- Preserved the worktree directory, files, and conversation.
- Added checks for shared worktrees, invalid or protected branches, stale metadata, and branch conflicts.
- Added rollback handling when metadata updates fail.
- Added documentation and regression tests.
- Kept the existing directory-moving rename workflow unchanged.

## Benefits

Users can rename active session branches without disrupting their work. Repeated requests for the current branch complete as no-ops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




