### PR TITLE
fix(hooks): report read-only agent settings once, not on every launch

### DIFF
--- a/src/session/instance/hooks.rs
+++ b/src/session/instance/hooks.rs
@@ -596,11 +596,66 @@ impl Instance {
         ) {
             Ok(()) => true,
             Err(error) => {
-                tracing::warn!(target: "session.store", "Failed to install agent hooks: {}", error);
+                if is_read_only_filesystem(&error) {
+                    match first_read_only_report(&settings_path) {
+                        // The memo is keyed on the resolved target, so name it
+                        // whenever it differs: two settings paths can share one
+                        // target, and only saying the first would silence the
+                        // second without ever telling the user which file it is.
+                        Some(target) if target != settings_path => {
+                            tracing::warn!(target: "session.store",
+                                "Agent settings at {} resolve to {}, which is on a read-only filesystem, so AoE status hooks cannot be installed there; not reported again for that target while this process runs.",
+                                settings_path.display(), target.display());
+                        }
+                        Some(_) => {
+                            tracing::warn!(target: "session.store",
+                                "Agent settings at {} are on a read-only filesystem, so AoE status hooks cannot be installed there; not reported again for that file while this process runs.",
+                                settings_path.display());
+                        }
+                        None => {
+                            tracing::debug!(target: "session.store",
+                                "Agent settings at {} are still read-only; hook install skipped again.",
+                                settings_path.display());
+                        }
+                    }
+                } else {
+                    tracing::warn!(target: "session.store", "Failed to install agent hooks: {}", error);
+                }
                 false
             }
         }
     }
+}
+
+/// Settings files already reported as unwritable because they sit on a
+/// read-only filesystem. Externally managed settings (a Nix store symlink, a
+/// read-only mount) never become writable, so the identical warning would
+/// otherwise repeat for every session this process touches. Process-local by
+/// design: a one-shot `aoe add` still warns once, which is the first time that
+/// invocation says anything about it.
+static READ_ONLY_SETTINGS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashSet<std::path::PathBuf>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+fn is_read_only_filesystem(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
+        .any(|io| io.kind() == std::io::ErrorKind::ReadOnlyFilesystem)
+}
+
+/// The resolved target to report, or `None` when it has already been reported.
+/// Keyed on the target rather than the path, so a replaced symlink (a Nix
+/// profile switch points it at a new store path) is reported once for the new
+/// file. The install itself still runs, so a path that becomes writable
+/// installs with no special case.
+fn first_read_only_report(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    READ_ONLY_SETTINGS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(key.clone())
+        .then_some(key)
 }
 
 #[cfg(test)]
@@ -623,6 +678,78 @@ mod tests {
             state.has_acknowledged_agent_hooks = true;
         })
         .unwrap();
+    }
+
+    #[test]
+    fn read_only_settings_are_reported_once_per_path() {
+        let cases = [
+            (
+                anyhow::Error::from(std::io::Error::from(std::io::ErrorKind::ReadOnlyFilesystem)),
+                true,
+            ),
+            (
+                anyhow::Error::from(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+                false,
+            ),
+            (anyhow::anyhow!("hooks key is not a JSON object"), false),
+        ];
+        for (error, want) in &cases {
+            assert_eq!(is_read_only_filesystem(error), *want, "{error}");
+        }
+
+        // Per target, so one unwritable settings file does not silence the
+        // report for another, and two paths onto one target report once.
+        let dir = tempfile::tempdir().unwrap();
+        let one = dir.path().join("one.json");
+        let two = dir.path().join("two.json");
+        std::fs::write(&one, "{}").unwrap();
+        std::fs::write(&two, "{}").unwrap();
+        assert!(first_read_only_report(&one).is_some());
+        assert!(first_read_only_report(&one).is_none());
+        assert!(first_read_only_report(&two).is_some());
+
+        #[cfg(unix)]
+        {
+            let target = dir.path().join("shared.json");
+            std::fs::write(&target, "{}").unwrap();
+            let link = dir.path().join("link.json");
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+            let reported = first_read_only_report(&target).expect("first report names the target");
+            assert_eq!(reported, std::fs::canonicalize(&target).unwrap());
+            assert!(
+                first_read_only_report(&link).is_none(),
+                "a symlink onto an already-reported target must not report again"
+            );
+        }
+    }
+
+    /// The cases above build their own errors, so they cannot show that a real
+    /// `install_hooks` failure carries a downcastable `io::Error` at all, which
+    /// is what the classification rests on. A genuinely read-only filesystem is
+    /// not portable to make, so this drives a failure any machine can produce
+    /// and asserts the chain is reachable and classified as not read-only.
+    #[test]
+    fn a_real_install_hooks_error_keeps_its_io_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings = dir.path().join("settings.json");
+        // A directory where the settings file belongs: `install_hooks` reads it
+        // before writing, so the error comes from the real path.
+        std::fs::create_dir(&settings).unwrap();
+
+        let error = crate::hooks::install_hooks(
+            &settings,
+            &[] as &[crate::agents::ResolvedHookEvent],
+            crate::hooks::HookInstallTarget::Host,
+        )
+        .expect_err("reading a directory as settings must fail");
+
+        assert!(
+            error
+                .chain()
+                .any(|cause| cause.downcast_ref::<std::io::Error>().is_some()),
+            "install_hooks must keep an io::Error in its chain: {error:?}"
+        );
+        assert!(!is_read_only_filesystem(&error), "{error:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Where an agent's `settings.json` is managed outside the agent (a Nix
store symlink, a read-only mount, a managed image), AoE cannot install
its status hooks and says so for every session it touches:

    WARN session.store: Failed to install agent hooks: Read-only file
    system (os error 30) at path "/nix/store/.tmpiaOTBO"

Population on one such machine, `grep -c` over the two debug logs
present, measured 2026-09-12T12:06 +0200: 24 lines in `debug.log`, whose
span begins 2026-09-10T11:39, and 224 in `debug.log.1`, spanning
2026-07-13T20:26 to 2026-09-10T11:39. `debug.log` is the live log, so its
end moves; every one of the 248 is the read-only variety. 17 of the 24
fall inside twelve seconds, one per session in a batch launch: the line
two above the first of them reads `INFO session.startup_recovery:
starting daemon recovery for missing tmux sessions count=17`. The
condition behind them cannot change while the process runs.

The message also names the wrong path. `/nix/store/.tmpiaOTBO` is the
temp file `atomic_write` opened next to the resolved target, so the line
identifies neither the agent nor the settings file to fix.

Warn once per settings target, naming the settings path, and log later
read-only failures for that target at debug. The memo is keyed on the
canonicalized target rather than the path, so a replaced symlink (a Nix
profile switch points it at a new store path) is reported once for the
new file; where the two differ the message names both, because two
settings paths can share one target and naming only the first would
silence the second without saying which file it was. The install itself
still runs, so a path that becomes writable installs with no special
case. Failures that are not read-only keep the existing message.

Measured against a genuinely read-only `settings.json`, one `aoe serve`
recovering three sessions: before, three `Failed to install agent hooks`
warnings; after, one warning naming the settings file and two debug
lines.

The detection reads `ErrorKind::ReadOnlyFilesystem` off the error chain
rather than a raw errno, because the temp-file layer rebuilds the error:
`session::atomic_write` into /nix/store surfaces
`kind: ReadOnlyFilesystem` with `raw_os_error: None`, so an errno check
would have matched nothing.

`a_real_install_hooks_error_keeps_its_io_error` drives a real
`install_hooks` failure and asserts the chain still carries a
downcastable `io::Error`, which is what the classification rests on and
what an error built inside the test cannot show. It uses a failure any
machine can produce, because a read-only filesystem is not portable to
make; that the read-only kind in particular survives that chain is the
/nix/store measurement above, not a test.

Not covered. The memo is process-local, which the warning now says: a
one-shot `aoe add` warns once per invocation, so a shell loop over N
sessions still prints N warnings. Collapsing those needs durable state
and is not attempted here. That the install keeps running after a
read-only failure is true by reading (`install_hooks` is called
unconditionally; only the reporting branches) and is driven by no test.
Only the JSON-settings host install is touched; the Codex, Cursor
sidecar and standalone sidecar installs in this file have the same shape
and carry their own messages, and sandboxed installs are untouched.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Related issues:** none that I could find — searched for
`Failed to install agent hooks` and `read-only settings hooks`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass <!-- left unticked on purpose, and not because of this change: the merge base is not green on my machine. Numbers below. -->
- [x] Documentation was updated where necessary <!-- nothing needed: checked, no file under docs/ describes this warning or the hook-install failure path -->
- [ ] For UI changes: included screenshot or recording <!-- not applicable: no UI change, the diff is src/session/instance/hooks.rs only -->

**On the tests box, which I left unticked.** `cargo fmt --check` and
`cargo clippy --all-targets` are clean, and this PR's own tests pass. I am not
ticking it anyway, because the box says *existing* tests pass and I could not
verify that: **`cargo test` is not green at the merge base `c008671d` on my
machine**, so a tick would be claiming something I did not see.

What I ran, in case it is useful to you: `cargo test --lib` three times at the
base and three times at this commit, each in its own `CARGO_TARGET_DIR`, each run
checked to contain this PR's own tests by name rather than by count. At the base,
four tests fail every run and three more come and go between runs:

```
merge base c008671d, cargo test --lib, three runs
  run1  6952 passed; 5 failed; 2 ignored   (6959 tests)
  run2  6953 passed; 4 failed; 2 ignored   (6959 tests)
  run3  6951 passed; 6 failed; 2 ignored   (6959 tests)

fails in all three runs
  containers::runtime::tests::build_exec_argv_apple_container_wraps_for_path_without_splicing
  session::instance::sid_persist::tests::publish_captured_sid::finalize_publish_applied_writes_omp_metadata
  session::instance::sid_persist::tests::publish_captured_sid::legacy_omp_pane_backfills_typed_metadata_from_tmux_creation
  tmux::tests::timed_out_agent_probes_release_waiters_and_invalidation

fails in one run of three, each
  session::projects::tests::set_pinned_toggles_without_removing_entry
  session::projects::tests::update_base_branch_sets_clears_and_reports_not_found
  tmux::vt::tests::reader_holds_viewer_wakeups_inside_a_synchronized_output_bracket
```

And the same three runs at this commit:

```
this commit 686986a8, cargo test --lib, three runs
  run1  6955 passed; 4 failed; 2 ignored   (6961 tests)
  run2  6954 passed; 5 failed; 2 ignored   (6961 tests)
  run3  6954 passed; 5 failed; 2 ignored   (6961 tests)

  the same four fail in every run here and in every run at the base:
    containers::runtime::tests::build_exec_argv_apple_container_wraps_for_path_without_splicing
    session::instance::sid_persist::tests::publish_captured_sid::finalize_publish_applied_writes_omp_metadata
    session::instance::sid_persist::tests::publish_captured_sid::legacy_omp_pane_backfills_typed_metadata_from_tmux_creation
    tmux::tests::timed_out_agent_probes_release_waiters_and_invalidation

  intermittent: never in every run, and the set differs run to run
    base 0/3, here 1/3   session::instance::terminal::tests::container_terminal_command_preserves_runtime_boundaries
    base 0/3, here 1/3   session::mcp::mcp_state::tests::resolve_conflict_aoe_wins_promotes_to_global_and_clears
    base 1/3, here 0/3   session::projects::tests::set_pinned_toggles_without_removing_entry
    base 1/3, here 0/3   session::projects::tests::update_base_branch_sets_clears_and_reports_not_found
    base 1/3, here 0/3   tmux::vt::tests::reader_holds_viewer_wakeups_inside_a_synchronized_output_bracket

  this commit's own tests, each checked by name in each run:
    ok, ok, ok   session::instance::hooks::tests::read_only_settings_are_reported_once_per_path
    ok, ok, ok   session::instance::hooks::tests::a_real_install_hooks_error_keeps_its_io_error

  No failure is attributable to this commit on this evidence: the four
  deterministic failures are the base's, identically. Every other name came
  and went between runs on one side or both. Three runs cannot separate a
  flake I happened to catch here from one this commit makes likelier, so that
  is the limit of the claim rather than a clean bill.
```

At least one of the four is my host rather than your code:
`build_exec_argv_apple_container_wraps_for_path_without_splicing` resolves an
absolute `printf` from `["/usr/bin/printf", "/bin/printf"]` and this is a NixOS
machine, which has neither — `printf` here is a shell builtin and coreutils lives
under `/nix/store`. That one is not a bug on your side. The
intermittent ones look like genuine flakes — two of them are in
`session::projects::tests`, whose `setup()` does
`std::env::set_var("HOME", ...)`, which is process-global. I am reporting that as
an observation, not a diagnosis, and I have not touched any of them. Happy to
open a separate issue with the logs if you want it.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: **no test was added under `tests/e2e/`; the coverage landed as in-crate tests, and I would rather say so than tick the box above.** This is on the session-build path, so the N/A box is not true either.

Two tests were added in `src/session/instance/hooks.rs`:

    read_only_settings_are_reported_once_per_path
    a_real_install_hooks_error_keeps_its_io_error

The first drives the memo: two reports against the same settings target, second
one suppressed, and a second target still reported, which is the part a
per-process flag would get wrong. The second exists because the obvious way to
write the first — matching on the error text — would also swallow a genuine
install failure, so it asserts a non-read-only error still arrives intact.

`AGENTS.md` asks for the cheapest test that can catch the regression, prefers
Rust unit tests, and reserves full-binary tests for behaviour that needs that
environment, so I read in-crate tests as following that rule rather than dodging
it — but the template's box asks specifically about `tests/e2e/`, so it stays
unticked and this is the reason.

A `tests/e2e/` case is also awkward here rather than unwanted: reproducing the
real condition needs a settings path that is genuinely read-only to the test
process, which on the machine where this was found is a Nix store symlink. If
you want it pinned end-to-end, I will take a suggestion on how you would rather
fake that.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code, running Claude Opus 5 and Claude Fable 5.1.

**Any Additional AI Details you'd like to share:**

Drafted by an agent, then reviewed over four rounds by separate agents that did
not see the earlier ones. The re-review verified the read-only detection against
the real error chain rather than taking the commit's word for it, which is why
`a_real_install_hooks_error_keeps_its_io_error` exists: an error constructed
inside a test cannot show the downcastable `io::Error` the classification rests
on. The log population quoted above (24 lines in `debug.log`, 224 in
`debug.log.1`, every one of them the read-only variety) was reproduced
independently by a second agent rather than carried over from the first.

The "Not covered" paragraph above was written by the same process and is not
padding: the memo is process-local, and that the install keeps running after a
read-only failure is true by reading and driven by no test.

I review the result and decide what ships, and I will answer review questions
here myself rather than pasting them into a model.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved read-only settings installation reporting.
- Canonicalized missing settings paths through their parent directories.
- Reported each canonical target once and logged repeated failures at debug level.
- Added coverage for symlinked paths, target changes, error handling, and preserved I/O errors.

## Benefits

This reduces duplicate warnings and makes read-only settings issues easier to diagnose without changing installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
