### PR TITLE
ci: run the core-rest leg under a symlinked temp root

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,25 @@ jobs:
             --test integration -- daemon_core_web_optional plugin_install
           cargo test --features web,e2e-tests --lib -- \
             server::assets:: tui::dialogs::serve::qr_seam
+      # macOS reaches its per-user temp root through a symlink, so a test that
+      # compares `TempDir::path()` against a path that has been through
+      # `canonicalize()` or a reported cwd passes on Linux and fails there.
+      # That asymmetry has broken main twice (#3535, #3919), and the macOS
+      # leg only runs post-merge, so nothing catches it on the PR. Pointing
+      # TMPDIR at a symlink reproduces the difference on the leg that runs the
+      # unit tests, where this class lives.
+      #
+      # Scoped to core-rest deliberately: lib + bins + integration were measured
+      # clean under a symlinked root, the e2e legs were not, and those are the
+      # ones binding sockets under `temp_dir()`. Keep the path short for the
+      # same reason (`sun_path` is 104 bytes on macOS, and src/tmux/vt.rs binds
+      # inside `temp_dir()`).
+      - name: Symlinked temp root
+        if: matrix.leg == 'core-rest'
+        run: |
+          mkdir -p /tmp/aoe-real
+          ln -sfn /tmp/aoe-real /tmp/aoe-link
+          echo "TMPDIR=/tmp/aoe-link" >> "$GITHUB_ENV"
       # core-rest: the full default-feature suite minus e2e (lib + bins +
       # the consolidated integration binary). The daemon is core, so this
       # leg covers it end to end with no dashboard bundle and no npm in the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,11 @@ jobs:
       # skipped here while every non-e2e test binary stays auto-discovered.
       - name: Cargo test (default features, everything except e2e)
         if: matrix.leg == 'core-rest'
-        run: cargo test
+        # Echo the temp root so a silently-dropped TMPDIR is visible in the log
+        # rather than passing as a green run with the guard gone.
+        run: |
+          echo "TMPDIR=${TMPDIR:-unset}"
+          cargo test
       # bare-core: the three no-default-features feature corners. `web` is not
       # a default feature, so these runs are also the dashboard-off compile
       # gate that keeps the `cfg(feature = "web")` sites from rotting.


### PR DESCRIPTION
## Description

macOS reaches its per-user temp root through a symlink, so a test comparing `TempDir::path()` against a path that has been through `canonicalize()` or a reported cwd passes on Linux and fails on macOS. The macOS leg runs post-merge only, so this class lands on main before anyone sees it. Twice so far: #3535 compared a canonicalized observation against a raw `tempfile::tempdir()` path, #3919 compared a store path against a cwd Node had already resolved.

Point `TMPDIR` at a symlink for the core-rest leg, reproducing the difference where the unit tests run.

Verified against #3919: its failing test fails identically under a symlinked root on Linux, and passes once fixed.

**Scope.** core-rest only (`cargo test` = lib + bins + integration), which is the surface measured clean. The e2e legs are left alone; they could not be measured cleanly and they are the ones binding sockets under `temp_dir()`, where `sun_path` headroom matters. The symlink path is short for the same reason.

**Measurements.**

| suite | control | symlinked |
| --- | --- | --- |
| `cargo test --lib` x3 (6953 tests) | 0, 0, 2 failures | 0, 0, 1 failure |
| `cargo test --test integration` | not run | 289 passed, 0 failed |
| `cargo test --test e2e` | 11 failures | 12 failures |

The lib failures on both sides come from one population of pre-existing flaky tests (`acp_client::steer`, `acp_client::spawn`, `session::instance::terminal`, `session::smart_rename`), each passing in isolation. No runtime difference: 153s symlinked vs 151s control.

The e2e numbers are from a sandbox with 11 baseline failures (missing agent stubs, container process handling), so that row proves nothing either way. The two sets are identical except `live_send_paste_e2e::test_live_send_paste_into_non_bracketed_pane_has_no_marker_debris`, which fails 2/2 in isolation under both conditions.

Known gap: a path bug that only shows up in the e2e suite still reaches main.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Measurements run by the model, reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ivbF2Ag256wWuUk2Vwe8s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Run `core-rest` tests with a symlinked `TMPDIR` to reproduce macOS-style paths on Linux.
- Log the effective temporary directory for easier CI verification.
- Keep e2e jobs unchanged because temporary socket behavior produced unreliable results.
- Validate 289 integration tests successfully. Library test failures remain pre-existing and flaky.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->