### PR TITLE
docs(cli): say what `aoe rm --purge` actually removes

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -327,7 +327,7 @@ Remove a session
 * `--force` — Force worktree removal even with untracked/modified files
 * `--keep-container` — Keep container instead of deleting it (default: delete per config)
 * `--keep-scratch` — For scratch sessions, keep the scratch directory on disk instead of removing it. The session record is still deleted; the kept path is logged so you can find the files later. No effect on non-scratch sessions
-* `--purge` — Permanently delete instead of moving to trash. By default `rm` moves the session to the trash (when `session.delete_to_trash` is enabled, the default) so it can be restored; `--purge` forces the irreversible teardown (worktree/branch/container cleanup per the other flags, plus the session's structured-view transcript and its own agent store, which for a sandboxed session is that agent's config home). A host agent's conversation history outside those is not removed
+* `--purge` — Permanently delete instead of moving to trash. By default `rm` moves the session to the trash (when `session.delete_to_trash` is enabled, the default) so it can be restored; `--purge` forces the irreversible teardown (worktree/branch/container cleanup per the other flags) and removes the session's structured-view transcript. Removing the sandbox container also attempts to remove its private agent stores, including its config home; keeping the container keeps those stores. Host agent conversation history outside these stores is not removed
 
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -327,7 +327,7 @@ Remove a session
 * `--force` — Force worktree removal even with untracked/modified files
 * `--keep-container` — Keep container instead of deleting it (default: delete per config)
 * `--keep-scratch` — For scratch sessions, keep the scratch directory on disk instead of removing it. The session record is still deleted; the kept path is logged so you can find the files later. No effect on non-scratch sessions
-* `--purge` — Permanently delete instead of moving to trash. By default `rm` moves the session to the trash (when `session.delete_to_trash` is enabled, the default) so it can be restored; `--purge` forces the irreversible teardown (worktree/branch/container cleanup per the other flags, plus transcript removal)
+* `--purge` — Permanently delete instead of moving to trash. By default `rm` moves the session to the trash (when `session.delete_to_trash` is enabled, the default) so it can be restored; `--purge` forces the irreversible teardown (worktree/branch/container cleanup per the other flags, plus the session's structured-view transcript and its own agent store, which for a sandboxed session is that agent's config home). A host agent's conversation history outside those is not removed
 
 
 

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -37,10 +37,11 @@ pub struct RemoveArgs {
     /// Permanently delete instead of moving to trash. By default `rm` moves
     /// the session to the trash (when `session.delete_to_trash` is enabled,
     /// the default) so it can be restored; `--purge` forces the irreversible
-    /// teardown (worktree/branch/container cleanup per the other flags, plus
-    /// the session's structured-view transcript and its own agent store, which
-    /// for a sandboxed session is that agent's config home). A host agent's
-    /// conversation history outside those is not removed.
+    /// teardown (worktree/branch/container cleanup per the other flags) and
+    /// removes the session's structured-view transcript. Removing the sandbox
+    /// container also attempts to remove its private agent stores, including
+    /// its config home; keeping the container keeps those stores. Host agent
+    /// conversation history outside these stores is not removed.
     #[arg(long)]
     purge: bool,
 }

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -38,7 +38,9 @@ pub struct RemoveArgs {
     /// the session to the trash (when `session.delete_to_trash` is enabled,
     /// the default) so it can be restored; `--purge` forces the irreversible
     /// teardown (worktree/branch/container cleanup per the other flags, plus
-    /// transcript removal).
+    /// the session's structured-view transcript and its own agent store, which
+    /// for a sandboxed session is that agent's config home). A host agent's
+    /// conversation history outside those is not removed.
     #[arg(long)]
     purge: bool,
 }


### PR DESCRIPTION
## Description

`aoe rm --purge --help` promises "the irreversible teardown
(worktree/branch/container cleanup per the other flags, plus transcript
removal)". A reader takes "transcript" to mean the conversation, and for
a host session it is not that.

What `aoe rm` removes under that word is the session's rows in AoE's own
structured-view event store: `purge_acp_transcript`
(src/cli/mod.rs:121-129) deletes from `acp_events.db` and nothing else,
and its own doc comment calls the target "the local UI transcript".
`remove.rs:247-254` reaches it through `complete_with` and never touches
the supervisor. For a terminal session it deletes zero transcript rows,
which the implementation states in as many words: "deleting zero rows
for a terminal session is harmless".

The purge does remove one more thing the help never mentions, and it is
the half that can lose a conversation: `stage_remove_agent_stores`
(src/session/deletion.rs:1220) calls
`sandbox_store_reclaim::remove_stores_for`, deleting the per-instance
agent store. For a sandboxed session that store is the containerized
agent's own config home, so its history goes with it. Saying only that
the conversation survives would have pointed the other dangerous way.

So the help now names both, and scopes what survives to a host agent's
own history outside them. `docs/cli/reference.md` is regenerated with
`cargo run -p xtask -- gen-docs`, which leaves no other diff.

Scoped to the CLI on purpose. The web delete dialog makes the same claim
in the same words, but the web "Delete permanently" path is not this one.
For a structured session (`delete.rs:115`, gated on
`instance.is_structured()`) it reaches `shutdown_and_delete`, which calls
`try_session_delete` under `delete_adapter_state`
(supervisor.rs:3130-3134, whose comment reads "Only permanent removal
deletes the agent-side transcript"), and
`docs/development/internals/structured-view.md:37` records that adapters
implementing that RPC clear their on-disk session record. The CLI has no
running worker to send it, which `purge_acp_transcript`'s own doc comment
says (`mod.rs:112-114`). The dialog therefore needs its own sentence and
is left alone here.

Established by reading the deletion stages and the mount map, not by
purging a sandboxed session end to end: this seat has no container
runtime.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Updated after review, at `79a98263`.** The description above is the first
commit's, and one of its claims did not survive: the per-instance agent store is
**not** removed unconditionally — it goes with the sandbox container, so keeping
the container keeps the stores. The shipped help text is the reviewer's own
suggested wording, and `docs/cli/reference.md` was regenerated with
`cargo xtask gen-docs` rather than hand-edited, so the source and the reference
cannot drift. The paragraph beginning "The purge does remove one more thing"
should be read against that correction.

**Related issues:** none that I could find — searched for `purge transcript`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass <!-- left unticked on purpose, and not because of this change: the merge base is not green on my machine. Numbers below. -->
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- not applicable: no UI change -->

`docs/cli/reference.md` is generated, so it was regenerated rather than hand
edited: `cargo run -q -p xtask -- gen-docs` exits 0 and leaves the tree clean at
this commit, which is the check that the doc comment and the reference cannot
drift apart here.

**On the tests box, which I left unticked.** `cargo fmt --check` and
`cargo clippy --all-targets` are clean, and this PR's own tests pass. I am not
ticking it anyway, because the box says *existing* tests pass and I could not
verify that: **`cargo test` is not green at the merge base `c008671d` on my
machine**, so a tick would be claiming something I did not see.

What I ran, in case it is useful to you: `cargo test --lib` three times at the
base and three times at this commit, each in its own `CARGO_TARGET_DIR`, each run
checked to contain this PR's own tests by name rather than by count. At the base,
four tests fail every run and three more come and go between runs:

```
merge base c008671d, cargo test --lib, three runs
  run1  6952 passed; 5 failed; 2 ignored   (6959 tests)
  run2  6953 passed; 4 failed; 2 ignored   (6959 tests)
  run3  6951 passed; 6 failed; 2 ignored   (6959 tests)

fails in all three runs
  containers::runtime::tests::build_exec_argv_apple_container_wraps_for_path_without_splicing
  session::instance::sid_persist::tests::publish_captured_sid::finalize_publish_applied_writes_omp_metadata
  session::instance::sid_persist::tests::publish_captured_sid::legacy_omp_pane_backfills_typed_metadata_from_tmux_creation
  tmux::tests::timed_out_agent_probes_release_waiters_and_invalidation

fails in one run of three, each
  session::projects::tests::set_pinned_toggles_without_removing_entry
  session::projects::tests::update_base_branch_sets_clears_and_reports_not_found
  tmux::vt::tests::reader_holds_viewer_wakeups_inside_a_synchronized_output_bracket
```

And the same three runs at this commit:

```
this commit 18c5295e, cargo test --lib, three runs
  run1  6952 passed; 5 failed; 2 ignored   (6959 tests)
  run2  6952 passed; 5 failed; 2 ignored   (6959 tests)
  run3  6952 passed; 5 failed; 2 ignored   (6959 tests)

  the same four fail in every run here and in every run at the base:
    containers::runtime::tests::build_exec_argv_apple_container_wraps_for_path_without_splicing
    session::instance::sid_persist::tests::publish_captured_sid::finalize_publish_applied_writes_omp_metadata
    session::instance::sid_persist::tests::publish_captured_sid::legacy_omp_pane_backfills_typed_metadata_from_tmux_creation
    tmux::tests::timed_out_agent_probes_release_waiters_and_invalidation

  intermittent: never in every run, and the set differs run to run
    base 0/3, here 1/3   acp::acp_client::resolve_command::tests::probe_version_bounded_reads_version_output
    base 1/3, here 1/3   session::projects::tests::set_pinned_toggles_without_removing_entry
    base 1/3, here 1/3   session::projects::tests::update_base_branch_sets_clears_and_reports_not_found
    base 1/3, here 0/3   tmux::vt::tests::reader_holds_viewer_wakeups_inside_a_synchronized_output_bracket

  No failure is attributable to this commit on this evidence: the four
  deterministic failures are the base's, identically. Every other name came
  and went between runs on one side or both. Three runs cannot separate a
  flake I happened to catch here from one this commit makes likelier, so that
  is the limit of the claim rather than a clean bill.
```

This commit adds no tests, so the population here is the base's exactly —
6959 both sides — and nothing in `src/` or `tests/` asserts the `--purge` help
text, which I checked with a positive control rather than an empty grep.

At least one of the four is my host rather than your code:
`build_exec_argv_apple_container_wraps_for_path_without_splicing` resolves an
absolute `printf` from `["/usr/bin/printf", "/bin/printf"]` and this is a NixOS
machine, which has neither — `printf` here is a shell builtin and coreutils lives
under `/nix/store`. That one is not a bug on your side. The
intermittent ones look like genuine flakes — two of them are in
`session::projects::tests`, whose `setup()` does
`std::env::set_var("HOME", ...)`, which is process-global. I am reporting that as
an observation, not a diagnosis, and I have not touched any of them. Happy to
open a separate issue with the logs if you want it.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: copy only. The change is the `--purge` doc comment and the reference line generated from it; no code path, flag behaviour or output other than the help text changes, which is the "copy change" case the template names.

The claim the wording makes is about `--purge`'s actual scope, which is why the
review's correction mattered more here than it would for an ordinary copy change:
**the first commit, and the first version of this paragraph, said the agent store
goes unconditionally. It does not.** `--keep-container` or
`sandbox.auto_cleanup=false` sets `delete_sandbox=false` (`remove.rs:220-222`),
`container_gone` then stays false (`deletion.rs:723-731`) and
`stage_remove_agent_stores` is skipped (`:749-750`). A *failed* teardown leaves
`container_gone` false as well, even where `delete_sandbox` was true, so the
reviewer's "attempts to remove" covers a case the original report did not.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code, running Claude Opus 5 and Claude Fable 5.1.

**Any Additional AI Details you'd like to share:**

Drafted by an agent, then reviewed over four rounds by separate agents that did
not see the earlier ones.

Worth being explicit about for a wording change, since the wording is the whole
claim: what `--purge` removes was established by reading the code paths —
`purge_acp_transcript` (`src/cli/mod.rs:121`) for the structured-view transcript
and `stage_remove_agent_stores` (`src/session/deletion.rs:1220`) for the
per-instance agent store — and **not** by purging a sandboxed session and looking
at what disappeared. If you would rather the sentence rest on an observation than
on a reading, that is a fair thing to ask for and I will go and get it.

I review the result and decide what ships, and I will answer review questions
here myself rather than pasting them into a model.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Clarified `aoe rm --purge --help` and the generated CLI reference.
- Documented which transcript rows and sandbox agent stores CLI purge removes.
- Clarified that sandbox stores are removed only when sandbox teardown removes the container.
- Confirmed that host agent history outside those stores remains unaffected.
- Documented that CLI purge does not invoke the `session/delete` adapter flow.

This improves purge transparency and reduces the risk of unexpected data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

