### PR TITLE
feat(tui): name the host terminal tab after the selected session

### DIFF
--- a/src/session/config/mod.rs
+++ b/src/session/config/mod.rs
@@ -1124,6 +1124,12 @@ pub struct SessionConfig {
     #[setting(label = "Mouse Capture", widget = "toggle", category = "Interaction")]
     pub mouse_capture: bool,
 
+    /// Set the host terminal tab to `aoe: {session}` from the TUI
+    /// selection via OSC 0. Disable to keep the terminal's own naming.
+    #[serde(default = "default_true")]
+    #[setting(label = "Host Tab Title", widget = "toggle", category = "Interaction")]
+    pub host_tab_title: bool,
+
     /// User-defined agents: name=command (e.g. lenovo-claude=ssh -t lenovo
     /// claude). Custom agent names appear in the TUI agent picker alongside
     /// built-in agents.
@@ -1738,6 +1744,7 @@ impl Default for SessionConfig {
             auto_resume_on_restart: true,
             opencode_preassign_session_id: false,
             mouse_capture: true,
+            host_tab_title: true,
             custom_agents: HashMap::new(),
             agent_detect_as: HashMap::new(),
             agent_config_dir: HashMap::new(),
@@ -5039,6 +5046,7 @@ mod tests {
         let session: SessionConfig = toml::from_str("").unwrap();
         assert!(session.confirm_before_quit, "confirm_before_quit (#1569)");
         assert!(session.confirm_delete, "confirm_delete (#3364)");
+        assert!(session.host_tab_title, "host_tab_title (#3444)");
     }
 
     #[test]

--- a/src/session/config/settings_schema/registry.rs
+++ b/src/session/config/settings_schema/registry.rs
@@ -119,6 +119,16 @@ mod tests {
     }
 
     #[test]
+    fn session_host_tab_title_is_an_interaction_toggle() {
+        let d = descriptor("session", "host_tab_title").expect("host_tab_title");
+        assert_eq!(d.category, "Interaction");
+        assert_eq!(d.widget, WidgetKind::Toggle);
+        assert!(d.profile_overridable);
+        assert!(!d.advanced);
+        assert!(matches!(d.web_write, WebWritePolicy::Allow));
+    }
+
+    #[test]
     fn session_row_tag_is_select_with_options() {
         let d = descriptor("session", "row_tag").expect("row_tag");
         match &d.widget {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -185,6 +185,9 @@ pub struct App {
     /// effect without a restart. When false, `sync_mouse_capture` keeps xterm
     /// tracking off entirely.
     mouse_capture_allowed: bool,
+    /// Last OSC 0 host-tab title written. Dedups unchanged selections and
+    /// is invalidated after `tmux attach` so the dashboard title is restored.
+    host_title: super::host_title::HostTitleTracker,
     /// True when running under Mosh (`MOSH_CONNECTION` set). Mosh mangles
     /// xterm mouse-tracking escapes, so `tui::run` skips the startup
     /// `EnableMouseCapture` and `sync_mouse_capture` must not re-enable
@@ -514,6 +517,7 @@ impl App {
             // `mouse_capture_allowed` is permission only and ignores Mosh.
             mouse_captured: crate::tui::mouse_capture_requested(&config.session) && !mosh_active,
             mouse_capture_allowed: crate::tui::mouse_capture_requested(&config.session),
+            host_title: super::host_title::HostTitleTracker::default(),
             mosh_active,
             pending_structured_view_open: None,
             pending_daemon_start_open: None,
@@ -553,6 +557,24 @@ impl App {
             crossterm::execute!(terminal.backend_mut(), DisableMouseCapture)?;
         }
         self.mouse_captured = desired;
+        Ok(())
+    }
+
+    /// Write OSC 0 when the dashboard selection (or its title) changes.
+    ///
+    /// Emitted after the frame so it does not interleave with OSC 8 runs
+    /// inside `HyperlinkBackend::draw`. No-ops when the setting is off
+    /// and we have never written, so opt-out users keep the terminal's
+    /// own naming.
+    fn sync_host_title(&mut self, terminal: &mut Terminal<TuiBackend>) -> Result<()> {
+        let Some(title) = self
+            .host_title
+            .sync(self.home.host_tab_title, self.home.selected_session_title())
+        else {
+            return Ok(());
+        };
+        crossterm::execute!(terminal.backend_mut(), crossterm::terminal::SetTitle(title))?;
+        super::host_title::note_emitted();
         Ok(())
     }
 
@@ -612,6 +634,7 @@ impl App {
         );
         draw_result?;
         end_result?;
+        self.sync_host_title(terminal)?;
         Ok(())
     }
 
@@ -684,6 +707,9 @@ impl App {
         // to the serve view. sync_mouse_capture itself respects the Mouse
         // Capture setting and the AOE_MOUSE_CAPTURE opt-out.
         self.sync_mouse_capture(terminal)?;
+        // Attach may have overwritten the host tab via the pane's OSC 0.
+        self.host_title.invalidate();
+        self.sync_host_title(terminal)?;
         std::io::Write::flush(terminal.backend_mut())?;
 
         // Recreate the event stream with a fresh reader before re-entering the

--- a/src/tui/home/config_refresh.rs
+++ b/src/tui/home/config_refresh.rs
@@ -95,6 +95,7 @@ impl HomeView {
         self.refresh_status_hook_config_cache();
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.confirm_before_quit = config.session.confirm_before_quit;
+        self.host_tab_title = config.session.host_tab_title;
         self.row_tag_mode = config.session.row_tag;
         // Keep the strip in sync when the Settings UI or a config-file edit
         // flips the toggle from any settings surface.

--- a/src/tui/home/lifecycle.rs
+++ b/src/tui/home/lifecycle.rs
@@ -133,6 +133,7 @@ impl HomeView {
             .unwrap_or_else(|| resolved.status_hooks.clone());
         let strict_hotkeys = resolved.session.strict_hotkeys;
         let confirm_before_quit = resolved.session.confirm_before_quit;
+        let host_tab_title = resolved.session.host_tab_title;
         let idle_decay_window =
             crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
         crate::session::set_unread_enabled(resolved.session.unread_indicator);
@@ -381,6 +382,7 @@ impl HomeView {
             status_hook_configs,
             strict_hotkeys,
             confirm_before_quit,
+            host_tab_title,
             active_tui_count: 1,
             idle_decay_window,
             settings_view: None,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -764,6 +764,10 @@ pub struct HomeView {
     // confirmation first (guards against accidental exits, #1569).
     pub(super) confirm_before_quit: bool,
 
+    /// Cached `session.host_tab_title`. The App loop reads this to emit
+    /// OSC 0; refreshed from config at construction and on reload.
+    pub(super) host_tab_title: bool,
+
     // Number of live `aoe` TUI processes (including this one), refreshed on a
     // throttle from the app loop. The footer surfaces it when >1 so the user
     // knows another instance is attached (the two clash over agent pane sizes

--- a/src/tui/home/rows.rs
+++ b/src/tui/home/rows.rs
@@ -37,6 +37,12 @@ impl HomeView {
         self.instances.get(id)
     }
 
+    /// Title of the currently selected session row, if the cursor is on one.
+    pub(in crate::tui) fn selected_session_title(&self) -> Option<&str> {
+        let id = self.selected_session.as_deref()?;
+        Some(self.get_instance(id)?.title.as_str())
+    }
+
     /// Materialize `self.instances` into a `Vec` for callsites that hand off
     /// a `&[Instance]` slice to a downstream API. Single seam so the day
     /// `HomeView` grows a cache, only this helper needs to change.

--- a/src/tui/home/tests/search.rs
+++ b/src/tui/home/tests/search.rs
@@ -201,6 +201,32 @@ fn test_selected_session_updates_on_cursor_move() {
 
 #[test]
 #[serial]
+fn test_selected_session_title_tracks_cursor() {
+    let mut env = create_test_env_with_sessions(3);
+    let first = env.view.selected_session_title().map(str::to_string);
+    assert!(first.is_some());
+    env.view.handle_key(key(KeyCode::Down), None);
+    let second = env.view.selected_session_title().map(str::to_string);
+    assert_ne!(first, second);
+}
+
+#[test]
+#[serial]
+fn test_selected_session_title_none_on_group() {
+    let mut env = create_test_env_with_groups();
+    for i in 0..env.view.flat_items.len() {
+        env.view.cursor = i;
+        env.view.update_selected();
+        if env.view.selected_session.is_none() {
+            assert_eq!(env.view.selected_session_title(), None);
+            return;
+        }
+    }
+    panic!("No group found in flat_items");
+}
+
+#[test]
+#[serial]
 fn test_selected_group_set_when_on_group() {
     let mut env = create_test_env_with_groups();
     for i in 0..env.view.flat_items.len() {

--- a/src/tui/host_title.rs
+++ b/src/tui/host_title.rs
@@ -1,0 +1,142 @@
+//! Host terminal tab title (OSC 0) for the TUI dashboard (#3444).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Title restored when the TUI exits, and used when nothing is selected
+/// or the user has opted out.
+pub const FALLBACK_TITLE: &str = "aoe";
+
+/// Set when this process has written OSC 0, so TerminalGuard can restore
+/// [`FALLBACK_TITLE`] on exit without touching tabs we never named.
+static DID_EMIT: AtomicBool = AtomicBool::new(false);
+
+pub fn note_emitted() {
+    DID_EMIT.store(true, Ordering::Relaxed);
+}
+
+pub fn take_emitted() -> bool {
+    DID_EMIT.swap(false, Ordering::Relaxed)
+}
+
+/// Strip control bytes so a session title cannot inject OSC/CSI into the
+/// host stream. Matches the OSC 8 URI sanitizer in [`super::hyperlink`].
+pub fn sanitize_title(raw: &str) -> String {
+    raw.chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+/// Tab string for a selected session: `aoe: {title}`. Empty or missing
+/// titles fall back to [`FALLBACK_TITLE`].
+pub fn format_tab_title(session_title: Option<&str>) -> String {
+    match session_title.map(sanitize_title) {
+        Some(title) if !title.is_empty() => format!("{FALLBACK_TITLE}: {title}"),
+        _ => FALLBACK_TITLE.to_string(),
+    }
+}
+
+/// Last OSC 0 payload written, so an unchanged selection does not re-emit.
+#[derive(Debug, Default)]
+pub struct HostTitleTracker {
+    last: Option<String>,
+}
+
+impl HostTitleTracker {
+    /// Title to write, or `None` if the host already has it.
+    ///
+    /// Disabled and never written: stay hands-off so we do not overwrite
+    /// the terminal's own naming. Disabled after a write: restore
+    /// [`FALLBACK_TITLE`] once. After [`Self::invalidate`], the next
+    /// enabled sync re-emits even if the string is unchanged (needed
+    /// after `tmux attach`, which may have overwritten the host title).
+    pub fn sync(&mut self, enabled: bool, session_title: Option<&str>) -> Option<String> {
+        let desired = if enabled {
+            format_tab_title(session_title)
+        } else if self.last.is_some() {
+            FALLBACK_TITLE.to_string()
+        } else {
+            return None;
+        };
+        if self.last.as_deref() == Some(desired.as_str()) {
+            return None;
+        }
+        self.last = enabled.then(|| desired.clone());
+        Some(desired)
+    }
+
+    pub fn invalidate(&mut self) {
+        self.last = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_session_title_with_aoe_prefix() {
+        assert_eq!(format_tab_title(Some("fix auth")), "aoe: fix auth");
+    }
+
+    #[test]
+    fn empty_or_missing_title_is_bare_aoe() {
+        assert_eq!(format_tab_title(None), "aoe");
+        assert_eq!(format_tab_title(Some("")), "aoe");
+        assert_eq!(format_tab_title(Some("   ")), "aoe");
+    }
+
+    #[test]
+    fn strips_control_bytes_from_titles() {
+        assert_eq!(sanitize_title("fix\x1b]0;pwn\x07 auth"), "fix]0;pwn auth");
+        assert_eq!(format_tab_title(Some("ok\nline")), "aoe: okline");
+    }
+
+    #[test]
+    fn tracker_skips_unchanged_titles() {
+        let mut t = HostTitleTracker::default();
+        assert_eq!(t.sync(true, Some("one")), Some("aoe: one".to_string()));
+        assert_eq!(t.sync(true, Some("one")), None);
+        assert_eq!(t.sync(true, Some("two")), Some("aoe: two".to_string()));
+    }
+
+    #[test]
+    fn tracker_stays_quiet_when_disabled_from_the_start() {
+        let mut t = HostTitleTracker::default();
+        assert_eq!(t.sync(false, Some("one")), None);
+        assert_eq!(t.sync(false, Some("two")), None);
+    }
+
+    #[test]
+    fn tracker_restores_fallback_once_when_toggled_off() {
+        let mut t = HostTitleTracker::default();
+        assert_eq!(t.sync(true, Some("one")), Some("aoe: one".to_string()));
+        assert_eq!(t.sync(false, Some("one")), Some("aoe".to_string()));
+        assert_eq!(t.sync(false, Some("one")), None);
+    }
+
+    #[test]
+    fn invalidate_forces_a_rewrite() {
+        let mut t = HostTitleTracker::default();
+        assert_eq!(t.sync(true, Some("one")), Some("aoe: one".to_string()));
+        t.invalidate();
+        assert_eq!(t.sync(true, Some("one")), Some("aoe: one".to_string()));
+    }
+
+    #[test]
+    fn group_or_no_selection_uses_fallback_while_enabled() {
+        let mut t = HostTitleTracker::default();
+        assert_eq!(t.sync(true, None), Some("aoe".to_string()));
+        assert_eq!(t.sync(true, None), None);
+    }
+
+    #[test]
+    fn take_emitted_is_one_shot() {
+        let _ = take_emitted();
+        assert!(!take_emitted());
+        note_emitted();
+        assert!(take_emitted());
+        assert!(!take_emitted());
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -12,6 +12,7 @@ mod deletion_poller;
 pub mod dialogs;
 pub mod diff;
 pub(crate) mod home;
+mod host_title;
 pub mod hyperlink;
 pub(crate) mod links;
 pub(crate) mod markdown;
@@ -58,7 +59,9 @@ use crossterm::{
         KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{
+        disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, SetTitle,
+    },
 };
 use ratatui::prelude::*;
 use std::io::{self, IsTerminal};
@@ -183,8 +186,11 @@ impl Drop for TerminalGuard {
             stdout,
             LeaveAlternateScreen,
             DisableBracketedPaste,
-            crossterm::cursor::Show
+            crossterm::cursor::Show,
         );
+        if host_title::take_emitted() {
+            let _ = execute!(stdout, SetTitle(host_title::FALLBACK_TITLE));
+        }
     }
 }
 use crate::session::get_update_settings;

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -1636,6 +1636,7 @@ mod tests {
             "session.click_action",
             "session.live_send_exit_chord",
             "session.mouse_capture",
+            "session.host_tab_title",
             "session.show_session_colors",
         ] {
             assert!(


### PR DESCRIPTION
## Description

Fixes #3444.

The TUI never emitted OSC 0/2, so the host terminal tab stayed on the shell's name (`aoe`) while you moved between sessions. tmux `set-titles` cannot fix this: it is server-wide and does not know which session the dashboard is previewing.

This writes OSC 0 from the TUI's own stdout when the home-list selection (or its title) changes:

- Format: `aoe: {session title}`
- Default on, opt out with **Settings → Interaction → Host Tab Title** (`session.host_tab_title`)
- Control bytes are stripped from titles (same rule as OSC 8)
- Unchanged titles are not rewritten
- After `tmux attach` / detach, the dashboard title is applied again
- On TUI exit, the tab is restored to `aoe` only if this process actually wrote a title, so opt-out users keep the terminal's own naming

Out of scope (as discussed on the issue): web `document.title`, the `AOE_DAEMON_URL` remote-home client, tmux `set-titles`, and a `{tool}-{title}` template. That last one can follow if maintainers want it.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The setting is schema-backed (`#[setting]` on `SessionConfig`), so it appears on the TUI and web settings surfaces with no extra registry. I could not capture a real terminal-tab recording from this environment; happy to add one if a maintainer wants it from iTerm2 / Ghostty.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The new toggle is a TUI host-tab effect. It shows up on the web Settings page automatically via the schema, but it does not change a dashboard user flow.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: asserting the host tab title needs a real terminal emulator. Coverage is unit tests for format (`aoe: {title}`), sanitization, dedup, opt-out (no emit until first write), restore-once on disable, invalidate-after-attach, TOML default-on, schema placement on the Interaction tab, and `selected_session_title` tracking.

`cargo fmt`, `cargo clippy --lib -- -D warnings`, and the feature unit tests all pass.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Grok 4.6 (Grok Build)

**Any Additional AI Details you'd like to share:**

Helped read the issue, draft the claim comment, and implement the patch against the discussed plan (default on, `aoe: {title}`, no tool-name template in v1). I reviewed the hook points (`HomeView.selected_session`, `HyperlinkBackend`, `TerminalGuard`, `with_raw_mode_disabled`) and the test results before opening this PR.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds automatic terminal tab titles for the selected session, using the format `aoe: {session title}`.
- Adds the `session.host_tab_title` setting under **Settings → Interaction**, enabled by default.
- Sanitizes session titles and avoids repeated title updates.
- Restores the default `aoe` title when needed, including after tmux attach or detach.
- Updates configuration, settings, and schema integration.
- Adds unit tests for title handling, selection changes, defaults, and settings registration.

This helps the host terminal tab match the session shown in the TUI while providing a clear opt-out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->