### PR TITLE
refactor(session): quote the whole Prime extension path

### DIFF
--- a/src/session/instance/session_id.rs
+++ b/src/session/instance/session_id.rs
@@ -725,8 +725,10 @@ impl Instance {
                     (
                         Path::new(PRIME_AGENT_DIR_IN_CONTAINER),
                         format!(
-                            " -e {}/extensions/aoe-session-id.js",
-                            shell_escape(PRIME_AGENT_DIR_IN_CONTAINER),
+                            " -e {}",
+                            shell_escape(&format!(
+                                "{PRIME_AGENT_DIR_IN_CONTAINER}/extensions/aoe-session-id.js"
+                            ))
                         ),
                     )
                 }


### PR DESCRIPTION
## Description

Follow-up to #3915. That PR replaced the full-path `PRIME_AGENT_EXTENSION_IN_CONTAINER` constant with a root constant plus an inline suffix, which left `shell_escape` wrapping only the directory:

```
-e '/root/.prime/agent'/extensions/aoe-session-id.js
```

Not a live bug. `PRIME_AGENT_DIR_IN_CONTAINER` has no shell-special characters, and the concatenation parses to the same argv word under bash and dash either way. The problem is that the call reads as though it escapes the path it builds, which turns into a real bug the day the constant changes. Escape the joined path so the guarantee matches the appearance.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the emitted argv word is unchanged, so a regression test would assert the same string before and after. Adding one would need a container launch to be worth anything.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (6,956 + 289 passed, 0 failed) all pass. Rust only, no web build.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:** Found during review of #3915, raised there as non-blocking, split out at the maintainer's request.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xk8X6bw944fd8v3HHkxrbB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Prime extension path handling to escape the complete path, including the filename.
- Preserved the current emitted argument.
- Improved safety if path constants change in the future.
- Formatting, linting, and all 7,245 tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->