### PR TITLE
fix(web): let terminal link clicks reach the anchor

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1320,6 +1320,11 @@ export function MobileLiveTerminal({
       if (e.pointerType !== "mouse" || !forwardModeRef.current || e.shiftKey) return;
       const base = e.button === 1 ? 1 : e.button === 2 ? 2 : e.button === 0 ? 0 : -1;
       if (base < 0) return;
+      // A primary press that lands on a linkified URL belongs to the browser.
+      // The preventDefault and pointer capture below would retarget the click
+      // to this container, so the anchor would never navigate (#3918). Other
+      // buttons still reach the app, which keeps its context menu suppression.
+      if (base === 0 && (e.target as Element | null)?.closest?.("a[href]")) return;
       e.preventDefault();
       // Keep the hidden input focused so the physical keyboard still types
       // even though we suppressed the click's default focus.

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -434,3 +434,37 @@ describe("MobileLiveTerminal forward-mode flick momentum", () => {
     }
   });
 });
+
+describe("MobileLiveTerminal link clicks in forward mode", () => {
+  const linkFrame = () =>
+    frame({ content: "see https://example.com/x\n", altScreen: true, mouse: true, mouseSgr: true });
+
+  it("lets a primary press on a linkified URL reach the anchor", () => {
+    // Forwarding a press calls preventDefault and captures the pointer on the
+    // scroller, which retargets the click away from the anchor and leaves the
+    // link inert (#3918).
+    const { container, forwardButton } = renderTerm(linkFrame());
+    const anchor = container.querySelector("a[href='https://example.com/x']") as HTMLElement;
+    expect(anchor).not.toBeNull();
+    // A real press lands on one of the anchor's cell spans, not the anchor.
+    const target = anchor.querySelector("span") as HTMLElement;
+    expect(target).not.toBeNull();
+    const down = fireEvent.pointerDown(target, { pointerType: "mouse", button: 0, clientX: 10, clientY: 10 });
+    expect(down).toBe(true); // not defaultPrevented
+    fireEvent.pointerUp(anchor, { pointerType: "mouse", button: 0, clientX: 10, clientY: 10 });
+    expect(forwardButton).not.toHaveBeenCalled();
+  });
+
+  it("still forwards a press on plain output", () => {
+    const { scroller, forwardButton } = renderTerm(linkFrame());
+    fireEvent.pointerDown(scroller, { pointerType: "mouse", button: 0, clientX: 10, clientY: 10 });
+    expect(forwardButton).toHaveBeenCalled();
+  });
+
+  it("still forwards a right-click on a link so the app keeps its own menu", () => {
+    const { container, forwardButton } = renderTerm(linkFrame());
+    const anchor = container.querySelector("a[href='https://example.com/x']") as HTMLElement;
+    fireEvent.pointerDown(anchor, { pointerType: "mouse", button: 2, clientX: 10, clientY: 10 });
+    expect(forwardButton.mock.calls[0]![0]).toBe(2);
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -195,7 +195,11 @@
       "id": "terminal.live-clickable-urls",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/lib/liveTermLines.test.ts", "src/components/__tests__/MobileLiveTerminal.linkify.test.tsx"],
+      "specs": [
+        "src/lib/liveTermLines.test.ts",
+        "src/components/__tests__/MobileLiveTerminal.linkify.test.tsx",
+        "src/components/__tests__/MobileLiveTerminal.forward.test.tsx"
+      ],
       "components": ["web/src/components/MobileLiveTerminal.tsx"]
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -203,6 +203,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx"]
     },
     {
+      "id": "terminal.live-clickable-urls-e2e",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/live-link-click.spec.ts"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/lib/liveTermLines.ts"]
+    },
+    {
       "id": "terminal.live-cursor-wide-chars",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/live-link-click.spec.ts
+++ b/web/tests/live-link-click.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+import { mockTerminalApis, seedSettings, type MockHandle } from "./helpers/terminal-mocks";
+
+// A URL an agent prints is rendered as a target=_blank anchor. Under a
+// full-screen mouse app the scroller preventDefaults the press and takes
+// pointer capture so it can forward press/drag/release; capture retargets
+// pointerup, and so click, to the scroller, so the anchor never navigated
+// (#3918). This needs a real browser driven by real input: jsdom implements
+// neither pointer capture nor the retargeting, and dispatchEvent skips the
+// gesture entirely.
+
+const LINK = "https://example.com/pull/1375";
+const PROMPT = "$ open the PR";
+const scroller = (page: Page) => page.locator("[data-live-terminal] > div").first();
+const anchor = (page: Page) => page.locator(`a[href="${LINK}"]`).first();
+const mouseBytes = (h: MockHandle) => h.liveMessages.map((b) => b.toString("latin1")).filter((s) => /\x1b\[</.test(s));
+
+/** A full-screen SGR-mouse frame whose output contains a URL. */
+function pushLinkFrame(handle: MockHandle) {
+  const lines = [PROMPT, `see ${LINK} for details`, ...Array<string>(22).fill("")];
+  handle.pushLiveFrame({
+    content: `${lines.join("\n")}\n`,
+    rows: 24,
+    history: 0,
+    altScreen: true,
+    mouse: true,
+    mouseSgr: true,
+  });
+}
+
+/** Centre of `locator`, once the point actually hits it. The mobile sidebar
+ *  is an overlay with a 300ms slide-out, and `toBeVisible` does not hit-test,
+ *  so without this a tap lands on the closing sidebar. */
+async function hittableCentre(page: Page, selector: string) {
+  const box = (await page.locator(selector).first().boundingBox())!;
+  const point = [box.x + box.width / 2, box.y + box.height / 2] as const;
+  await expect
+    .poll(
+      () =>
+        page.evaluate(([x, y, sel]) => !!document.elementFromPoint(x as number, y as number)?.closest(sel as string), [
+          point[0],
+          point[1],
+          selector,
+        ] as const),
+      { timeout: 5_000 },
+    )
+    .toBe(true);
+  return point;
+}
+
+/** Wait until the client stops sending control messages. The mock answers
+ *  every resize/window with its own default frame, so pushing the link frame
+ *  before the layout settles (mobile sends extra resizes) loses it. */
+async function quiesce(handle: MockHandle) {
+  let last = -1;
+  await expect
+    .poll(
+      async () => {
+        const seen = handle.liveMessages.length;
+        const settled = seen === last;
+        last = seen;
+        return settled;
+      },
+      { timeout: 10_000, intervals: [300] },
+    )
+    .toBe(true);
+}
+
+async function setup(page: Page, mobile: boolean) {
+  // Route on the CONTEXT, not the page: the link opens a new tab, and a
+  // page-scoped route would leave that tab to hit the real network.
+  await page
+    .context()
+    .route("https://example.com/**", (route) =>
+      route.fulfill({ contentType: "text/html", body: "<title>linked page</title>ok" }),
+    );
+  const handle = await mockTerminalApis(page);
+  await page.goto("/");
+  await seedSettings(page, { mobileFontSize: 14, desktopFontSize: 14 });
+  await page.reload();
+  if (mobile) await openMobileSidebar(page);
+  await clickSidebarSession(page, "pinch-test");
+  await page.locator("[data-live-terminal]").first().waitFor({ state: "visible", timeout: 10_000 });
+  await expect.poll(() => handle.liveMessages.length, { timeout: 5_000 }).toBeGreaterThan(0);
+  await quiesce(handle);
+  pushLinkFrame(handle);
+  await expect(scroller(page)).toHaveClass(/overflow-hidden/);
+  await expect(anchor(page)).toBeVisible();
+  return handle;
+}
+
+test.describe("Live terminal link clicks (desktop)", () => {
+  test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
+  test("a real click on a printed URL opens it in a new tab", async ({ page }) => {
+    const handle = await setup(page, false);
+    const [x, y] = await hittableCentre(page, `a[href="${LINK}"]`);
+    // Real mouse input, not dispatchEvent: only the browser's own
+    // press/capture/release sequence reproduces the retargeting.
+    const [popup] = await Promise.all([page.context().waitForEvent("page"), page.mouse.click(x, y)]);
+    await popup.waitForLoadState();
+    expect(popup.url()).toBe(LINK);
+    // The press that opened the link is the browser's, not the app's.
+    expect(mouseBytes(handle)).toHaveLength(0);
+  });
+
+  test("a click on output beside the link still forwards to the app", async ({ page }) => {
+    const handle = await setup(page, false);
+    const box = (await page.getByText(PROMPT, { exact: true }).boundingBox())!;
+    await page.mouse.click(box.x + 4, box.y + box.height / 2);
+    // Press (`M`) then release (`m`) for SGR left button 0.
+    await expect.poll(() => mouseBytes(handle).some((s) => /\x1b\[<0;\d+;\d+M/.test(s))).toBe(true);
+    await expect.poll(() => mouseBytes(handle).some((s) => /\x1b\[<0;\d+;\d+m/.test(s))).toBe(true);
+  });
+
+  test("a right-click on the link still reaches the app", async ({ page }) => {
+    const handle = await setup(page, false);
+    const [x, y] = await hittableCentre(page, `a[href="${LINK}"]`);
+    await page.mouse.click(x, y, { button: "right" });
+    // SGR right button is 2.
+    await expect.poll(() => mouseBytes(handle).some((s) => /\x1b\[<2;\d+;\d+M/.test(s))).toBe(true);
+  });
+});
+
+test.describe("Live terminal link taps (mobile)", () => {
+  // `defaultBrowserType` would force a new worker, which test.use inside a
+  // group forbids; the rest of the descriptor is what matters here.
+  const { defaultBrowserType: _browser, ...iPhone13 } = devices["iPhone 13"];
+  test.use(iPhone13);
+
+  test("a real tap on a printed URL opens it in a new tab", async ({ page }) => {
+    // Touch never enters the forwarding path (it is gated to pointerType
+    // "mouse"), but the same anchor has to work under a finger.
+    await setup(page, true);
+    const [x, y] = await hittableCentre(page, `a[href="${LINK}"]`);
+    const [popup] = await Promise.all([page.context().waitForEvent("page"), page.touchscreen.tap(x, y)]);
+    await popup.waitForLoadState();
+    expect(popup.url()).toBe(LINK);
+  });
+
+  test("a tap on output beside the link opens nothing", async ({ page }) => {
+    await setup(page, true);
+    const [x, y] = await hittableCentre(page, "[data-live-terminal]");
+    await page.touchscreen.tap(x, y);
+    await page.waitForTimeout(500);
+    expect(page.context().pages()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Description

When an agent prints a URL in the web dashboard's terminal, the dashboard turns it into a link. Clicking that link did nothing at all: no tab opened, no error appeared. The reason is that while a full-screen agent is running, the terminal grabs the mouse so it can pass presses and drags through to the agent, and that grab was strong enough that the browser stopped treating a press on a link as a click on the link. This change makes the terminal let go for ordinary left-clicks that land on a link, so the link opens in a new tab like any other link on the page. Right-clicks and middle-clicks still go to the agent as before, so nothing the agent does with the mouse changes.

Mechanically: in forward mode (`altScreen && frame.mouse`) `onPointerDown` calls `preventDefault()` plus `setPointerCapture()` on the scroller. Capture retargets `pointerup`, and therefore `click`, to the scroller, so the anchor never received the click and its default navigation never ran. The fix skips forwarding for a plain primary press whose target is inside an `a[href]`.

Not fixed here: the issue also reports that a URL wrapping onto the next terminal row linkifies only its first row, truncating the href. That needs a per-row wrap flag the wire format does not carry. `vt100::Screen::row_wrapped()` exists but is never called and would read `false` for every pre-seed row, since the grid is seeded from `capture-pane` output with LF promoted to CRLF; the `capture-pane` fallback transport has no wrap information at all, and a single-pane frame does not even carry pane width. Tracked separately in #3920.

Verified in real Chromium, since jsdom implements neither pointer capture nor the retargeting that caused the bug. `web/tests/live-link-click.spec.ts` drives the built bundle with real mouse and touch input against a full-screen SGR-mouse frame. Desktop: the click opens a tab at the anchor's href and forwards no mouse bytes; a click beside the link still forwards `ESC[<0;..M`/`m`; a right-click on the link still forwards `ESC[<2;..M`. Mobile (iPhone 13): the same tap opens the link. Reverting the one-line guard and rebuilding fails the desktop link case and nothing else.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Diagnosis, fix and tests were produced through back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #3918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhLtwFoJdAXtoVUb3H2581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed terminal URL links in the web dashboard so primary clicks and mobile taps open the link.
- Preserved forwarding for clicks outside links and for right-click actions.
- Added unit and Playwright coverage for desktop and mobile behavior.
- Updated the coverage matrix.

## Benefit

Users can open detected terminal URLs normally without breaking terminal mouse controls.

Wrapped URLs that span terminal rows remain a separate follow-up issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->