### PR TITLE
fix(test): compare the Prime root publication against a canonical store

### DIFF
--- a/src/session/instance/launch_command.rs
+++ b/src/session/instance/launch_command.rs
@@ -1002,9 +1002,12 @@ mod tests {
             "wrapped command failed: {}",
             String::from_utf8_lossy(&output.stderr),
         );
+        // `pwd` prints the logical path on BSD and the physical one under GNU
+        // coreutils, so compare the directories rather than their spellings.
+        let printed = String::from_utf8_lossy(&output.stdout);
         assert_eq!(
-            String::from_utf8_lossy(&output.stdout).trim(),
-            working_dir.to_string_lossy(),
+            std::path::Path::new(printed.trim()).canonicalize().unwrap(),
+            working_dir.canonicalize().unwrap(),
         );
     }
 

--- a/src/session/instance/session_id.rs
+++ b/src/session/instance/session_id.rs
@@ -2288,9 +2288,16 @@ process.stdout.write(JSON.stringify({ rootOnly, defaultMode }));
             "custom-sessions/children/child.jsonl",
             "Pi default path publication changed"
         );
+        // The extension resolves a relative session file against the process cwd,
+        // which Node reports with symlinks resolved (/var -> /private/var on macOS).
         assert_eq!(
             published["rootOnly"]["path"],
-            store.join("custom-sessions/parent.jsonl").to_str().unwrap()
+            store
+                .canonicalize()
+                .unwrap()
+                .join("custom-sessions/parent.jsonl")
+                .to_str()
+                .unwrap()
         );
 
         publish_root(child_id, "child.jsonl");


### PR DESCRIPTION
## Description

`Cargo Test (macos)` is red on main ([run 34623500998](https://github.com/agent-of-empires/agent-of-empires/actions/runs/34623500998/job/103342896360)). One test fails: `session::instance::session_id::tests::prime_extension_root_only_keeps_parent_publication`.

The session-id extension publishes `resolve(file)`, and the test drives it with a relative session file after `process.chdir(store)`. Node anchors `resolve()` on the cwd as the kernel reports it, with symlinks already resolved, so on macOS the published path came back under `/private/var/folders/...` while the assertion compared it to `TempDir::path()` under `/var/folders/...`.

Canonicalize the store before joining. Test-only; inside the container both spellings name the same path.

Reproduced on Linux by pointing `TMPDIR` at a symlink, which fails identically before the change and passes after.

Second commit fixes the one other test that a symlinked temp root breaks, `test_wrap_command_reasserts_working_dir_after_login_shell`. The wrapper runs `exec env pwd`, and BSD `pwd` prints the logical path while GNU coreutils defaults to `-P` and prints the physical one, so the byte comparison only held where the temp root is not a symlink. Both sides are canonicalized now; the contract is that the login shell lands in `working_dir`, not that a given `pwd` spells it one way. Green on macOS today, so this is a latent break rather than a live one.

With both, the full lib suite passes under a symlinked `TMPDIR`, which is what would let the Linux jobs gate this class on the PR instead of catching it post-merge on main.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Diagnosis and fix drafted by the model, reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ivbF2Ag256wWuUk2Vwe8s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed platform-dependent test failures caused by different path spellings.
- Canonicalized temporary store paths before checking published session paths.
- Canonicalized working-directory values before comparing them in the shell wrapper test.
- Preserved product behavior and public interfaces.
- Improved test reliability across macOS, Linux, and symlinked temporary directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->