### PR TITLE
fix(fork): decide fork eligibility on the row and the user's own config

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -384,12 +384,27 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         }
         // The child must fork the SAME agent as the parent: a captured id is
         // agent-shaped (a Claude UUID resumes only under Claude, etc.), so
-        // handing it to a different agent's `--resume` fails or resumes garbage.
-        // When the user did not explicitly choose a tool (`--tool`/`--cmd`),
-        // inherit the parent's; when they did and it differs, reject rather than
-        // launch a cross-agent fork.
+        // handing it to a different agent's `--resume` fails or resumes
+        // garbage. Compared on the built-in each name resolves to, so an
+        // `agent_detect_as` wrapper and its base are one agent. Without an
+        // explicit `--tool`/`--cmd` the parent's tool is inherited instead.
         let user_chose_tool = args.tool.is_some() || args.command.is_some();
-        if user_chose_tool && resolved_tool != source.tool {
+        let parent_agent = pinned_capture_agent(source);
+        // Authorization may not read the checked-out repo. `agent_detect_as`
+        // is `repo = "allow"`, so `.agent-of-empires/config.toml` can re-point
+        // an alias; the profile-only config is the user's own answer.
+        let profile_config =
+            crate::session::config::profile_config::resolve_config_or_warn(profile);
+        if user_chose_tool
+            && resolved_tool != source.tool
+            && fork_agent_for(
+                &resolved_tool,
+                parent_agent,
+                &profile_config.session,
+                &config.session,
+            )
+            .is_none()
+        {
             bail!(
                 "Cannot fork session '{}' (agent '{}') as agent '{}': a fork must use the parent's \
                  agent. Drop --tool/--cmd to inherit it, or fork a session created with '{}'.",
@@ -403,8 +418,18 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             resolved_tool = source.tool.clone();
         }
         let parent_agent_session_id = source.agent_session_id.clone();
-        let seed = crate::session::fork::terminal_fork_seed(
+        // The alias is resolved for the seed only where the row itself proves
+        // the child runs the parent's built-in. Without that proof the raw
+        // name goes through, which is the refusal this path had before.
+        let fork_agent = fork_agent_for(
             &resolved_tool,
+            parent_agent,
+            &profile_config.session,
+            &config.session,
+        )
+        .unwrap_or(resolved_tool.as_str());
+        let seed = crate::session::fork::terminal_fork_seed(
+            fork_agent,
             parent_agent_session_id.as_deref(),
             crate::session::capture::generate_session_uuid(),
         )
@@ -1551,6 +1576,75 @@ fn override_launch_binary(
     shell_words::split(&command).ok()?.into_iter().next()
 }
 
+/// The built-in a tool name being chosen now resolves to: the built-in itself,
+/// or the base a `session.agent_detect_as` wrapper declares. Reads the live
+/// map, which is also what the new session's own `detect_as` is written from.
+fn capture_agent_for_tool(
+    tool: &str,
+    session: &crate::session::config::SessionConfig,
+) -> Option<&'static str> {
+    crate::agents::get_agent(tool)
+        .or_else(|| {
+            session
+                .agent_detect_as
+                .get(tool)
+                .and_then(|base| crate::agents::get_agent(base))
+        })
+        .map(|agent| agent.name)
+}
+
+/// The built-in that captured a parent row's session id, from the row and the
+/// agent registry alone: its tool when that names a built-in (the registry
+/// wins there, as it does everywhere), else the `agent_detect_as` alias the
+/// row recorded.
+///
+/// Deliberately narrower than `Instance::resolved_agent`, which falls back to
+/// the live alias map when the stored value is empty: `effective_detect_as`
+/// returns the stored alias only when it is non-empty, and rows with an empty
+/// one keep being written (`add.rs` stores `unwrap_or_default()` for a tool
+/// with no entry). Such a row records no evidence of what shaped its id, and
+/// the live map may have been retargeted since, so `None` is the honest
+/// answer. The recorded alias is only as good as the map when it was written,
+/// which is session build or the `v024` backfill, not the capture itself.
+fn pinned_capture_agent(parent: &Instance) -> Option<&'static str> {
+    crate::agents::get_agent(&parent.tool)
+        .or_else(|| {
+            let pinned = parent.detect_as.trim();
+            (!pinned.is_empty())
+                .then(|| crate::agents::get_agent(pinned))
+                .flatten()
+        })
+        .map(|agent| agent.name)
+}
+
+/// The built-in a fork would run under, when the parent row proves the child
+/// resolves to that same one. `None` whenever the two sides cannot be shown to
+/// match, including when the row recorded nothing: the caller then falls back
+/// to the raw name, which is what this path did before the alias was resolved
+/// at all. So the permitted set only ever grows where the row itself is
+/// evidence.
+///
+/// `chosen` is resolved from `profile`, the user's own config, and the fork is
+/// refused outright when `merged` (the same config with the project repo's
+/// `.agent-of-empires/config.toml` layered on) resolves it differently. A
+/// repo-supplied `agent_detect_as` entry may steer status detection, which is
+/// what it was marked `repo = "allow"` for; it may not decide whose session id
+/// a fork hands to which agent, and it cannot be read only on the authorizing
+/// side because the row this call creates stores the merged alias and launches
+/// under it.
+fn fork_agent_for(
+    chosen: &str,
+    parent: Option<&'static str>,
+    profile: &crate::session::config::SessionConfig,
+    merged: &crate::session::config::SessionConfig,
+) -> Option<&'static str> {
+    let chosen_agent = capture_agent_for_tool(chosen, profile)?;
+    if capture_agent_for_tool(chosen, merged) != Some(chosen_agent) {
+        return None;
+    }
+    (Some(chosen_agent) == parent).then_some(chosen_agent)
+}
+
 enum NamedToolSelection {
     Custom(String),
     BuiltIn(String),
@@ -1656,7 +1750,9 @@ fn resolve_sandbox_image(
 
 #[cfg(test)]
 mod tests {
-    use super::{override_launch_binary, parse_repo_base, resolve_sandbox_image};
+    use super::{
+        capture_agent_for_tool, override_launch_binary, parse_repo_base, resolve_sandbox_image,
+    };
     use crate::session::config::SessionConfig;
 
     #[test]
@@ -1676,6 +1772,26 @@ mod tests {
         }
         for raw in ["api", "=develop", "api=", "  =  "] {
             assert!(parse_repo_base(raw).is_err(), "{raw:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn capture_agent_for_tool_resolves_detect_as_wrappers() {
+        let mut session = SessionConfig::default();
+        session
+            .agent_detect_as
+            .insert("claude-work".to_string(), "claude".to_string());
+
+        let cases = [
+            ("claude-work", Some("claude")),
+            ("claude", Some("claude")),
+            ("codex", Some("codex")),
+            // No entry, no built-in: the caller falls back to a literal
+            // comparison rather than guessing.
+            ("mystery-agent", None),
+        ];
+        for (tool, want) in cases {
+            assert_eq!(capture_agent_for_tool(tool, &session), want, "{tool:?}");
         }
     }
 
@@ -1754,19 +1870,19 @@ mod tests {
     }
 
     /// Argument-level coverage of the #148 guard on `add`.
-    mod profile_guard {
-        use crate::cli::{Cli, Commands};
+    fn dispatch_argv(argv: &[&str]) -> (String, super::AddArgs) {
         use clap::Parser;
-        use serial_test::serial;
-
-        fn dispatch_argv(argv: &[&str]) -> (String, super::super::AddArgs) {
-            let cli = Cli::try_parse_from(argv).expect("argv parses");
-            let profile = cli.profile.unwrap_or_default();
-            match cli.command {
-                Some(Commands::Add(args)) => (profile, *args),
-                _ => panic!("expected an add invocation"),
-            }
+        let cli = crate::cli::Cli::try_parse_from(argv).expect("argv parses");
+        let profile = cli.profile.unwrap_or_default();
+        match cli.command {
+            Some(crate::cli::Commands::Add(args)) => (profile, *args),
+            _ => panic!("expected an add invocation"),
         }
+    }
+
+    mod profile_guard {
+        use super::dispatch_argv;
+        use serial_test::serial;
 
         #[tokio::test]
         #[serial]
@@ -1816,6 +1932,243 @@ mod tests {
                 msg.contains("Path does not exist"),
                 "a known profile must reach path validation, got: {msg}"
             );
+        }
+    }
+
+    mod fork_gate {
+        use super::dispatch_argv;
+        use serial_test::serial;
+
+        /// An isolated app dir holding one profile and one parent row. The
+        /// parent has no captured id, so every case below stops at the gate or
+        /// at the seed and creates nothing.
+        fn set_up(app: &std::path::Path, claude_work_maps_to: &str, parent: (&str, &str)) {
+            std::fs::write(
+                app.join("config.toml"),
+                format!(
+                    "[session.custom_agents]\n\
+                     \"claude-work\" = \"claude-work\"\n\
+                     \"codex-work\" = \"codex-work\"\n\
+                     [session.agent_detect_as]\n\
+                     \"claude-work\" = \"{claude_work_maps_to}\"\n\
+                     \"codex-work\" = \"codex\"\n"
+                ),
+            )
+            .unwrap();
+            let profile = app.join("profiles").join("real");
+            std::fs::create_dir_all(&profile).unwrap();
+            let (tool, detect_as) = parent;
+            std::fs::write(
+                profile.join("sessions.json"),
+                format!(
+                    "[{{\"id\":\"ab00000000000001\",\"title\":\"parent\",\
+                     \"project_path\":\"/tmp\",\"group_path\":\"\",\"command\":\"\",\
+                     \"tool\":\"{tool}\",\"detect_as\":\"{detect_as}\",\"yolo_mode\":false,\
+                     \"status\":\"idle\",\"created_at\":\"2026-09-12T08:00:00Z\",\
+                     \"last_accessed_at\":\"2026-09-12T08:00:00Z\",\
+                     \"agent_session_id\":null,\"lifecycle_generation\":1}}]"
+                ),
+            )
+            .unwrap();
+        }
+
+        /// A project directory carrying a repo-scoped `agent_detect_as`.
+        fn repo_declaring(entry: &str) -> tempfile::TempDir {
+            let project = tempfile::tempdir().unwrap();
+            let dir = project.path().join(".agent-of-empires");
+            std::fs::create_dir(&dir).unwrap();
+            std::fs::write(
+                dir.join("config.toml"),
+                format!("[session.agent_detect_as]\n{entry}\n"),
+            )
+            .unwrap();
+            project
+        }
+
+        async fn fork_as(project: &std::path::Path, tool: &str) -> String {
+            let (profile, args) = dispatch_argv(&[
+                "aoe",
+                "add",
+                project.to_str().unwrap(),
+                "-p",
+                "real",
+                "--fork-from",
+                "parent",
+                "--tool",
+                tool,
+            ]);
+            super::super::run(&profile, args)
+                .await
+                .expect_err("the parent has no captured id, so no case may succeed")
+                .to_string()
+        }
+
+        /// `--fork-from` with NO `--tool`: the gate is skipped entirely
+        /// (`user_chose_tool` is false), so this drives only the seed.
+        async fn fork_inheriting_tool(project: &std::path::Path) -> String {
+            let (profile, args) = dispatch_argv(&[
+                "aoe",
+                "add",
+                project.to_str().unwrap(),
+                "-p",
+                "real",
+                "--fork-from",
+                "parent",
+            ]);
+            super::super::run(&profile, args)
+                .await
+                .expect_err("the parent has no captured id, so no case may succeed")
+                .to_string()
+        }
+
+        const REFUSED: &str = "a fork must use the parent's agent";
+        const PASSED_THE_GATE: &str = "has no captured agent session yet";
+
+        /// A wrapper and the base it declares are one agent, a wrapper on a
+        /// different base is not, and a retargeted `agent_detect_as` entry does
+        /// not change what an existing row's captured id is shaped like.
+        #[tokio::test]
+        #[serial]
+        async fn fork_gate_reads_the_row_and_the_configured_alias() {
+            let project = tempfile::tempdir().unwrap();
+            // (claude-work maps to, parent row (tool, detect_as), fork as, want)
+            let cases = [
+                ("claude", ("claude", ""), "claude-work", PASSED_THE_GATE),
+                ("claude", ("claude", ""), "codex-work", REFUSED),
+                // The row was created while claude-work meant claude and its id
+                // is Claude-shaped; the entry now says codex.
+                ("codex", ("claude-work", "claude"), "codex-work", REFUSED),
+            ];
+            for (maps_to, parent, fork_as_tool, want) in cases {
+                let guard = crate::session::test_support::isolate_app_dir();
+                let app = crate::session::get_app_dir().unwrap();
+                set_up(&app, maps_to, parent);
+                let msg = fork_as(project.path(), fork_as_tool).await;
+                assert!(
+                    msg.contains(want),
+                    "claude-work->{maps_to}, parent {parent:?}, fork as {fork_as_tool}: \
+                     wanted {want:?}, got: {msg}"
+                );
+                drop(guard);
+            }
+        }
+
+        /// A row whose stored `detect_as` is EMPTY is pinned to nothing:
+        /// `effective_detect_as` answers it from the live map, and rows in that
+        /// state keep being written. So a retarget does reach such a parent,
+        /// which is the case the gate is documented to refuse.
+        #[tokio::test]
+        #[serial]
+        async fn fork_gate_refuses_a_parent_row_with_no_pinned_alias() {
+            let project = tempfile::tempdir().unwrap();
+            let guard = crate::session::test_support::isolate_app_dir();
+            let app = crate::session::get_app_dir().unwrap();
+            // claude-work now names codex; the row was created before the
+            // entry existed, so it stored no alias, and its captured id is
+            // whatever claude-work was when it ran.
+            set_up(&app, "codex", ("claude-work", ""));
+            let msg = fork_as(project.path(), "codex-work").await;
+            assert!(
+                msg.contains(REFUSED),
+                "empty-detect_as parent, claude-work retargeted to codex, \
+                 fork as codex-work: wanted a refusal, got: {msg}"
+            );
+            drop(guard);
+        }
+
+        /// Without `--tool` the gate never runs, so the seed is the only thing
+        /// standing between a retargeted entry and a parent id captured under
+        /// the old one. Stock refuses this with `AgentCannotFork`, because the
+        /// raw wrapper name is not a built-in, and so must this.
+        #[tokio::test]
+        #[serial]
+        async fn fork_seed_without_tool_ignores_the_rows_pinned_alias() {
+            let project = tempfile::tempdir().unwrap();
+            let guard = crate::session::test_support::isolate_app_dir();
+            let app = crate::session::get_app_dir().unwrap();
+            // The row pinned claude and its captured id is Claude-shaped; the
+            // entry now names codex.
+            set_up(&app, "codex", ("claude-work", "claude"));
+            let msg = fork_inheriting_tool(project.path()).await;
+            assert!(
+                msg.contains("does not support forking"),
+                "no --tool, row pins claude, entry retargeted to codex: the seed must not \
+                 resolve through the live map; got: {msg}"
+            );
+            drop(guard);
+        }
+
+        /// A project's `.agent-of-empires/config.toml` can carry
+        /// `agent_detect_as` (`repo = "allow"`). It may not decide a fork: the
+        /// chosen side is resolved from the user's own config, so a repo
+        /// claiming codex-work is claude does not make it one.
+        #[tokio::test]
+        #[serial]
+        async fn fork_gate_resolves_the_chosen_tool_from_the_users_own_config() {
+            let project = repo_declaring("\"codex-work\" = \"claude\"");
+            let guard = crate::session::test_support::isolate_app_dir();
+            let app = crate::session::get_app_dir().unwrap();
+            set_up(&app, "claude", ("claude", ""));
+            let msg = fork_as(project.path(), "codex-work").await;
+            assert!(
+                msg.contains(REFUSED),
+                "a repo alias must not authorize a cross-agent fork, got: {msg}"
+            );
+            drop(guard);
+        }
+
+        /// And the other direction: the repo may not re-point a tool the user
+        /// did name, because the row this creates stores the merged alias and
+        /// launches under it. Same setup as the allowed case, plus a repo file.
+        #[tokio::test]
+        #[serial]
+        async fn fork_gate_refuses_when_a_repo_repoints_the_chosen_tool() {
+            let project = repo_declaring("\"claude-work\" = \"codex\"");
+            let guard = crate::session::test_support::isolate_app_dir();
+            let app = crate::session::get_app_dir().unwrap();
+            set_up(&app, "claude", ("claude", ""));
+            let msg = fork_as(project.path(), "claude-work").await;
+            assert!(
+                msg.contains(REFUSED),
+                "a repo re-pointing the chosen tool must refuse, got: {msg}"
+            );
+            drop(guard);
+        }
+
+        /// The bail is guarded on the names differing, so nothing stock allowed
+        /// is newly refused: a row that records no alias still reaches the
+        /// seed, which refuses it by name exactly as before.
+        #[tokio::test]
+        #[serial]
+        async fn fork_gate_leaves_a_same_name_fork_to_the_seed() {
+            let project = tempfile::tempdir().unwrap();
+            let guard = crate::session::test_support::isolate_app_dir();
+            let app = crate::session::get_app_dir().unwrap();
+            set_up(&app, "claude", ("claude-work", ""));
+            let msg = fork_as(project.path(), "claude-work").await;
+            assert!(
+                msg.contains("does not support forking"),
+                "same name on both sides must not bail at the gate, got: {msg}"
+            );
+            drop(guard);
+        }
+
+        /// The alias is still resolved where the row proves it: same parent
+        /// row, entry NOT retargeted, so the inherited wrapper forks.
+        #[tokio::test]
+        #[serial]
+        async fn fork_seed_without_tool_resolves_a_pinned_alias_that_still_agrees() {
+            let project = tempfile::tempdir().unwrap();
+            let guard = crate::session::test_support::isolate_app_dir();
+            let app = crate::session::get_app_dir().unwrap();
+            set_up(&app, "claude", ("claude-work", "claude"));
+            let msg = fork_inheriting_tool(project.path()).await;
+            assert!(
+                msg.contains(PASSED_THE_GATE),
+                "no --tool, row pins claude, entry still claude: the fork must be allowed; \
+                 got: {msg}"
+            );
+            drop(guard);
         }
     }
 }


### PR DESCRIPTION
## Description

`aoe add --fork-from <parent> --tool <wrapper>` is refused whenever the
wrapper's name differs from the parent row's stored tool, even when
`session.agent_detect_as` declares the wrapper to be that same built-in:

    [session.custom_agents]
    "claude-work" = "claude-work"
    [session.agent_detect_as]
    "claude-work" = "claude"

    $ aoe add . --fork-from parent --tool claude-work
    Error: Cannot fork session 'parent' (agent 'claude') as agent
    'claude-work': a fork must use the parent's agent.

The same fork spelled as a command is allowed, because `--cmd` resolves
through `detect_tool` and `agents::resolve_tool_name` (src/agents.rs:1940),
a substring match that collapses `claude-work` to `claude`.

Two comparisons in `add` key on the raw name: the gate (src/cli/add.rs:392)
and the tool handed to `terminal_fork_seed` (src/cli/add.rs:406), which looks
that name up with `get_agent` and so answers `AgentCannotFork` for every
custom agent. What runs afterwards already resolves the alias: the launch path
picks the fork strategy through `Instance::resolved_agent`
(src/session/instance/session_id.rs:1277-1279), and
`launch_can_carry_resume_selector` (src/session/instance/accessors.rs:289-302)
states the rule this commit applies to the gate, in its own words:
`agent_detect_as` is the user declaring what a wrapper wraps (#3638).

Both sides of that comparison are inputs an attacker may reach, so both are
narrowed rather than resolved the obvious way.

The parent side answers from what its row records: its tool when that names a
built-in, else the alias the row itself carries, and `None` otherwise.
`Instance::resolved_agent` is not used, because `effective_detect_as`
(src/tmux/status_rules.rs:220-231) returns the stored alias **only when it is
non-empty** and otherwise consults the live map, and rows with an empty one
keep being written (`add.rs:681-686` stores `unwrap_or_default()` for a tool
with no entry). A row that records nothing is evidence of nothing.

The chosen side is resolved from the **profile** config, not the repo-merged
one `add` otherwise uses. `agent_detect_as` is `repo = "allow"`
(settings_schema/registry.rs:231) in a section whose `repo_default` is `deny`,
and that exception was granted while the field only picked status heuristics.
Deciding a fork on it lets a checked-out `.agent-of-empires/config.toml`
authorize handing one agent's session id to another, with the user's own
config saying the opposite and nothing of theirs edited.

Resolving only the authorizing side from profile config is not enough, and the
test `fork_gate_refuses_when_a_repo_repoints_the_chosen_tool` pins why: the row
this call creates stores the **merged** alias (add.rs:681-686) and launches
under it, so a repo that re-points a tool the user did name would be authorized
against one agent and run as another. `fork_agent_for` therefore refuses
outright when the two layers disagree about the chosen tool.

The alternative was to mark the field `repo = "deny"`. That is the wider fix
and it would close the same hole for `resolved_agent`'s other consumers, but it
reverses a deliberate exception (#3154), changes behaviour for repos that use
it for status detection today, and rewrites the repo-override tests that assert
it merges. It belongs in its own change, with its own argument; this commit
stops fork authorization from depending on it and says so rather than quietly
relying on the exception standing.

Measured at c008671d with three debug binaries, distinct md5s. `nm -C` finds
`fork_agent_for` and `pinned_capture_agent` in both patched binaries and in
neither stock one, and `terminal_fork_seed` in all three as a control that
`nm` reads symbols at all; that check separates patched from stock, not the
two patched builds from each other, for which the md5s and the behaviour below
are the discriminator. Isolated XDG_CONFIG_HOME and tmux socket, parent row
carrying a Claude UUID, wrappers on fake binaries that record argv. Profile
config says `claude-work = claude` and `codex-work = codex` throughout.

    repo file declares codex-work = claude; fork as codex-work
      stock    refused
      earlier  created; ARGV[codex-work]: --resume 11111111-... --fork-session
      this     refused
    no repo file; fork as claude-work                        [control]
      stock    refused
      earlier  created and forks
      this     created and forks

The control differs from the first arm only in the repo file, so the file is
the whole difference. The other direction (a repo re-pointing a tool the user
did name) is refused by every build here and is pinned by a test rather than
by this table: the design it discriminates against is one no binary ships.

Seven tests drive `add`'s gate and seed through `run()`. Resolving the chosen
side from the merged config fails the repo test; dropping the layer-agreement
check fails the other repo test; reverting both call sites to the raw name
fails the two that expect a fork; resolving the parent through
`Instance::capture_agent_name` and the seed through the live map fails the two
that expect a refusal; dropping the `resolved_tool != source.tool` clause fails
the same-name test. Each mutation fails one test and disturbs no other.

Not covered. The alias a row carries is not pinned at capture: it is written at
session build and can be rewritten later by the `v024` backfill from whatever
the map says then. Measured: a row with an empty alias and `.schema_version`
below 24 has it rewritten by a read-only `aoe list`. So a map retargeted before
that backfill records the wrong agent, and this gate believes it. The backfill
is one-shot per app dir, which leaves the window open for a restored backup or
a copied profile directory. Closing it needs provenance the row does not have.

A row that records no alias is refused even where the live map agrees, which is
stock's behaviour. The two spellings still diverge for a `custom_agents`
wrapper with no `agent_detect_as` entry at all. Two names sharing a base need
not share the agent's conversation store. A wrapper whose configured command
carries flags cannot carry a resume selector (accessors.rs:303-323), so a fork
intent is stored and dropped at launch with no message; `--cmd` reaches that on
stock today and it is reported separately. The TUI
(src/tui/home/input.rs:3056, 3269) and the server create path
(src/server/api/sessions/create.rs:163) decide eligibility from the raw name
and are untouched; the server path performs no same-agent check at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Related issues:** none that I could find. I searched this repo's issues and PRs
for `fork agent_detect_as`, `fork must use the parent` and `agent_detect_as` and
got nothing covering this; #3154 and #3638 are cited above as the prior context
this reasons from, not as issues it closes.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass <!-- left unticked on purpose, and not because of this change: the merge base is not green on my machine. Numbers below. -->
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- not applicable: no UI change, the diff is src/cli/add.rs only -->

**Documentation is deliberately left unticked, and this is the one thing in this
PR I would like a maintainer's call on.** `docs/guides/session-fork.md` states
the rule this commit relaxes:

> If you do pass one, it must match the parent's agent: a captured conversation
> is agent-specific, so forking a Claude session as Codex is rejected rather
> than run against the wrong agent.

After this change a wrapper the user mapped to the parent's built-in with
`session.agent_detect_as` is accepted, so that sentence is no longer the whole
rule. I have not edited it here because this PR's commit is reviewed and I did
not want to move it; say the word and I will add the doc change to this PR or
open it separately.

**On the tests box, which I left unticked.** `cargo fmt --check` and
`cargo clippy --all-targets` are clean, and this PR's own tests pass. I am not
ticking it anyway, because the box says *existing* tests pass and I could not
verify that: **`cargo test` is not green at the merge base `c008671d` on my
machine**, so a tick would be claiming something I did not see.

What I ran, in case it is useful to you: `cargo test --lib` three times at the
base and three times at this commit, each in its own `CARGO_TARGET_DIR`, each run
checked to contain this PR's own tests by name rather than by count. At the base,
four tests fail every run and three more come and go between runs:

```
merge base c008671d, cargo test --lib, three runs
  run1  6952 passed; 5 failed; 2 ignored   (6959 tests)
  run2  6953 passed; 4 failed; 2 ignored   (6959 tests)
  run3  6951 passed; 6 failed; 2 ignored   (6959 tests)

fails in all three runs
  containers::runtime::tests::build_exec_argv_apple_container_wraps_for_path_without_splicing
  session::instance::sid_persist::tests::publish_captured_sid::finalize_publish_applied_writes_omp_metadata
  session::instance::sid_persist::tests::publish_captured_sid::legacy_omp_pane_backfills_typed_metadata_from_tmux_creation
  tmux::tests::timed_out_agent_probes_release_waiters_and_invalidation

fails in one run of three, each
  session::projects::tests::set_pinned_toggles_without_removing_entry
  session::projects::tests::update_base_branch_sets_clears_and_reports_not_found
  tmux::vt::tests::reader_holds_viewer_wakeups_inside_a_synchronized_output_bracket
```

And the same three runs at this commit:

```
this commit e9c95717, cargo test --lib, three runs
  run1  6961 passed; 4 failed; 2 ignored   (6967 tests)
  run2  6960 passed; 5 failed; 2 ignored   (6967 tests)
  run3  6960 passed; 5 failed; 2 ignored   (6967 tests)

  the same four fail in every run here and in every run at the base:
    containers::runtime::tests::build_exec_argv_apple_container_wraps_for_path_without_splicing
    session::instance::sid_persist::tests::publish_captured_sid::finalize_publish_applied_writes_omp_metadata
    session::instance::sid_persist::tests::publish_captured_sid::legacy_omp_pane_backfills_typed_metadata_from_tmux_creation
    tmux::tests::timed_out_agent_probes_release_waiters_and_invalidation

  intermittent: never in every run, and the set differs run to run
    base 0/3, here 1/3   server::startup::tests::shutdown_deadline_runs_from_the_cancel_not_the_watchdog_poll
    base 1/3, here 1/3   session::projects::tests::set_pinned_toggles_without_removing_entry
    base 1/3, here 0/3   session::projects::tests::update_base_branch_sets_clears_and_reports_not_found
    base 1/3, here 0/3   tmux::vt::tests::reader_holds_viewer_wakeups_inside_a_synchronized_output_bracket

  this commit's own tests matching cli::add::tests::fork_gate::*:
    passed [7, 7, 7] across the three runs, failed [0, 0, 0] -- checked by name, not by count

  No failure is attributable to this commit on this evidence: the four
  deterministic failures are the base's, identically. Every other name came
  and went between runs on one side or both. Three runs cannot separate a
  flake I happened to catch here from one this commit makes likelier, so that
  is the limit of the claim rather than a clean bill.
```

At least one of the four is my host rather than your code:
`build_exec_argv_apple_container_wraps_for_path_without_splicing` resolves an
absolute `printf` from `["/usr/bin/printf", "/bin/printf"]` and this is a NixOS
machine, which has neither — `printf` here is a shell builtin and coreutils lives
under `/nix/store`. That one is not a bug on your side. The
intermittent ones look like genuine flakes — two of them are in
`session::projects::tests`, whose `setup()` does
`std::env::set_var("HOME", ...)`, which is process-global. I am reporting that as
an observation, not a diagnosis, and I have not touched any of them. Happy to
open a separate issue with the logs if you want it.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: **no test was added under `tests/e2e/`; the regression coverage landed as in-crate tests instead, and I would rather say so than tick the box above.** This does change a CLI subcommand, so the N/A box is not true either.

Eight tests were added in `src/cli/add.rs`. Seven of them drive `add`'s gate and
fork seed through `run()` against a real parent row and a real config, and what
they discriminate is **which refusal you get**, not whether a fork happens: the
fixture parent's `agent_session_id` is null (`add.rs:1969`), so `fork_as` asserts
an error in every case and none of the seven reaches session creation or argv
capture. The argv-recording fake binaries are the separate manual probe against
three built binaries described in the AI section below, not these tests.

That distinction is corrected here — an earlier version of this paragraph
attributed the argv capture to these tests, which was wrong, and the review was
right to ask for the two to be separated. The tests:

    fork_gate_reads_the_row_and_the_configured_alias
    fork_gate_refuses_a_parent_row_with_no_pinned_alias
    fork_seed_without_tool_ignores_the_rows_pinned_alias
    fork_gate_resolves_the_chosen_tool_from_the_users_own_config
    fork_gate_refuses_when_a_repo_repoints_the_chosen_tool
    fork_gate_leaves_a_same_name_fork_to_the_seed
    fork_seed_without_tool_resolves_a_pinned_alias_that_still_agrees
    capture_agent_for_tool_resolves_detect_as_wrappers

They were checked for discrimination rather than only for passing: each of six
mutations of the fix fails exactly one of them and disturbs no other — resolving
the chosen side from the merged config fails
`fork_gate_resolves_the_chosen_tool_from_the_users_own_config`, dropping the
layer-agreement check fails `fork_gate_refuses_when_a_repo_repoints_the_chosen_tool`,
reverting both call sites to the raw name fails the two that expect a fork,
resolving the parent through `Instance::capture_agent_name` fails the two that
expect a refusal, and dropping the `resolved_tool != source.tool` clause fails
`fork_gate_leaves_a_same_name_fork_to_the_seed`.

`AGENTS.md` asks for the cheapest test that can catch the regression, prefers
Rust unit tests, and reserves full-binary tests for behaviour that needs that
environment, so I read in-crate tests as following that rule rather than dodging
it — but the template's box asks specifically about `tests/e2e/`, so it stays
unticked and this is the reason.

If you would rather have it pinned under `tests/e2e/` too, say so and I will add it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code, running Claude Opus 5 and Claude Fable 5.1.

**Any Additional AI Details you'd like to share:**

Drafted by an agent, then reviewed over four rounds by separate agents that did
not see the earlier ones. Each round found a real defect the previous fix had not
closed, and the description's account of that is not tidied up: rounds 1-3 each
fixed the comparison and left a different input open.

The behavioural claims were driven rather than argued. Three debug binaries with
distinct md5s — stock, the round-3 build and this one — run against fixtures with
their own `XDG_CONFIG_HOME` and tmux socket and fake agent binaries that record
their argv, with `nm -C` used to confirm which build is which and one symbol
present in all three as a control that `nm` reads symbols at all. The two arms in
the table differ only in the repo config file. The tests were then checked for
discrimination by mutating the fix six ways, not just for passing.

I review the result and decide what ships, and I will answer review questions
here myself rather than pasting them into a model.

- [x] I am an AI Agent filling out this form (check box if true)

---

### Unrelated to this patch: a defect in this repo's own PR template check

I hit this while restoring this PR's body, so it is here rather than in an issue.
It has nothing to do with the fork gate, and if you would rather have it as its
own issue, say so and I will move it — that is probably where it belongs.

`.github/workflows/pr-template-check.yml` reports `check-template: success` on a
PR whose body has no checklist at all. On the `!hasChecklist` path it lists the
PR's labels and, when `missing-template` is already there:

```js
console.log('PR already labeled, skipping comment');
return;
```

That `return` comes before `core.setFailed`, so **only the first run of the check
can ever fail.** The `opened` run fails and applies the label; every later
`edited` run takes the early return and reports green. It does not need the
author to do anything either — a bot appending release notes to the body fires
`edited` on its own, which is what happened here.

Both runs on this PR, against the same unchanged body:

```
check-template  failure  job 103594039151  started 2026-09-12T17:40:49Z
check-template  success  job 103594191632  started 2026-09-12T17:42:01Z
```

and the successful job's own log says why it was green:

```
2026-09-12T17:42:03.8656797Z PR already labeled, skipping comment
```

The label is not removed on that path, and `close-stale` keys on the label alone,
so the PR still gets closed 24 hours later while its check reads green. That is
the harmful half: **`gh pr checks` cannot be used to confirm a template fix**, and
the `missing-template` label is the only signal that reflects what the closer will
do. Moving the `core.setFailed` call above the early `return` would be enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `aoe add --fork-from ... --tool ...` to compare resolved agents instead of raw tool names.
- Added support for custom-agent wrappers and tool aliases that resolve to the parent’s built-in agent.
- Forks now use the parent row’s recorded tool metadata and the selected tool from the user’s profile configuration.
- Forks are rejected when agent metadata is missing or when profile and repository configuration resolve the tool differently.
- Updated fork seeding to use the resolved agent.
- Added tests for fork eligibility, aliases, missing metadata, wrapper resolution, and configuration differences.
- TUI and server-session fork behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
